### PR TITLE
feat(grant-engine): discovery events + 16 council grant sources

### DIFF
--- a/packages/grant-engine/package.json
+++ b/packages/grant-engine/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:contracts": "tsx --test tests/**/*.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/grant-engine/src/agents/grant-monitor.ts
+++ b/packages/grant-engine/src/agents/grant-monitor.ts
@@ -51,10 +51,12 @@ export function createGrantMonitor(): AgentConfig {
           .filter((url): url is string => typeof url === 'string' && url.length > 0)
       );
 
-      for await (const { grant, stats } of registry.discoverAll({ status: 'open' })) {
+      for await (const event of registry.discoverAll({ status: 'open' })) {
+        if (event.kind !== 'grant') continue;
         found++;
 
         // Check if this is new
+        const grant = event.grant;
         const normalized = normalize(grant);
         if (existingNames.has(normalized.name.toLowerCase())) continue;
         if (normalized.url && existingUrls.has(normalized.url)) continue;

--- a/packages/grant-engine/src/engine.ts
+++ b/packages/grant-engine/src/engine.ts
@@ -37,6 +37,22 @@ import { createACTGrantsPlugin } from './sources/act-grants';
 import { createNTGrantsPlugin } from './sources/nt-grants';
 import { createSAGrantsPlugin } from './sources/sa-grants';
 import { createWAGrantsPlugin } from './sources/wa-grants';
+import { createCityOfSydneyGrantsPlugin } from './sources/cityofsydney-grants';
+import { createBrisbaneCityGrantsPlugin } from './sources/brisbane-city-grants';
+import { createRedlandCityGrantsPlugin } from './sources/redland-city-grants';
+import { createLoganCityGrantsPlugin } from './sources/logan-city-grants';
+import { createDarwinCityGrantsPlugin } from './sources/darwin-city-grants';
+import { createTablelandsGrantsPlugin } from './sources/tablelands-grants';
+import { createSunshineCoastGrantsPlugin } from './sources/sunshinecoast-grants';
+import { createCookShireGrantsPlugin } from './sources/cookshire-grants';
+import { createFraserCoastGrantsPlugin } from './sources/frasercoast-grants';
+import { createToowoombaGrantsPlugin } from './sources/toowoomba-grants';
+import { createScenicRimGrantsPlugin } from './sources/scenicrim-grants';
+import { createWhitsundayGrantsPlugin } from './sources/whitsunday-grants';
+import { createCentralHighlandsGrantsPlugin } from './sources/centralhighlands-grants';
+import { createNoosaGrantsPlugin } from './sources/noosa-grants';
+import { createChartersTowersGrantsPlugin } from './sources/charterstowers-grants';
+import { createLockyerValleyGrantsPlugin } from './sources/lockyervalley-grants';
 
 export class GrantEngine {
   private registry: SourceRegistry;
@@ -64,6 +80,22 @@ export class GrantEngine {
     this.registry.register(createNTGrantsPlugin());
     this.registry.register(createSAGrantsPlugin());
     this.registry.register(createWAGrantsPlugin());
+    this.registry.register(createCityOfSydneyGrantsPlugin());
+    this.registry.register(createBrisbaneCityGrantsPlugin());
+    this.registry.register(createRedlandCityGrantsPlugin());
+    this.registry.register(createLoganCityGrantsPlugin());
+    this.registry.register(createDarwinCityGrantsPlugin());
+    this.registry.register(createTablelandsGrantsPlugin());
+    this.registry.register(createSunshineCoastGrantsPlugin());
+    this.registry.register(createCookShireGrantsPlugin());
+    this.registry.register(createFraserCoastGrantsPlugin());
+    this.registry.register(createToowoombaGrantsPlugin());
+    this.registry.register(createScenicRimGrantsPlugin());
+    this.registry.register(createWhitsundayGrantsPlugin());
+    this.registry.register(createCentralHighlandsGrantsPlugin());
+    this.registry.register(createNoosaGrantsPlugin());
+    this.registry.register(createChartersTowersGrantsPlugin());
+    this.registry.register(createLockyerValleyGrantsPlugin());
   }
 
   private log(message: string): void {
@@ -84,7 +116,19 @@ export class GrantEngine {
    */
   async discover(query: DiscoveryQuery = {}): Promise<DiscoveryRunResult> {
     const startedAt = new Date().toISOString();
-    const sourcesUsed = this.config.sources || ['grantconnect', 'web-search', 'llm-knowledge'];
+    const sourcesUsed = this.config.sources?.length
+      ? this.config.sources
+      : this.registry.getEnabled().map(plugin => plugin.id);
+
+    try {
+      const staleRunsClosed = await this.repo.cleanupStaleRuns();
+      if (staleRunsClosed > 0) {
+        this.log(`[GrantScope] Marked ${staleRunsClosed} stale discovery runs as failed`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`[GrantScope] Failed to clean stale discovery runs: ${message}`);
+    }
 
     // Start run record
     let runId: string;
@@ -100,18 +144,19 @@ export class GrantEngine {
     // Step 1: Discover from all sources
     const allRaw: CanonicalGrant[] = [];
     const errors: Array<{ source: string; error: string }> = [];
-    const pluginStats = new Map<string, number>();
+    const sourceStats = new Map<string, { source: string; grantsFound: number; errors: string[]; durationMs: number }>();
 
-    for await (const { grant, stats } of this.registry.discoverAll(query, sourcesUsed)) {
-      const canonical = normalize(grant);
-      allRaw.push(canonical);
+    for await (const event of this.registry.discoverAll(query, sourcesUsed)) {
+      if (event.kind === 'grant') {
+        const canonical = normalize(event.grant);
+        allRaw.push(canonical);
+        continue;
+      }
 
-      const current = pluginStats.get(stats.source) || 0;
-      pluginStats.set(stats.source, current + 1);
-
-      if (stats.errors.length > 0) {
-        for (const err of stats.errors) {
-          errors.push({ source: stats.source, error: err });
+      sourceStats.set(event.stats.source, event.stats);
+      if (event.stats.errors.length > 0) {
+        for (const err of event.stats.errors) {
+          errors.push({ source: event.stats.source, error: err });
         }
       }
     }
@@ -145,7 +190,7 @@ export class GrantEngine {
       // Also try to update existing grants with new source info
       for (const grant of deduped) {
         if (!newGrants.includes(grant) && grant.url) {
-          const result = await this.repo.upsertGrant(grant);
+          const result = await this.repo.updateExistingGrant(grant);
           if (result === 'updated') grantsUpdated++;
         }
       }
@@ -158,9 +203,9 @@ export class GrantEngine {
     }
 
     // Step 5: Update plugin stats
-    for (const [pluginId, count] of pluginStats) {
+    for (const [pluginId, stats] of sourceStats) {
       try {
-        await this.repo.updatePluginStats(pluginId, count, 'success');
+        await this.repo.updatePluginStats(pluginId, stats.grantsFound, stats.errors.length > 0 ? 'partial' : 'success');
       } catch {
         // Non-critical
       }
@@ -173,6 +218,7 @@ export class GrantEngine {
       startedAt,
       completedAt,
       sourcesUsed,
+      sourceStats: [...sourceStats.values()],
       grantsDiscovered: allRaw.length,
       grantsNew,
       grantsUpdated,

--- a/packages/grant-engine/src/index.ts
+++ b/packages/grant-engine/src/index.ts
@@ -23,6 +23,7 @@ export type {
   DiscoveryQuery,
   DiscoveryRunResult,
   DiscoveryRunStats,
+  DiscoveryEvent,
   RawGrant,
   CanonicalGrant,
   GrantSource,
@@ -48,6 +49,22 @@ export { createACTGrantsPlugin } from './sources/act-grants';
 export { createNTGrantsPlugin } from './sources/nt-grants';
 export { createSAGrantsPlugin } from './sources/sa-grants';
 export { createWAGrantsPlugin } from './sources/wa-grants';
+export { createCityOfSydneyGrantsPlugin } from './sources/cityofsydney-grants';
+export { createBrisbaneCityGrantsPlugin } from './sources/brisbane-city-grants';
+export { createRedlandCityGrantsPlugin } from './sources/redland-city-grants';
+export { createLoganCityGrantsPlugin } from './sources/logan-city-grants';
+export { createDarwinCityGrantsPlugin } from './sources/darwin-city-grants';
+export { createTablelandsGrantsPlugin } from './sources/tablelands-grants';
+export { createSunshineCoastGrantsPlugin } from './sources/sunshinecoast-grants';
+export { createCookShireGrantsPlugin } from './sources/cookshire-grants';
+export { createFraserCoastGrantsPlugin } from './sources/frasercoast-grants';
+export { createToowoombaGrantsPlugin } from './sources/toowoomba-grants';
+export { createScenicRimGrantsPlugin } from './sources/scenicrim-grants';
+export { createWhitsundayGrantsPlugin } from './sources/whitsunday-grants';
+export { createCentralHighlandsGrantsPlugin } from './sources/centralhighlands-grants';
+export { createNoosaGrantsPlugin } from './sources/noosa-grants';
+export { createChartersTowersGrantsPlugin } from './sources/charterstowers-grants';
+export { createLockyerValleyGrantsPlugin } from './sources/lockyervalley-grants';
 export { SourceRegistry } from './sources/registry';
 
 // Foundations

--- a/packages/grant-engine/src/normalizer.ts
+++ b/packages/grant-engine/src/normalizer.ts
@@ -204,6 +204,7 @@ export function normalize(raw: RawGrant): CanonicalGrant {
     description: raw.description?.trim() || null,
     categories: normalizeCategories(raw.categories || []),
     geography: raw.geography || ['AU'],
+    applicationStatus: raw.applicationStatus || null,
     sources: [source],
     discoveryMethod: raw.sourceId,
     dedupKey: generateDedupKey(raw.provider, raw.title),

--- a/packages/grant-engine/src/sources/brisbane-city-grants.ts
+++ b/packages/grant-engine/src/sources/brisbane-city-grants.ts
@@ -1,0 +1,225 @@
+/**
+ * Brisbane City Council Grants Source Plugin
+ *
+ * Scrapes official Brisbane City Council grants and sponsorship pages.
+ * The main landing page exposes stable internal grant category URLs.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const BRISBANE_GRANTS_URL = 'https://www.brisbane.qld.gov.au/community-support-and-safety/grants-and-sponsorship';
+const BRISBANE_BASE = 'https://www.brisbane.qld.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const BRISBANE_SEED_PATHS = [
+  '/community-support-and-safety/grants-and-sponsorship/applying-for-a-grant/community-grants',
+  '/community-support-and-safety/grants-and-sponsorship/applying-for-a-grant/environment-grants',
+  '/community-support-and-safety/grants-and-sponsorship/applying-for-a-grant/creative-and-history-grants',
+  '/community-support-and-safety/grants-and-sponsorship/sponsorship',
+];
+
+const BRISBANE_EXCLUDED_PATTERNS = [
+  /\/applying-for-a-grant$/i,
+  /\/grants-and-sponsorship$/i,
+  /grant-register/i,
+  /tips/i,
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/community|housing|seniors|local/.test(text)) cats.push('community');
+  if (/environment|climate|sustainab|green/.test(text)) cats.push('regenerative');
+  if (/creative|history|arts?|culture|heritage/.test(text)) cats.push('arts');
+  if (/business|economic/.test(text)) cats.push('enterprise');
+  if (/sport|recreation|safer suburbs/.test(text)) cats.push('sport');
+  if (/education|training|school/.test(text)) cats.push('education');
+
+  return [...new Set(cats)];
+}
+
+function extractAmounts(text: string): { min?: number; max?: number } {
+  const rangeMatch = text.match(/\$([0-9,]+)\s*(?:to|–|-)\s*\$([0-9,]+)/i);
+  if (rangeMatch) {
+    return {
+      min: parseInt(rangeMatch[1].replace(/,/g, ''), 10),
+      max: parseInt(rangeMatch[2].replace(/,/g, ''), 10),
+    };
+  }
+
+  const upToMatch = text.match(/up to \$([0-9,]+)/i);
+  if (upToMatch) {
+    return { max: parseInt(upToMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  const singleMatch = text.match(/\$([0-9,]{4,})/);
+  if (singleMatch) {
+    return { max: parseInt(singleMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  return {};
+}
+
+function extractDeadline(text: string): string | undefined {
+  const patterns = [
+    /(?:applications?\s+close|closes?|closing|deadline|due)[\s:]+(?:at\s+midnight\s+on\s+)?(?:\w+\s+)?(\d{1,2}\s+\w+\s+\d{4})/i,
+    /(\d{1,2}\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return match[1];
+  }
+
+  return undefined;
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        'Accept': 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(href: string): string | null {
+  try {
+    return new URL(href, BRISBANE_BASE).toString();
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(pathname: string): boolean {
+  return BRISBANE_EXCLUDED_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+function isGrantLikePath(pathname: string, text: string): boolean {
+  const haystack = `${pathname} ${text}`.toLowerCase();
+  if (!pathname.startsWith('/community-support-and-safety/grants-and-sponsorship/')) return false;
+  if (isIgnoredPath(pathname)) return false;
+  return /grant|fund|sponsorship|apply|community|environment|creative|history/.test(haystack);
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string, pathname: string): boolean {
+  const text = `${title} ${description} ${body} ${pathname}`.toLowerCase();
+  if (isIgnoredPath(pathname)) return false;
+
+  const hasGrantSignal = /grant|fund|sponsorship/.test(text);
+  const hasApplicationSignal = /apply|application|eligib|grant round|open\/apply now|funding/.test(text);
+
+  return hasGrantSignal && hasApplicationSignal;
+}
+
+async function collectCandidateUrls(): Promise<string[]> {
+  const html = await fetchPage(BRISBANE_GRANTS_URL);
+  if (!html) return BRISBANE_SEED_PATHS.map(path => `${BRISBANE_BASE}${path}`);
+
+  const $ = cheerio.load(html);
+  const urls = new Set<string>(BRISBANE_SEED_PATHS.map(path => `${BRISBANE_BASE}${path}`));
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') || '';
+    const text = compressWhitespace($(el).text());
+    const absolute = toAbsoluteUrl(href);
+    if (!absolute) return;
+
+    const url = new URL(absolute);
+    if (url.origin !== BRISBANE_BASE) return;
+    if (!isGrantLikePath(url.pathname, text)) return;
+
+    urls.add(url.toString());
+  });
+
+  return [...urls];
+}
+
+export function createBrisbaneCityGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'brisbane-city-grants',
+    name: 'Brisbane City Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[brisbane-city-grants] Scraping Brisbane City Council grants...');
+
+      const candidateUrls = await collectCandidateUrls();
+      console.log(`[brisbane-city-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const title = compressWhitespace(
+          $('h1').first().text() ||
+          $('meta[property="og:title"]').attr('content') ||
+          $('title').text().replace(/\s*\|\s*Brisbane City Council\s*$/i, '')
+        );
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          $('main p').first().text() ||
+          $('#main-content p').first().text()
+        );
+        const bodyText = compressWhitespace(
+          $('main, #main-content').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText, pathname)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const amount = extractAmounts(bodyText);
+        const categories = inferCategories(title, `${description} ${bodyText}`);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'Brisbane City Council',
+          sourceUrl: url,
+          amount: amount.min || amount.max ? amount : undefined,
+          deadline: extractDeadline(bodyText),
+          description: (description || bodyText).slice(0, 500) || undefined,
+          categories,
+          sourceId: 'brisbane-city-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[brisbane-city-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/centralhighlands-grants.ts
+++ b/packages/grant-engine/src/sources/centralhighlands-grants.ts
@@ -1,0 +1,170 @@
+/**
+ * Central Highlands Regional Council Grants Source Plugin
+ *
+ * Scrapes the live Central Highlands grants page and yields the current
+ * community grants categories with their upcoming round timing.
+ */
+
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const GRANTS_URL = 'https://chrc.qld.gov.au/community-services/grants-and-funding/';
+
+type ProgramDefinition = {
+  title: string;
+  sourceUrl: string;
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+  deadline?: string;
+  applicationStatus?: GrantApplicationStatus;
+};
+
+const PROGRAM_MARKER = 'Community Grants Program';
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Community Grants Program - Community Assistance',
+    sourceUrl: `${GRANTS_URL}#community-assistance`,
+    requiredSignals: [
+      'Community assistance – up to $5000',
+      'Organisations with a community focus, not providing organised sport and recreation activities.',
+      'Grants are offered twice a year.',
+      'Round 2, 2026 1 August 15 September October Six months',
+    ],
+    description:
+      'Supports community-focused organisations through Central Highlands Regional Council’s Community Assistance stream in the upcoming 2026 round.',
+    categories: ['community'],
+    amount: { max: 5000 },
+    deadline: '2026-09-15',
+    applicationStatus: 'upcoming',
+  },
+  {
+    title: 'Community Grants Program - Sport and Recreation Assistance',
+    sourceUrl: `${GRANTS_URL}#sport-recreation-assistance`,
+    requiredSignals: [
+      'Sport and recreation assistance – up to $5000',
+      'Organisations providing organised sport and recreation activities.',
+      'Grants are offered twice a year.',
+      'Round 2, 2026 1 August 15 September October Six months',
+    ],
+    description:
+      'Supports sport and recreation organisations through Central Highlands Regional Council’s upcoming 2026 community grants round.',
+    categories: ['community', 'sport'],
+    amount: { max: 5000 },
+    deadline: '2026-09-15',
+    applicationStatus: 'upcoming',
+  },
+  {
+    title: 'Community Grants Program - Community Improvement',
+    sourceUrl: `${GRANTS_URL}#community-improvement`,
+    requiredSignals: [
+      'Community improvement – up to $20,000',
+      'Organisations with a focus on completing aspirations of their community in alignment with Council Strategic documents.',
+      'Grants are offered twice a year.',
+      'Round 2, 2026 1 August 15 September October Six months',
+    ],
+    description:
+      'Supports larger community-improvement projects aligned to council strategy through the upcoming 2026 Central Highlands community grants round.',
+    categories: ['community'],
+    amount: { max: 20000 },
+    deadline: '2026-09-15',
+    applicationStatus: 'upcoming',
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&#8211;/g, '–')
+      .replace(/&amp;/gi, '&')
+  );
+
+  const start = text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+
+  const endMarkers = ['Was this page helpful?', 'Enquiries', 'Back to top'];
+  let end = sliced.length;
+  for (const endMarker of endMarkers) {
+    const idx = sliced.indexOf(endMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(url: string, marker: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker);
+  } catch {
+    return null;
+  }
+}
+
+export function createCentralHighlandsGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'centralhighlands-grants',
+    name: 'Central Highlands Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[centralhighlands-grants] Scraping Central Highlands Regional Council grants...');
+
+      const text = await fetchPageText(GRANTS_URL, PROGRAM_MARKER);
+      if (!text) {
+        console.log('[centralhighlands-grants] Yielded 0 grants');
+        return;
+      }
+
+      let yielded = 0;
+      for (const definition of PROGRAMS) {
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Central Highlands Regional Council',
+          sourceUrl: definition.sourceUrl,
+          amount: definition.amount,
+          deadline: definition.deadline,
+          applicationStatus: definition.applicationStatus,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'centralhighlands-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[centralhighlands-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/charterstowers-grants.ts
+++ b/packages/grant-engine/src/sources/charterstowers-grants.ts
@@ -1,0 +1,162 @@
+/**
+ * Charters Towers Regional Council Grants Source Plugin
+ *
+ * Scrapes current and upcoming Charters Towers council grant pages and yields
+ * only the live rolling or upcoming grant programs.
+ */
+
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const COMMUNITY_GRANTS_URL =
+  'https://www.charterstowers.qld.gov.au/Community/Scholarships-Grants-funding/Community-grants-programme';
+const ATHLETE_SUPPORT_URL =
+  'https://www.charterstowers.qld.gov.au/Community/Scholarships-Grants-funding/Financial-support-for-a-local-athlete';
+
+type ProgramDefinition = {
+  title: string;
+  pageUrl: string;
+  sourceUrl: string;
+  marker: string;
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+  deadline?: string;
+  applicationStatus?: GrantApplicationStatus;
+};
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Community Grants Programme',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    sourceUrl: COMMUNITY_GRANTS_URL,
+    marker: 'APPLY NOW',
+    requiredSignals: [
+      'Significant Dates',
+      'Round 1 - Opens Friday, 1 May 2026. Closes Friday, 29 May 2026.',
+      'Grant Limit A limit of up to $5,000 maximum in monetary value and/or in-kind support may be requested.',
+      'Be a not for profit, incorporated community organisation',
+    ],
+    description:
+      'Provides seed funding and in-kind support for eligible not-for-profit community organisations in the Charters Towers Region, with the 2026 round opening in May.',
+    categories: ['community'],
+    amount: { max: 5000 },
+    deadline: '2026-05-29',
+    applicationStatus: 'upcoming',
+  },
+  {
+    title: 'Financial Support for a Local Athlete',
+    pageUrl: ATHLETE_SUPPORT_URL,
+    sourceUrl: ATHLETE_SUPPORT_URL,
+    marker: 'Applications must be received prior to the competition.',
+    requiredSignals: [
+      'Applications must be received prior to the competition.',
+      'Funding from this source has not exceeded $2,000 per applicant, per calendar year.',
+      'Representing Australia Overseas - $2,000',
+      'Applications for competitions that have already occurred will not be considered',
+    ],
+    description:
+      'Provides progressive financial support for local athletes representing North Queensland, Queensland, or Australia, with applications accepted before the competition.',
+    categories: ['sport', 'education'],
+    amount: { max: 2000 },
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&#8211;/g, '–')
+      .replace(/&amp;/gi, '&')
+  );
+
+  const start = text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+
+  const endMarkers = ['Back to top', 'Contact Us'];
+  let end = sliced.length;
+  for (const endMarker of endMarkers) {
+    const idx = sliced.indexOf(endMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(url: string, marker: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker);
+  } catch {
+    return null;
+  }
+}
+
+export function createChartersTowersGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'charterstowers-grants',
+    name: 'Charters Towers Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[charterstowers-grants] Scraping Charters Towers Regional Council grants...');
+
+      const pageCache = new Map<string, string | null>();
+      let yielded = 0;
+
+      for (const definition of PROGRAMS) {
+        const cacheKey = `${definition.pageUrl}|${definition.marker}`;
+        if (!pageCache.has(cacheKey)) {
+          pageCache.set(cacheKey, await fetchPageText(definition.pageUrl, definition.marker));
+        }
+
+        const text = pageCache.get(cacheKey);
+        if (!text) continue;
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Charters Towers Regional Council',
+          sourceUrl: definition.sourceUrl,
+          amount: definition.amount,
+          deadline: definition.deadline,
+          applicationStatus: definition.applicationStatus,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'charterstowers-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[charterstowers-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/cityofsydney-grants.ts
+++ b/packages/grant-engine/src/sources/cityofsydney-grants.ts
@@ -1,0 +1,303 @@
+/**
+ * City of Sydney Grants Source Plugin
+ *
+ * Scrapes City of Sydney grants and funding pages from the official portal.
+ * The main grants landing page already exposes direct program links in SSR HTML.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+import { normalizeDate } from '../normalizer';
+
+const CITY_OF_SYDNEY_URL = 'https://www.cityofsydney.nsw.gov.au/grants-sponsorships';
+const CITY_OF_SYDNEY_BASE = 'https://www.cityofsydney.nsw.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const SYDNEY_SEED_PATHS = [
+  '/grants-sponsorships',
+  '/community-support-funding',
+  '/cultural-support-funding',
+  '/business-support-funding',
+  '/environmental-support-funding',
+];
+
+const SYDNEY_SECTION_LANDING_PATHS = new Set([
+  '/community-support-funding',
+  '/cultural-support-funding',
+  '/business-support-funding',
+  '/environmental-support-funding',
+]);
+
+const SYDNEY_EXCLUDED_PATTERNS = [
+  /\/$/,
+  /approved-grants/i,
+  /guidelines/i,
+  /newsletter/i,
+  /contact-us/i,
+  /areas-of-service/i,
+  /terms-conditions/i,
+  /website-accessibility/i,
+  /privacy/i,
+  /careers/i,
+  /request-city-records/i,
+  /reconciliation/i,
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/aboriginal|torres strait|first nations|indigenous/.test(text)) cats.push('indigenous');
+  if (/arts?|culture|creative|heritage|live work/.test(text)) cats.push('arts');
+  if (/community|social|housing|inclusion|asylum|refugee/.test(text)) cats.push('community');
+  if (/business|enterprise|economic|street banner/.test(text)) cats.push('enterprise');
+  if (/environment|climate|sustainab|green|ecology/.test(text)) cats.push('regenerative');
+  if (/education|student|training|school|scholarship/.test(text)) cats.push('education');
+  if (/health|wellbeing|mental health/.test(text)) cats.push('health');
+  if (/research|innovation/.test(text)) cats.push('research');
+
+  return [...new Set(cats)];
+}
+
+function extractAmounts(text: string): { min?: number; max?: number } {
+  const rangeMatch = text.match(/\$([0-9,]+)\s*(?:to|–|-)\s*\$([0-9,]+)/i);
+  if (rangeMatch) {
+    return {
+      min: parseInt(rangeMatch[1].replace(/,/g, ''), 10),
+      max: parseInt(rangeMatch[2].replace(/,/g, ''), 10),
+    };
+  }
+
+  const upToMatch = text.match(/up to \$([0-9,]+)/i);
+  if (upToMatch) {
+    return { max: parseInt(upToMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  const singleMatch = text.match(/\$([0-9,]{4,})/);
+  if (singleMatch) {
+    return { max: parseInt(singleMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  return {};
+}
+
+function extractDeadline(text: string): string | undefined {
+  const patterns = [
+    /(?:applications?\s+close|closes?|closing|deadline|due)[\s:]+(?:at\s+midnight\s+on\s+)?(?:\w+\s+)?(\d{1,2}\s+\w+\s+\d{4})/i,
+    /(\d{1,2}\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return match[1];
+  }
+
+  return undefined;
+}
+
+function startOfToday(): Date {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+function deriveApplicationStatus(deadline: string | undefined): GrantApplicationStatus | undefined {
+  const normalized = normalizeDate(deadline);
+  if (!normalized) return undefined;
+
+  const [yearText, monthText, dayText] = normalized.split('-');
+  const year = Number.parseInt(yearText || '', 10);
+  const month = Number.parseInt(monthText || '', 10);
+  const day = Number.parseInt(dayText || '', 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return undefined;
+  }
+
+  const closesAt = new Date(year, month - 1, day);
+  closesAt.setHours(0, 0, 0, 0);
+  return closesAt < startOfToday() ? 'closed' : 'open';
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        'Accept': 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(href: string): string | null {
+  try {
+    return new URL(href, CITY_OF_SYDNEY_BASE).toString();
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(pathname: string): boolean {
+  return SYDNEY_EXCLUDED_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+function isSectionLandingPath(pathname: string): boolean {
+  return SYDNEY_SECTION_LANDING_PATHS.has(pathname);
+}
+
+function isGrantLikePath(pathname: string, text: string): boolean {
+  const haystack = `${pathname} ${text}`.toLowerCase();
+
+  if (isIgnoredPath(pathname)) return false;
+  if (isSectionLandingPath(pathname)) return false;
+
+  if (
+    pathname.startsWith('/community-support-funding/') ||
+    pathname.startsWith('/cultural-support-funding/') ||
+    pathname.startsWith('/business-support-funding/') ||
+    pathname.startsWith('/environmental-support-funding/')
+  ) {
+    return /grant|fund|funding|sponsorship|scholarship|bursary/.test(haystack);
+  }
+
+  return /grant|fund|funding|sponsorship|scholarship|bursary/.test(haystack);
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string, pathname: string): boolean {
+  const text = `${title} ${description} ${body} ${pathname}`.toLowerCase();
+  const pathLeaf = pathname.split('/').filter(Boolean).at(-1) || '';
+  const titleAndPathLeaf = `${title} ${pathLeaf}`.toLowerCase();
+
+  if (isIgnoredPath(pathname)) return false;
+  if (isSectionLandingPath(pathname)) return false;
+  if (/success stories|approved grants|newsletter|contact us/.test(text)) return false;
+
+  const hasSpecificGrantSignal = /grant|fund|funding|sponsorship|scholarship|bursary/.test(titleAndPathLeaf);
+  const hasFinancialSupportSignal = /\$[0-9,]+|grant round|funding is available|applications?\s+(?:open|close|closed)|closing date|deadline|eligible|eligibility|sponsorship amounts?/.test(text);
+  const hasGenericProgramSignal = /program/.test(titleAndPathLeaf);
+
+  if (!hasSpecificGrantSignal) {
+    return false;
+  }
+
+  if (hasGenericProgramSignal && !hasFinancialSupportSignal) {
+    return false;
+  }
+
+  return hasFinancialSupportSignal || /apply|application|eligib|closing|deadline/.test(text);
+}
+
+async function collectCandidateUrls(): Promise<string[]> {
+  const html = await fetchPage(CITY_OF_SYDNEY_URL);
+  if (!html) return SYDNEY_SEED_PATHS.map(path => `${CITY_OF_SYDNEY_BASE}${path}`);
+
+  const $ = cheerio.load(html);
+  const urls = new Set<string>(SYDNEY_SEED_PATHS.map(path => `${CITY_OF_SYDNEY_BASE}${path}`));
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') || '';
+    const text = compressWhitespace($(el).text());
+    const absolute = toAbsoluteUrl(href);
+    if (!absolute) return;
+
+    const url = new URL(absolute);
+    if (url.origin !== CITY_OF_SYDNEY_BASE) return;
+    if (!isGrantLikePath(url.pathname, text)) return;
+
+    urls.add(url.toString());
+  });
+
+  return [...urls];
+}
+
+export function createCityOfSydneyGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'cityofsydney-grants',
+    name: 'City of Sydney Grants',
+    type: 'scraper',
+    geography: ['AU-NSW'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[cityofsydney-grants] Scraping City of Sydney grants...');
+
+      const candidateUrls = await collectCandidateUrls();
+      console.log(`[cityofsydney-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const title = compressWhitespace(
+          $('h1').first().text() ||
+          $('meta[property="og:title"]').attr('content') ||
+          $('title').text().replace(/\s*-\s*City of Sydney\s*$/i, '')
+        );
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          $('main p').first().text() ||
+          $('#main-content p').first().text()
+        );
+        const bodyText = compressWhitespace(
+          $('main, [role="main"], #main-content').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText, pathname)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const amount = extractAmounts(bodyText);
+        const categories = inferCategories(title, `${description} ${bodyText}`);
+        const deadline = extractDeadline(bodyText);
+        const applicationStatus = deriveApplicationStatus(deadline);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        if (query.status === 'open' && applicationStatus === 'closed') {
+          continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'City of Sydney',
+          sourceUrl: url,
+          amount: amount.min || amount.max ? amount : undefined,
+          deadline,
+          applicationStatus,
+          description: (description || bodyText).slice(0, 500) || undefined,
+          categories,
+          sourceId: 'cityofsydney-grants',
+          geography: ['AU-NSW'],
+        };
+        yielded++;
+      }
+
+      console.log(`[cityofsydney-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/cookshire-grants.ts
+++ b/packages/grant-engine/src/sources/cookshire-grants.ts
@@ -1,0 +1,174 @@
+/**
+ * Cook Shire Council Grants Source Plugin
+ *
+ * Scrapes explicit Cook Shire Council grant and sponsorship program pages.
+ * The grants directory links to a small set of stable program URLs.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const COOK_BASE = 'https://www.cook.qld.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const PROGRAM_PRESETS: Record<string, { description: string; amount?: { min?: number; max?: number } }> = {
+  '/community-economic-development-grants/': {
+    description: 'Supports community and economic development projects that bring people together, improve facilities, protect the environment, and strengthen the local economy.',
+    amount: { max: 6000 },
+  },
+  '/radf-funding/': {
+    description: 'Regional Arts Development Fund support for arts, culture, and heritage projects in partnership with the Queensland Government.',
+  },
+  '/council_sponsorship/': {
+    description: 'Supports community members, events, and initiatives that benefit Cook Shire, with funding available year-round.',
+    amount: { max: 4000 },
+  },
+};
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/community|sponsorship|benefit|initiative/.test(text)) cats.push('community');
+  if (/economic|business|tourism/.test(text)) cats.push('enterprise');
+  if (/arts?|culture|heritage|radf/.test(text)) cats.push('arts');
+  if (/environment/.test(text)) cats.push('regenerative');
+
+  return [...new Set(cats)];
+}
+
+function extractContent($: cheerio.CheerioAPI): string {
+  const selectors = [
+    'article',
+    '.entry-content',
+    '.elementor-widget-theme-post-content',
+    '.elementor-location-single',
+    '.site-main',
+  ];
+
+  for (const selector of selectors) {
+    const text = compressWhitespace($(selector).first().text());
+    if (text) return text;
+  }
+
+  return compressWhitespace($('body').text());
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string): boolean {
+  const text = `${title} ${description} ${body}`.toLowerCase();
+  if (/page not found|access denied|just a moment/.test(text)) return false;
+
+  const hasGrantSignal = /grant|fund|sponsorship|radf/.test(text);
+  const hasApplicationSignal = /apply|application|open|closing|guidelines|year-round|rounds? per year/.test(text);
+
+  return hasGrantSignal && hasApplicationSignal;
+}
+
+function extractDeadline(pathname: string, body: string): string | undefined {
+  if (pathname !== '/community-economic-development-grants/') return undefined;
+
+  const patterns = [
+    /closing\s+\w+\s+(\d{1,2}\s+\w+\s+\d{4})/i,
+    /(?:applications?\s+close|closes?|closing|deadline|due)[^.\n]*?(\d{1,2}\s+\w+\s+\d{4})/i,
+    /(\d{1,2}\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = body.match(pattern);
+    if (match) return match[1];
+  }
+
+  return undefined;
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+export function createCookShireGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'cookshire-grants',
+    name: 'Cook Shire Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[cookshire-grants] Scraping Cook Shire Council grants...');
+
+      const candidateUrls = Object.keys(PROGRAM_PRESETS).map(path => `${COOK_BASE}${path}`);
+      console.log(`[cookshire-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const preset = PROGRAM_PRESETS[pathname];
+        const title = compressWhitespace(
+          $('h1').first().text() ||
+          $('meta[property="og:title"]').attr('content') ||
+          $('title').text().replace(/\s*\|\s*Cook Shire Council\s*$/i, '')
+        );
+        const bodyText = extractContent($);
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          preset.description
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const categories = inferCategories(title, `${description} ${bodyText}`);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'Cook Shire Council',
+          sourceUrl: url,
+          amount: preset.amount,
+          deadline: extractDeadline(pathname, bodyText),
+          description: description.slice(0, 500) || undefined,
+          categories,
+          sourceId: 'cookshire-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[cookshire-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/darwin-city-grants.ts
+++ b/packages/grant-engine/src/sources/darwin-city-grants.ts
@@ -1,0 +1,343 @@
+/**
+ * City of Darwin Grants Source Plugin
+ *
+ * Scrapes official City of Darwin funding pages for current grant and sponsorship programs.
+ * The landing page exposes direct links to stable program pages in server-rendered HTML.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const DARWIN_GRANTS_URL = 'https://www.darwin.nt.gov.au/community/programs/funding-opportunities';
+const DARWIN_BASE = 'https://www.darwin.nt.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const DARWIN_SEED_PATHS = [
+  '/community/programs/grants-sponsorship/community-grants',
+  '/community/programs/grants-sponsorship/sponsorship-program',
+  '/community/programs/grants-sponsorship/environment-and-climate-change-grants',
+  '/community/programs/grants-sponsorship/reconciliation-week-naidoc-week-funding',
+];
+
+const DARWIN_EXCLUDED_PATTERNS = [
+  /\/community\/programs\/funding-opportunities$/i,
+  /\/community\/programs\/grants-sponsorship\/sponsorship-0$/i,
+  /previously-successful-grants/i,
+  /guidelines/i,
+];
+
+const MONTH_LOOKUP: Record<string, number> = {
+  january: 0,
+  february: 1,
+  march: 2,
+  april: 3,
+  may: 4,
+  june: 5,
+  july: 6,
+  august: 7,
+  september: 8,
+  october: 9,
+  november: 10,
+  december: 11,
+};
+
+function startOfToday(): Date {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now;
+}
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/community|volunteer|neighbourhood/.test(text)) cats.push('community');
+  if (/environment|climate|green|waste|recovery|sustainab/.test(text)) cats.push('regenerative');
+  if (/naidoc|reconciliation|larrakia|first nations|indigenous/.test(text)) cats.push('indigenous');
+  if (/arts?|culture|festival|history|heritage/.test(text)) cats.push('arts');
+  if (/business|economic|tourism|place activation|sponsorship/.test(text)) cats.push('enterprise');
+
+  return [...new Set(cats)];
+}
+
+function extractAmounts(text: string): { min?: number; max?: number } {
+  const rangeMatch = text.match(/\$([0-9,]+)\s*(?:to|–|-)\s*\$([0-9,]+)/i);
+  if (rangeMatch) {
+    return {
+      min: parseInt(rangeMatch[1].replace(/,/g, ''), 10),
+      max: parseInt(rangeMatch[2].replace(/,/g, ''), 10),
+    };
+  }
+
+  const upToMatch = text.match(/up to \$([0-9,]+)/i);
+  if (upToMatch) {
+    return { max: parseInt(upToMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  return {};
+}
+
+function resolveDeadline(dayText: string, monthText: string, yearText?: string): { iso: string; time: number } | null {
+  const day = parseInt(dayText, 10);
+  const month = MONTH_LOOKUP[monthText.toLowerCase()];
+
+  if (!Number.isFinite(day) || month === undefined) return null;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  let year = yearText ? parseInt(yearText, 10) : today.getFullYear();
+  let candidate = new Date(year, month, day);
+
+  if (
+    Number.isNaN(candidate.getTime()) ||
+    candidate.getFullYear() !== year ||
+    candidate.getMonth() !== month ||
+    candidate.getDate() !== day
+  ) {
+    return null;
+  }
+
+  if (!yearText && candidate < today) {
+    year += 1;
+    candidate = new Date(year, month, day);
+  }
+
+  const iso = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+  return {
+    iso,
+    time: candidate.getTime(),
+  };
+}
+
+function extractDeadline(text: string): string | undefined {
+  const candidates: Array<{ iso: string; time: number }> = [];
+  const patterns = [
+    /round\s+\d+\s*-\s*opens\s+\d{1,2}\s+\w+(?:\s+\d{4})?\s+and\s+closes?\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?/ig,
+    /applications?\s+open\s+\d{1,2}\s+\w+(?:\s+\d{4})?\s+and\s+close\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?/ig,
+    /(?:applications?\s+close|closes?|closing|deadline|due)\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?/ig,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const resolved = resolveDeadline(match[1], match[2], match[3]);
+      if (resolved) candidates.push(resolved);
+    }
+  }
+
+  if (candidates.length === 0) return undefined;
+
+  candidates.sort((a, b) => a.time - b.time);
+  return candidates[0].iso;
+}
+
+function resolveAnnualWindow(openMonth: number, openDay: number, closeMonth: number, closeDay: number): GrantApplicationStatus {
+  const today = startOfToday();
+  const year = today.getFullYear();
+
+  const openDate = new Date(year, openMonth, openDay);
+  const closeDate = new Date(year, closeMonth, closeDay);
+
+  if (today >= openDate && today <= closeDate) return 'open';
+  return 'upcoming';
+}
+
+function inferApplicationStatus(pathname: string, bodyText: string): GrantApplicationStatus | undefined {
+  const text = bodyText.toLowerCase();
+
+  if (pathname.includes('/sponsorship-program') && /currently closed to new applications/.test(text)) {
+    return 'closed';
+  }
+
+  if (pathname.includes('/environment-and-climate-change-grants')) {
+    const match = text.match(/will open for applications here in (\w+)\s+(\d{4})/i);
+    if (match) {
+      const month = MONTH_LOOKUP[match[1].toLowerCase()];
+      const year = Number.parseInt(match[2], 10);
+      if (month !== undefined && Number.isFinite(year)) {
+        const openDate = new Date(year, month, 1);
+        return startOfToday() < openDate ? 'upcoming' : 'open';
+      }
+    }
+  }
+
+  if (
+    pathname.includes('/community-grants') &&
+    /opens 1 march and closes 31 march/.test(text) &&
+    /opens 1 september and closes 30 september/.test(text)
+  ) {
+    const marchWindow = resolveAnnualWindow(2, 1, 2, 31);
+    if (marchWindow === 'open') return 'open';
+    return resolveAnnualWindow(8, 1, 8, 30);
+  }
+
+  if (
+    pathname.includes('/reconciliation-week-naidoc-week-funding') &&
+    /applications open 1 march and close 31 march/.test(text)
+  ) {
+    return resolveAnnualWindow(2, 1, 2, 31);
+  }
+
+  return undefined;
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        'Accept': 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(href: string): string | null {
+  try {
+    const url = new URL(href, DARWIN_BASE);
+    if (url.pathname === '/community/programs/grants-sponsorship/sponsorship-0') {
+      url.pathname = '/community/programs/grants-sponsorship/sponsorship-program';
+    }
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(pathname: string): boolean {
+  return DARWIN_EXCLUDED_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+function isGrantLikePath(pathname: string, text: string): boolean {
+  const haystack = `${pathname} ${text}`.toLowerCase();
+
+  if (!pathname.startsWith('/community/programs/grants-sponsorship/')) return false;
+  if (isIgnoredPath(pathname)) return false;
+
+  return /grant|fund|funding|sponsorship|naidoc|reconciliation/.test(haystack);
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string, pathname: string): boolean {
+  const text = `${title} ${description} ${body} ${pathname}`.toLowerCase();
+
+  if (isIgnoredPath(pathname)) return false;
+  if (/404 page not found|we couldn't find the page/.test(text)) return false;
+
+  const hasGrantSignal = /grant|funding|sponsorship/.test(text);
+  const hasApplicationSignal = /apply|application|eligib|priority areas|assessment criteria|funding guidelines|currently closed to new applications/.test(text);
+
+  return hasGrantSignal && hasApplicationSignal;
+}
+
+async function collectCandidateUrls(): Promise<string[]> {
+  const html = await fetchPage(DARWIN_GRANTS_URL);
+  if (!html) return DARWIN_SEED_PATHS.map(path => `${DARWIN_BASE}${path}`);
+
+  const $ = cheerio.load(html);
+  const urls = new Set<string>(DARWIN_SEED_PATHS.map(path => `${DARWIN_BASE}${path}`));
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') || '';
+    const text = compressWhitespace($(el).text());
+    const absolute = toAbsoluteUrl(href);
+    if (!absolute) return;
+
+    const url = new URL(absolute);
+    if (url.origin !== DARWIN_BASE) return;
+    if (!isGrantLikePath(url.pathname, text)) return;
+
+    urls.add(url.toString());
+  });
+
+  return [...urls];
+}
+
+export function createDarwinCityGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'darwin-city-grants',
+    name: 'City of Darwin Grants',
+    type: 'scraper',
+    geography: ['AU-NT'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[darwin-city-grants] Scraping City of Darwin funding pages...');
+
+      const candidateUrls = await collectCandidateUrls();
+      console.log(`[darwin-city-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const title = (
+          compressWhitespace($('h1').first().text()) ||
+          compressWhitespace($('meta[property="og:title"]').attr('content') || '') ||
+          compressWhitespace($('title').text().replace(/\s*\|\s*City of Darwin.*$/i, ''))
+        );
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          $('main p').first().text() ||
+          $('#main-content p').first().text()
+        );
+        const bodyText = compressWhitespace(
+          $('main, #main-content, .node__content, .layout-content').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText, pathname)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const amount = pathname.includes('/sponsorship-program') ? {} : extractAmounts(bodyText);
+        const categories = inferCategories(title, `${description} ${bodyText}`);
+        const applicationStatus = inferApplicationStatus(pathname, bodyText);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'City of Darwin',
+          sourceUrl: url,
+          amount: amount.min || amount.max ? amount : undefined,
+          deadline: extractDeadline(bodyText),
+          applicationStatus,
+          description: (description || bodyText).slice(0, 500) || undefined,
+          categories,
+          sourceId: 'darwin-city-grants',
+          geography: ['AU-NT'],
+        };
+        yielded++;
+      }
+
+      console.log(`[darwin-city-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/frasercoast-grants.ts
+++ b/packages/grant-engine/src/sources/frasercoast-grants.ts
@@ -1,0 +1,331 @@
+/**
+ * Fraser Coast Regional Council Grants Source Plugin
+ *
+ * Scrapes the official Fraser Coast grants page and extracts only current or
+ * upcoming opportunities from the live grants table plus the evergreen
+ * discretionary program section.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const FRASER_MAIN_URL = 'https://www.frasercoast.qld.gov.au/Community/Grants-and-Sponsorships';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const MONTHS = new Map([
+  ['january', 0],
+  ['february', 1],
+  ['march', 2],
+  ['april', 3],
+  ['may', 4],
+  ['june', 5],
+  ['july', 6],
+  ['august', 7],
+  ['september', 8],
+  ['october', 9],
+  ['november', 10],
+  ['december', 11],
+]);
+
+type ExtractedRow = { text: string; links: Array<{ text: string; href: string }> };
+type ExtractedSection = { text: string; links: Array<{ text: string; href: string }> };
+
+type TableProgramDefinition = {
+  title: string;
+  matcher: RegExp;
+  description: string;
+  categories: string[];
+  getSourceUrl: (row: ExtractedRow) => string;
+  getAmount?: (row: ExtractedRow) => { min?: number; max?: number } | undefined;
+};
+
+type SectionProgramDefinition = {
+  title: string;
+  heading: RegExp;
+  description: string;
+  categories: string[];
+  sourceUrl: string;
+  requireUpcomingDeadline?: boolean;
+  getAmount?: (section: ExtractedSection) => { min?: number; max?: number } | undefined;
+};
+
+const TABLE_PROGRAMS: TableProgramDefinition[] = [
+  {
+    title: 'Community Grants',
+    matcher: /^Community Grants\b/i,
+    description: 'Supports projects and activities that benefit the Fraser Coast community through the council community grants program.',
+    categories: ['community'],
+    getSourceUrl: row => findAbsoluteUrl(row, /guidelines/i, `${FRASER_MAIN_URL}#community-grants`),
+  },
+  {
+    title: 'Individual Excellence and Development Grants',
+    matcher: /^Individual Excellence and Development Grants/i,
+    description: 'Supports individuals participating in sport and STEAM opportunities at state, national, and international levels.',
+    categories: ['education', 'sport', 'arts'],
+    getSourceUrl: row => findAbsoluteUrl(row, /smartygrants|individual excellence/i, `${FRASER_MAIN_URL}#individual-excellence-and-development-grants`),
+    getAmount: row => {
+      const values = extractCurrencyValues(row.text);
+      if (values.length === 0) return undefined;
+      return { min: Math.min(...values), max: Math.max(...values) };
+    },
+  },
+  {
+    title: 'RADF Grants',
+    matcher: /^RADF\b/i,
+    description: 'Regional Arts Development Fund support for arts, culture, and heritage projects across the Fraser Coast.',
+    categories: ['arts'],
+    getSourceUrl: row => findAbsoluteUrl(row, /regional-arts-development-fund|radf/i, `${FRASER_MAIN_URL}#radf-grants`),
+  },
+  {
+    title: 'Australia Day Events',
+    matcher: /^Australia Day\b/i,
+    description: 'Supports community organisations delivering Australia Day events across the Fraser Coast.',
+    categories: ['community'],
+    getSourceUrl: row => findAbsoluteUrl(row, /guidelines/i, `${FRASER_MAIN_URL}#australia-day-events`),
+  },
+  {
+    title: 'Community Grants - Festive Events',
+    matcher: /^Community Grants - Festive Events\b/i,
+    description: 'Supports festive season community events delivered in the Fraser Coast region.',
+    categories: ['community', 'enterprise'],
+    getSourceUrl: row => findAbsoluteUrl(row, /guidelines/i, `${FRASER_MAIN_URL}#community-grants-festive-events`),
+  },
+];
+
+const SECTION_PROGRAMS: SectionProgramDefinition[] = [
+  {
+    title: "Councillor's Discretionary Fund",
+    heading: /^Councillor's Discretionary Fund$/i,
+    description: 'Supports community-purpose initiatives that provide services to the Fraser Coast region through councillor discretionary funding.',
+    categories: ['community'],
+    sourceUrl: `${FRASER_MAIN_URL}#councillors-discretionary-fund`,
+  },
+  {
+    title: 'Major Regional Events Sponsorships',
+    heading: /^Major Regional Events Sponsorships$/i,
+    description: 'Supports major regional events that deliver visitation and economic outcomes for the Fraser Coast.',
+    categories: ['enterprise', 'community'],
+    sourceUrl: `${FRASER_MAIN_URL}#major-regional-events-sponsorships`,
+    requireUpcomingDeadline: true,
+    getAmount: section => {
+      const match = section.text.match(/upwards of \$([0-9,]+)/i);
+      if (!match) return undefined;
+      return { min: parseInt(match[1].replace(/,/g, ''), 10) };
+    },
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function toAbsoluteUrl(href: string): string {
+  return new URL(href, FRASER_MAIN_URL).toString();
+}
+
+function extractCurrencyValues(text: string): number[] {
+  return [...text.matchAll(/\$([0-9][0-9,]*)/g)].map(match => parseInt(match[1].replace(/,/g, ''), 10));
+}
+
+function parseDateParts(day: string, month: string, year: string): Date | null {
+  const monthIndex = MONTHS.get(month.toLowerCase());
+  if (monthIndex == null) return null;
+
+  const date = new Date(Date.UTC(parseInt(year, 10), monthIndex, parseInt(day, 10)));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function extractNextClosingDate(text: string): string | undefined {
+  const today = new Date();
+  const todayUtc = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  const matches: Date[] = [];
+
+  const closingBlock = text.match(/closing dates are:\s*(.*?)(?:total funding|$)/i);
+  if (closingBlock) {
+    for (const match of closingBlock[1].matchAll(/(\d{1,2})\s*(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})/gi)) {
+      const parsed = parseDateParts(match[1], match[2], match[3]);
+      if (parsed) matches.push(parsed);
+    }
+  }
+
+  for (const match of text.matchAll(/(?:Closed:|Applications close:|Applications close|closes?:|closing)\s*(?:\w+,\s*)?(\d{1,2})\s*(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})/gi)) {
+    const parsed = parseDateParts(match[1], match[2], match[3]);
+    if (parsed) matches.push(parsed);
+  }
+
+  matches.sort((a, b) => a.getTime() - b.getTime());
+  const next = matches.find(date => date.getTime() >= todayUtc);
+  return next ? toIsoDate(next) : undefined;
+}
+
+function findAbsoluteUrl(row: ExtractedRow, matcher: RegExp, fallback: string): string {
+  const link = row.links.find(item => matcher.test(`${item.text} ${item.href}`));
+  return link ? toAbsoluteUrl(link.href) : fallback;
+}
+
+function extractTableRows($: cheerio.CheerioAPI): ExtractedRow[] {
+  return $('table')
+    .first()
+    .find('tr')
+    .toArray()
+    .map(tr => {
+      const text = compressWhitespace($(tr).text());
+      const links = $(tr)
+        .find('a[href]')
+        .toArray()
+        .map(a => ({
+          text: compressWhitespace($(a).text()),
+          href: $(a).attr('href') || '',
+        }))
+        .filter(link => Boolean(link.href));
+      return { text, links };
+    })
+    .filter(row => row.text.length > 0);
+}
+
+function extractSection($: cheerio.CheerioAPI, headingMatcher: RegExp): ExtractedSection | null {
+  const heading = $('h2, h3, h4')
+    .toArray()
+    .find(node => headingMatcher.test(compressWhitespace($(node).text())));
+
+  if (!heading) return null;
+
+  const chunks: string[] = [];
+  const links: Array<{ text: string; href: string }> = [];
+  const startLevel = parseInt((heading.tagName || 'h4').slice(1), 10);
+  let current = $(heading).next();
+
+  while (current.length) {
+    const tag = (current.get(0)?.tagName || '').toLowerCase();
+    if (/^h[2-4]$/.test(tag)) {
+      const level = parseInt(tag.slice(1), 10);
+      if (level <= startLevel) break;
+    }
+
+    const text = compressWhitespace(current.text());
+    if (text) chunks.push(text);
+
+    current.find('a[href]').each((_, el) => {
+      const href = $(el).attr('href') || '';
+      if (!href) return;
+      links.push({
+        text: compressWhitespace($(el).text()),
+        href,
+      });
+    });
+
+    current = current.next();
+  }
+
+  const text = compressWhitespace(chunks.join(' '));
+  return text ? { text, links } : null;
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+export function createFraserCoastGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'frasercoast-grants',
+    name: 'Fraser Coast Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[frasercoast-grants] Scraping Fraser Coast Regional Council grants...');
+
+      const html = await fetchPage(FRASER_MAIN_URL);
+      if (!html) {
+        console.log('[frasercoast-grants] Failed to fetch grants page');
+        return;
+      }
+
+      const $ = cheerio.load(html);
+      const tableRows = extractTableRows($);
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const definition of TABLE_PROGRAMS) {
+        const row = tableRows.find(item => definition.matcher.test(item.text));
+        if (!row) continue;
+
+        const deadline = extractNextClosingDate(row.text);
+        if (!deadline) continue;
+
+        const text = `${definition.title} ${definition.description} ${row.text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        const sourceUrl = definition.getSourceUrl(row);
+        if (seen.has(sourceUrl)) continue;
+        seen.add(sourceUrl);
+
+        yield {
+          title: definition.title,
+          provider: 'Fraser Coast Regional Council',
+          sourceUrl,
+          amount: definition.getAmount?.(row),
+          deadline,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'frasercoast-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      for (const definition of SECTION_PROGRAMS) {
+        const section = extractSection($, definition.heading);
+        if (!section) continue;
+
+        const deadline = extractNextClosingDate(section.text);
+        if (definition.requireUpcomingDeadline && !deadline) continue;
+
+        const text = `${definition.title} ${definition.description} ${section.text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (seen.has(definition.sourceUrl)) continue;
+        seen.add(definition.sourceUrl);
+
+        yield {
+          title: definition.title,
+          provider: 'Fraser Coast Regional Council',
+          sourceUrl: definition.sourceUrl,
+          amount: definition.getAmount?.(section),
+          deadline,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'frasercoast-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[frasercoast-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/grantconnect.ts
+++ b/packages/grant-engine/src/sources/grantconnect.ts
@@ -26,6 +26,18 @@ interface GrantConnectConfig {
 }
 
 export function createGrantConnectPlugin(config: GrantConnectConfig = {}): SourcePlugin {
+  function todayInAustralia(): string {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Australia/Brisbane',
+    }).format(new Date());
+  }
+
+  function normalizeDeadline(deadline: string | undefined): string | null {
+    if (!deadline) return null;
+    const parsed = new Date(deadline);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return parsed.toISOString().split('T')[0];
+  }
 
   function extractAgency(title: string, description: string): string {
     const deptMatch = description.match(/Department of ([\w\s]+?)(?:\.|,|\s(?:is|has|will))/i);
@@ -273,26 +285,25 @@ export function createGrantConnectPlugin(config: GrantConnectConfig = {}): Sourc
         listGrants = await scrapeFullList(config.maxListPages ?? 20);
       }
 
-      // Merge: prefer Playwright data (has deadlines), use RSS to fill gaps
-      const seen = new Set<string>();
       const allGrants: RawGrant[] = [];
 
-      // Playwright grants first (richer data)
-      for (const g of listGrants) {
-        const key = g.title.toLowerCase();
-        if (!seen.has(key)) {
-          seen.add(key);
-          allGrants.push(g);
-        }
-      }
+      if (listGrants.length > 0) {
+        // When the live list scrape succeeds, treat it as the source of truth for
+        // currently open opportunities. The RSS feed can contain historical items,
+        // so only use it to enrich matching live rows, never to add RSS-only rows.
+        const rssByTitle = new Map(rssGrants.map(grant => [grant.title.toLowerCase(), grant]));
 
-      // Then RSS grants to fill gaps
-      for (const g of rssGrants) {
-        const key = g.title.toLowerCase();
-        if (!seen.has(key)) {
-          seen.add(key);
-          allGrants.push(g);
+        for (const grant of listGrants) {
+          const rssMatch = rssByTitle.get(grant.title.toLowerCase());
+          allGrants.push({
+            ...grant,
+            description: grant.description || rssMatch?.description,
+            categories: grant.categories?.length ? grant.categories : rssMatch?.categories,
+            provider: grant.provider || rssMatch?.provider || 'Australian Government',
+          });
         }
+      } else {
+        allGrants.push(...rssGrants);
       }
 
       console.log(`[grantconnect] Total: ${allGrants.length} unique grants (${listGrants.length} from list, ${rssGrants.length} from RSS)`);
@@ -300,8 +311,17 @@ export function createGrantConnectPlugin(config: GrantConnectConfig = {}): Sourc
       // Apply query filters
       const queryCategories = new Set(query.categories?.map(c => c.toLowerCase()) || []);
       const queryKeywords = query.keywords?.map(k => k.toLowerCase()) || [];
+      const today = todayInAustralia();
 
       for (const grant of allGrants) {
+        const closesAt = normalizeDeadline(grant.deadline);
+        const inferredStatus = grant.applicationStatus
+          || (closesAt ? (closesAt < today ? 'closed' : 'open') : undefined);
+
+        if (query.status === 'open' && inferredStatus === 'closed') {
+          continue;
+        }
+
         // Filter by categories
         if (queryCategories.size > 0) {
           const hasMatch = grant.categories?.some(c => queryCategories.has(c));
@@ -315,7 +335,10 @@ export function createGrantConnectPlugin(config: GrantConnectConfig = {}): Sourc
           if (!hasMatch) continue;
         }
 
-        yield grant;
+        yield {
+          ...grant,
+          applicationStatus: inferredStatus,
+        };
       }
     },
   };

--- a/packages/grant-engine/src/sources/lockyervalley-grants.ts
+++ b/packages/grant-engine/src/sources/lockyervalley-grants.ts
@@ -1,0 +1,169 @@
+/**
+ * Lockyer Valley Regional Council Grants Source Plugin
+ *
+ * Scrapes live Lockyer Valley grant pages and yields the grant programs that
+ * are currently open or rolling.
+ */
+
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const MINOR_COMMUNITY_GRANTS_URL =
+  'https://www.lockyervalley.qld.gov.au/our-council/grants-and-funding/minor-community-grants-program';
+const RADF_GRANTS_URL =
+  'https://www.lockyervalley.qld.gov.au/our-council/grants-and-funding/radf-grants';
+
+type ProgramDefinition = {
+  title: string;
+  pageUrl: string;
+  sourceUrl: string;
+  marker: string;
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+  deadline?: string;
+};
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Minor Community Grants Program',
+    pageUrl: MINOR_COMMUNITY_GRANTS_URL,
+    sourceUrl: MINOR_COMMUNITY_GRANTS_URL,
+    marker: "Council's Minor Community Grants Program is for non-recurrent grants up to $1000",
+    requiredSignals: [
+      "Council's Minor Community Grants Program is for non-recurrent grants up to $1000",
+      'Funding applications will be accepted throughout the financial year under this category',
+      'Requests must be provided in writing and set out details of the request and its purpose.',
+    ],
+    description:
+      'Provides rolling minor community grants for not-for-profit organisations seeking support for projects or activities that contribute to the Lockyer Valley community.',
+    categories: ['community'],
+    amount: { max: 1000 },
+  },
+  {
+    title: 'RADF Grants - Round 3',
+    pageUrl: RADF_GRANTS_URL,
+    sourceUrl: `${RADF_GRANTS_URL}#round-3`,
+    marker: 'Rounds',
+    requiredSignals: [
+      'Round 3 for 2025-26 is open and closes at 10am on 24 April 2026 .',
+      'Applications will only be accepted online via SmartyGrants .',
+    ],
+    description:
+      'Supports arts and cultural projects through Lockyer Valley Regional Council’s open 2025-26 RADF Round 3.',
+    categories: ['arts', 'community'],
+    deadline: '2026-04-24',
+  },
+  {
+    title: 'RADF Grants - Quick Response',
+    pageUrl: RADF_GRANTS_URL,
+    sourceUrl: `${RADF_GRANTS_URL}#quick-response`,
+    marker: 'Rounds',
+    requiredSignals: [
+      'Quick Response applications are open and will close at midnight 12 June 2026 .',
+      'Applications will only be accepted online via SmartyGrants .',
+    ],
+    description:
+      'Provides quick-response arts funding through Lockyer Valley Regional Council’s open RADF quick response pathway.',
+    categories: ['arts', 'community'],
+    deadline: '2026-06-12',
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&#8211;/g, '–')
+      .replace(/&amp;/gi, '&')
+  );
+
+  const start = text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+
+  const endMarkers = ['Share this', 'Resources Online Services'];
+  let end = sliced.length;
+  for (const endMarker of endMarkers) {
+    const idx = sliced.indexOf(endMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(url: string, marker: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker);
+  } catch {
+    return null;
+  }
+}
+
+export function createLockyerValleyGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'lockyervalley-grants',
+    name: 'Lockyer Valley Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[lockyervalley-grants] Scraping Lockyer Valley Regional Council grants...');
+
+      const pageCache = new Map<string, string | null>();
+      let yielded = 0;
+
+      for (const definition of PROGRAMS) {
+        const cacheKey = `${definition.pageUrl}|${definition.marker}`;
+        if (!pageCache.has(cacheKey)) {
+          pageCache.set(cacheKey, await fetchPageText(definition.pageUrl, definition.marker));
+        }
+
+        const text = pageCache.get(cacheKey);
+        if (!text) continue;
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Lockyer Valley Regional Council',
+          sourceUrl: definition.sourceUrl,
+          amount: definition.amount,
+          deadline: definition.deadline,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'lockyervalley-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[lockyervalley-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/logan-city-grants.ts
+++ b/packages/grant-engine/src/sources/logan-city-grants.ts
@@ -1,0 +1,265 @@
+/**
+ * Logan City Council Grants Source Plugin
+ *
+ * Scrapes official Logan City Council grant program pages.
+ * The main grants page exposes direct links to each current program.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const LOGAN_GRANTS_URL = 'https://www.logan.qld.gov.au/community/grants';
+const LOGAN_BASE = 'https://www.logan.qld.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const LOGAN_SEED_PATHS = [
+  '/community/grants/community-project-grants',
+  '/community/grants/community-events-funding',
+  '/community/grants/envirogrants',
+  '/community/grants/investment-attraction-incentives-fund',
+  '/community/grants/radf',
+  '/community/grants/sport-and-recreation-funding',
+  '/community/grants/community-benefit-fund',
+  '/community/grants/tertiary-education-bursaries',
+];
+
+const LOGAN_EXCLUDED_PATTERNS = [
+  /\/community\/grants$/i,
+  /other-funding-opportunities/i,
+  /contact/i,
+  /grant-information-sessions/i,
+  /help-and-resources/i,
+  /recipients/i,
+  /schools-and-pc-associations/i,
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/community|benefit|events?/.test(text)) cats.push('community');
+  if (/enviro|environment|sustainab|green/.test(text)) cats.push('regenerative');
+  if (/arts?|culture|heritage|radf/.test(text)) cats.push('arts');
+  if (/investment|business|economic/.test(text)) cats.push('enterprise');
+  if (/sport|recreation/.test(text)) cats.push('sport');
+  if (/youth|intergenerational|schools?|training/.test(text)) cats.push('education');
+
+  return [...new Set(cats)];
+}
+
+function extractAmounts(text: string): { min?: number; max?: number } {
+  const rangeMatch = text.match(/\$([0-9,]+)\s*(?:to|–|-)\s*\$([0-9,]+)/i);
+  if (rangeMatch) {
+    return {
+      min: parseInt(rangeMatch[1].replace(/,/g, ''), 10),
+      max: parseInt(rangeMatch[2].replace(/,/g, ''), 10),
+    };
+  }
+
+  const upToMatch = text.match(/up to \$([0-9,]+)/i);
+  if (upToMatch) {
+    return { max: parseInt(upToMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  const singleMatch = text.match(/\$([0-9,]{3,})/);
+  if (singleMatch) {
+    return { max: parseInt(singleMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  return {};
+}
+
+function extractDeadline(text: string): string | undefined {
+  const normalizeDateCandidate = (value: string): string => {
+    return value
+      .replace(/^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\s+/i, '')
+      .trim();
+  };
+
+  const closePatterns = [
+    /(?:applications?\s+(?:for\s+the\s+\d{4}\/\d{4}\s+)?[^.]*?\s+close(?:d)?|closes?|closing|deadline|due)[^.\n]*?(\d{1,2}\s+\w+\s+\d{4})/i,
+    /outcomes\s+(?:for[^.]*?)?\s+will\s+be\s+advised\s+by\s+(\w+\s+\d{1,2}\s+\w+\s+\d{4})/i,
+    /(\d{1,2}\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})/i,
+  ];
+
+  for (const pattern of closePatterns) {
+    const match = text.match(pattern);
+    if (match) return normalizeDateCandidate(match[1]);
+  }
+
+  return undefined;
+}
+
+function inferApplicationStatus(pathname: string, bodyText: string): GrantApplicationStatus | undefined {
+  const text = bodyText.toLowerCase();
+
+  if (
+    (pathname.includes('/community-project-grants') || pathname.includes('/community-events-funding')) &&
+    /future rounds will open after 1 july 2026/.test(text) &&
+    /applications for the 2025\/2026 .* are now closed/.test(text)
+  ) {
+    return 'upcoming';
+  }
+
+  if (/currently closed/.test(text)) return 'closed';
+
+  return undefined;
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        'Accept': 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(href: string): string | null {
+  try {
+    const url = new URL(href, LOGAN_BASE);
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(pathname: string): boolean {
+  return LOGAN_EXCLUDED_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+function isGrantLikePath(pathname: string, text: string): boolean {
+  const haystack = `${pathname} ${text}`.toLowerCase();
+  if (!pathname.startsWith('/community/grants/')) return false;
+  if (isIgnoredPath(pathname)) return false;
+  return /grant|fund|enviro|radf|benefit|investment|sport/.test(haystack);
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string, pathname: string): boolean {
+  const text = `${title} ${description} ${body} ${pathname}`.toLowerCase();
+  if (isIgnoredPath(pathname)) return false;
+
+  const hasGrantSignal = /grant|fund|enviro|radf/.test(text);
+  const hasApplicationSignal = /apply|application|future rounds|outcomes|eligible|community grants policy/.test(text);
+
+  return hasGrantSignal && hasApplicationSignal;
+}
+
+async function collectCandidateUrls(): Promise<string[]> {
+  const html = await fetchPage(LOGAN_GRANTS_URL);
+  if (!html) return LOGAN_SEED_PATHS.map(path => `${LOGAN_BASE}${path}`);
+
+  const $ = cheerio.load(html);
+  const urls = new Set<string>(LOGAN_SEED_PATHS.map(path => `${LOGAN_BASE}${path}`));
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') || '';
+    const text = compressWhitespace($(el).text());
+    const absolute = toAbsoluteUrl(href);
+    if (!absolute) return;
+
+    const url = new URL(absolute);
+    if (url.origin !== LOGAN_BASE) return;
+    if (!isGrantLikePath(url.pathname, text)) return;
+
+    urls.add(url.toString());
+  });
+
+  return [...urls];
+}
+
+export function createLoganCityGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'logan-city-grants',
+    name: 'Logan City Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[logan-city-grants] Scraping Logan City Council grants...');
+
+      const candidateUrls = await collectCandidateUrls();
+      console.log(`[logan-city-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const title = compressWhitespace(
+          $('h1').first().text() ||
+          $('meta[property="og:title"]').attr('content') ||
+          $('title').text().replace(/\s*\|\s*Logan City Council\s*$/i, '')
+        );
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          $('main p').first().text() ||
+          $('#main-content p').first().text()
+        );
+        const bodyText = compressWhitespace(
+          $('main, #main-content, .oc-page-content').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText, pathname)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const amount = (
+          pathname.includes('/community-benefit-fund') ||
+          pathname.includes('/investment-attraction-incentives-fund')
+        )
+          ? {}
+          : extractAmounts(bodyText);
+        const categories = inferCategories(title, `${description} ${bodyText}`);
+        const applicationStatus = inferApplicationStatus(pathname, bodyText);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'Logan City Council',
+          sourceUrl: url,
+          amount: amount.min || amount.max ? amount : undefined,
+          deadline: extractDeadline(bodyText),
+          applicationStatus,
+          description: (description || bodyText).slice(0, 500) || undefined,
+          categories,
+          sourceId: 'logan-city-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[logan-city-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/noosa-grants.ts
+++ b/packages/grant-engine/src/sources/noosa-grants.ts
@@ -1,0 +1,183 @@
+/**
+ * Noosa Shire Council Grants Source Plugin
+ *
+ * Scrapes live Noosa council grant pages and yields currently open rolling
+ * grant programs with clear application details.
+ */
+
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const COMMUNITY_GRANTS_URL = 'https://www.noosa.qld.gov.au/Community/Grants/Community-Grants';
+const ECONOMIC_DEVELOPMENT_GRANT_URL = 'https://www.noosa.qld.gov.au/Business/Grants/Economic-development-grant';
+
+type ProgramDefinition = {
+  title: string;
+  pageUrl: string;
+  sourceUrl: string;
+  marker: string;
+  endMarker?: string;
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+  deadline?: string;
+};
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Community Quick Response Grants',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    sourceUrl: `${COMMUNITY_GRANTS_URL}#community-quick-response-grants`,
+    marker: 'Community Quick Response Grants - OPEN NOW!',
+    endMarker: 'Community Project Grants - Round 24 now closed',
+    requiredSignals: [
+      'Operating on a rolling basis, until the annual budget is exhausted.',
+      'Community Quick Response Grants are designed to support eligible not-for-profit organisations responding to emergent or time-sensitive matters',
+      'Round opens: 23 September 2025',
+      'Funding Available: 23 September - 30 June 2026',
+    ],
+    description:
+      'Provides rolling support for eligible not-for-profit organisations responding to emergent or time-sensitive matters in the Noosa community.',
+    categories: ['community'],
+    deadline: '2026-06-30',
+  },
+  {
+    title: 'Individual Sports Development Grants',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    sourceUrl: `${COMMUNITY_GRANTS_URL}#individual-sports-development-grants`,
+    marker: 'Individual Sports Development Grants - OPEN NOW!',
+    endMarker: 'Signature Community Event Grants',
+    requiredSignals: [
+      'Operating on a rolling basis, until the annual budget is exhausted.',
+      'Individual Sport Development Grants aim to support Noosa Shire residents who have been selected to represent Queensland or Australia',
+      'Round closes: 30 June 2026, or once all available grant funds have been expended.',
+      'Funding Period: September 2025 to June 2026',
+    ],
+    description:
+      'Supports Noosa Shire residents selected to represent Queensland or Australia at recognised national or international sporting competitions.',
+    categories: ['sport', 'education'],
+    deadline: '2026-06-30',
+  },
+  {
+    title: 'Economic Development Grant',
+    pageUrl: ECONOMIC_DEVELOPMENT_GRANT_URL,
+    sourceUrl: ECONOMIC_DEVELOPMENT_GRANT_URL,
+    marker: 'Economic Development Grant This Economic Development Grant Program is designed to support the delivery of projects',
+    requiredSignals: [
+      'This Grants Program operates on a rolling basis and is not subject to closing dates and application deadlines.',
+      'They remain open until the end of the financial year, or until all of the allocated funding has been distributed.',
+      'The minimum grant amount is $1000 and the maximum grant amount is $5000',
+      'Applicants will be notified within 30 days of application',
+    ],
+    description:
+      'Supports projects that strengthen the local business environment and economy in Noosa through a rolling economic development grants program.',
+    categories: ['enterprise', 'community'],
+    amount: { min: 1000, max: 5000 },
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string, endMarker?: string): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&#8211;/g, '–')
+      .replace(/&amp;/gi, '&')
+  );
+
+  const start = text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+  let end = sliced.length;
+
+  if (endMarker) {
+    const idx = sliced.indexOf(endMarker, marker.length);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  const fallbackEndMarkers = ['Was this page helpful?', 'Contact Us'];
+  for (const fallbackEndMarker of fallbackEndMarkers) {
+    const idx = sliced.indexOf(fallbackEndMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(url: string, marker: string, endMarker?: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker, endMarker);
+  } catch {
+    return null;
+  }
+}
+
+export function createNoosaGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'noosa-grants',
+    name: 'Noosa Shire Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[noosa-grants] Scraping Noosa Shire Council grants...');
+
+      const pageCache = new Map<string, string | null>();
+      let yielded = 0;
+
+      for (const definition of PROGRAMS) {
+        const cacheKey = `${definition.pageUrl}|${definition.marker}|${definition.endMarker || ''}`;
+        if (!pageCache.has(cacheKey)) {
+          pageCache.set(
+            cacheKey,
+            await fetchPageText(definition.pageUrl, definition.marker, definition.endMarker)
+          );
+        }
+
+        const text = pageCache.get(cacheKey);
+        if (!text) continue;
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Noosa Shire Council',
+          sourceUrl: definition.sourceUrl,
+          amount: definition.amount,
+          deadline: definition.deadline,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'noosa-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[noosa-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/nsw-grants.ts
+++ b/packages/grant-engine/src/sources/nsw-grants.ts
@@ -11,7 +11,8 @@
  */
 
 import * as cheerio from 'cheerio';
-import type { SourcePlugin, DiscoveryQuery, RawGrant } from '../types';
+import type { SourcePlugin, DiscoveryQuery, GrantApplicationStatus, RawGrant } from '../types';
+import { normalizeDate } from '../normalizer';
 
 const NSW_GRANTS_URL = 'https://www.nsw.gov.au/grants-and-funding';
 const NSW_ES_SEARCH = 'https://www.nsw.gov.au/api/v1/elasticsearch/prod_content/_search';
@@ -101,10 +102,50 @@ function unwrapNum(val: unknown): number | undefined {
   return typeof val === 'number' ? val : undefined;
 }
 
+function unwrapBool(val: unknown): boolean | undefined {
+  if (Array.isArray(val)) return typeof val[0] === 'boolean' ? val[0] : undefined;
+  return typeof val === 'boolean' ? val : undefined;
+}
+
 function unwrapArr(val: unknown): string[] {
   if (Array.isArray(val)) return val.map(String);
   if (typeof val === 'string') return [val];
   return [];
+}
+
+function startOfToday(): Date {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+function deriveApplicationStatus(deadline: string | undefined, isOngoing: boolean | undefined): GrantApplicationStatus | undefined {
+  if (isOngoing) return 'ongoing';
+  if (!deadline) return undefined;
+
+  const [yearText, monthText, dayText] = deadline.split('-');
+  const year = Number.parseInt(yearText || '', 10);
+  const month = Number.parseInt(monthText || '', 10);
+  const day = Number.parseInt(dayText || '', 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return undefined;
+  }
+
+  const closesAt = new Date(year, month - 1, day);
+  closesAt.setHours(0, 0, 0, 0);
+  return closesAt < startOfToday() ? 'closed' : 'open';
+}
+
+function shouldIncludeForStatus(queryStatus: DiscoveryQuery['status'], applicationStatus: GrantApplicationStatus | undefined): boolean {
+  if (queryStatus === 'open') {
+    return applicationStatus !== 'closed';
+  }
+
+  if (queryStatus === 'upcoming') {
+    return applicationStatus === 'upcoming';
+  }
+
+  return true;
 }
 
 /** Try the internal Elasticsearch _search API — structured data, 1600+ grants */
@@ -164,6 +205,7 @@ async function tryElasticsearchAPI(): Promise<RawGrant[] | null> {
 
         const urlPath = unwrap(src.url);
         const url = urlPath ? `https://www.nsw.gov.au${urlPath}` : undefined;
+        const isOngoing = unwrapBool(src.grant_is_ongoing);
 
         // Use structured grant amount fields when available
         const amountMax = unwrapNum(src.grant_amount_max) || unwrapNum(src.grant_amount_single);
@@ -177,8 +219,10 @@ async function tryElasticsearchAPI(): Promise<RawGrant[] | null> {
         ])];
 
         // Deadline from structured field
-        const endDate = unwrap(src.grant_dates_end);
-        const deadline = endDate || extractDeadline(description);
+        const rawDeadline = unwrap(src.grant_dates_end) || extractDeadline(description);
+        const normalizedDeadline = normalizeDate(rawDeadline) || undefined;
+        const applicationStatus = deriveApplicationStatus(normalizedDeadline, isOngoing);
+        const deadline = applicationStatus === 'ongoing' ? undefined : normalizedDeadline;
 
         const agency = unwrap(src.agency_name);
         const provider = agency ? `NSW Government — ${agency}` : 'NSW Government';
@@ -188,7 +232,8 @@ async function tryElasticsearchAPI(): Promise<RawGrant[] | null> {
           provider,
           sourceUrl: url,
           amount: amount.min || amount.max ? amount : undefined,
-          deadline: deadline || undefined,
+          deadline,
+          applicationStatus,
           description: description.slice(0, 500) || undefined,
           categories,
           sourceId: 'nsw-grants',
@@ -252,13 +297,17 @@ async function scrapeHTMLPages(query: DiscoveryQuery): Promise<RawGrant[]> {
 
         const context = $el.closest('li, div, article').text() || '';
         const fullUrl = href.startsWith('http') ? href : `https://www.nsw.gov.au${href}`;
+        const normalizedDeadline = normalizeDate(extractDeadline(context)) || undefined;
+        const applicationStatus = deriveApplicationStatus(normalizedDeadline, false);
+        const deadline = applicationStatus === 'ongoing' ? undefined : normalizedDeadline;
 
         grants.push({
           title: title.slice(0, 200),
           provider: 'NSW Government',
           sourceUrl: fullUrl,
           amount: extractAmounts(context),
-          deadline: extractDeadline(context),
+          deadline,
+          applicationStatus,
           description: context.replace(/\s+/g, ' ').trim().slice(0, 500) || undefined,
           categories: inferCategories(title, context),
           sourceId: 'nsw-grants',
@@ -311,6 +360,10 @@ export function createNSWGrantsPlugin(): SourcePlugin {
         if (query.keywords?.length) {
           const text = `${grant.title} ${grant.description || ''}`.toLowerCase();
           if (!query.keywords.some(k => text.includes(k.toLowerCase()))) continue;
+        }
+
+        if (!shouldIncludeForStatus(query.status, grant.applicationStatus)) {
+          continue;
         }
 
         yield grant;

--- a/packages/grant-engine/src/sources/qld-grants.ts
+++ b/packages/grant-engine/src/sources/qld-grants.ts
@@ -53,6 +53,13 @@ interface DatastoreResult<T> {
   };
 }
 
+type DateFormat = 'dd/mm/yyyy' | 'mm/dd/yyyy';
+
+const QLD_DATE_FIELDS = [
+  'Opening date (date format)',
+  'Closing date (date format)',
+] as const;
+
 function inferCategories(title: string, description: string, category?: string): string[] {
   const text = `${title} ${description} ${category || ''}`.toLowerCase();
   const cats: string[] = [];
@@ -79,14 +86,63 @@ function parseAmount(value: string | undefined | null): number | undefined {
   return isNaN(num) || num <= 0 ? undefined : num;
 }
 
-function parseDate(dateStr: string | undefined | null): string | undefined {
-  if (!dateStr) return undefined;
-  // Format: DD/MM/YYYY → YYYY-MM-DD
-  const match = dateStr.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-  if (match) {
-    return `${match[3]}-${match[2].padStart(2, '0')}-${match[1].padStart(2, '0')}`;
+function toIsoDate(year: number, month: number, day: number): string | undefined {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+  if (
+    candidate.getUTCFullYear() !== year
+    || candidate.getUTCMonth() !== month - 1
+    || candidate.getUTCDate() !== day
+  ) {
+    return undefined;
   }
-  return dateStr;
+
+  return candidate.toISOString().slice(0, 10);
+}
+
+function inferResourceDateFormat(records: QLDGrantRecord[]): DateFormat {
+  let ddmmyyyy = 0;
+  let mmddyyyy = 0;
+
+  for (const record of records) {
+    for (const field of QLD_DATE_FIELDS) {
+      const value = record[field];
+      if (!value || typeof value !== 'string') continue;
+
+      const match = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+      if (!match) continue;
+
+      const first = Number.parseInt(match[1], 10);
+      const second = Number.parseInt(match[2], 10);
+      if (first > 12 && second <= 12) ddmmyyyy++;
+      if (second > 12 && first <= 12) mmddyyyy++;
+    }
+  }
+
+  return mmddyyyy > ddmmyyyy ? 'mm/dd/yyyy' : 'dd/mm/yyyy';
+}
+
+function parseDate(dateStr: string | undefined | null, preferredFormat: DateFormat = 'dd/mm/yyyy'): string | undefined {
+  if (!dateStr) return undefined;
+
+  const trimmed = dateStr.trim();
+  const match = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!match) return trimmed;
+
+  const first = Number.parseInt(match[1], 10);
+  const second = Number.parseInt(match[2], 10);
+  const year = Number.parseInt(match[3], 10);
+  const candidateOrders = preferredFormat === 'mm/dd/yyyy'
+    ? [[first, second], [second, first]]
+    : [[second, first], [first, second]];
+
+  for (const [month, day] of candidateOrders) {
+    const parsed = toIsoDate(year, month, day);
+    if (parsed) return parsed;
+  }
+
+  return undefined;
 }
 
 export function createQLDGrantsPlugin(): SourcePlugin {
@@ -137,6 +193,7 @@ export function createQLDGrantsPlugin(): SourcePlugin {
 
           const data = await response.json() as DatastoreResult<QLDGrantRecord>;
           if (!data.success || !data.result?.records) continue;
+          const resourceDateFormat = inferResourceDateFormat(data.result.records);
 
           for (const record of data.result.records) {
             const name = record['Program title'] || '';
@@ -178,7 +235,7 @@ export function createQLDGrantsPlugin(): SourcePlugin {
                 min: undefined,
                 max: maxAmount || budget || undefined,
               },
-              deadline: parseDate(record['Closing date (date format)']) || undefined,
+              deadline: parseDate(record['Closing date (date format)'], resourceDateFormat) || undefined,
               description: description.slice(0, 1000) || undefined,
               categories,
               program: name,

--- a/packages/grant-engine/src/sources/redland-city-grants.ts
+++ b/packages/grant-engine/src/sources/redland-city-grants.ts
@@ -1,0 +1,341 @@
+/**
+ * Redland City Council Grants Source Plugin
+ *
+ * Scrapes official Redland City Council grants and sponsorship pages.
+ * The main grants page exposes direct links to each funding stream.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const REDLAND_GRANTS_URL = 'https://www.redland.qld.gov.au/Grants-and-sponsorship';
+const REDLAND_BASE = 'https://www.redland.qld.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const REDLAND_SEED_PATHS = [
+  '/Grants-and-sponsorship/Rapid-Response-Grant',
+  '/Grants-and-sponsorship/Community-Support-Grant',
+  '/Grants-and-sponsorship/Build-and-Thrive-Grant',
+  '/Grants-and-sponsorship/Community-Celebration-Grant',
+  '/Grants-and-sponsorship/Events-Grant',
+  '/Grants-and-sponsorship/Signature-Events-Attraction-and-Retention-Fund',
+  '/Grants-and-sponsorship/Regional-Arts-Development-Fund',
+  '/Grants-and-sponsorship/Local-Heritage-Grants',
+  '/Grants-and-sponsorship/Mayor-and-Councillors-Community-Benefit-Fund-Program',
+];
+
+const REDLAND_EXCLUDED_PATTERNS = [
+  /\/Grants-and-sponsorship$/i,
+  /Awarded-grants/i,
+  /Grant-Funding-Finder/i,
+  /Grant-and-Sponsorship-Logo-Downloads-and-Guidelines/i,
+  /Grant-workshops-and-assistance/i,
+  /newsletter/i,
+];
+
+const MONTH_LOOKUP: Record<string, number> = {
+  january: 0,
+  february: 1,
+  march: 2,
+  april: 3,
+  may: 4,
+  june: 5,
+  july: 6,
+  august: 7,
+  september: 8,
+  october: 9,
+  november: 10,
+  december: 11,
+};
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/community|celebration|benefit|support/.test(text)) cats.push('community');
+  if (/arts?|heritage|radf|creative|culture/.test(text)) cats.push('arts');
+  if (/events?|tourism|attraction/.test(text)) cats.push('enterprise');
+  if (/environment|conservation|indigiscapes|climate/.test(text)) cats.push('regenerative');
+  if (/sport|recreation/.test(text)) cats.push('sport');
+  if (/business|thrive/.test(text)) cats.push('enterprise');
+
+  return [...new Set(cats)];
+}
+
+function extractAmounts(text: string): { min?: number; max?: number } {
+  const rangeMatch = text.match(/\$([0-9,]+)\s*(?:to|–|-)\s*\$([0-9,]+)/i);
+  if (rangeMatch) {
+    return {
+      min: parseInt(rangeMatch[1].replace(/,/g, ''), 10),
+      max: parseInt(rangeMatch[2].replace(/,/g, ''), 10),
+    };
+  }
+
+  const fromMatch = text.match(/from \$([0-9,]+)\s+to\s+\$([0-9,]+)/i);
+  if (fromMatch) {
+    return {
+      min: parseInt(fromMatch[1].replace(/,/g, ''), 10),
+      max: parseInt(fromMatch[2].replace(/,/g, ''), 10),
+    };
+  }
+
+  const upToMatch = text.match(/up to \$([0-9,]+)/i);
+  if (upToMatch) {
+    return { max: parseInt(upToMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  const singleMatch = text.match(/\$([0-9,]{3,})/);
+  if (singleMatch) {
+    return { max: parseInt(singleMatch[1].replace(/,/g, ''), 10) };
+  }
+
+  return {};
+}
+
+function extractDeadline(text: string): string | undefined {
+  return extractRoundInfo(text).deadline;
+}
+
+function startOfToday(): Date {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now;
+}
+
+function toIsoDate(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+function parseRoundDate(dayText: string, monthText: string, yearText?: string, fallbackYear?: number): Date | null {
+  const month = MONTH_LOOKUP[monthText.toLowerCase()];
+  const day = Number.parseInt(dayText, 10);
+  const year = yearText ? Number.parseInt(yearText, 10) : fallbackYear;
+  if (month === undefined || !Number.isFinite(day) || !year) return null;
+
+  const date = new Date(year, month, day);
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+function extractRoundInfo(text: string): { deadline?: string; applicationStatus?: GrantApplicationStatus } {
+  const windows: Array<{ start: Date; end: Date }> = [];
+  const pattern = /open(?:ed)?\s+from\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?\s+to\s+(\d{1,2})\s+(\w+)\s+(\d{4})/ig;
+
+  for (const match of text.matchAll(pattern)) {
+    const closeYear = Number.parseInt(match[6], 10);
+    const closeMonth = MONTH_LOOKUP[match[5].toLowerCase()];
+    const startMonth = MONTH_LOOKUP[match[2].toLowerCase()];
+    if (closeMonth === undefined || startMonth === undefined || !Number.isFinite(closeYear)) continue;
+
+    const inferredStartYear = match[3]
+      ? Number.parseInt(match[3], 10)
+      : (startMonth > closeMonth ? closeYear - 1 : closeYear);
+
+    const start = parseRoundDate(match[1], match[2], match[3], inferredStartYear);
+    const end = parseRoundDate(match[4], match[5], match[6], closeYear);
+    if (!start || !end) continue;
+
+    windows.push({ start, end });
+  }
+
+  if (windows.length > 0) {
+    windows.sort((a, b) => a.start.getTime() - b.start.getTime());
+    const today = startOfToday().getTime();
+    const active = windows.find(window => today >= window.start.getTime() && today <= window.end.getTime());
+    if (active) {
+      return {
+        deadline: toIsoDate(active.end),
+        applicationStatus: 'open',
+      };
+    }
+
+    const future = windows.find(window => window.start.getTime() > today);
+    if (future) {
+      return {
+        deadline: toIsoDate(future.end),
+        applicationStatus: 'upcoming',
+      };
+    }
+  }
+
+  const closePatterns = [
+    /(?:applications?\s+close|closes?|closing|deadline|due)[^.\n]*?(\d{1,2}\s+\w+\s+\d{4})/i,
+    /(\d{1,2}\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})/i,
+  ];
+
+  for (const pattern of closePatterns) {
+    const match = text.match(pattern);
+    if (match) return { deadline: match[1] };
+  }
+
+  if (/applications are now closed|currently closed|closed for the \d{4}\/\d{2} program/i.test(text)) {
+    return { applicationStatus: 'closed' };
+  }
+
+  return {};
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        'Accept': 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(href: string): string | null {
+  try {
+    const url = new URL(href, REDLAND_BASE);
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(pathname: string): boolean {
+  return REDLAND_EXCLUDED_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+function isGrantLikePath(pathname: string, text: string): boolean {
+  const haystack = `${pathname} ${text}`.toLowerCase();
+  if (!pathname.startsWith('/Grants-and-sponsorship/')) return false;
+  if (isIgnoredPath(pathname)) return false;
+  return /grant|fund|sponsorship|events?|heritage|arts|benefit/.test(haystack);
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string, pathname: string): boolean {
+  const text = `${title} ${description} ${body} ${pathname}`.toLowerCase();
+  if (isIgnoredPath(pathname)) return false;
+
+  const hasGrantSignal = /grant|fund|sponsorship/.test(text);
+  const hasApplicationSignal = /apply|application|eligib|funding is available|round|outcomes|funding is available/.test(text);
+
+  return hasGrantSignal && hasApplicationSignal;
+}
+
+async function collectCandidateUrls(): Promise<string[]> {
+  const html = await fetchPage(REDLAND_GRANTS_URL);
+  if (!html) return REDLAND_SEED_PATHS.map(path => `${REDLAND_BASE}${path}`);
+
+  const $ = cheerio.load(html);
+  const urls = new Set<string>(REDLAND_SEED_PATHS.map(path => `${REDLAND_BASE}${path}`));
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') || '';
+    const text = compressWhitespace($(el).text());
+    const absolute = toAbsoluteUrl(href);
+    if (!absolute) return;
+
+    const url = new URL(absolute);
+    if (url.origin !== REDLAND_BASE) return;
+    if (!isGrantLikePath(url.pathname, text)) return;
+
+    urls.add(url.toString());
+  });
+
+  return [...urls];
+}
+
+export function createRedlandCityGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'redland-city-grants',
+    name: 'Redland City Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[redland-city-grants] Scraping Redland City Council grants...');
+
+      const candidateUrls = await collectCandidateUrls();
+      console.log(`[redland-city-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const title = compressWhitespace(
+          $('h1').first().text() ||
+          $('meta[property="og:title"]').attr('content') ||
+          $('title').text().replace(/\s*\|\s*Redland City Council\s*$/i, '')
+        );
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          $('main p').first().text() ||
+          $('#main-content p').first().text()
+        );
+        const bodyText = compressWhitespace(
+          $('main, #main-content, .oc-page-content').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText, pathname)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const amount = extractAmounts(bodyText);
+        const categories = inferCategories(title, `${description} ${bodyText}`);
+        const roundInfo = extractRoundInfo(bodyText);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'Redland City Council',
+          sourceUrl: url,
+          amount: amount.min || amount.max ? amount : undefined,
+          deadline: roundInfo.deadline || extractDeadline(bodyText),
+          applicationStatus: roundInfo.applicationStatus,
+          description: (description || bodyText).slice(0, 500) || undefined,
+          categories,
+          sourceId: 'redland-city-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[redland-city-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/registry.ts
+++ b/packages/grant-engine/src/sources/registry.ts
@@ -5,7 +5,7 @@
  * Each plugin runs independently — one failure doesn't stop others.
  */
 
-import type { SourcePlugin, SourcePluginConfig, DiscoveryQuery, RawGrant, DiscoveryRunStats } from '../types';
+import type { SourcePlugin, SourcePluginConfig, DiscoveryQuery, DiscoveryRunStats, DiscoveryEvent } from '../types';
 
 export class SourceRegistry {
   private plugins = new Map<string, SourcePlugin>();
@@ -46,7 +46,7 @@ export class SourceRegistry {
   async *discoverAll(
     query: DiscoveryQuery,
     sourceIds?: string[]
-  ): AsyncGenerator<{ grant: RawGrant; stats: DiscoveryRunStats }> {
+  ): AsyncGenerator<DiscoveryEvent> {
     const plugins = this.getEnabled(sourceIds);
 
     for (const plugin of plugins) {
@@ -61,7 +61,7 @@ export class SourceRegistry {
       try {
         for await (const grant of plugin.discover(query)) {
           stats.grantsFound++;
-          yield { grant, stats };
+          yield { kind: 'grant', grant, stats };
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -70,6 +70,7 @@ export class SourceRegistry {
       }
 
       stats.durationMs = Date.now() - start;
+      yield { kind: 'source-complete', stats: { ...stats, errors: [...stats.errors] } };
     }
   }
 }

--- a/packages/grant-engine/src/sources/scenicrim-grants.ts
+++ b/packages/grant-engine/src/sources/scenicrim-grants.ts
@@ -1,0 +1,201 @@
+/**
+ * Scenic Rim Regional Council Grants Source Plugin
+ *
+ * Scrapes explicit Scenic Rim Regional Council grant pages and yields the
+ * current program streams clearly described on those pages.
+ */
+
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const COMMUNITY_GRANTS_URL =
+  'https://www.scenicrim.qld.gov.au/Our-Community/Community-and-Culture/Grants-Funding-and-Awards/Community-Grants-Program';
+const RADF_URL =
+  'https://www.scenicrim.qld.gov.au/Our-Community/Community-and-Culture/Grants-Funding-and-Awards/Regional-Arts-Development-Fund';
+const EVENTS_SPONSORSHIP_URL =
+  'https://www.scenicrim.qld.gov.au/Our-Community/Community-and-Culture/Grants-Funding-and-Awards/Regional-Events-Sponsorship-Program';
+
+type ProgramDefinition = {
+  title: string;
+  pageUrl: string;
+  sourceUrl?: string;
+  marker: string;
+  markerOccurrence?: 'first' | 'last';
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+};
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Community Grants Program',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    marker: 'Community Grants Program',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'provides financial support to not-for-profit community groups for projects and events which benefit the region',
+      "All application forms for current grants including in kind applications forms - click on the 'all applications' link below.",
+    ],
+    description:
+      'Provides financial support to not-for-profit community groups for projects and events that benefit the Scenic Rim region.',
+    categories: ['community'],
+  },
+  {
+    title: 'RADF - Big Ideas Arts Grants',
+    pageUrl: RADF_URL,
+    sourceUrl: `${RADF_URL}#big-ideas-arts-grants`,
+    marker: 'Regional Arts Development Fund',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Applications open 1 July 2025 via SmartyGrants.',
+      'Big Ideas',
+      'The Big Ideas RADF grant stream has a total of $52,500 to allocate across successful applicants.',
+    ],
+    description:
+      'Supports larger creative projects through Scenic Rim’s Big Ideas arts grants stream within the 2025-2026 RADF program.',
+    categories: ['arts'],
+  },
+  {
+    title: 'RADF - Launch Pad Young Creatives Grants',
+    pageUrl: RADF_URL,
+    sourceUrl: `${RADF_URL}#launch-pad-young-creatives-grants`,
+    marker: 'Regional Arts Development Fund',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Launch Pad grants are capped at $1,000.',
+      'Emerging artists and producers aged 16-25 years.',
+    ],
+    description:
+      'Supports emerging artists and producers aged 16-25 through Scenic Rim’s Launch Pad Young Creatives grants stream.',
+    categories: ['arts', 'education'],
+    amount: { max: 1000 },
+  },
+  {
+    title: 'RADF - Express Lane Quick Response Grants',
+    pageUrl: RADF_URL,
+    sourceUrl: `${RADF_URL}#express-lane-quick-response-grants`,
+    marker: 'Regional Arts Development Fund',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Express Lane Quick Response grants are capped at $1,000',
+      '$1,500 for interstate.',
+    ],
+    description:
+      'Supports quick-response creative opportunities through Scenic Rim’s Express Lane RADF stream, including interstate activity support.',
+    categories: ['arts'],
+    amount: { max: 1500 },
+  },
+  {
+    title: 'Regional Events Sponsorship Program',
+    pageUrl: EVENTS_SPONSORSHIP_URL,
+    marker: 'Regional Events Sponsorship Program',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Regional Events Sponsorship Program is open for applications.',
+      'Applications must be received at least 3-6 months before your event.',
+    ],
+    description:
+      'Provides support for eligible events that activate the Scenic Rim and deliver economic outcomes for communities and businesses.',
+    categories: ['community', 'enterprise'],
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string, markerOccurrence: 'first' | 'last' = 'first'): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&amp;/gi, '&')
+  );
+  const start = markerOccurrence === 'last' ? text.lastIndexOf(marker) : text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+
+  const endMarkers = ['Back to top', 'Contact Us 82 Brisbane Street'];
+  let end = sliced.length;
+  for (const endMarker of endMarkers) {
+    const idx = sliced.indexOf(endMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(
+  url: string,
+  marker: string,
+  markerOccurrence: 'first' | 'last' = 'first'
+): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker, markerOccurrence);
+  } catch {
+    return null;
+  }
+}
+
+export function createScenicRimGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'scenicrim-grants',
+    name: 'Scenic Rim Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[scenicrim-grants] Scraping Scenic Rim Regional Council grants...');
+
+      const pageCache = new Map<string, string | null>();
+      let yielded = 0;
+
+      for (const definition of PROGRAMS) {
+        const cacheKey = `${definition.pageUrl}|${definition.marker}|${definition.markerOccurrence || 'first'}`;
+        if (!pageCache.has(cacheKey)) {
+          pageCache.set(
+            cacheKey,
+            await fetchPageText(definition.pageUrl, definition.marker, definition.markerOccurrence)
+          );
+        }
+
+        const text = pageCache.get(cacheKey);
+        if (!text) continue;
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Scenic Rim Regional Council',
+          sourceUrl: definition.sourceUrl || definition.pageUrl,
+          amount: definition.amount,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'scenicrim-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[scenicrim-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/sunshinecoast-grants.ts
+++ b/packages/grant-engine/src/sources/sunshinecoast-grants.ts
@@ -1,0 +1,172 @@
+/**
+ * Sunshine Coast Council Grants Source Plugin
+ *
+ * Scrapes explicit Sunshine Coast Council grants and sponsorship program pages.
+ * The grants-programs directory exposes stable child pages for each funding stream.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const SUNSHINE_BASE = 'https://www.sunshinecoast.qld.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const PROGRAM_PRESETS: Record<string, { description: string; amount?: { min?: number; max?: number } }> = {
+  '/living-and-community/grants-and-funding/grants-programs/major-grants': {
+    description: 'Project funding for not-for-profit community groups up to $15,000, and up to $30,000 for infrastructure projects.',
+    amount: { max: 30000 },
+  },
+  '/living-and-community/grants-and-funding/grants-programs/minor-grants': {
+    description: 'Project funding for not-for-profit community groups up to $3,000.',
+    amount: { max: 3000 },
+  },
+  '/living-and-community/grants-and-funding/grants-programs/festive-and-commemorative-events-grants': {
+    description: 'Funding for community-led Christmas, New Year, Australia Day, Anzac Day and Remembrance Day community events.',
+    amount: { max: 15000 },
+  },
+  '/living-and-community/grants-and-funding/grants-programs/emergency-grants': {
+    description: 'Funding to assist with an emergency or a significant impact caused by unforeseen circumstances.',
+    amount: { max: 3000 },
+  },
+  '/living-and-community/grants-and-funding/grants-programs/environment-levy-grants': {
+    description: 'Funding provided for not-for-profit community based organisations and private rural landholders under the environment levy.',
+  },
+  '/living-and-community/grants-and-funding/grants-programs/heritage-levy-funding': {
+    description: 'Funding provided to not-for-profit community museums and heritage groups.',
+    amount: { max: 7500 },
+  },
+  '/living-and-community/grants-and-funding/grants-programs/individual-development-grants': {
+    description: 'Funding to support residents performing, competing or presenting at national or international competitions, conferences or events.',
+    amount: { max: 2000 },
+  },
+  '/living-and-community/grants-and-funding/grants-programs/mayoral-and-councillor-discretionary-funding': {
+    description: 'This program allows funds to be allocated at the Councillor’s discretion to not-for-profit organisations for community purposes.',
+  },
+  '/living-and-community/grants-and-funding/grants-programs/community-partnership-funding': {
+    description: 'Operational funding for incorporated not-for-profit groups that provide key facilities or services to local communities.',
+  },
+  '/living-and-community/grants-and-funding/grants-programs/sports-field-maintenance-funding': {
+    description: 'Funding towards the cost of maintaining sports fields in the region.',
+  },
+  '/living-and-community/grants-and-funding/grants-programs/recreation-trails-partnership-program': {
+    description: 'Funding for community organisations contributing to the development, maintenance, and activation of publicly accessible trails and associated nature-based recreation infrastructure.',
+    amount: { max: 15000 },
+  },
+  '/business/major-events-sponsorship-program': {
+    description: 'Council aims to position the Sunshine Coast as Australia’s premier regional major events destination through event sponsorship support.',
+  },
+};
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/community|partnership|discretionary/.test(text)) cats.push('community');
+  if (/arts?|creative|heritage/.test(text)) cats.push('arts');
+  if (/environment|levy|nature|trails/.test(text)) cats.push('regenerative');
+  if (/individual development|competing|presenting|conference/.test(text)) cats.push('education');
+  if (/sport|sports field/.test(text)) cats.push('sport');
+  if (/events?|sponsorship|business/.test(text)) cats.push('enterprise');
+
+  return [...new Set(cats)];
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string): boolean {
+  const text = `${title} ${description} ${body}`.toLowerCase();
+  if (/^404\b|page not found|access denied|just a moment/.test(`${title} ${description}`.toLowerCase())) return false;
+  return /grant|funding|sponsorship/.test(text);
+}
+
+export function createSunshineCoastGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'sunshinecoast-grants',
+    name: 'Sunshine Coast Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[sunshinecoast-grants] Scraping Sunshine Coast Council grants...');
+
+      const candidateUrls = Object.keys(PROGRAM_PRESETS).map(path => `${SUNSHINE_BASE}${path}`);
+      console.log(`[sunshinecoast-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const preset = PROGRAM_PRESETS[pathname];
+        const title = (
+          compressWhitespace($('h1').first().text()) ||
+          compressWhitespace($('meta[property="og:title"]').attr('content') || '') ||
+          compressWhitespace($('title').text().replace(/\s*\|\s*Sunshine Coast Council.*$/i, ''))
+        );
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          preset.description
+        );
+        const bodyText = compressWhitespace(
+          $('main, [role="main"], body').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const categories = inferCategories(title, description);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'Sunshine Coast Council',
+          sourceUrl: url,
+          amount: preset.amount,
+          description: description.slice(0, 500) || undefined,
+          categories,
+          sourceId: 'sunshinecoast-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[sunshinecoast-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/tablelands-grants.ts
+++ b/packages/grant-engine/src/sources/tablelands-grants.ts
@@ -1,0 +1,253 @@
+/**
+ * Tablelands Regional Council Grants Source Plugin
+ *
+ * Scrapes official Tablelands Regional Council grant and sponsorship pages.
+ * The landing page exposes direct program URLs and brief summaries for each stream.
+ */
+
+import * as cheerio from 'cheerio';
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const TABLELANDS_GRANTS_URL = 'https://www.trc.qld.gov.au/our-community/funding-grants/trc-grants/';
+const TABLELANDS_BASE = 'https://www.trc.qld.gov.au';
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const TABLELANDS_SEED_PATHS = [
+  '/our-community/funding-grants/trc-grants/radf-grants/',
+  '/our-community/funding-grants/trc-grants/trc-community-grants/',
+  '/our-community/funding-grants/trc-grants/environment-grants/',
+  '/our-community/funding-grants/trc-grants/youth-grants/',
+  '/our-community/events/event-sponsorship/',
+];
+
+const TABLELANDS_EXCLUDED_PATTERNS = [
+  /\/our-community\/funding-grants\/trc-grants\/$/i,
+  /trc-grant-acquittal/i,
+  /requests-letters-support/i,
+  /guidelines/i,
+];
+
+const PROGRAM_PRESETS: Record<string, { description: string; amount?: { min?: number; max?: number } }> = {
+  '/our-community/funding-grants/trc-grants/radf-grants/': {
+    description: 'Supports quality arts and cultural experiences and builds local cultural capacity. Quick response grants are available year-round while funds last, with larger assessed rounds for major projects.',
+    amount: { max: 6000 },
+  },
+  '/our-community/funding-grants/trc-grants/trc-community-grants/': {
+    description: 'Supports activities that contribute to an active, inclusive, connected and empowered community.',
+    amount: { max: 2000 },
+  },
+  '/our-community/funding-grants/trc-grants/environment-grants/': {
+    description: 'Supports activities that contribute to a valued, managed and healthy environment.',
+    amount: { max: 2000 },
+  },
+  '/our-community/funding-grants/trc-grants/youth-grants/': {
+    description: 'Supports youth representing the region in sport, recreation, academic, arts, culture, leadership, and ambassadorship activities.',
+    amount: { min: 250, max: 500 },
+  },
+  '/our-community/events/event-sponsorship/': {
+    description: 'Provides in-kind and cash support to eligible event organisers delivering events in the Tablelands Regional Council area.',
+  },
+};
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function inferCategories(title: string, description: string): string[] {
+  const text = `${title} ${description}`.toLowerCase();
+  const cats: string[] = [];
+
+  if (/arts?|culture|heritage|radf/.test(text)) cats.push('arts');
+  if (/community|volunteer|inclusive|connected/.test(text)) cats.push('community');
+  if (/environment|climate|regeneration|healthy environment/.test(text)) cats.push('regenerative');
+  if (/youth|academic|leadership|training/.test(text)) cats.push('education');
+  if (/sport|recreation/.test(text)) cats.push('sport');
+  if (/event|sponsorship|economic|tourism/.test(text)) cats.push('enterprise');
+
+  return [...new Set(cats)];
+}
+
+function extractAmount(pathname: string): { min?: number; max?: number } | undefined {
+  const preset = PROGRAM_PRESETS[pathname];
+  return preset?.amount;
+}
+
+function inferApplicationStatus(pathname: string, bodyText: string): GrantApplicationStatus | undefined {
+  const text = bodyText.toLowerCase();
+
+  if (
+    pathname === '/our-community/funding-grants/trc-grants/trc-community-grants/' ||
+    pathname === '/our-community/funding-grants/trc-grants/environment-grants/' ||
+    pathname === '/our-community/funding-grants/trc-grants/youth-grants/'
+  ) {
+    if (/fully expended|open in july|opens in july|opening in july/.test(text)) return 'upcoming';
+  }
+
+  if (pathname === '/our-community/funding-grants/trc-grants/radf-grants/') {
+    if (/quick response grants are available year-round|year-round while funds last|applications are open/.test(text)) {
+      return 'open';
+    }
+  }
+
+  if (/applications closed|currently closed/.test(text)) return 'closed';
+
+  return undefined;
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(href: string): string | null {
+  try {
+    const url = new URL(href, TABLELANDS_BASE);
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredPath(pathname: string): boolean {
+  return TABLELANDS_EXCLUDED_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+function isGrantLikePath(pathname: string, text: string): boolean {
+  const haystack = `${pathname} ${text}`.toLowerCase();
+
+  if (isIgnoredPath(pathname)) return false;
+  if (
+    pathname.startsWith('/our-community/funding-grants/trc-grants/') ||
+    pathname === '/our-community/events/event-sponsorship/'
+  ) {
+    return /grant|funding|sponsorship|community|environment|youth|radf|event/.test(haystack);
+  }
+
+  return false;
+}
+
+function looksLikeGrantPage(title: string, description: string, body: string, pathname: string): boolean {
+  const text = `${title} ${description} ${body} ${pathname}`.toLowerCase();
+
+  if (isIgnoredPath(pathname)) return false;
+  const hasGrantSignal = /grant|funding|sponsorship|radf/.test(text);
+  const hasApplicationSignal = /apply|application|eligible|open in july|fully expended|cash support|in-kind/.test(text);
+
+  return hasGrantSignal && hasApplicationSignal;
+}
+
+async function collectCandidateUrls(): Promise<string[]> {
+  const html = await fetchPage(TABLELANDS_GRANTS_URL);
+  if (!html) return TABLELANDS_SEED_PATHS.map(path => `${TABLELANDS_BASE}${path}`);
+
+  const $ = cheerio.load(html);
+  const urls = new Set<string>(TABLELANDS_SEED_PATHS.map(path => `${TABLELANDS_BASE}${path}`));
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') || '';
+    const text = compressWhitespace($(el).text());
+    const absolute = toAbsoluteUrl(href);
+    if (!absolute) return;
+
+    const url = new URL(absolute);
+    if (url.origin !== TABLELANDS_BASE) return;
+    if (!isGrantLikePath(url.pathname, text)) return;
+
+    urls.add(url.toString());
+  });
+
+  return [...urls];
+}
+
+export function createTablelandsGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'tablelands-grants',
+    name: 'Tablelands Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[tablelands-grants] Scraping Tablelands Regional Council grants...');
+
+      const candidateUrls = await collectCandidateUrls();
+      console.log(`[tablelands-grants] Candidate pages: ${candidateUrls.length}`);
+
+      const seen = new Set<string>();
+      let yielded = 0;
+
+      for (const url of candidateUrls) {
+        const html = await fetchPage(url);
+        if (!html) continue;
+
+        const $ = cheerio.load(html);
+        const pathname = new URL(url).pathname;
+        const title = (
+          compressWhitespace($('h1').first().text()) ||
+          compressWhitespace($('meta[property="og:title"]').attr('content') || '') ||
+          compressWhitespace($('title').text().replace(/\s*-\s*TRC.*$/i, ''))
+        );
+        const preset = PROGRAM_PRESETS[pathname];
+        const description = compressWhitespace(
+          $('meta[name="description"]').attr('content') ||
+          $('.entry-content p').first().text() ||
+          $('article p').first().text() ||
+          preset?.description ||
+          ''
+        );
+        const bodyText = compressWhitespace(
+          $('main, #content, .entry-content, article').text() ||
+          $('body').text()
+        );
+
+        if (!title || title.length < 5) continue;
+        if (!looksLikeGrantPage(title, description, bodyText, pathname)) continue;
+
+        const dedupKey = `${title.toLowerCase()}|${pathname}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        const amount = extractAmount(pathname);
+        const categories = inferCategories(title, `${description} ${preset?.description || ''} ${bodyText}`);
+        const applicationStatus = inferApplicationStatus(pathname, bodyText);
+
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (categories.length > 0 && !categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        if (query.keywords?.length) {
+          const text = `${title} ${description} ${preset?.description || ''} ${bodyText}`.toLowerCase();
+          if (!query.keywords.some(keyword => text.includes(keyword.toLowerCase()))) continue;
+        }
+
+        yield {
+          title: title.slice(0, 200),
+          provider: 'Tablelands Regional Council',
+          sourceUrl: url,
+          amount,
+          applicationStatus,
+          description: (preset?.description || description || bodyText).slice(0, 500) || undefined,
+          categories,
+          sourceId: 'tablelands-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[tablelands-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/toowoomba-grants.ts
+++ b/packages/grant-engine/src/sources/toowoomba-grants.ts
@@ -1,0 +1,212 @@
+/**
+ * Toowoomba Regional Council Grants Source Plugin
+ *
+ * Scrapes explicit Toowoomba Regional Council grants pages and yields only the
+ * current or upcoming grant streams that are clearly described on those pages.
+ */
+
+import type { DiscoveryQuery, GrantApplicationStatus, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const COMMUNITY_GRANTS_URL = 'https://www.tr.qld.gov.au/Community/Grants-funding-and-scholarships/Community-Grants-Program';
+const SPONSORSHIP_URL = 'https://www.tr.qld.gov.au/Community/Grants-funding-and-scholarships/Request-for-sponsorship';
+const SHADE_TREES_URL = 'https://www.tr.qld.gov.au/Community/Grants-funding-and-scholarships/Shade-trees-and-shrubs-in-kind-grant';
+const HERITAGE_URL = 'https://www.tr.qld.gov.au/Community/Grants-funding-and-scholarships/Heritage-Incentive-Grant';
+
+type ProgramDefinition = {
+  title: string;
+  pageUrl: string;
+  sourceUrl?: string;
+  marker: string;
+  markerOccurrence?: 'first' | 'last';
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+  deadline?: string;
+  applicationStatus?: GrantApplicationStatus;
+};
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Community Grants Program - Micro Grant',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    sourceUrl: `${COMMUNITY_GRANTS_URL}#micro-grant`,
+    marker: 'Community Grants Program',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Micro grant for amounts up to $1,000',
+      'open across the calendar year from 1 July 2026 until funds are expended',
+    ],
+    description: 'Supports smaller community projects through micro grants available across the 2026/27 funding year until funds are expended.',
+    categories: ['community'],
+    amount: { max: 1000 },
+    applicationStatus: 'upcoming',
+  },
+  {
+    title: 'Community Grants Program - Minor Grant',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    sourceUrl: `${COMMUNITY_GRANTS_URL}#minor-grant`,
+    marker: 'Community Grants Program',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Minor grant for amounts from $1,001 up to $10,000',
+      'close at 5pm on Wednesday 12 August 2026',
+    ],
+    description: 'Supports community projects through the minor grants stream of Toowoomba Regional Council’s community grants program.',
+    categories: ['community'],
+    amount: { min: 1001, max: 10000 },
+    deadline: '2026-08-12',
+  },
+  {
+    title: 'Community Grants Program - Major Grant',
+    pageUrl: COMMUNITY_GRANTS_URL,
+    sourceUrl: `${COMMUNITY_GRANTS_URL}#major-grant`,
+    marker: 'Community Grants Program',
+    markerOccurrence: 'last',
+    requiredSignals: [
+      'Major grant for amounts over $10,001',
+      'close at 5pm on Wednesday 12 August 2026',
+    ],
+    description: 'Supports larger community projects with additional co-contribution requirements through the major grants stream.',
+    categories: ['community'],
+    amount: { min: 10001 },
+    deadline: '2026-08-12',
+  },
+  {
+    title: 'Request for Sponsorship',
+    pageUrl: SPONSORSHIP_URL,
+    marker: 'Request for sponsorship',
+    requiredSignals: [
+      'Requests up to $4,999',
+      'Requests of $5,000 and above',
+      'Due to the number of successful submissions, available funding for the 2025/26 Sponsorship Program is very limited',
+    ],
+    description: 'Provides financial or in-kind sponsorship for events, projects, services, and activities that contribute to the liveability of the region.',
+    categories: ['community', 'enterprise'],
+  },
+  {
+    title: 'Shade Trees and Shrubs In-Kind Grant',
+    pageUrl: SHADE_TREES_URL,
+    marker: 'Shade trees and shrubs in-kind grant',
+    requiredSignals: [
+      'provides 30 free plants to eligible non-profit organisations each year',
+      'Plants are distributed during the months of February - March and October - November',
+    ],
+    description: 'Provides 30 free plants to eligible non-profit organisations, subject to nursery stock availability.',
+    categories: ['community', 'regenerative'],
+  },
+  {
+    title: 'Heritage Incentive Grant',
+    pageUrl: HERITAGE_URL,
+    marker: 'Heritage Incentive Grant',
+    requiredSignals: [
+      'We assess applications on an ongoing basis throughout the year',
+      'up to a maximum of $20,000 per project',
+    ],
+    description: 'Supports preservation and enhancement works for eligible heritage-listed buildings in the public realm.',
+    categories: ['arts', 'community'],
+    amount: { max: 20000 },
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string, markerOccurrence: 'first' | 'last' = 'first'): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&amp;/gi, '&')
+  );
+  const start = markerOccurrence === 'last' ? text.lastIndexOf(marker) : text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+
+  const endMarkers = ['Was this page helpful?', 'Back to top'];
+  let end = sliced.length;
+  for (const endMarker of endMarkers) {
+    const idx = sliced.indexOf(endMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(
+  url: string,
+  marker: string,
+  markerOccurrence: 'first' | 'last' = 'first'
+): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker, markerOccurrence);
+  } catch {
+    return null;
+  }
+}
+
+export function createToowoombaGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'toowoomba-grants',
+    name: 'Toowoomba Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[toowoomba-grants] Scraping Toowoomba Regional Council grants...');
+
+      const pageCache = new Map<string, string | null>();
+      let yielded = 0;
+
+      for (const definition of PROGRAMS) {
+        const cacheKey = `${definition.pageUrl}|${definition.marker}|${definition.markerOccurrence || 'first'}`;
+        if (!pageCache.has(cacheKey)) {
+          pageCache.set(
+            cacheKey,
+            await fetchPageText(definition.pageUrl, definition.marker, definition.markerOccurrence)
+          );
+        }
+
+        const text = pageCache.get(cacheKey);
+        if (!text) continue;
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Toowoomba Regional Council',
+          sourceUrl: definition.sourceUrl || definition.pageUrl,
+          amount: definition.amount,
+          deadline: definition.deadline,
+          applicationStatus: definition.applicationStatus,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'toowoomba-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[toowoomba-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/sources/whitsunday-grants.ts
+++ b/packages/grant-engine/src/sources/whitsunday-grants.ts
@@ -1,0 +1,185 @@
+/**
+ * Whitsunday Regional Council Grants Source Plugin
+ *
+ * Scrapes the live Whitsunday grants directory page and yields the current
+ * evergreen grant programs that are clearly described there.
+ */
+
+import type { DiscoveryQuery, RawGrant, SourcePlugin } from '../types';
+
+const BROWSER_UA = 'GrantScope/1.0 (research; contact@act.place)';
+
+const GRANTS_URL =
+  'https://www.whitsundayrc.qld.gov.au/Community-and-Environment/Our-Community/Grants-and-Community-Assistance';
+
+type ProgramDefinition = {
+  title: string;
+  sourceUrl: string;
+  marker: string;
+  endMarker?: string;
+  requiredSignals: string[];
+  description: string;
+  categories: string[];
+  amount?: { min?: number; max?: number };
+};
+
+const PROGRAMS: ProgramDefinition[] = [
+  {
+    title: 'Sport & Recreation Clubs Grant',
+    sourceUrl: `${GRANTS_URL}#sport-recreation-clubs-grant`,
+    marker: 'Sport & Recreation Clubs Grant',
+    endMarker: 'Facility Management Grant',
+    requiredSignals: [
+      'This is available to sport & recreation clubs with funding based on participation levels.',
+      'Available all year-round.',
+    ],
+    description:
+      'Provides year-round support to sport and recreation clubs in the Whitsunday region, with funding based on participation levels.',
+    categories: ['community', 'sport'],
+  },
+  {
+    title: 'Facility Management Grant',
+    sourceUrl: `${GRANTS_URL}#facility-management-grant`,
+    marker: 'Facility Management Grant',
+    endMarker: 'Special Projects Grant',
+    requiredSignals: [
+      'This is available to organisations that manage multi use sports facilities.',
+      'Conditions apply.',
+      'Available all year-round.',
+    ],
+    description:
+      'Provides year-round support for organisations that manage multi-use sports facilities in the Whitsunday region.',
+    categories: ['community', 'sport'],
+  },
+  {
+    title: 'Facade Improvement Incentive',
+    sourceUrl: `${GRANTS_URL}#facade-improvement-incentive`,
+    marker: 'Facade Improvement Incentive',
+    endMarker: 'Junior Elite Athlete Financial Support',
+    requiredSignals: [
+      'The purpose of the Facade Improvement Policy is to incentivise property and/or business owners',
+      'maximum Council contribution of $3000 may be granted',
+      'maximum Council contribution of $5000 may be granted',
+      'Facade Improvement Policy',
+      'Facade Improvement Application Form',
+    ],
+    description:
+      'Supports eligible shopfront improvements in key Whitsunday town centres through matched facade-improvement funding.',
+    categories: ['enterprise', 'community'],
+    amount: { max: 5000 },
+  },
+  {
+    title: 'Junior Elite Athlete Financial Support',
+    sourceUrl: `${GRANTS_URL}#junior-elite-athlete-financial-support`,
+    marker: 'Junior Elite Athlete Financial Support',
+    endMarker: 'Major Events and Conferences Sponsorship Program',
+    requiredSignals: [
+      'Financial support for a Junior Elite Athlete is available for all residents who are 18 years or younger',
+      'Applications must be received prior to the competition.',
+      'Applications for competitions that have already occurred will NOT be considered.',
+      'Financial Support for a Junior Elite Athlete - Application and Guidelines',
+    ],
+    description:
+      'Provides pre-competition financial support for eligible junior athletes representing North Queensland, Queensland, Australia, or equivalent levels.',
+    categories: ['sport', 'education'],
+  },
+];
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractPageText(html: string, marker: string, endMarker?: string): string {
+  const text = compressWhitespace(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;|&#160;/gi, ' ')
+      .replace(/&rsquo;|&#8217;/gi, "'")
+      .replace(/&amp;/gi, '&')
+  );
+
+  const start = text.indexOf(marker);
+  const sliced = start >= 0 ? text.slice(start) : text;
+  let end = sliced.length;
+
+  if (endMarker) {
+    const idx = sliced.indexOf(endMarker, marker.length);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  const fallbackEndMarkers = ['Was this page helpful?', 'Back to top'];
+  for (const fallbackEndMarker of fallbackEndMarkers) {
+    const idx = sliced.indexOf(fallbackEndMarker);
+    if (idx >= 0) end = Math.min(end, idx);
+  }
+
+  return compressWhitespace(sliced.slice(0, end));
+}
+
+async function fetchPageText(url: string, marker: string, endMarker?: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+
+    const html = await res.text();
+    return extractPageText(html, marker, endMarker);
+  } catch {
+    return null;
+  }
+}
+
+export function createWhitsundayGrantsPlugin(): SourcePlugin {
+  return {
+    id: 'whitsunday-grants',
+    name: 'Whitsunday Regional Council Grants',
+    type: 'scraper',
+    geography: ['AU-QLD'],
+
+    async *discover(query: DiscoveryQuery): AsyncGenerator<RawGrant> {
+      console.log('[whitsunday-grants] Scraping Whitsunday Regional Council grants...');
+
+      const pageCache = new Map<string, string | null>();
+      let yielded = 0;
+
+      for (const definition of PROGRAMS) {
+        const cacheKey = `${definition.marker}|${definition.endMarker || ''}`;
+        if (!pageCache.has(cacheKey)) {
+          pageCache.set(cacheKey, await fetchPageText(GRANTS_URL, definition.marker, definition.endMarker));
+        }
+
+        const text = pageCache.get(cacheKey);
+        if (!text) continue;
+        if (!definition.requiredSignals.every(signal => text.includes(signal))) continue;
+
+        const haystack = `${definition.title} ${definition.description} ${text}`.toLowerCase();
+        if (query.keywords?.length && !query.keywords.some(keyword => haystack.includes(keyword.toLowerCase()))) continue;
+        if (query.categories?.length) {
+          const queryLower = query.categories.map(cat => cat.toLowerCase());
+          if (!definition.categories.some(cat => queryLower.includes(cat))) continue;
+        }
+
+        yield {
+          title: definition.title,
+          provider: 'Whitsunday Regional Council',
+          sourceUrl: definition.sourceUrl,
+          amount: definition.amount,
+          description: definition.description,
+          categories: definition.categories,
+          sourceId: 'whitsunday-grants',
+          geography: ['AU-QLD'],
+        };
+        yielded++;
+      }
+
+      console.log(`[whitsunday-grants] Yielded ${yielded} grants`);
+    },
+  };
+}

--- a/packages/grant-engine/src/storage/repository.ts
+++ b/packages/grant-engine/src/storage/repository.ts
@@ -6,28 +6,124 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { CanonicalGrant, DiscoveryRunResult, ExistingGrantRecord } from '../types';
+import type { CanonicalGrant, DiscoveryRunResult, ExistingGrantRecord, GrantApplicationStatus, GrantSource } from '../types';
+
+const AUSTRALIA_TIME_ZONE = 'Australia/Brisbane';
+
+function todayInAustralia(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: AUSTRALIA_TIME_ZONE,
+  }).format(new Date());
+}
+
+function resolveGrantStatuses(
+  applicationStatus: GrantApplicationStatus | null | undefined,
+  closesAt: string | null | undefined,
+): { status: string; applicationStatus: string } {
+  if (applicationStatus === 'closed') {
+    return { status: 'closed', applicationStatus };
+  }
+
+  if (applicationStatus === 'upcoming') {
+    return { status: 'closed', applicationStatus };
+  }
+
+  if (applicationStatus === 'ongoing' || applicationStatus === 'unknown') {
+    return { status: applicationStatus, applicationStatus };
+  }
+
+  if (applicationStatus === 'open') {
+    return { status: 'open', applicationStatus };
+  }
+
+  if (!closesAt) {
+    return { status: 'open', applicationStatus: 'open' };
+  }
+
+  return closesAt < todayInAustralia()
+    ? { status: 'closed', applicationStatus: 'closed' }
+    : { status: 'open', applicationStatus: 'open' };
+}
+
+export function resolveCanonicalSourceIdentity(
+  existingSourceId: string | null | undefined,
+  incomingDiscoveryMethod: string | null | undefined,
+): { sourceId: string | null; discoveryMethod: string | null } {
+  const currentSourceId = existingSourceId?.trim() || null;
+  const incomingSourceId = incomingDiscoveryMethod?.trim() || null;
+  const canonicalSourceId = currentSourceId && !currentSourceId.includes('::duplicate::')
+    ? currentSourceId
+    : incomingSourceId;
+
+  return {
+    sourceId: canonicalSourceId ?? null,
+    discoveryMethod: canonicalSourceId ?? incomingSourceId ?? null,
+  };
+}
+
+function confidenceScore(confidence: GrantSource['confidence']): number {
+  if (confidence === 'verified') return 3;
+  if (confidence === 'scraped') return 2;
+  return 1;
+}
+
+function normalizeExistingSources(existingSources: unknown): GrantSource[] {
+  let parsedSources = existingSources;
+
+  if (typeof existingSources === 'string') {
+    try {
+      parsedSources = JSON.parse(existingSources);
+    } catch {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(parsedSources)) return [];
+
+  return parsedSources.filter((source): source is GrantSource => {
+    if (!source || typeof source !== 'object') return false;
+    const maybeSource = source as Partial<GrantSource>;
+    return typeof maybeSource.pluginId === 'string'
+      && typeof maybeSource.foundAt === 'string'
+      && (maybeSource.confidence === 'verified' || maybeSource.confidence === 'scraped' || maybeSource.confidence === 'llm_knowledge');
+  });
+}
+
+export function mergeGrantSources(existingSources: unknown, incomingSources: GrantSource[]): GrantSource[] {
+  const merged = new Map<string, GrantSource>();
+
+  for (const source of normalizeExistingSources(existingSources)) {
+    merged.set(source.pluginId, source);
+  }
+
+  for (const incomingSource of incomingSources) {
+    const existingSource = merged.get(incomingSource.pluginId);
+    if (!existingSource) {
+      merged.set(incomingSource.pluginId, incomingSource);
+      continue;
+    }
+
+    merged.set(incomingSource.pluginId, {
+      pluginId: incomingSource.pluginId,
+      foundAt: new Date(incomingSource.foundAt) > new Date(existingSource.foundAt)
+        ? incomingSource.foundAt
+        : existingSource.foundAt,
+      rawUrl: existingSource.rawUrl || incomingSource.rawUrl,
+      confidence: confidenceScore(incomingSource.confidence) >= confidenceScore(existingSource.confidence)
+        ? incomingSource.confidence
+        : existingSource.confidence,
+    });
+  }
+
+  return [...merged.values()];
+}
 
 export class GrantRepository {
   constructor(private supabase: SupabaseClient) {}
 
-  /**
-   * Get existing grants for dedup comparison.
-   */
-  async getExistingGrants(): Promise<ExistingGrantRecord[]> {
-    const { data, error } = await this.supabase
-      .from('grant_opportunities')
-      .select('url, name');
-
-    if (error) throw new Error(`Failed to fetch existing grants: ${error.message}`);
-    return (data || []) as ExistingGrantRecord[];
-  }
-
-  /**
-   * Upsert a canonical grant. Returns true if inserted (new), false if skipped.
-   */
-  async upsertGrant(grant: CanonicalGrant): Promise<'inserted' | 'updated' | 'skipped'> {
-    const row = {
+  private buildGrantRow(grant: CanonicalGrant) {
+    const statuses = resolveGrantStatuses(grant.applicationStatus, grant.closesAt);
+    return {
       name: grant.name,
       provider: grant.provider,
       program: grant.program,
@@ -37,14 +133,146 @@ export class GrantRepository {
       closes_at: grant.closesAt,
       url: grant.url,
       categories: grant.categories,
-      sources: JSON.stringify(grant.sources),
+      sources: grant.sources,
       discovery_method: grant.discoveryMethod,
+      source_id: grant.discoveryMethod || null,
       last_verified_at: grant.sources.some(s => s.confidence === 'verified')
         ? new Date().toISOString()
         : null,
       discovered_by: 'grant_engine',
       source: grant.discoveryMethod || 'grant_engine',
+      application_status: statuses.applicationStatus,
+      status: statuses.status,
     };
+  }
+
+  private buildGrantUpdateRow(
+    grant: CanonicalGrant,
+    existingClosesAt: string | null = null,
+    existingSourceId: string | null = null,
+    existingSources: unknown = null,
+  ): Record<string, unknown> {
+    const statuses = resolveGrantStatuses(grant.applicationStatus, grant.closesAt);
+    const sourceIdentity = resolveCanonicalSourceIdentity(existingSourceId, grant.discoveryMethod);
+    const mergedSources = mergeGrantSources(existingSources, grant.sources);
+    const updateRow: Record<string, unknown> = {
+      sources: mergedSources,
+      discovery_method: sourceIdentity.discoveryMethod,
+      source_id: sourceIdentity.sourceId,
+      last_verified_at: new Date().toISOString(),
+      application_status: statuses.applicationStatus,
+      status: statuses.status,
+    };
+    if (grant.description) updateRow.description = grant.description;
+    if (grant.closesAt) updateRow.closes_at = grant.closesAt;
+    if (!grant.closesAt && existingClosesAt && existingClosesAt < todayInAustralia() && statuses.applicationStatus === 'open') {
+      updateRow.closes_at = null;
+    }
+    return updateRow;
+  }
+
+  async updateExistingGrant(grant: CanonicalGrant): Promise<'updated' | 'skipped'> {
+    if (!grant.url) return 'skipped';
+    const { data: existingGrant, error: existingError } = await this.supabase
+      .from('grant_opportunities')
+      .select('id, closes_at, source_id, sources')
+      .eq('url', grant.url)
+      .neq('status', 'duplicate')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (existingError) {
+      console.error(`Failed to load existing grant "${grant.name}": ${existingError.message}`);
+      return 'skipped';
+    }
+
+    if (!existingGrant?.id) {
+      console.error(`Failed to locate canonical existing grant "${grant.name}" for URL update`);
+      return 'skipped';
+    }
+
+    const updateRow = this.buildGrantUpdateRow(
+      grant,
+      existingGrant.closes_at ?? null,
+      existingGrant.source_id ?? null,
+      existingGrant.sources ?? null,
+    );
+
+    const { error, count } = await this.supabase
+      .from('grant_opportunities')
+      .update(updateRow, { count: 'exact' })
+      .eq('id', existingGrant.id);
+
+    if (error) {
+      console.error(`Failed to update existing grant "${grant.name}": ${error.message}`);
+      return 'skipped';
+    }
+
+    return count && count > 0 ? 'updated' : 'skipped';
+  }
+
+  /**
+   * Mark abandoned runs as failed so run history reflects reality.
+   */
+  async cleanupStaleRuns(maxAgeMs = 6 * 60 * 60 * 1000): Promise<number> {
+    const cutoffIso = new Date(Date.now() - maxAgeMs).toISOString();
+    const { data, error } = await this.supabase
+      .from('grant_discovery_runs')
+      .select('id')
+      .eq('status', 'running')
+      .is('completed_at', null)
+      .lt('started_at', cutoffIso);
+
+    if (error) throw new Error(`Failed to fetch stale discovery runs: ${error.message}`);
+    if (!data?.length) return 0;
+
+    const completedAt = new Date().toISOString();
+    const hours = Math.round(maxAgeMs / (60 * 60 * 1000));
+    const staleIds = data.map(row => row.id);
+    const { error: updateError } = await this.supabase
+      .from('grant_discovery_runs')
+      .update({
+        completed_at: completedAt,
+        status: 'failed',
+        errors: [{ source: 'system', error: `Marked stale after exceeding ${hours}h without completion` }],
+      })
+      .in('id', staleIds);
+
+    if (updateError) throw new Error(`Failed to close stale discovery runs: ${updateError.message}`);
+    return staleIds.length;
+  }
+
+  /**
+   * Get existing grants for dedup comparison.
+   */
+  async getExistingGrants(): Promise<ExistingGrantRecord[]> {
+    const pageSize = 1000;
+    const rows: ExistingGrantRecord[] = [];
+    let from = 0;
+
+    while (true) {
+      const { data, error } = await this.supabase
+        .from('grant_opportunities')
+        .select('url, name')
+        .order('id', { ascending: true })
+        .range(from, from + pageSize - 1);
+
+      if (error) throw new Error(`Failed to fetch existing grants: ${error.message}`);
+      const batch = (data || []) as ExistingGrantRecord[];
+      rows.push(...batch);
+      if (batch.length < pageSize) break;
+      from += pageSize;
+    }
+
+    return rows;
+  }
+
+  /**
+   * Upsert a canonical grant. Returns true if inserted (new), false if skipped.
+   */
+  async upsertGrant(grant: CanonicalGrant): Promise<'inserted' | 'updated' | 'skipped'> {
+    const row = this.buildGrantRow(grant);
 
     // Try insert first
     const { error } = await this.supabase
@@ -58,20 +286,7 @@ export class GrantRepository {
 
     // Duplicate URL — try to update with new source info
     if (error.code === '23505' && grant.url) {
-      const updateRow: Record<string, unknown> = {
-          sources: JSON.stringify(grant.sources),
-          discovery_method: grant.discoveryMethod,
-          last_verified_at: new Date().toISOString(),
-        };
-      // Backfill description and geography if missing
-      if (grant.description) updateRow.description = grant.description;
-
-      const { error: updateError } = await this.supabase
-        .from('grant_opportunities')
-        .update(updateRow)
-        .eq('url', grant.url);
-
-      if (!updateError) return 'updated';
+      return this.updateExistingGrant(grant);
     }
 
     return 'skipped';

--- a/packages/grant-engine/src/types.ts
+++ b/packages/grant-engine/src/types.ts
@@ -27,6 +27,10 @@ export interface DiscoveryRunStats {
   durationMs: number;
 }
 
+export type DiscoveryEvent =
+  | { kind: 'grant'; grant: RawGrant; stats: DiscoveryRunStats }
+  | { kind: 'source-complete'; stats: DiscoveryRunStats };
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // GRANTS
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -38,12 +42,15 @@ export interface RawGrant {
   sourceUrl?: string;
   amount?: { min?: number; max?: number };
   deadline?: string;          // any parseable date string
+  applicationStatus?: GrantApplicationStatus;
   description?: string;
   categories?: string[];
   program?: string;
   geography?: string[];       // e.g. ['AU', 'AU-QLD']
   sourceId: string;           // which plugin found this
 }
+
+export type GrantApplicationStatus = 'open' | 'closed' | 'ongoing' | 'upcoming' | 'unknown';
 
 /** Normalized grant ready for storage */
 export interface CanonicalGrant {
@@ -58,6 +65,7 @@ export interface CanonicalGrant {
   description: string | null;
   categories: string[];
   geography: string[];
+  applicationStatus: GrantApplicationStatus | null;
   sources: GrantSource[];
   discoveryMethod: string;
   dedupKey: string;           // lowercase(provider):lowercase(name)
@@ -128,6 +136,7 @@ export interface DiscoveryRunResult {
   startedAt: string;
   completedAt: string;
   sourcesUsed: string[];
+  sourceStats: DiscoveryRunStats[];
   grantsDiscovered: number;
   grantsNew: number;
   grantsUpdated: number;

--- a/packages/grant-engine/tests/cityofsydney-grants.contract.test.ts
+++ b/packages/grant-engine/tests/cityofsydney-grants.contract.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { createCityOfSydneyGrantsPlugin } from '../src/sources/cityofsydney-grants';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function htmlPage({ title, description, h1, body }: { title?: string; description?: string; h1: string; body: string }) {
+  return `<!doctype html>
+    <html>
+      <head>
+        ${title ? `<title>${title}</title>` : ''}
+        ${description ? `<meta name="description" content="${description}">` : ''}
+      </head>
+      <body>
+        <main>
+          <h1>${h1}</h1>
+          <p>${body}</p>
+        </main>
+      </body>
+    </html>`;
+}
+
+function mockCityOfSydneyFetch() {
+  const pages = new Map<string, string>([
+    ['https://www.cityofsydney.nsw.gov.au/grants-sponsorships', htmlPage({
+      h1: 'Grants and sponsorships',
+      body: `
+        <a href="/community-support-funding">Community support & funding</a>
+        <a href="/cultural-support-funding/future-cultural-grant">Future Cultural Grant</a>
+        <a href="/cultural-support-funding/dixon-street-improvement-grant">Dixon Street improvement grant</a>
+        <a href="/cultural-support-funding/short-term-empty-properties-program">Short-term empty properties program</a>
+      `,
+    })],
+    ['https://www.cityofsydney.nsw.gov.au/community-support-funding', htmlPage({
+      description: 'Support for community wellbeing.',
+      h1: 'Community support & funding',
+      body: 'This page lists funding streams and support options for community organisations.',
+    })],
+    ['https://www.cityofsydney.nsw.gov.au/cultural-support-funding', htmlPage({
+      description: 'Support for culture and creativity.',
+      h1: 'Cultural support & funding',
+      body: 'This page lists cultural funding opportunities and support programs.',
+    })],
+    ['https://www.cityofsydney.nsw.gov.au/cultural-support-funding/future-cultural-grant', htmlPage({
+      description: 'Applications open for the next cultural grant round.',
+      h1: 'Future Cultural Grant',
+      body: 'Funding is available. Applications close 31 December 2026. Eligible organisations may apply for up to $25,000.',
+    })],
+    ['https://www.cityofsydney.nsw.gov.au/cultural-support-funding/dixon-street-improvement-grant', htmlPage({
+      description: 'Legacy grant round.',
+      h1: 'Dixon Street improvement grant',
+      body: 'Funding is available. Applications close 9 July 2024. Eligible organisations may apply for up to $60,000.',
+    })],
+    ['https://www.cityofsydney.nsw.gov.au/cultural-support-funding/short-term-empty-properties-program', htmlPage({
+      description: 'Temporary occupancy of under-used properties.',
+      h1: 'Short-term empty properties program',
+      body: 'The program provides immediate and short-term occupancy of temporarily vacant or under-used properties within our portfolio.',
+    })],
+  ]);
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const page = pages.get(url);
+    if (!page) {
+      return {
+        ok: false,
+        status: 404,
+        text: async () => 'not found',
+      } as Response;
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      text: async () => page,
+    } as Response;
+  }) as typeof fetch;
+}
+
+async function collectOpenTitles() {
+  const plugin = createCityOfSydneyGrantsPlugin();
+  const grants = [];
+
+  for await (const grant of plugin.discover({ status: 'open' })) {
+    grants.push(grant);
+  }
+
+  return grants;
+}
+
+test('cityofsydney-grants excludes landing pages, generic programs, and past-deadline rounds from open discovery', async () => {
+  mockCityOfSydneyFetch();
+
+  const grants = await collectOpenTitles();
+
+  assert.deepEqual(
+    grants.map((grant) => grant.title),
+    ['Future Cultural Grant'],
+  );
+  assert.equal(grants[0]?.applicationStatus, 'open');
+  assert.equal(grants[0]?.deadline, '31 December 2026');
+});

--- a/packages/grant-engine/tests/nsw-grants.contract.test.ts
+++ b/packages/grant-engine/tests/nsw-grants.contract.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { createNSWGrantsPlugin } from '../src/sources/nsw-grants';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockFetchWithHits(hits: Array<Record<string, unknown>>) {
+  globalThis.fetch = (async () => ({
+    ok: true,
+    json: async () => ({
+      hits: {
+        total: { value: hits.length },
+        hits: hits.map((_source) => ({ _source })),
+      },
+    }),
+  })) as typeof fetch;
+}
+
+async function collectTitles(status: 'open' | 'all') {
+  const plugin = createNSWGrantsPlugin();
+  const grants = [];
+
+  for await (const grant of plugin.discover({ status })) {
+    grants.push(grant);
+  }
+
+  return grants;
+}
+
+test('nsw-grants excludes past-deadline grants when open grants are requested', async () => {
+  mockFetchWithHits([
+    {
+      title: 'Past Grant',
+      url: '/grants-and-funding/past-grant',
+      field_summary: 'Closed grant round',
+      grant_dates_end: '2025-01-10',
+      agency_name: 'Create NSW',
+    },
+    {
+      title: 'Future Grant',
+      url: '/grants-and-funding/future-grant',
+      field_summary: 'Current open grant round',
+      grant_dates_end: '2026-12-10',
+      agency_name: 'Create NSW',
+    },
+    {
+      title: 'Rolling Grant',
+      url: '/grants-and-funding/rolling-grant',
+      field_summary: 'Rolling program',
+      grant_is_ongoing: true,
+      agency_name: 'Create NSW',
+    },
+  ]);
+
+  const grants = await collectTitles('open');
+  assert.deepEqual(
+    grants.map((grant) => grant.title),
+    ['Future Grant', 'Rolling Grant'],
+  );
+  assert.equal(grants[0]?.applicationStatus, 'open');
+  assert.equal(grants[1]?.applicationStatus, 'ongoing');
+  assert.equal(grants[1]?.deadline, undefined);
+});
+
+test('nsw-grants still exposes closed rounds when all grants are requested', async () => {
+  mockFetchWithHits([
+    {
+      title: 'Past Grant',
+      url: '/grants-and-funding/past-grant',
+      field_summary: 'Closed grant round',
+      grant_dates_end: '2025-01-10',
+      agency_name: 'Create NSW',
+    },
+    {
+      title: 'Future Grant',
+      url: '/grants-and-funding/future-grant',
+      field_summary: 'Current open grant round',
+      grant_dates_end: '2026-12-10',
+      agency_name: 'Create NSW',
+    },
+  ]);
+
+  const grants = await collectTitles('all');
+  assert.equal(grants.length, 2);
+
+  const pastGrant = grants.find((grant) => grant.title === 'Past Grant');
+  const futureGrant = grants.find((grant) => grant.title === 'Future Grant');
+
+  assert.equal(pastGrant?.applicationStatus, 'closed');
+  assert.equal(futureGrant?.applicationStatus, 'open');
+});

--- a/packages/grant-engine/tests/repository-source-identity.test.ts
+++ b/packages/grant-engine/tests/repository-source-identity.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mergeGrantSources, resolveCanonicalSourceIdentity } from '../src/storage/repository';
+
+test('preserves an existing canonical source id over a new discovery method', () => {
+  assert.deepEqual(
+    resolveCanonicalSourceIdentity('qld-grants', 'web-search'),
+    { sourceId: 'qld-grants', discoveryMethod: 'qld-grants' },
+  );
+});
+
+test('adopts the incoming discovery method when no source id exists yet', () => {
+  assert.deepEqual(
+    resolveCanonicalSourceIdentity(null, 'web-search'),
+    { sourceId: 'web-search', discoveryMethod: 'web-search' },
+  );
+});
+
+test('ignores duplicate shadow ids when choosing the canonical source key', () => {
+  assert.deepEqual(
+    resolveCanonicalSourceIdentity('qld-grants::duplicate::abc', 'qld-grants'),
+    { sourceId: 'qld-grants', discoveryMethod: 'qld-grants' },
+  );
+});
+
+test('merges existing and incoming grant sources without losing provenance', () => {
+  const merged = mergeGrantSources(
+    [{ pluginId: 'web-search', foundAt: '2026-04-24T00:00:00.000Z', rawUrl: 'https://example.com/a', confidence: 'verified' }],
+    [{ pluginId: 'qld-grants', foundAt: '2026-04-24T01:00:00.000Z', rawUrl: 'https://example.com/b', confidence: 'scraped' }],
+  );
+
+  assert.deepEqual(
+    merged,
+    [
+      { pluginId: 'web-search', foundAt: '2026-04-24T00:00:00.000Z', rawUrl: 'https://example.com/a', confidence: 'verified' },
+      { pluginId: 'qld-grants', foundAt: '2026-04-24T01:00:00.000Z', rawUrl: 'https://example.com/b', confidence: 'scraped' },
+    ],
+  );
+});
+
+test('prefers stronger and newer provenance when the same plugin is seen again', () => {
+  const merged = mergeGrantSources(
+    [{ pluginId: 'web-search', foundAt: '2026-04-24T00:00:00.000Z', rawUrl: 'https://example.com/a', confidence: 'llm_knowledge' }],
+    [{ pluginId: 'web-search', foundAt: '2026-04-24T02:00:00.000Z', rawUrl: 'https://example.com/b', confidence: 'verified' }],
+  );
+
+  assert.deepEqual(
+    merged,
+    [
+      { pluginId: 'web-search', foundAt: '2026-04-24T02:00:00.000Z', rawUrl: 'https://example.com/a', confidence: 'verified' },
+    ],
+  );
+});
+
+test('parses existing JSON string sources before merging', () => {
+  const merged = mergeGrantSources(
+    '[{"pluginId":"web-search","foundAt":"2026-04-24T00:00:00.000Z","rawUrl":"https://example.com/a","confidence":"verified"}]',
+    [{ pluginId: 'qld-grants', foundAt: '2026-04-24T03:00:00.000Z', rawUrl: 'https://example.com/b', confidence: 'verified' }],
+  );
+
+  assert.deepEqual(
+    merged,
+    [
+      { pluginId: 'web-search', foundAt: '2026-04-24T00:00:00.000Z', rawUrl: 'https://example.com/a', confidence: 'verified' },
+      { pluginId: 'qld-grants', foundAt: '2026-04-24T03:00:00.000Z', rawUrl: 'https://example.com/b', confidence: 'verified' },
+    ],
+  );
+});


### PR DESCRIPTION
## Summary

Two coupled changes that ship together because the new sources rely on the new event format.

**1. Discovery event refactor** — `SourceRegistry.discoverAll()` now yields a discriminated `DiscoveryEvent` union (`{kind: 'grant', ...} | {kind: 'source-complete', ...}`) instead of a raw `{grant, stats}` tuple. Updated:
- `src/sources/registry.ts`
- `src/types.ts`
- `src/engine.ts`, `src/index.ts`, `src/normalizer.ts`, `src/storage/repository.ts`
- `src/agents/grant-monitor.ts`
- Existing sources updated to emit the new event shape: `grantconnect.ts`, `nsw-grants.ts`, `qld-grants.ts`

**2. 16 new local-government grant sources** — Brisbane City, Central Highlands, Charters Towers, City of Sydney, Cookshire, Darwin City, Fraser Coast, Lockyer Valley, Logan City, Noosa, Redland City, Scenic Rim, Sunshine Coast, Tablelands, Toowoomba, Whitsunday.

Plus 3 new contract tests:
- `tests/cityofsydney-grants.contract.test.ts`
- `tests/nsw-grants.contract.test.ts`
- `tests/repository-source-identity.test.ts`

Carved from the working-tree snapshot (2026-04-24).

## Test plan

- [x] `cd packages/grant-engine && npx tsc --noEmit` produces same 9 pre-existing errors as `origin/main` (zero new errors introduced)
- [ ] Run contract tests: `cd packages/grant-engine && npm run test:contracts`
- [ ] Smoke discovery against one new source (e.g. `cityofsydney`) end-to-end through `engine.discoverFromSource()`
- [ ] Verify repository writes grants with the new identity reconciliation logic

## Notes

- The 9 pre-existing typecheck errors in `minimax.ts`, `grant-monitor.ts`, `enrichment-free.ts`, `foundation-profiler.ts` are inherited from `origin/main` and need a separate cleanup PR (`.ts` import extensions + 2 `unknown` type narrows).