### PR TITLE
feat: briefing generator — composer, controls, lane/output loop bar

### DIFF
--- a/apps/web/src/app/briefing/briefing-composer.tsx
+++ b/apps/web/src/app/briefing/briefing-composer.tsx
@@ -1,0 +1,720 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { parseBriefingLanes } from '@/app/components/briefing-loop-bar';
+
+type StartPointKey = 'company' | 'funding' | 'procurement' | 'place';
+type OutputKey = 'board-memo' | 'funding-brief' | 'tender-pack' | 'story-handoff';
+type LaneKey = 'entity' | 'funding' | 'procurement' | 'place' | 'clarity';
+type AgentKey = 'scout' | 'link' | 'draft' | 'story';
+
+type StartPoint = {
+  key: StartPointKey;
+  label: string;
+  description: string;
+  directRoute: string;
+};
+
+type OutputOption = {
+  key: OutputKey;
+  label: string;
+  description: string;
+  primaryHref: string;
+  primaryLabel: string;
+  supportHrefs: Array<{ label: string; href: string }>;
+};
+
+type Lane = {
+  key: LaneKey;
+  label: string;
+  description: string;
+};
+
+type Agent = {
+  key: AgentKey;
+  label: string;
+  description: string;
+};
+
+const START_POINTS: StartPoint[] = [
+  {
+    key: 'company',
+    label: 'Company / organisation',
+    description: 'Use this when the core question is about one organisation, its relationships, and what to do next.',
+    directRoute: '/entities',
+  },
+  {
+    key: 'funding',
+    label: 'Grant / funder',
+    description: 'Use this when the work starts from a funding pathway, topic, or funder landscape.',
+    directRoute: '/grants',
+  },
+  {
+    key: 'procurement',
+    label: 'Procurement / market',
+    description: 'Use this when the decision is about suppliers, pathways, or a live procurement move.',
+    directRoute: '/tender-intelligence',
+  },
+  {
+    key: 'place',
+    label: 'Place / field',
+    description: 'Use this when the work starts from a geography, system problem, or field-level question.',
+    directRoute: '/power',
+  },
+];
+
+const OUTPUTS: OutputOption[] = [
+  {
+    key: 'board-memo',
+    label: 'Board memo',
+    description: 'Generate an internal memo or partner-facing brief from linked organisation context.',
+    primaryHref: '/home/board-report',
+    primaryLabel: 'Open board memo generator',
+    supportHrefs: [
+      { label: 'Open power map', href: '/power' },
+      { label: 'Check clarity layer', href: '/clarity' },
+    ],
+  },
+  {
+    key: 'funding-brief',
+    label: 'Funding brief',
+    description: 'Turn a topic, geography, or opportunity set into a stronger funding landscape read.',
+    primaryHref: '/home/report-builder',
+    primaryLabel: 'Open funding report builder',
+    supportHrefs: [
+      { label: 'Search grants', href: '/grants' },
+      { label: 'Review funders', href: '/foundations' },
+    ],
+  },
+  {
+    key: 'tender-pack',
+    label: 'Tender pack',
+    description: 'Carry the evidence into supplier review, market testing, and sign-off-ready procurement work.',
+    primaryHref: '/tender-intelligence',
+    primaryLabel: 'Open tender intelligence',
+    supportHrefs: [
+      { label: 'See market power', href: '/power' },
+      { label: 'Review reports', href: '/reports' },
+    ],
+  },
+  {
+    key: 'story-handoff',
+    label: 'Story handoff',
+    description: 'Prepare the evidence chain for reporting, company stories, and aligned narrative analysis.',
+    primaryHref: '/clarity',
+    primaryLabel: 'Open clarity handoff',
+    supportHrefs: [
+      { label: 'Open reporting', href: '/reports' },
+      { label: 'See entities', href: '/entities' },
+    ],
+  },
+];
+
+const TOPIC_OPTIONS = [
+  { value: 'youth-justice', label: 'Youth Justice' },
+  { value: 'child-protection', label: 'Child Protection' },
+  { value: 'ndis', label: 'NDIS' },
+  { value: 'family-services', label: 'Family Services' },
+  { value: 'indigenous', label: 'Indigenous' },
+  { value: 'legal-services', label: 'Legal Services' },
+  { value: 'diversion', label: 'Diversion' },
+  { value: 'prevention', label: 'Prevention' },
+] as const;
+
+const STATE_OPTIONS = ['', 'NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'] as const;
+
+const LANES: Lane[] = [
+  {
+    key: 'entity',
+    label: 'Entity identity',
+    description: 'Resolved organisation records, identifiers, and relationship context.',
+  },
+  {
+    key: 'funding',
+    label: 'Funding context',
+    description: 'Grants, foundations, and the surrounding funding environment.',
+  },
+  {
+    key: 'procurement',
+    label: 'Procurement context',
+    description: 'Suppliers, pathways, procurement packs, and decision records.',
+  },
+  {
+    key: 'place',
+    label: 'Place and power',
+    description: 'Place signals, power concentration, and field-level context.',
+  },
+  {
+    key: 'clarity',
+    label: 'Story handoff',
+    description: 'Evidence lineage and narrative-ready framing for downstream reporting.',
+  },
+];
+
+const AGENTS: Agent[] = [
+  {
+    key: 'scout',
+    label: 'Scout',
+    description: 'Find new signals, pathways, and changes worth briefing.',
+  },
+  {
+    key: 'link',
+    label: 'Link',
+    description: 'Resolve entities, places, and related systems into one working context.',
+  },
+  {
+    key: 'draft',
+    label: 'Draft',
+    description: 'Assemble the memo, recommendation, or report shell from the evidence.',
+  },
+  {
+    key: 'story',
+    label: 'Story layer',
+    description: 'Prepare a clean handoff for company stories, reporting, and aligned analysis.',
+  },
+];
+
+function parseStart(value: string | null): StartPointKey {
+  return START_POINTS.some((item) => item.key === value) ? (value as StartPointKey) : 'company';
+}
+
+function parseOutput(value: string | null): OutputKey {
+  return OUTPUTS.some((item) => item.key === value) ? (value as OutputKey) : 'board-memo';
+}
+
+function recommendationLanes(start: StartPointKey, output: OutputKey): LaneKey[] {
+  const fromStart: Record<StartPointKey, LaneKey[]> = {
+    company: ['entity', 'funding', 'place'],
+    funding: ['funding', 'place', 'entity'],
+    procurement: ['procurement', 'entity', 'place'],
+    place: ['place', 'funding', 'entity'],
+  };
+
+  const fromOutput: Record<OutputKey, LaneKey[]> = {
+    'board-memo': ['entity', 'funding', 'place'],
+    'funding-brief': ['funding', 'place', 'clarity'],
+    'tender-pack': ['procurement', 'entity', 'place'],
+    'story-handoff': ['clarity', 'entity', 'place'],
+  };
+
+  return Array.from(new Set([...fromStart[start], ...fromOutput[output]]));
+}
+
+function recommendedAgents(output: OutputKey): AgentKey[] {
+  const map: Record<OutputKey, AgentKey[]> = {
+    'board-memo': ['scout', 'link', 'draft'],
+    'funding-brief': ['scout', 'link', 'draft'],
+    'tender-pack': ['scout', 'link', 'draft'],
+    'story-handoff': ['link', 'draft', 'story'],
+  };
+
+  return map[output];
+}
+
+function buildWorkingAsk(start: StartPointKey, output: OutputKey) {
+  const startText: Record<StartPointKey, string> = {
+    company: 'What is actually happening around this organisation, and what is the next move?',
+    funding: 'Which funding pathway is real, and how should we frame it for action?',
+    procurement: 'Which procurement move is strongest, and what evidence supports it?',
+    place: 'What is happening in this place or field, and what recommendation follows from that reality?',
+  };
+
+  const outputText: Record<OutputKey, string> = {
+    'board-memo': 'End with a board-ready memo that can support an internal decision.',
+    'funding-brief': 'End with a brief that sharpens the funding opportunity or landscape.',
+    'tender-pack': 'End with a procurement recommendation or sign-off-ready pack.',
+    'story-handoff': 'End with a narrative handoff that can support reporting or a company story.',
+  };
+
+  return [startText[start], outputText[output]];
+}
+
+function focusLabel(start: StartPointKey, output: OutputKey) {
+  if (output === 'board-memo') return 'Organisation or company';
+  if (output === 'funding-brief') return 'Funding angle or partner';
+  if (output === 'tender-pack') return 'Supplier, buyer, or procurement angle';
+
+  switch (start) {
+    case 'company':
+      return 'Organisation or company';
+    case 'funding':
+      return 'Funding angle';
+    case 'procurement':
+      return 'Procurement angle';
+    case 'place':
+    default:
+      return 'Place, field, or story angle';
+  }
+}
+
+function focusPlaceholder(start: StartPointKey, output: OutputKey) {
+  if (output === 'board-memo') return 'e.g. Life Without Barriers';
+  if (output === 'funding-brief') return 'e.g. Youth justice reform';
+  if (output === 'tender-pack') return 'e.g. Remote service delivery suppliers';
+
+  switch (start) {
+    case 'company':
+      return 'e.g. Save the Children Australia';
+    case 'funding':
+      return 'e.g. Diversion and prevention';
+    case 'procurement':
+      return 'e.g. Community-led procurement';
+    case 'place':
+    default:
+      return 'e.g. Townsville youth justice';
+  }
+}
+
+function buildPrimaryHref({
+  output,
+  subject,
+  topicPreset,
+  stateFocus,
+  selectedLaneKeys,
+}: {
+  output: OutputOption;
+  subject: string;
+  topicPreset: string;
+  stateFocus: string;
+  selectedLaneKeys: LaneKey[];
+}) {
+  const params = new URLSearchParams();
+  const trimmedSubject = subject.trim();
+
+  if (output.key === 'board-memo') {
+    if (trimmedSubject) {
+      params.set('q', trimmedSubject);
+      params.set('autosearch', '1');
+    }
+  }
+
+  if (output.key === 'funding-brief') {
+    params.set('topic', topicPreset);
+    params.set('autogenerate', '1');
+    if (stateFocus) params.set('state', stateFocus);
+    if (trimmedSubject) params.set('focus', trimmedSubject);
+  }
+
+  if (output.key === 'tender-pack') {
+    params.set('tab', 'pack');
+    if (trimmedSubject) params.set('subject', trimmedSubject);
+    if (stateFocus) params.set('state', stateFocus);
+  }
+
+  if (output.key === 'story-handoff') {
+    params.set('output', output.key);
+    if (trimmedSubject) params.set('subject', trimmedSubject);
+    if (stateFocus) params.set('state', stateFocus);
+  }
+
+  params.set('lanes', selectedLaneKeys.join(','));
+
+  const query = params.toString();
+  return query ? `${output.primaryHref}?${query}` : output.primaryHref;
+}
+
+function buildContextHref(start: StartPoint, subject: string) {
+  const trimmedSubject = subject.trim();
+  if (!trimmedSubject) return start.directRoute;
+
+  if (start.key === 'company') {
+    return `/entities?q=${encodeURIComponent(trimmedSubject)}`;
+  }
+
+  if (start.key === 'funding') {
+    return `/grants?q=${encodeURIComponent(trimmedSubject)}`;
+  }
+
+  return start.directRoute;
+}
+
+export function BriefingComposer() {
+  const searchParams = useSearchParams();
+  const [startPoint, setStartPoint] = useState<StartPointKey>('company');
+  const [output, setOutput] = useState<OutputKey>('board-memo');
+  const [subject, setSubject] = useState('');
+  const [topicPreset, setTopicPreset] = useState<string>('youth-justice');
+  const [stateFocus, setStateFocus] = useState<string>('');
+  const [selectedLanes, setSelectedLanes] = useState<LaneKey[]>(recommendationLanes('company', 'board-memo'));
+
+  useEffect(() => {
+    const nextStart = parseStart(searchParams.get('start'));
+    const nextOutput = parseOutput(searchParams.get('output'));
+    const nextSubject = searchParams.get('subject') || '';
+    const nextTopic = searchParams.get('topic') || 'youth-justice';
+    const nextState = searchParams.get('state') || '';
+    const nextLanes = parseBriefingLanes(searchParams.get('lanes'));
+    setStartPoint(nextStart);
+    setOutput(nextOutput);
+    setSubject(nextSubject);
+    setTopicPreset(TOPIC_OPTIONS.some((item) => item.value === nextTopic) ? nextTopic : 'youth-justice');
+    setStateFocus(STATE_OPTIONS.includes(nextState as (typeof STATE_OPTIONS)[number]) ? nextState : '');
+    setSelectedLanes(nextLanes.length > 0 ? nextLanes : recommendationLanes(nextStart, nextOutput));
+  }, [searchParams]);
+
+  const currentStart = START_POINTS.find((item) => item.key === startPoint) || START_POINTS[0];
+  const currentOutput = OUTPUTS.find((item) => item.key === output) || OUTPUTS[0];
+  const activeAgents = recommendedAgents(output)
+    .map((key) => AGENTS.find((agent) => agent.key === key))
+    .filter((agent): agent is Agent => Boolean(agent));
+  const activeLanes = selectedLanes
+    .map((key) => LANES.find((lane) => lane.key === key))
+    .filter((lane): lane is Lane => Boolean(lane));
+  const workingAsk = buildWorkingAsk(startPoint, output);
+  const launchHref = buildPrimaryHref({
+    output: currentOutput,
+    subject,
+    topicPreset,
+    stateFocus,
+    selectedLaneKeys: selectedLanes,
+  });
+  const contextHref = buildContextHref(currentStart, subject);
+
+  function toggleLane(laneKey: LaneKey) {
+    setSelectedLanes((current) =>
+      current.includes(laneKey) ? current.filter((item) => item !== laneKey) : [...current, laneKey],
+    );
+  }
+
+  return (
+    <section id="composer">
+      <div
+        className="rounded-xl border p-5"
+        style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)' }}
+      >
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-6">
+          <div className="space-y-6">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                Compose The Brief
+              </p>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight" style={{ color: 'var(--ws-text)' }}>
+                Configure the decision before you open the generator.
+              </h2>
+              <p className="mt-2 text-sm max-w-3xl" style={{ color: 'var(--ws-text-secondary)' }}>
+                Pick the subject, choose the output, and confirm which evidence lanes need to travel with the work.
+                This keeps the older memo and report tools inside one simpler operating flow.
+              </p>
+            </div>
+
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide mb-3" style={{ color: 'var(--ws-text-tertiary)' }}>
+                1. Start point
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {START_POINTS.map((item) => {
+                  const active = item.key === startPoint;
+                  return (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={() => {
+                        setStartPoint(item.key);
+                        setSelectedLanes(recommendationLanes(item.key, output));
+                      }}
+                      className="rounded-lg border px-4 py-4 text-left transition-colors"
+                      style={{
+                        borderColor: active ? 'var(--ws-accent)' : 'var(--ws-border)',
+                        background: active ? 'rgba(37,99,235,0.06)' : 'var(--ws-surface-0)',
+                      }}
+                    >
+                      <p className="text-sm font-medium" style={{ color: 'var(--ws-text)' }}>
+                        {item.label}
+                      </p>
+                      <p className="mt-1 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                        {item.description}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide mb-3" style={{ color: 'var(--ws-text-tertiary)' }}>
+                2. Output
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {OUTPUTS.map((item) => {
+                  const active = item.key === output;
+                  return (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={() => {
+                        setOutput(item.key);
+                        setSelectedLanes(recommendationLanes(startPoint, item.key));
+                      }}
+                      className="rounded-lg border px-4 py-4 text-left transition-colors"
+                      style={{
+                        borderColor: active ? 'var(--ws-accent)' : 'var(--ws-border)',
+                        background: active ? 'rgba(37,99,235,0.06)' : 'var(--ws-surface-0)',
+                      }}
+                    >
+                      <p className="text-sm font-medium" style={{ color: 'var(--ws-text)' }}>
+                        {item.label}
+                      </p>
+                      <p className="mt-1 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                        {item.description}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide mb-3" style={{ color: 'var(--ws-text-tertiary)' }}>
+                3. Brief focus
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_180px_180px] gap-3">
+                <div
+                  className="rounded-lg border px-4 py-4"
+                  style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                >
+                  <label className="block text-[11px] font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--ws-text-tertiary)' }}>
+                    {focusLabel(startPoint, output)}
+                  </label>
+                  <input
+                    type="text"
+                    value={subject}
+                    onChange={(event) => setSubject(event.target.value)}
+                    placeholder={focusPlaceholder(startPoint, output)}
+                    className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
+                    style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)', color: 'var(--ws-text)' }}
+                  />
+                  <p className="mt-2 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                    Keep this short. It becomes the search seed or handoff label when the next tool opens.
+                  </p>
+                </div>
+
+                <div
+                  className="rounded-lg border px-4 py-4"
+                  style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                >
+                  <label className="block text-[11px] font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--ws-text-tertiary)' }}>
+                    Topic preset
+                  </label>
+                  <select
+                    value={topicPreset}
+                    onChange={(event) => setTopicPreset(event.target.value)}
+                    className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
+                    style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)', color: 'var(--ws-text)' }}
+                  >
+                    {TOPIC_OPTIONS.map((item) => (
+                      <option key={item.value} value={item.value}>
+                        {item.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="mt-2 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                    Used when the output is a funding brief.
+                  </p>
+                </div>
+
+                <div
+                  className="rounded-lg border px-4 py-4"
+                  style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                >
+                  <label className="block text-[11px] font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--ws-text-tertiary)' }}>
+                    State focus
+                  </label>
+                  <select
+                    value={stateFocus}
+                    onChange={(event) => setStateFocus(event.target.value)}
+                    className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
+                    style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)', color: 'var(--ws-text)' }}
+                  >
+                    <option value="">National / all states</option>
+                    {STATE_OPTIONS.filter(Boolean).map((item) => (
+                      <option key={item} value={item}>
+                        {item}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="mt-2 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                    Passed into funding briefs when useful.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                  4. Evidence lanes
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setSelectedLanes(recommendationLanes(startPoint, output))}
+                  className="text-[11px] font-medium"
+                  style={{ color: 'var(--ws-accent)' }}
+                >
+                  Reset to recommended
+                </button>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {LANES.map((lane) => {
+                  const active = selectedLanes.includes(lane.key);
+                  return (
+                    <button
+                      key={lane.key}
+                      type="button"
+                      onClick={() => toggleLane(lane.key)}
+                      className="rounded-lg border px-4 py-4 text-left transition-colors"
+                      style={{
+                        borderColor: active ? 'var(--ws-accent)' : 'var(--ws-border)',
+                        background: active ? 'rgba(37,99,235,0.06)' : 'var(--ws-surface-0)',
+                      }}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-medium" style={{ color: 'var(--ws-text)' }}>
+                          {lane.label}
+                        </p>
+                        <span
+                          className="rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+                          style={{
+                            background: active ? 'var(--ws-accent)' : 'var(--ws-surface-1)',
+                            color: active ? '#fff' : 'var(--ws-text-tertiary)',
+                          }}
+                        >
+                          {active ? 'Included' : 'Optional'}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                        {lane.description}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div
+            className="rounded-xl border p-5 h-fit"
+            style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+              Current Brief
+            </p>
+            <h3 className="mt-1 text-lg font-semibold tracking-tight" style={{ color: 'var(--ws-text)' }}>
+              {currentStart.label} to {currentOutput.label}
+            </h3>
+            <p className="mt-2 text-sm" style={{ color: 'var(--ws-text-secondary)' }}>
+              {currentOutput.description}
+            </p>
+
+            <div className="mt-4 space-y-3">
+              {workingAsk.map((item) => (
+                <div
+                  key={item}
+                  className="rounded-lg border px-4 py-3"
+                  style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)' }}
+                >
+                  <p className="text-sm" style={{ color: 'var(--ws-text)' }}>
+                    {item}
+                  </p>
+                </div>
+              ))}
+              {(subject.trim() || output === 'funding-brief' || stateFocus) && (
+                <div
+                  className="rounded-lg border px-4 py-3"
+                  style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)' }}
+                >
+                  <p className="text-sm" style={{ color: 'var(--ws-text)' }}>
+                    {subject.trim() ? `Focus: ${subject.trim()}. ` : ''}
+                    {output === 'funding-brief' ? `Topic preset: ${TOPIC_OPTIONS.find((item) => item.value === topicPreset)?.label || topicPreset}. ` : ''}
+                    {stateFocus ? `State focus: ${stateFocus}.` : 'State focus: National.'}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <div className="mt-5">
+              <p className="text-[11px] font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--ws-text-tertiary)' }}>
+                Evidence carried forward
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {activeLanes.map((lane) => (
+                  <span
+                    key={lane.key}
+                    className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                    style={{ background: 'rgba(37,99,235,0.06)', color: 'var(--ws-accent)' }}
+                  >
+                    {lane.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-5">
+              <p className="text-[11px] font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--ws-text-tertiary)' }}>
+                Agent support
+              </p>
+              <div className="space-y-2">
+                {activeAgents.map((agent) => (
+                  <div
+                    key={agent.key}
+                    className="rounded-lg border px-4 py-3"
+                    style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)' }}
+                  >
+                    <p className="text-sm font-medium" style={{ color: 'var(--ws-text)' }}>
+                      {agent.label}
+                    </p>
+                    <p className="mt-1 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                      {agent.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-2">
+              <Link
+                href={launchHref}
+                className="flex items-center justify-center rounded-lg px-4 py-2.5 text-sm font-medium transition-colors"
+                style={{ background: 'var(--ws-accent)', color: '#fff' }}
+              >
+                {currentOutput.primaryLabel}
+              </Link>
+              <div className="grid grid-cols-1 gap-2">
+                <Link
+                  href={contextHref}
+                  className="rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors hover:border-[var(--ws-accent)]"
+                  style={{ borderColor: 'var(--ws-border)', color: 'var(--ws-text-secondary)' }}
+                >
+                  Open subject context
+                </Link>
+                {currentOutput.supportHrefs.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className="rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors hover:border-[var(--ws-accent)]"
+                    style={{ borderColor: 'var(--ws-border)', color: 'var(--ws-text-secondary)' }}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div
+              className="mt-5 rounded-lg border px-4 py-3"
+              style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)' }}
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                Story bridge
+              </p>
+              <p className="mt-1 text-sm" style={{ color: 'var(--ws-text-secondary)' }}>
+                Keep company facts, procurement opportunity analysis, and reporting notes in the same thread so the downstream story layer does not have to reconstruct reality from scratch.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/briefing/page.tsx
+++ b/apps/web/src/app/briefing/page.tsx
@@ -1,0 +1,534 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { WorkspacePageHeader } from '@/app/components/workspace-page-header';
+import { getServiceSupabase } from '@/lib/supabase';
+import { createSupabaseServer } from '@/lib/supabase-server';
+import { BriefingComposer } from './briefing-composer';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Briefing Hub | CivicGraph',
+  description:
+    'Start from a company, funder, procurement pathway, or place and turn the same evidence chain into a memo, pack, report, or story handoff.',
+};
+
+type LinkAction = {
+  label: string;
+  href: string;
+};
+
+type StartPoint = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  outcome: string;
+  primary: LinkAction;
+  secondary: LinkAction;
+};
+
+type OutputCard = {
+  title: string;
+  description: string;
+  carries: string;
+  href: string;
+  hrefLabel: string;
+};
+
+type EvidenceCard = {
+  title: string;
+  description: string;
+  sources: string[];
+};
+
+type AgentCard = {
+  title: string;
+  description: string;
+};
+
+function compactNumber(value: number | null | undefined) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat('en-AU', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
+}
+
+function CardShell({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="rounded-xl border p-5"
+      style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-1)' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SectionTitle({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+        {eyebrow}
+      </p>
+      <h2 className="mt-1 text-lg font-semibold tracking-tight" style={{ color: 'var(--ws-text)' }}>
+        {title}
+      </h2>
+      <p className="mt-1 text-sm max-w-3xl" style={{ color: 'var(--ws-text-secondary)' }}>
+        {description}
+      </p>
+    </div>
+  );
+}
+
+const START_POINTS: StartPoint[] = [
+  {
+    eyebrow: 'Company / Organisation',
+    title: 'Start with the entity that needs a move.',
+    description:
+      'Pull together company facts, linked entities, funding signals, and relationship context before writing anything.',
+    outcome: 'Best when you need a board memo, partner note, or company intelligence pack.',
+    primary: { label: 'Compose Board Memo', href: '/briefing?start=company&output=board-memo#composer' },
+    secondary: { label: 'Browse Entities', href: '/entities' },
+  },
+  {
+    eyebrow: 'Grant / Funder',
+    title: 'Start with the funding pathway.',
+    description:
+      'Compare grants, foundation logic, and topic coverage, then frame the next move as a brief instead of a search result.',
+    outcome: 'Best when you need an opportunity brief, funder read, or topic landscape.',
+    primary: { label: 'Compose Funding Brief', href: '/briefing?start=funding&output=funding-brief#composer' },
+    secondary: { label: 'Search Funding', href: '/grants' },
+  },
+  {
+    eyebrow: 'Procurement / Market',
+    title: 'Start with the procurement decision.',
+    description:
+      'Review suppliers, shortlist logic, market structure, and approval workflow from the same operating context.',
+    outcome: 'Best when you need a tender decision pack or procurement recommendation.',
+    primary: { label: 'Compose Tender Pack', href: '/briefing?start=procurement&output=tender-pack#composer' },
+    secondary: { label: 'See Market Context', href: '/power' },
+  },
+  {
+    eyebrow: 'Place / Field',
+    title: 'Start with the place or system problem.',
+    description:
+      'Read power, funding concentration, place signals, and under-served territory before pushing a narrative or recommendation.',
+    outcome: 'Best when you need a place brief, field scan, or reporting angle.',
+    primary: { label: 'Compose Story Handoff', href: '/briefing?start=place&output=story-handoff#composer' },
+    secondary: { label: 'Check Data Coverage', href: '/clarity' },
+  },
+];
+
+const OUTPUTS: OutputCard[] = [
+  {
+    title: 'Board memo',
+    description:
+      'Turn entity, funder, and network context into a printable memo for leadership, partners, or internal review.',
+    carries: 'Entity profile, inbound and outbound relationships, justice funding, and supporting notes.',
+    href: '/briefing?start=company&output=board-memo#composer',
+    hrefLabel: 'Configure board memo',
+  },
+  {
+    title: 'Funding landscape brief',
+    description:
+      'Build a topical report that translates the graph into a working view of funders, programs, organisations, and place.',
+    carries: 'Topic, geography, top programs, top organisations, and field-level context.',
+    href: '/briefing?start=funding&output=funding-brief#composer',
+    hrefLabel: 'Configure funding brief',
+  },
+  {
+    title: 'Tender decision pack',
+    description:
+      'Carry the same evidence into shortlist review, procurement decisions, and sign-off-ready market packs.',
+    carries: 'Supplier evidence, review tasks, recommendation text, and approval status.',
+    href: '/briefing?start=procurement&output=tender-pack#composer',
+    hrefLabel: 'Configure tender pack',
+  },
+  {
+    title: 'Story handoff',
+    description:
+      'Keep the evidence chain clean so reporting and editorial systems can build company stories or aligned analysis without starting over.',
+    carries: 'Place context, power signals, evidence lineage, and a usable narrative brief.',
+    href: '/briefing?start=place&output=story-handoff#composer',
+    hrefLabel: 'Configure story handoff',
+  },
+];
+
+const EVIDENCE_CARDS: EvidenceCard[] = [
+  {
+    title: 'Company and entity identity',
+    description: 'Work from the resolved organisation record, not from disconnected notes.',
+    sources: ['gs_entities', 'entity_identifiers', 'gs_relationships'],
+  },
+  {
+    title: 'Funding and funders',
+    description: 'See the opportunity surface and the historical funding environment in one place.',
+    sources: ['grant_opportunities', 'foundations', 'justice_funding'],
+  },
+  {
+    title: 'Procurement and market context',
+    description: 'Bring procurement pathways and supplier evidence into the same decision thread.',
+    sources: ['austender_contracts', 'procurement shortlists', 'procurement pack exports'],
+  },
+  {
+    title: 'Place, power, and influence',
+    description: 'Add place need, power concentration, and influence signals before framing the recommendation.',
+    sources: ['postcode_geo', 'seifa_2021', 'political_donations'],
+  },
+];
+
+const AGENT_CARDS: AgentCard[] = [
+  {
+    title: 'Scout',
+    description: 'Find new opportunities, market movement, and relevant signals worth briefing.',
+  },
+  {
+    title: 'Link',
+    description: 'Resolve ABNs, entities, places, and related organisations into one clean working context.',
+  },
+  {
+    title: 'Draft',
+    description: 'Assemble memo sections, report structure, and recommendation text from approved evidence.',
+  },
+  {
+    title: 'Story layer',
+    description: 'Hand off a clear evidence chain so narrative systems can build company stories and aligned analysis.',
+  },
+];
+
+export default async function BriefingPage() {
+  const supabase = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login?next=/briefing');
+  }
+
+  const db = getServiceSupabase();
+  const [
+    { count: openGrantCount },
+    { count: foundationCount },
+    { count: entityCount },
+    { count: contractCount },
+  ] = await Promise.all([
+    db.from('grant_opportunities').select('*', { count: 'exact', head: true }).gt('deadline', new Date().toISOString()),
+    db.from('foundations').select('*', { count: 'exact', head: true }),
+    db.from('gs_entities').select('*', { count: 'exact', head: true }),
+    db.from('austender_contracts').select('*', { count: 'exact', head: true }),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-6 py-6 space-y-6">
+      <WorkspacePageHeader
+        eyebrow="Decision Infrastructure"
+        title="Briefing Hub"
+        description="Start from a company, funding path, procurement decision, or place. Carry one evidence chain through memo, pack, report, and story handoff."
+        actions={(
+          <>
+            <Link
+              href="/briefing?start=company&output=board-memo#composer"
+              className="rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:border-[var(--ws-accent)]"
+              style={{ borderColor: 'var(--ws-border)', color: 'var(--ws-text-secondary)' }}
+            >
+              Compose Brief
+            </Link>
+            <Link
+              href="/power"
+              className="rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:border-[var(--ws-accent)]"
+              style={{ borderColor: 'var(--ws-border)', color: 'var(--ws-text-secondary)' }}
+            >
+              Open Power Map
+            </Link>
+            <Link
+              href="/clarity"
+              className="rounded-lg px-3 py-2 text-sm font-medium transition-colors"
+              style={{ background: 'var(--ws-accent)', color: '#fff' }}
+            >
+              Story Handoff
+            </Link>
+          </>
+        )}
+      />
+
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_340px] gap-6">
+        <div className="space-y-6">
+          <CardShell>
+            <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_320px] gap-6">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                  Start With Action
+                </p>
+                <h2 className="mt-1 text-2xl font-semibold tracking-tight" style={{ color: 'var(--ws-text)' }}>
+                  The product should route people into the next decision, not into a bigger dashboard.
+                </h2>
+                <p className="mt-3 text-sm max-w-2xl" style={{ color: 'var(--ws-text-secondary)' }}>
+                  Use this page to decide what the subject is, what the output needs to be, and which evidence needs to travel with it.
+                  Company information, procurement opportunity analysis, reporting context, and story prep should stay connected.
+                </p>
+                <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+                  {[
+                    {
+                      title: 'Start from the decision',
+                      text: 'Pick the company, opportunity, market, or place first.',
+                    },
+                    {
+                      title: 'Reuse the same evidence',
+                      text: 'Do not rebuild context when moving from memo to report to story.',
+                    },
+                    {
+                      title: 'Let agents support judgement',
+                      text: 'Agents should scout, link, and draft. The team still decides.',
+                    },
+                  ].map((item) => (
+                    <div
+                      key={item.title}
+                      className="rounded-lg border px-4 py-3"
+                      style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                    >
+                      <p className="text-sm font-medium" style={{ color: 'var(--ws-text)' }}>
+                        {item.title}
+                      </p>
+                      <p className="mt-1 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                        {item.text}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  { label: 'Open funding lines', value: compactNumber(openGrantCount) },
+                  { label: 'Foundations indexed', value: compactNumber(foundationCount) },
+                  { label: 'Entities linked', value: compactNumber(entityCount) },
+                  { label: 'Contracts loaded', value: compactNumber(contractCount) },
+                ].map((item) => (
+                  <div
+                    key={item.label}
+                    className="rounded-lg border px-4 py-4"
+                    style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                  >
+                    <p className="text-xl font-semibold tabular-nums" style={{ color: 'var(--ws-text)' }}>
+                      {item.value}
+                    </p>
+                    <p className="mt-1 text-[11px] uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                      {item.label}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </CardShell>
+
+          <BriefingComposer />
+
+          <section>
+            <SectionTitle
+              eyebrow="Choose The Start Point"
+              title="Pick the subject of the decision."
+              description="Each route starts from a different subject, but each one should still end with a memo, recommendation, or clean handoff."
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {START_POINTS.map((item) => (
+                <CardShell key={item.title}>
+                  <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                    {item.eyebrow}
+                  </p>
+                  <h3 className="mt-1 text-lg font-semibold tracking-tight" style={{ color: 'var(--ws-text)' }}>
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6" style={{ color: 'var(--ws-text-secondary)' }}>
+                    {item.description}
+                  </p>
+                  <p className="mt-3 text-xs leading-5" style={{ color: 'var(--ws-text-tertiary)' }}>
+                    {item.outcome}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <Link
+                      href={item.primary.href}
+                      className="rounded-lg px-3 py-2 text-sm font-medium transition-colors"
+                      style={{ background: 'var(--ws-accent)', color: '#fff' }}
+                    >
+                      {item.primary.label}
+                    </Link>
+                    <Link
+                      href={item.secondary.href}
+                      className="rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:border-[var(--ws-accent)]"
+                      style={{ borderColor: 'var(--ws-border)', color: 'var(--ws-text-secondary)' }}
+                    >
+                      {item.secondary.label}
+                    </Link>
+                  </div>
+                </CardShell>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <SectionTitle
+              eyebrow="Choose The Output"
+              title="One context, four outputs."
+              description="The same evidence should support internal decision-making, procurement, reporting, and narrative work without spawning four different research processes."
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {OUTPUTS.map((item) => (
+                <CardShell key={item.title}>
+                  <h3 className="text-lg font-semibold tracking-tight" style={{ color: 'var(--ws-text)' }}>
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6" style={{ color: 'var(--ws-text-secondary)' }}>
+                    {item.description}
+                  </p>
+                  <div
+                    className="mt-4 rounded-lg border px-4 py-3"
+                    style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                  >
+                    <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--ws-text-tertiary)' }}>
+                      Carries forward
+                    </p>
+                    <p className="mt-1 text-sm" style={{ color: 'var(--ws-text)' }}>
+                      {item.carries}
+                    </p>
+                  </div>
+                  <Link
+                    href={item.href}
+                    className="mt-4 inline-flex rounded-lg px-3 py-2 text-sm font-medium transition-colors"
+                    style={{ background: 'var(--ws-surface-0)', color: 'var(--ws-accent)' }}
+                  >
+                    {item.hrefLabel}
+                  </Link>
+                </CardShell>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <SectionTitle
+              eyebrow="Evidence Chain"
+              title="Keep the evidence visible."
+              description="A useful briefing flow shows where claims came from, which systems are connected, and what kind of confidence the team should have."
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {EVIDENCE_CARDS.map((item) => (
+                <CardShell key={item.title}>
+                  <h3 className="text-base font-semibold" style={{ color: 'var(--ws-text)' }}>
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6" style={{ color: 'var(--ws-text-secondary)' }}>
+                    {item.description}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {item.sources.map((source) => (
+                      <span
+                        key={source}
+                        className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                        style={{ background: 'var(--ws-surface-0)', color: 'var(--ws-text-secondary)' }}
+                      >
+                        {source}
+                      </span>
+                    ))}
+                  </div>
+                </CardShell>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <div className="space-y-6">
+          <CardShell>
+            <SectionTitle
+              eyebrow="Agent Support"
+              title="Agents should reduce lift, not hide the reasoning."
+              description="Use agents to do the repetitive work around evidence gathering, linking, and drafting. Keep the decision and sign-off human."
+            />
+            <div className="space-y-3">
+              {AGENT_CARDS.map((item) => (
+                <div
+                  key={item.title}
+                  className="rounded-lg border px-4 py-3"
+                  style={{ borderColor: 'var(--ws-border)', background: 'var(--ws-surface-0)' }}
+                >
+                  <p className="text-sm font-medium" style={{ color: 'var(--ws-text)' }}>
+                    {item.title}
+                  </p>
+                  <p className="mt-1 text-xs leading-5" style={{ color: 'var(--ws-text-secondary)' }}>
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </CardShell>
+
+          <CardShell>
+            <SectionTitle
+              eyebrow="Story Handoff"
+              title="Bridge to the narrative layer."
+              description="This hub should make it easy to move from company information and procurement analysis into a story-ready structure without re-researching the basics."
+            />
+            <div className="space-y-3 text-sm" style={{ color: 'var(--ws-text-secondary)' }}>
+              <p>
+                Treat the narrative layer as a handoff from the same operating context: company facts, linked organisations,
+                procurement signals, place context, and the recommendation logic that came out of the work.
+              </p>
+              <p>
+                That keeps company stories, reporting, and aligned analysis grounded in the same evidence chain instead of becoming a separate editorial exercise.
+              </p>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Link
+                href="/clarity"
+                className="rounded-lg px-3 py-2 text-sm font-medium transition-colors"
+                style={{ background: 'var(--ws-accent)', color: '#fff' }}
+              >
+                Open clarity layer
+              </Link>
+              <Link
+                href="/reports"
+                className="rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:border-[var(--ws-accent)]"
+                style={{ borderColor: 'var(--ws-border)', color: 'var(--ws-text-secondary)' }}
+              >
+                Open reporting
+              </Link>
+            </div>
+          </CardShell>
+
+          <CardShell>
+            <SectionTitle
+              eyebrow="Run The Loop"
+              title="Use this sequence."
+              description="Keep the product flow short enough that someone can move from signal to recommendation in one sitting."
+            />
+            <ol className="space-y-3">
+              {[
+                'Choose the subject: company, funder, procurement path, or place.',
+                'Pull the evidence that matters and drop what does not affect the decision.',
+                'Generate the right output: memo, pack, report, or story handoff.',
+              ].map((item, index) => (
+                <li key={item} className="flex gap-3">
+                  <span
+                    className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+                    style={{ background: 'var(--ws-surface-0)', color: 'var(--ws-text)' }}
+                  >
+                    {index + 1}
+                  </span>
+                  <p className="text-sm leading-6" style={{ color: 'var(--ws-text-secondary)' }}>
+                    {item}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </CardShell>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/briefing-control-panel.tsx
+++ b/apps/web/src/app/components/briefing-control-panel.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+interface BriefingControlPanelProps {
+  title: string;
+  children: ReactNode;
+  note?: string;
+  error?: string;
+  className?: string;
+}
+
+export function BriefingControlPanel({
+  title,
+  children,
+  note,
+  error,
+  className = '',
+}: BriefingControlPanelProps) {
+  return (
+    <div className={`border-4 border-bauhaus-black p-6 mb-8 ${className}`.trim()}>
+      <div className="text-xs font-black text-bauhaus-muted uppercase tracking-widest mb-4">{title}</div>
+      {children}
+      {note && <p className="text-xs text-bauhaus-muted mt-3">{note}</p>}
+      {error && <p className="text-sm text-bauhaus-red mt-3">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/briefing-entry-section.tsx
+++ b/apps/web/src/app/components/briefing-entry-section.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { BriefingControlPanel } from '@/app/components/briefing-control-panel';
+import { BriefingGeneratorControls } from '@/app/components/briefing-generator-controls';
+
+interface BriefingEntrySectionProps {
+  action: ReactNode;
+  children: ReactNode;
+  className?: string;
+  error?: string;
+  footer?: ReactNode;
+  header?: ReactNode;
+  note?: string;
+  rowClassName?: string;
+  title: string;
+}
+
+export function BriefingEntrySection({
+  action,
+  children,
+  className,
+  error,
+  footer,
+  header,
+  note,
+  rowClassName,
+  title,
+}: BriefingEntrySectionProps) {
+  return (
+    <BriefingControlPanel title={title} className={className} note={note} error={error}>
+      <BriefingGeneratorControls header={header} footer={footer} action={action} rowClassName={rowClassName}>
+        {children}
+      </BriefingGeneratorControls>
+    </BriefingControlPanel>
+  );
+}

--- a/apps/web/src/app/components/briefing-generator-controls.tsx
+++ b/apps/web/src/app/components/briefing-generator-controls.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface BriefingGeneratorControlsProps {
+  action: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  header?: ReactNode;
+  rowClassName?: string;
+}
+
+export function BriefingGeneratorControls({
+  action,
+  children,
+  footer,
+  header,
+  rowClassName = 'flex flex-wrap gap-4 items-end',
+}: BriefingGeneratorControlsProps) {
+  return (
+    <>
+      {header}
+      <div className={rowClassName}>
+        {children}
+        {action}
+      </div>
+      {footer}
+    </>
+  );
+}

--- a/apps/web/src/app/components/briefing-generator-shell.tsx
+++ b/apps/web/src/app/components/briefing-generator-shell.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { BriefingLoopBar, type BriefingLaneKey, type BriefingOutputKey } from './briefing-loop-bar';
+
+type BriefingLoopConfig = {
+  message: string;
+  output: BriefingOutputKey;
+  subject?: string;
+  state?: string;
+  lanes?: BriefingLaneKey[];
+};
+
+interface BriefingGeneratorShellProps {
+  hubHref: string;
+  title: string;
+  description: string;
+  badge: string;
+  children: ReactNode;
+  loop?: BriefingLoopConfig;
+}
+
+export function BriefingGeneratorShell({
+  hubHref,
+  title,
+  description,
+  badge,
+  children,
+  loop,
+}: BriefingGeneratorShellProps) {
+  return (
+    <div className="max-w-6xl mx-auto py-8 px-4">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-4">
+        <div>
+          <Link href={hubHref} className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">
+            &larr; Briefing Hub
+          </Link>
+          <h1 className="text-2xl font-black text-bauhaus-black mt-1">{title}</h1>
+          <p className="text-sm text-bauhaus-muted mt-1">{description}</p>
+        </div>
+        <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest">
+          {badge}
+        </div>
+      </div>
+
+      {loop && (
+        <BriefingLoopBar
+          refineHref={hubHref}
+          output={loop.output}
+          subject={loop.subject}
+          state={loop.state}
+          lanes={loop.lanes}
+          className="mb-6"
+          message={loop.message}
+        />
+      )}
+
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/briefing-loop-bar.tsx
+++ b/apps/web/src/app/components/briefing-loop-bar.tsx
@@ -1,0 +1,139 @@
+import Link from 'next/link';
+
+export type BriefingStartPointKey = 'company' | 'funding' | 'procurement' | 'place';
+export type BriefingOutputKey = 'board-memo' | 'funding-brief' | 'tender-pack' | 'story-handoff';
+export type BriefingLaneKey = 'entity' | 'funding' | 'procurement' | 'place' | 'clarity';
+
+const LANE_LABELS: Record<BriefingLaneKey, string> = {
+  entity: 'Entity identity',
+  funding: 'Funding context',
+  procurement: 'Procurement context',
+  place: 'Place and power',
+  clarity: 'Story handoff',
+};
+
+const OUTPUT_LABELS: Record<BriefingOutputKey, string> = {
+  'board-memo': 'Board memo',
+  'funding-brief': 'Funding brief',
+  'tender-pack': 'Tender pack',
+  'story-handoff': 'Story handoff',
+};
+
+export function parseBriefingLanes(value: string | null | undefined): BriefingLaneKey[] {
+  if (!value) return [];
+
+  const laneSet = new Set<BriefingLaneKey>();
+  for (const item of value.split(',')) {
+    const trimmed = item.trim();
+    if (trimmed === 'entity' || trimmed === 'funding' || trimmed === 'procurement' || trimmed === 'place' || trimmed === 'clarity') {
+      laneSet.add(trimmed);
+    }
+  }
+
+  return Array.from(laneSet);
+}
+
+export function briefingLaneLabel(value: BriefingLaneKey | string) {
+  if (value === 'entity' || value === 'funding' || value === 'procurement' || value === 'place' || value === 'clarity') {
+    return LANE_LABELS[value];
+  }
+
+  return value.replace(/-/g, ' ');
+}
+
+export function briefingOutputLabel(value: BriefingOutputKey) {
+  return OUTPUT_LABELS[value];
+}
+
+export function buildBriefingComposeHref({
+  start,
+  output,
+  subject,
+  state,
+  topic,
+  lanes,
+}: {
+  start: BriefingStartPointKey;
+  output: BriefingOutputKey;
+  subject?: string;
+  state?: string;
+  topic?: string;
+  lanes?: BriefingLaneKey[];
+}) {
+  const params = new URLSearchParams();
+  params.set('start', start);
+  params.set('output', output);
+
+  const trimmedSubject = subject?.trim();
+  if (trimmedSubject) params.set('subject', trimmedSubject);
+
+  const trimmedState = state?.trim();
+  if (trimmedState) params.set('state', trimmedState);
+
+  const trimmedTopic = topic?.trim();
+  if (trimmedTopic) params.set('topic', trimmedTopic);
+
+  const validLanes = (lanes || []).filter(Boolean);
+  if (validLanes.length > 0) params.set('lanes', validLanes.join(','));
+
+  return `/briefing?${params.toString()}#composer`;
+}
+
+export function BriefingLoopBar({
+  refineHref,
+  message,
+  output,
+  subject,
+  state,
+  lanes,
+  className = '',
+}: {
+  refineHref: string;
+  message: string;
+  output: BriefingOutputKey;
+  subject?: string;
+  state?: string;
+  lanes?: BriefingLaneKey[];
+  className?: string;
+}) {
+  const detailChips = [
+    subject ? `Subject: ${subject}` : null,
+    state ? `State: ${state}` : null,
+    `Output: ${briefingOutputLabel(output)}`,
+  ].filter(Boolean);
+
+  return (
+    <div className={`border-4 border-bauhaus-blue bg-blue-50 px-5 py-4 ${className}`.trim()}>
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div className="max-w-4xl">
+          <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Briefing Loop</p>
+          <p className="mt-2 text-sm font-bold text-bauhaus-black">{message}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {detailChips.map((chip) => (
+              <span
+                key={chip}
+                className="border-2 border-bauhaus-blue bg-white px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue"
+              >
+                {chip}
+              </span>
+            ))}
+            {(lanes || []).map((lane) => (
+              <span
+                key={lane}
+                className="border-2 border-bauhaus-blue/30 bg-blue-100 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue"
+              >
+                {briefingLaneLabel(lane)}
+              </span>
+            ))}
+          </div>
+        </div>
+        <Link
+          href={refineHref}
+          className="inline-flex items-center justify-center border-4 border-bauhaus-blue bg-white px-4 py-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue transition-colors hover:bg-bauhaus-blue hover:text-white"
+        >
+          Refine In Briefing Hub
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/briefing-page-params.ts
+++ b/apps/web/src/app/components/briefing-page-params.ts
@@ -1,0 +1,254 @@
+import { briefingLaneLabel, buildBriefingComposeHref, parseBriefingLanes } from '@/app/components/briefing-loop-bar';
+
+import type { BriefingLaneKey, BriefingOutputKey } from '@/app/components/briefing-loop-bar';
+
+export type BoardReportPageSearchParams = {
+  q?: string;
+  autosearch?: string;
+  subject?: string;
+  lanes?: string;
+};
+
+export type ReportBuilderPageSearchParams = {
+  topic?: string;
+  state?: string;
+  focus?: string;
+  autogenerate?: string;
+  lanes?: string;
+};
+
+export type SharedBriefingSearchParams = {
+  subject?: string;
+  state?: string;
+  lanes?: string;
+  output?: string;
+};
+
+type BriefingLoopState = {
+  output: BriefingOutputKey;
+  subject?: string;
+  state?: string;
+  lanes: BriefingLaneKey[];
+  message: string;
+};
+
+type BriefingPageState = {
+  briefingComposeHref: string;
+  briefingLanes: BriefingLaneKey[];
+  nextPath: string;
+  showBriefingLoop: boolean;
+  loop?: BriefingLoopState;
+};
+
+type SharedBriefingContext = {
+  briefingComposeHref: string;
+  briefingLanes: BriefingLaneKey[];
+  briefingOutput: string;
+  briefingState: string;
+  briefingSubject: string;
+  hasBriefingContext: boolean;
+  loop?: BriefingLoopState;
+};
+
+export type ClarityPageState = SharedBriefingContext;
+
+export type TenderBriefingState = SharedBriefingContext & {
+  notice: string;
+  seed: string;
+};
+
+function buildNextPath(basePath: string, nextParams: URLSearchParams) {
+  const query = nextParams.toString();
+  return query ? `${basePath}?${query}` : basePath;
+}
+
+function buildLoopState({
+  output,
+  subject,
+  state,
+  lanes,
+  withSubjectMessage,
+  withoutSubjectMessage,
+}: {
+  output: BriefingOutputKey;
+  subject?: string;
+  state?: string;
+  lanes: BriefingLaneKey[];
+  withSubjectMessage: (subject: string) => string;
+  withoutSubjectMessage: string;
+}): BriefingLoopState {
+  return {
+    output,
+    subject,
+    state,
+    lanes,
+    message: subject ? withSubjectMessage(subject) : withoutSubjectMessage,
+  };
+}
+
+function buildSharedBriefingContext({
+  start,
+  output,
+  params,
+  topic,
+  withSubjectMessage,
+  withoutSubjectMessage,
+}: {
+  start: 'company' | 'funding' | 'procurement' | 'place';
+  output: BriefingOutputKey;
+  params: SharedBriefingSearchParams;
+  topic?: string;
+  withSubjectMessage: (subject: string) => string;
+  withoutSubjectMessage: string;
+}): SharedBriefingContext {
+  const briefingSubject = params.subject?.trim() || '';
+  const briefingState = params.state?.trim() || '';
+  const briefingOutput = params.output || '';
+  const briefingLanes = parseBriefingLanes(params.lanes);
+  const hasBriefingContext = !!briefingSubject || !!briefingState || briefingLanes.length > 0 || !!briefingOutput;
+
+  return {
+    briefingComposeHref: buildBriefingComposeHref({
+      start,
+      output,
+      subject: briefingSubject,
+      state: briefingState,
+      topic,
+      lanes: briefingLanes,
+    }),
+    briefingLanes,
+    briefingOutput,
+    briefingState,
+    briefingSubject,
+    hasBriefingContext,
+    loop: hasBriefingContext
+      ? buildLoopState({
+          output,
+          subject: briefingSubject,
+          state: briefingState,
+          lanes: briefingLanes,
+          withSubjectMessage,
+          withoutSubjectMessage,
+        })
+      : undefined,
+  };
+}
+
+export function buildBoardReportPageState(params: BoardReportPageSearchParams): BriefingPageState {
+  const initialSearchTerm = params.q || '';
+  const autoSearch = params.autosearch === '1';
+  const shared = buildSharedBriefingContext({
+    start: 'company',
+    output: 'board-memo',
+    params: {
+      subject: params.subject?.trim() || initialSearchTerm.trim(),
+      lanes: params.lanes,
+    },
+    withSubjectMessage: (subject) =>
+      `This memo is carrying the briefing context for ${subject}. Refine the subject or evidence lanes in the hub, then come back here to regenerate the board pack.`,
+    withoutSubjectMessage:
+      'This memo is carrying briefing context from the hub. Refine the subject or evidence lanes there if the board pack needs a tighter frame.',
+  });
+  const { briefingComposeHref, briefingLanes, loop } = shared;
+  const showBriefingLoop = autoSearch || briefingLanes.length > 0;
+
+  const nextParams = new URLSearchParams();
+  if (initialSearchTerm) nextParams.set('q', initialSearchTerm);
+  if (autoSearch) nextParams.set('autosearch', '1');
+  if (params.subject) nextParams.set('subject', params.subject);
+  if (params.lanes) nextParams.set('lanes', params.lanes);
+
+  return {
+    briefingComposeHref,
+    briefingLanes,
+    nextPath: buildNextPath('/home/board-report', nextParams),
+    showBriefingLoop,
+    loop: showBriefingLoop ? loop : undefined,
+  };
+}
+
+export function buildReportBuilderPageState(params: ReportBuilderPageSearchParams): BriefingPageState {
+  const initialTopic = params.topic || 'youth-justice';
+  const initialStateFilter = params.state || '';
+  const initialFocus = params.focus || '';
+  const autoGenerate = params.autogenerate === '1';
+  const shared = buildSharedBriefingContext({
+    start: 'funding',
+    output: 'funding-brief',
+    params: {
+      subject: initialFocus,
+      state: initialStateFilter,
+      lanes: params.lanes,
+    },
+    topic: initialTopic,
+    withSubjectMessage: (subject) =>
+      `This funding brief is carrying the briefing context for ${subject}. Refine the topic, geography, or evidence lanes in the hub, then come back here to regenerate the report.`,
+    withoutSubjectMessage:
+      'This funding brief is carrying briefing context from the hub. Refine the topic, geography, or evidence lanes there if the report needs a different frame.',
+  });
+  const { briefingComposeHref, briefingLanes, loop } = shared;
+  const showBriefingLoop = autoGenerate || !!initialFocus || !!initialStateFilter || briefingLanes.length > 0;
+
+  const nextParams = new URLSearchParams();
+  if (initialTopic) nextParams.set('topic', initialTopic);
+  if (initialStateFilter) nextParams.set('state', initialStateFilter);
+  if (initialFocus) nextParams.set('focus', initialFocus);
+  if (autoGenerate) nextParams.set('autogenerate', '1');
+  if (params.lanes) nextParams.set('lanes', params.lanes);
+
+  return {
+    briefingComposeHref,
+    briefingLanes,
+    nextPath: buildNextPath('/home/report-builder', nextParams),
+    showBriefingLoop,
+    loop: showBriefingLoop ? loop : undefined,
+  };
+}
+
+export function buildClarityPageState(params: SharedBriefingSearchParams): ClarityPageState {
+  return buildSharedBriefingContext({
+    start: 'place',
+    output: 'story-handoff',
+    params,
+    withSubjectMessage: (subject) =>
+      `Clarity is carrying the story handoff for ${subject}. Verify the evidence chain here, then return to the hub if the subject, geography, or lanes need to change before narrative work starts.`,
+    withoutSubjectMessage:
+      'Clarity is carrying story context from the briefing hub. Verify the evidence chain here, then return to the hub if the subject, geography, or evidence lanes need to change.',
+  });
+}
+
+export function buildTenderBriefingState(params: SharedBriefingSearchParams): TenderBriefingState {
+  const shared = buildSharedBriefingContext({
+    start: 'procurement',
+    output: 'tender-pack',
+    params,
+    withSubjectMessage: (subject) =>
+      `Tender Intelligence is carrying the briefing context for ${subject}. Change the subject, geography, or evidence lanes in the hub, then come back here to keep the decision pack tight.`,
+    withoutSubjectMessage:
+      'Tender Intelligence is carrying briefing context from the hub. Adjust the decision frame there if the procurement pack needs a different subject, geography, or evidence mix.',
+  });
+
+  const seed = [
+    shared.briefingSubject,
+    shared.briefingState,
+    shared.briefingOutput,
+    shared.briefingLanes.join(','),
+  ].filter(Boolean).join('|');
+
+  const laneSummary = shared.briefingLanes
+    .map((lane) => briefingLaneLabel(lane).toLowerCase())
+    .join(', ');
+
+  return {
+    ...shared,
+    notice: [
+      'Loaded briefing handoff',
+      shared.briefingSubject ? `for ${shared.briefingSubject}` : null,
+      shared.briefingState ? `in ${shared.briefingState}` : null,
+      shared.briefingOutput === 'story-handoff' ? 'with story mode context' : null,
+      laneSummary ? `carrying ${laneSummary}` : null,
+      'Use the workspace search and current shortlist to turn that context into a procurement decision pack.',
+    ].filter(Boolean).join(' '),
+    seed,
+  };
+}


### PR DESCRIPTION
## Summary

New self-contained briefing generator UI. All 8 files are new (no shared-file conflicts). Carved from the working-tree snapshot (2026-04-24).

- `apps/web/src/app/briefing/page.tsx` + `briefing-composer.tsx` — page + composer
- 6 new components: `briefing-control-panel`, `briefing-entry-section`, `briefing-generator-controls`, `briefing-generator-shell`, `briefing-loop-bar`, `briefing-page-params`

Imports only existing exports from `@/lib/supabase`, `@/lib/supabase-server`, and `@/app/components/workspace-page-header` — all present on `main`.

## Test plan

- [x] `npx tsc --noEmit` passes from clean state on this branch
- [ ] Smoke `/briefing` route locally (sign in required for the protected paths it composes from)
- [ ] Verify composer renders and lane/output bar interacts correctly