### PR TITLE
docs: bittensor integration research and money model plans

### DIFF
--- a/thoughts/plans/bittensor-integration-spec.md
+++ b/thoughts/plans/bittensor-integration-spec.md
@@ -1,0 +1,234 @@
+# Bittensor Integration Spec — GrantScope/CivicScope
+
+**Date:** 2026-03-29
+**Status:** Draft — awaiting outreach responses
+**Scope:** Consumer integration only. No mining. No validators. No on-chain operations.
+
+---
+
+## 1. Djinn SN103 — Web Attestation for Evidence Packs
+
+### What it does
+
+Djinn uses TLSNotary to cryptographically prove a webpage showed specific content at a specific time. Proofs are validator-attested on Base (L2) and archived to Arweave. This is stronger than screenshots, web archives, or timestamps.
+
+### Why we want it
+
+Our decision packs, due diligence packs, and funder profiles are only as trustworthy as their source data. Today when we say "this foundation funds Indigenous health in NT" — that's our LLM's interpretation of a webpage we scraped at some point. With attestation:
+
+- **Procurement intelligence:** "This AusTender notice was live at [URL] on [date]" — cryptographic proof
+- **Foundation profiles:** "Giving focus verified from foundation website on [date]" — not just our enrichment
+- **R&D evidence:** Attest our own project pages, git hosting, deployment logs for ATO claims
+- **Competitive moat:** "Attested intelligence" is a differentiator no competitor has
+
+### Integration architecture
+
+```
+┌─────────────────────┐
+│  GrantScope Backend  │
+│                      │
+│  1. Identify high-   │
+│     value source     │──── agent_tasks queue ────┐
+│     URLs to attest   │                           │
+│                      │                           ▼
+│  4. Store proof +    │     ┌──────────────────────────┐
+│     update entity    │◄────│  Attestation Worker       │
+│     confidence       │     │  (new: attest-worker.mjs) │
+│                      │     │                           │
+│  5. Display badge    │     │  2. Submit URL to Djinn   │
+│     in UI + packs    │     │     (Base smart contract  │
+└─────────────────────┘     │      or API when avail)   │
+                             │                           │
+                             │  3. Receive proof bundle  │
+                             │     (TLSNotary + Arweave) │
+                             └──────────────────────────┘
+```
+
+### Schema additions
+
+```sql
+-- New table
+CREATE TABLE attestations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id uuid REFERENCES gs_entities(id),
+  source_url text NOT NULL,
+  attested_at timestamptz NOT NULL,
+  proof_hash text NOT NULL,           -- TLSNotary proof hash
+  arweave_tx text,                    -- Arweave archive reference
+  chain_tx text,                      -- Base L2 transaction hash
+  content_snapshot jsonb,             -- Key extracted claims at attestation time
+  status text DEFAULT 'pending',      -- pending | verified | failed | expired
+  cost_usd numeric(10,4),            -- Track attestation costs
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_attestations_entity ON attestations(entity_id);
+CREATE INDEX idx_attestations_status ON attestations(status);
+
+-- Add attestation count to entity confidence scoring
+ALTER TABLE gs_entities ADD COLUMN attestation_count int DEFAULT 0;
+```
+
+### Integration with existing patterns
+
+| Existing pattern | How attestation plugs in |
+|---|---|
+| `PackReadinessBlocker` codes (`missing_confidence`, `missing_source_count`) | Add `missing_attestation` blocker for premium packs |
+| `confidenceBadge()` (green/yellow/grey) | Add "attested" tier above "high" — new badge color (blue?) |
+| `assembleDueDiligencePack()` | Include attestation proofs in pack payload |
+| `agent_tasks` queue + `claim_next_task()` | New task type `attest_source_url` — same queue, new worker |
+| Stripe tiers — `governed-proof` module (enterprise only) | Gate attested exports behind `funder` ($499) or `enterprise` ($1,999) |
+| `profile_confidence` scoring | Boost confidence score when attestations exist |
+
+### Pricing model for attested intelligence
+
+| Tier | Attestation access |
+|---|---|
+| community (free) | See attestation badges, can't export proofs |
+| professional ($79) | 10 attested entity lookups/month |
+| organisation ($249) | 100 attested lookups + attested decision packs |
+| funder ($499) | Unlimited attested lookups + API access to proofs |
+| enterprise ($1,999) | Bulk attestation + white-label proof embedding |
+
+### Current Djinn integration status
+
+- **No public API/SDK yet.** Integration is via Base smart contract interaction.
+- **Attestation product is live** at djinn.gg/attest but may be gated/early access.
+- **Action required:** Outreach to Djinn team for API access / partnership.
+- **Fallback:** If Djinn API is not available, use TLSNotary directly (open source) with our own verifier — more work but no dependency.
+
+### Cost model (estimated)
+
+- Attestation fee: ~$0.50-2.00 per URL (USDC, paid to Djinn contract)
+- At 100 attestations/day = $50-200/day = $1,500-6,000/month
+- Break-even: 3-12 funder-tier subscriptions cover attestation costs
+- **Unit economics work if attestation is a premium feature, not a default**
+
+---
+
+## 2. Macrocosmos SN13 — Data Enrichment Feed
+
+### What it does
+
+Macrocosmos runs the Data Universe subnet. 350M rows/day of web/social data, scraped and structured by distributed miners. They have a production Python SDK and API.
+
+### Why we want it
+
+569,424 of our 587,307 entities have source_count ≤ 1. We need:
+- Foundation website content for the 3,304 with websites but no enrichment
+- Social media presence for entity profiles (Twitter, LinkedIn mentions)
+- News/media mentions for entity activity signals
+- Grant program page changes (stale-record detection)
+
+### Integration architecture
+
+```
+┌──────────────────────┐     ┌─────────────────────────┐
+│  GrantScope Backend   │     │  Macrocosmos Gravity API │
+│                       │     │  (SN13)                  │
+│  1. Queue enrichment  │     │                          │
+│     tasks for low-    │────►│  2. Query social/web     │
+│     source entities   │     │     data by entity name  │
+│                       │     │     or URL               │
+│  4. Score + ingest    │◄────│                          │
+│     accepted deltas   │     │  3. Return structured    │
+│                       │     │     results              │
+│  5. Reject low-conf   │     └─────────────────────────┘
+│     results to review │
+└──────────────────────┘
+```
+
+### SDK access (already available)
+
+```bash
+pip install macrocosmos
+```
+
+```python
+from macrocosmos import Macrocosmos
+client = Macrocosmos(api_key="...")
+
+# Search for entity mentions
+results = client.gravity.search(
+    query="ACT Foundation Indigenous grants Queensland",
+    sources=["twitter", "reddit"],
+    limit=50
+)
+```
+
+### Integration with existing patterns
+
+| Existing pattern | How Macrocosmos plugs in |
+|---|---|
+| `agent_tasks` queue | New task type `enrich_from_sn13` |
+| Multi-provider LLM profiler (MiniMax → Groq → Gemini fallback) | Add Macrocosmos as a data source (not LLM — raw data feed) |
+| `source_count` confidence metric | Each accepted Macrocosmos result increments source_count |
+| Provenance tracking | Tag source as `sn13_gravity` with query params + timestamp |
+
+### Cost model
+
+- **Free tier:** $5 credits included (enough for proof-of-concept)
+- **Paid:** TBD — contact hello@macrocosmos.ai for bulk pricing
+- **Estimated:** $0.001-0.01 per query at scale
+- At 10,000 queries/month = $10-100/month (trivial vs value added)
+
+### Gating rules (critical)
+
+- **Never write SN13 data directly to production truth tables.**
+- All results go to `enrichment_candidates` staging table.
+- Auto-accept if confidence > 0.8 AND source_url validates.
+- Route everything else to human review queue.
+- Tag provenance: `{source: "sn13_gravity", query: "...", retrieved_at: "..."}`.
+
+---
+
+## 3. Implementation Sequence
+
+### Week 1: Outreach + proof of concept
+- [ ] Send outreach messages (see companion doc)
+- [ ] Sign up for Macrocosmos free tier ($5 credits)
+- [ ] Run 50 test queries against foundation names → evaluate result quality
+- [ ] Research Djinn attestation contract ABI on Base
+
+### Week 2: Macrocosmos enrichment pipeline
+- [ ] Create `enrichment_candidates` staging table
+- [ ] Build `enrich-from-sn13.mjs` worker (uses agent_tasks queue)
+- [ ] Run against 100 low-source foundations → measure acceptance rate
+- [ ] If acceptance > 60%, scale to full 3,304 foundation backfill
+
+### Week 3: Djinn attestation integration
+- [ ] Build `attest-worker.mjs` (depends on API access from outreach)
+- [ ] Create `attestations` table
+- [ ] Attest 50 high-value source pages (AusTender, foundation websites)
+- [ ] Add attestation badge to entity profile UI
+
+### Week 4: Monetize
+- [ ] Configure Stripe env vars (the 4 that are missing)
+- [ ] Gate attested exports behind funder tier
+- [ ] Add "attested intelligence" marketing to Goods Workspace
+- [ ] Price attested decision packs at 2-3x unattested
+
+---
+
+## 4. What we are NOT doing
+
+- ❌ Running Bittensor miners or validators
+- ❌ Holding TAO as treasury asset (yet)
+- ❌ Building our own MPC/ZK infrastructure
+- ❌ Registering a subnet
+- ❌ Sending any sensitive EL/JusticeHub/community data to Bittensor
+- ❌ Making core product uptime dependent on subnet economics
+
+---
+
+## 5. Success metrics (90 days)
+
+| Metric | Target |
+|---|---|
+| Entities enriched via SN13 | 3,000+ |
+| Source pages attested | 500+ |
+| Stripe billing activated | Yes |
+| Paying subscribers (any tier) | 3+ |
+| Attestation cost per entity | < $1.00 |
+| Enrichment acceptance rate | > 60% |
+| Revenue from attested tier premium | > $0 (proof of concept) |

--- a/thoughts/plans/bittensor-money-engine-plan-2026-04-09.md
+++ b/thoughts/plans/bittensor-money-engine-plan-2026-04-09.md
@@ -1,0 +1,158 @@
+# Bittensor Money Engine Plan — CivicGraph (2026-04-09)
+
+## Goal
+
+Build a high-margin data and intelligence business that uses Bittensor as a compute/refinement layer, while CivicGraph remains the source of truth and product surface.
+
+This plan is intentionally commercial-first:
+- **Track 1:** Monetize better data (SN13 enrichment)
+- **Track 2:** Monetize trust (SN103 attestation)
+- **Track 3:** Monetize speed + interpretation (signals, API, decision packs)
+- **Track 4:** Add mining only when it beats Track 1-3 ROI
+
+---
+
+## Current baseline (from live DB)
+
+- `gs_entities`: **587,307**
+- `source_count <= 1`: **569,424** (largest immediate value gap)
+- `foundations` in entity graph: **10,748**
+- `enrichment_candidates`: **0 rows** (SN13 loop not yet producing reviewable candidates)
+
+Interpretation: the highest-value arbitrage right now is **coverage/refinement**, not token speculation.
+
+---
+
+## Core thesis: where money comes from
+
+### 1) Subnet Consumer Products (highest near-term certainty)
+
+Use SN13 and SN103 to improve CivicGraph output, then sell:
+- enriched entity dossiers,
+- attested due diligence packs,
+- premium monitoring/alerts.
+
+Why this wins:
+- you already own the demand surface (`/tender-intelligence`, entity dossiers, due diligence pack flows),
+- this can invoice in AUD today,
+- no dependency on miner emissions volatility.
+
+### 2) Signals + Intelligence Products
+
+Productize:
+- monthly sector/region watch briefs,
+- API access to scored/attested signals,
+- high-ticket custom intelligence for buyers/funders/government teams.
+
+Why this wins:
+- moves value from raw data to “decision speed + judgement,”
+- direct path to enterprise revenue bands.
+
+### 3) Mining Operations (conditional)
+
+Run miners only when:
+- measured net USD/TAO yield after infra and operations is positive for 8+ weeks,
+- and does not cannibalize product shipping velocity.
+
+Why conditional:
+- emissions and subnet economics are volatile,
+- teams routinely over-invest in mining infra before proving commercial pull.
+
+---
+
+## 90-day execution plan
+
+## Phase 1 (Days 1-21): Revenue rail before scale
+
+1. Turn on SN13 enrichment loop to `enrichment_candidates` (staging only).
+2. Add acceptance gate (confidence + provenance + URL validation).
+3. Expose “enriched” badge + source trail in paid outputs only.
+4. Ship attestation-ready field model (even before SN103 API automation is complete).
+5. Launch one paid offer:
+   - **Attested Due Diligence Pack** (fixed-price SKU).
+
+Exit criteria:
+- 1,000+ enrichment candidates generated.
+- 60%+ acceptance into production fields.
+- first paid attested/enriched output sold.
+
+## Phase 2 (Days 22-56): Productized recurring revenue
+
+1. Add subscription modules:
+   - monitored entities,
+   - change alerts,
+   - attested export allowance.
+2. Launch “Signals API” for shortlisted customers.
+3. Implement packaging tiers around:
+   - unverified vs enriched vs attested intelligence.
+4. Formalize outbound with proof-rich case studies.
+
+Exit criteria:
+- 10+ paying customers,
+- recurring monthly revenue across at least 2 products,
+- established COGS/GM by SKU.
+
+## Phase 3 (Days 57-90): Mining decision gate
+
+1. Run controlled mining pilot (small miner set).
+2. Track weekly:
+   - TAO earned,
+   - net USD after infra,
+   - engineering hours consumed.
+3. Compare mining ROI against direct product ROI.
+
+Decision:
+- scale mining only if 8-week net return beats equivalent product investment.
+- otherwise keep Bittensor usage focused on consumer layer and ship faster.
+
+---
+
+## Non-negotiable rules
+
+1. **No sensitive community data to public subnet tasks.**
+2. **All subnet outputs go to staging first, never direct-to-truth.**
+3. **Every accepted result has provenance metadata.**
+4. **Commercial KPI beats vanity KPI.**
+5. **Do not treat TAO emissions as primary business model.**
+
+---
+
+## KPI stack (weekly)
+
+- Revenue:
+  - MRR,
+  - attested pack sales,
+  - API revenue.
+- Data quality:
+  - enrichment acceptance rate,
+  - source_count uplift in target segments,
+  - stale-record reduction.
+- Unit economics:
+  - COGS per enriched entity,
+  - COGS per attested pack,
+  - gross margin by SKU.
+- Mining (pilot only):
+  - net TAO yield in USD,
+  - infra cost per TAO,
+  - engineering hours per $1k generated.
+
+---
+
+## Immediate actions this week
+
+1. Run `node scripts/enrich-from-sn13.mjs --dry-run --limit=100 --source=x`.
+2. Run live SN13 sweep on a constrained segment (e.g. foundations only).
+3. Build reviewer workflow for `enrichment_candidates` acceptance.
+4. Price and publish one attested pack offer.
+5. Track economics with `node scripts/bittensor-money-model.mjs`.
+
+---
+
+## Why this is the practical path
+
+If the objective is “make serious money,” your fastest route is:
+- use Bittensor to improve output quality and trust,
+- sell higher-trust decisions,
+- only scale mining when it is a proven multiplier.
+
+That order preserves focus, protects cash, and compounds your existing CivicGraph moat.

--- a/thoughts/plans/bittensor-money-model.json
+++ b/thoughts/plans/bittensor-money-model.json
@@ -1,0 +1,106 @@
+{
+  "baseline": {
+    "asOf": "2026-04-09",
+    "entitiesTotal": 587307,
+    "lowSourceEntities": 569424,
+    "foundationsTotal": 10748
+  },
+  "marketAssumptions": {
+    "taoPriceUsd": 480
+  },
+  "scenarios": {
+    "base": {
+      "consumerTrack": {
+        "enrichedEntitiesPerMonth": 3000,
+        "pricePerEnrichedEntityUsd": 4,
+        "costPerEnrichedEntityUsd": 0.8,
+        "attestedExportsPerMonth": 300,
+        "pricePerAttestedExportUsd": 95,
+        "costPerAttestedExportUsd": 1.5,
+        "subscriptionCustomers": 30,
+        "subscriptionArpuUsd": 299,
+        "subscriptionDeliveryCostRate": 0.25
+      },
+      "miningTrack": {
+        "miners": 6,
+        "taoPerMinerPerDay": 0.03,
+        "uptimeRate": 0.93,
+        "infraCostPerMinerUsd": 380,
+        "opsAndMonitoringCostUsd": 1800,
+        "validatorOrDelegationCostUsd": 1200
+      },
+      "signalsTrack": {
+        "monthlyReportClients": 8,
+        "pricePerMonthlyReportUsd": 2400,
+        "apiCustomers": 6,
+        "apiArpuUsd": 1800,
+        "customEngagementsPerMonth": 2,
+        "customEngagementValueUsd": 6500,
+        "deliveryCostRate": 0.3,
+        "fixedTeamCostUsd": 9500
+      }
+    },
+    "push": {
+      "consumerTrack": {
+        "enrichedEntitiesPerMonth": 8000,
+        "pricePerEnrichedEntityUsd": 4.5,
+        "costPerEnrichedEntityUsd": 0.9,
+        "attestedExportsPerMonth": 850,
+        "pricePerAttestedExportUsd": 110,
+        "costPerAttestedExportUsd": 1.7,
+        "subscriptionCustomers": 75,
+        "subscriptionArpuUsd": 349,
+        "subscriptionDeliveryCostRate": 0.22
+      },
+      "miningTrack": {
+        "miners": 14,
+        "taoPerMinerPerDay": 0.035,
+        "uptimeRate": 0.95,
+        "infraCostPerMinerUsd": 420,
+        "opsAndMonitoringCostUsd": 3200,
+        "validatorOrDelegationCostUsd": 2200
+      },
+      "signalsTrack": {
+        "monthlyReportClients": 20,
+        "pricePerMonthlyReportUsd": 2900,
+        "apiCustomers": 20,
+        "apiArpuUsd": 2200,
+        "customEngagementsPerMonth": 4,
+        "customEngagementValueUsd": 10000,
+        "deliveryCostRate": 0.28,
+        "fixedTeamCostUsd": 18000
+      }
+    },
+    "aggressive": {
+      "consumerTrack": {
+        "enrichedEntitiesPerMonth": 20000,
+        "pricePerEnrichedEntityUsd": 5,
+        "costPerEnrichedEntityUsd": 1,
+        "attestedExportsPerMonth": 2500,
+        "pricePerAttestedExportUsd": 130,
+        "costPerAttestedExportUsd": 2,
+        "subscriptionCustomers": 160,
+        "subscriptionArpuUsd": 399,
+        "subscriptionDeliveryCostRate": 0.2
+      },
+      "miningTrack": {
+        "miners": 30,
+        "taoPerMinerPerDay": 0.04,
+        "uptimeRate": 0.96,
+        "infraCostPerMinerUsd": 450,
+        "opsAndMonitoringCostUsd": 6000,
+        "validatorOrDelegationCostUsd": 4500
+      },
+      "signalsTrack": {
+        "monthlyReportClients": 45,
+        "pricePerMonthlyReportUsd": 3200,
+        "apiCustomers": 40,
+        "apiArpuUsd": 2600,
+        "customEngagementsPerMonth": 8,
+        "customEngagementValueUsd": 15000,
+        "deliveryCostRate": 0.25,
+        "fixedTeamCostUsd": 35000
+      }
+    }
+  }
+}

--- a/thoughts/plans/bittensor-outreach-messages.md
+++ b/thoughts/plans/bittensor-outreach-messages.md
@@ -1,0 +1,166 @@
+# Bittensor Outreach Messages
+
+**Date:** 2026-03-29
+**Context:** GrantScope/CivicScope seeking consumer-level integration with Bittensor subnet services
+
+---
+
+## 1. Djinn (SN103) — Web Attestation Partnership
+
+### Target contacts
+- **Harry Crane** — Co-founder, Professor of Statistics at Rutgers. [@HarryDCrane on X](https://x.com/HarryDCrane). Also reachable via [Rutgers faculty page](https://statistics.rutgers.edu/people-pages/faculty/people/373-harry-crane) or his Substack.
+- **Iosif Gershteyn** — Co-founder, CEO of ImmuVia. LinkedIn.
+- **@djinn_gg** — Project X/Twitter account
+- **Discord** — likely the fastest path for technical questions
+
+### Channel recommendation
+DM Harry Crane on X first (he's active), then follow up on Discord for technical details.
+
+### Message (X DM to Harry Crane)
+
+```
+Hi Harry — I run GrantScope (civicgraph.app), an open intelligence platform
+mapping $800M+ in Australian grant funding, 795K government contracts, and
+312K political donations across 587K entities.
+
+We're building "attested intelligence" — cryptographic proof that our source
+data (AusTender procurement notices, foundation websites, ACNC filings)
+showed specific content at specific times. Our customers (funders, procurement
+teams, government) need evidence-grade data, not just scraped snapshots.
+
+Djinn's web attestation is exactly the infrastructure layer we need. We don't
+want to build MPC/TLSNotary ourselves — we want to use yours as a service.
+
+Specific integration: we'd submit ~100-500 URLs/day for attestation, store
+the proof bundles, and surface "cryptographically verified" badges on our
+decision packs and due diligence reports. Our enterprise customers would
+pay premium for attested vs unattested intelligence.
+
+Questions:
+1. Is the attestation product available for programmatic/API access today?
+2. What's the cost per attestation at that volume?
+3. Is there a developer sandbox or testnet we can build against?
+4. Open to a 15-min call this week to explore?
+
+This feels like a non-sports vertical that proves Djinn's general-purpose
+thesis — accountable intelligence for procurement and funding decisions,
+not just predictions.
+
+Ben Knight
+A Curious Tractor / GrantScope
+benjamin@act.place
+```
+
+### Why this message works
+- Leads with our data scale (587K entities, $800M grants) — shows we're real
+- Positions us as a paying customer, not a competitor or feature request
+- Names the exact volume (100-500/day) so they can price it
+- Frames it as proof of their "beyond sports" thesis — they want this narrative
+- Asks 4 specific questions — easy to respond to
+- Short enough for a DM
+
+---
+
+## 2. Macrocosmos (SN13) — Data Enrichment Access
+
+### Target contacts
+- **hello@macrocosmos.ai** — official contact
+- **Will Squires** — CEO, co-founder (ex-OpenTensor Foundation)
+- **Steffen Cruz** — CTO, co-founder (ex-OpenTensor Foundation)
+- **Discord** — Macrocosmos server for technical support
+
+### Channel recommendation
+Email hello@macrocosmos.ai first (they have a proper developer relations flow), then sign up for the free tier simultaneously.
+
+### Message (email to hello@macrocosmos.ai)
+
+```
+Subject: Bulk data enrichment for Australian civic intelligence platform — API access
+
+Hi Macrocosmos team,
+
+I'm Ben Knight, founder of GrantScope (civicgraph.app) — an open intelligence
+platform for Australian grants, procurement, and civic accountability. We track
+587K entities, 30K grants, 795K government contracts, and 1.5M relationship
+edges across government registries.
+
+We have a specific enrichment gap: 569K of our entities have source_count ≤ 1
+(single registry source). We need web/social data to triangulate and enrich
+these records — foundation website content, social media presence, news
+mentions, and activity signals.
+
+We've reviewed the Gravity API docs and the Python SDK looks like a clean fit
+for our existing pipeline (we already run a multi-provider enrichment queue
+with claim_next_task() concurrency control in Supabase).
+
+Our planned usage:
+- Initial backfill: ~10K queries (3,304 foundations with websites but no
+  enrichment, plus top community organisations)
+- Ongoing: ~500-2K queries/day for new entities and stale-record refresh
+- Sources of interest: Twitter/X, Reddit, news, web content
+- We'd gate all results through a confidence threshold before ingesting
+  into our production graph
+
+Questions:
+1. Is the free tier ($5 credits) sufficient for a proof-of-concept batch
+   of ~200 queries?
+2. What's the pricing model for the volumes above?
+3. Are there rate limits or batch endpoints for bulk enrichment?
+4. Do you have Australian-specific data coverage, or is it primarily
+   US/global? (Our entities are Australian orgs, foundations, and
+   government bodies)
+5. Any existing integrations with Supabase/PostgreSQL pipelines?
+
+Happy to share more about our data model and enrichment architecture if
+helpful. We're looking for a data vendor relationship, not mining — your
+subnet does the hard work, we consume the results.
+
+Ben Knight
+A Curious Tractor / GrantScope
+benjamin@act.place
+https://civicgraph.app
+```
+
+### Why this message works
+- Professional vendor inquiry tone — they're used to this from enterprise
+- Specific volumes so they can route to the right pricing tier
+- Mentions their SDK by name — shows we've done homework
+- Asks about Australian coverage — critical qualifier before we invest time
+- Frames as "data vendor relationship" — clear expectation setting
+
+---
+
+## 3. Follow-up sequence
+
+### If Djinn responds positively
+1. Get API/contract docs
+2. Build proof-of-concept: attest 10 AusTender pages
+3. Measure: time to proof, cost per attestation, proof bundle size
+4. If viable: propose case study / co-marketing ("first non-sports vertical")
+
+### If Djinn doesn't respond in 7 days
+1. Try Discord (often faster than DMs)
+2. If still no response in 14 days: evaluate TLSNotary direct integration (open source, more work, no dependency)
+3. Fallback: signed timestamps + Merkle proofs (simpler, less impressive, but shippable)
+
+### If Macrocosmos responds positively
+1. Sign up for free tier immediately
+2. Run 50 test queries: Australian foundation names → evaluate hit rate
+3. If hit rate > 40%: negotiate bulk pricing
+4. If hit rate < 20%: Australian coverage is insufficient, deprioritize
+
+### If Macrocosmos Australian coverage is poor
+1. Stick with existing enrichment pipeline (Firecrawl + multi-LLM)
+2. Revisit in 6 months as their crawler coverage grows
+3. Consider contributing Australian seed URLs to improve their coverage (goodwill play)
+
+---
+
+## 4. What NOT to say in outreach
+
+- Don't mention "we want to mine" — we don't, and it changes the conversation
+- Don't mention TAO price or token economics — we're customers, not speculators
+- Don't oversell our scale — 587K entities is real but modest by global standards
+- Don't promise integration timelines — wait for their API reality before committing
+- Don't mention other subnets — keep each conversation focused
+- Don't share sensitive data details (JusticeHub, Indigenous community data) — only public registry data


### PR DESCRIPTION
## Summary

Research + planning docs for Bittensor integration, carved from the working-tree snapshot (2026-04-24). No code changes.

- `thoughts/plans/bittensor-integration-spec.md` — integration spec
- `thoughts/plans/bittensor-money-engine-plan-2026-04-09.md` — money engine plan
- `thoughts/plans/bittensor-money-model.json` — model parameters
- `thoughts/plans/bittensor-outreach-messages.md` — outreach messages

Per the strategic plan memory, Bittensor is "not now (18-24mo); build Proof of Impact scoring within CivicGraph instead" — these docs are background for that decision, not implementation.

## Test plan

- [x] No code changes; nothing to test
- [x] Files render as markdown / valid JSON