### PR TITLE
feat(data-api): board-power, catalog, rankings routes

### DIFF
--- a/apps/web/src/app/api/data/board-power/route.ts
+++ b/apps/web/src/app/api/data/board-power/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getServiceSupabase } from '@/lib/supabase';
+import { esc, whitelist } from '@/lib/sql';
+import { rateLimit } from '@/lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const limiter = rateLimit();
+
+const SORTS = ['board_seats', 'total_org_revenue', 'total_org_assets', 'total_org_fte'] as const;
+
+const schema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  sort: z.string().optional(),
+  min_seats: z.coerce.number().int().min(2).max(100).optional().default(2),
+  q: z.string().max(100).optional(),
+});
+
+export async function GET(request: Request) {
+  const limited = limiter(request);
+  if (limited) return limited;
+
+  const { searchParams } = new URL(request.url);
+  const parsed = schema.safeParse(Object.fromEntries(searchParams));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 });
+
+  const { limit, offset, min_seats, q } = parsed.data;
+  const safeSort = whitelist(parsed.data.sort ?? null, SORTS, 'board_seats');
+
+  try {
+    const supabase = getServiceSupabase();
+    const conditions: string[] = [`board_seats >= ${min_seats}`];
+
+    if (q) conditions.push(`person_name ILIKE '%${esc(q)}%'`);
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+
+    const [{ data, error }, { data: countData, error: countErr }] = await Promise.all([
+      supabase.rpc('exec_sql', {
+        query: `SELECT person_name, board_seats,
+                  total_org_revenue::bigint, total_org_assets::bigint, total_org_fte::numeric(10,1),
+                  organizations[1:5] as top_organizations,
+                  array_length(organizations, 1) as org_count,
+                  sectors, states
+           FROM mv_board_power
+           ${whereClause}
+           ORDER BY ${safeSort} DESC NULLS LAST
+           LIMIT ${limit} OFFSET ${offset}`,
+      }),
+      supabase.rpc('exec_sql', {
+        query: `SELECT COUNT(*)::int as total FROM mv_board_power ${whereClause}`,
+      }),
+    ]);
+
+    if (error) throw error;
+    if (countErr) throw countErr;
+
+    const total = (countData as Array<{ total: number }>)?.[0]?.total ?? 0;
+
+    const response = NextResponse.json({ results: data || [], total, limit, offset });
+    response.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+    return response;
+  } catch (error) {
+    console.error('Board power error:', error);
+    return NextResponse.json({ error: 'Failed to fetch board power data' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/data/catalog/route.ts
+++ b/apps/web/src/app/api/data/catalog/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+type CatalogRow = {
+  table_name: string;
+  domain: string;
+  owner_team: string;
+  description: string | null;
+  source_of_truth: boolean;
+  pii_level: string;
+  sla_hours: number;
+  freshness_key: string | null;
+  provenance_field: string | null;
+  confidence_field: string | null;
+  active: boolean;
+  snapshot_at: string | null;
+  row_count: number | null;
+  freshness_hours: number | null;
+  provenance_coverage_pct: number | null;
+  confidence_coverage_pct: number | null;
+};
+
+function computeStatus(row: CatalogRow): 'fresh' | 'warning' | 'stale' | 'unknown' | 'no_snapshot' {
+  if (!row.snapshot_at) return 'no_snapshot';
+  if (row.freshness_hours === null || Number.isNaN(Number(row.freshness_hours))) return 'unknown';
+  if (row.freshness_hours <= row.sla_hours) return 'fresh';
+  if (row.freshness_hours <= row.sla_hours * 1.5) return 'warning';
+  return 'stale';
+}
+
+export async function GET(request: Request) {
+  try {
+    const db = getServiceSupabase();
+    const { searchParams } = new URL(request.url);
+
+    const domain = searchParams.get('domain');
+    const ownerTeam = searchParams.get('owner_team');
+    const active = searchParams.get('active');
+    const staleOnly = searchParams.get('stale') === 'true';
+
+    let query = db
+      .from('v_data_catalog_latest')
+      .select('*')
+      .order('domain', { ascending: true })
+      .order('table_name', { ascending: true });
+
+    if (domain) query = query.eq('domain', domain);
+    if (ownerTeam) query = query.eq('owner_team', ownerTeam);
+    if (active === 'true') query = query.eq('active', true);
+    if (active === 'false') query = query.eq('active', false);
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json(
+        {
+          error: 'Failed to load data catalog',
+          detail: error.message,
+        },
+        { status: 500 },
+      );
+    }
+
+    const rows = ((data ?? []) as CatalogRow[]).map((row) => ({
+      ...row,
+      status: computeStatus(row),
+    }));
+
+    const filtered = staleOnly ? rows.filter((row) => row.status === 'stale') : rows;
+    const summary = {
+      total: filtered.length,
+      fresh: filtered.filter((row) => row.status === 'fresh').length,
+      warning: filtered.filter((row) => row.status === 'warning').length,
+      stale: filtered.filter((row) => row.status === 'stale').length,
+      unknown: filtered.filter((row) => row.status === 'unknown').length,
+      no_snapshot: filtered.filter((row) => row.status === 'no_snapshot').length,
+      by_domain: filtered.reduce<Record<string, number>>((acc, row) => {
+        acc[row.domain] = (acc[row.domain] ?? 0) + 1;
+        return acc;
+      }, {}),
+    };
+
+    const response = NextResponse.json({
+      captured_at: new Date().toISOString(),
+      summary,
+      rows: filtered,
+    });
+
+    response.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+    response.headers.set('Access-Control-Allow-Origin', '*');
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      {
+        error: 'Unexpected catalog error',
+        detail: message,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/data/data-health/route.ts
+++ b/apps/web/src/app/api/data/data-health/route.ts
@@ -45,7 +45,11 @@ export async function GET() {
       grantOpCount,
       // 6. Contract coverage
       contractStatsResult,
-      // 7. Agent health
+      // 7. Grant semantics health
+      grantSemanticsResult,
+      // 8. Grant source identity health
+      sourceIdentityResult,
+      // 9. Agent health
       agentHealthResult,
     ] = await Promise.all([
       // Entity stats
@@ -128,6 +132,37 @@ export async function GET() {
           ROUND(COUNT(supplier_abn)::numeric / NULLIF(COUNT(*), 0) * 100, 1) as abn_pct
         FROM austender_contracts`,
       })),
+      // Grant semantics health
+      safe(db.rpc('exec_sql', {
+        query: `SELECT
+          COUNT(*) FILTER (WHERE status IS NULL) as status_null,
+          COUNT(*) FILTER (WHERE application_status IS NULL) as application_status_null,
+          COUNT(*) FILTER (WHERE status = 'open' AND closes_at < CURRENT_DATE) as open_past_deadline,
+          COUNT(*) FILTER (WHERE source = 'ghl_sync' AND status = 'unknown') as ghl_unknown
+        FROM grant_opportunities`,
+      })),
+      // Grant source identity health
+      safe(db.rpc('exec_sql', {
+        query: `SELECT
+          COUNT(*) FILTER (
+            WHERE discovered_by = 'grant_engine'
+              AND COALESCE(discovery_method, '') <> ''
+              AND COALESCE(source_id, '') = ''
+          ) as blank_source_id,
+          COUNT(*) FILTER (
+            WHERE discovered_by = 'grant_engine'
+              AND COALESCE(discovery_method, '') <> ''
+              AND COALESCE(source_id, '') <> ''
+              AND source_id NOT LIKE '%::duplicate::%'
+              AND source_id <> discovery_method
+          ) as canonical_mismatch,
+          COUNT(*) FILTER (
+            WHERE discovered_by = 'grant_engine'
+              AND source_id LIKE '%::duplicate::%'
+              AND status = 'duplicate'
+          ) as duplicate_shadows
+        FROM grant_opportunities`,
+      })),
       // Agent health: latest run per agent
       safe(db.rpc('exec_sql', {
         query: `SELECT DISTINCT ON (agent_name)
@@ -157,6 +192,8 @@ export async function GET() {
     const foundationStats = parseFirst(foundationStatsResult);
     const grantOps = parseFirst(grantOpCount);
     const contractStats = parseFirst(contractStatsResult);
+    const grantSemantics = parseFirst(grantSemanticsResult);
+    const sourceIdentity = parseFirst(sourceIdentityResult);
     const agentHealth = parse(agentHealthResult);
 
     const response = NextResponse.json({
@@ -199,6 +236,17 @@ export async function GET() {
         total: Number(contractStats.total ?? 0),
         with_abn: Number(contractStats.with_abn ?? 0),
         abn_pct: Number(contractStats.abn_pct ?? 0),
+      },
+      grant_semantics: {
+        status_null: Number(grantSemantics.status_null ?? 0),
+        application_status_null: Number(grantSemantics.application_status_null ?? 0),
+        open_past_deadline: Number(grantSemantics.open_past_deadline ?? 0),
+        ghl_unknown: Number(grantSemantics.ghl_unknown ?? 0),
+      },
+      source_identity: {
+        blank_source_id: Number(sourceIdentity.blank_source_id ?? 0),
+        canonical_mismatch: Number(sourceIdentity.canonical_mismatch ?? 0),
+        duplicate_shadows: Number(sourceIdentity.duplicate_shadows ?? 0),
       },
       agents: agentHealth,
     });

--- a/apps/web/src/app/api/data/rankings/route.ts
+++ b/apps/web/src/app/api/data/rankings/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getServiceSupabase } from '@/lib/supabase';
+import { esc, whitelist } from '@/lib/sql';
+import { rateLimit } from '@/lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const limiter = rateLimit();
+
+const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'ACT', 'NT'] as const;
+const SORTS = [
+  'score_composite', 'revenue', 'cagr', 'fte', 'volunteers',
+  'vol_fte_ratio', 'rev_per_fte', 'network_connections', 'expenses', 'assets',
+  'score_revenue', 'score_growth', 'score_leverage', 'score_efficiency', 'score_network', 'score_health',
+] as const;
+const SIZES = ['Small', 'Medium', 'Large'] as const;
+
+const schema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  sort: z.string().optional(),
+  state: z.string().optional(),
+  size: z.string().optional(),
+  type: z.string().max(50).optional(),
+  cc: z.string().optional(),
+  q: z.string().max(100).optional(),
+  abn: z.string().max(11).optional(),
+});
+
+export async function GET(request: Request) {
+  const limited = limiter(request);
+  if (limited) return limited;
+
+  const { searchParams } = new URL(request.url);
+  const parsed = schema.safeParse(Object.fromEntries(searchParams));
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 });
+
+  const { limit, offset, type, cc, q, abn } = parsed.data;
+  const safeSort = whitelist(parsed.data.sort ?? null, SORTS, 'score_composite');
+  const safeState = whitelist(parsed.data.state?.toUpperCase() ?? null, STATES, null as unknown as typeof STATES[number]);
+  const safeSize = whitelist(parsed.data.size ?? null, SIZES, null as unknown as typeof SIZES[number]);
+
+  try {
+    const supabase = getServiceSupabase();
+    const conditions: string[] = [];
+
+    if (safeState) conditions.push(`state = '${safeState}'`);
+    if (safeSize) conditions.push(`charity_size = '${safeSize}'`);
+    if (type) conditions.push(`entity_type = '${esc(type)}'`);
+    if (cc === 'true') conditions.push(`is_community_controlled = true`);
+    if (q) conditions.push(`name ILIKE '%${esc(q)}%'`);
+
+    // Single-entity lookup by ABN
+    if (abn) {
+      const { data, error } = await supabase.rpc('exec_sql', {
+        query: `SELECT * FROM mv_charity_rankings WHERE abn = '${esc(abn)}' LIMIT 1`,
+      });
+      if (error) throw error;
+      return NextResponse.json({ result: (data as unknown[])?.[0] ?? null });
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sortDir = ['cagr'].includes(safeSort) ? 'DESC NULLS LAST' : 'DESC NULLS LAST';
+
+    const [{ data, error }, { data: countData, error: countErr }] = await Promise.all([
+      supabase.rpc('exec_sql', {
+        query: `SELECT abn, name, gs_id, entity_type, sector, state, charity_size,
+                  is_community_controlled,
+                  revenue::bigint, expenses::bigint, assets::bigint,
+                  fte, volunteers, vol_fte_ratio::numeric(10,1), rev_per_fte::bigint,
+                  cagr::numeric(10,1), network_connections,
+                  score_composite, score_revenue::numeric(10,1), score_growth::numeric(10,1),
+                  score_leverage::numeric(10,1), score_efficiency::numeric(10,1),
+                  score_network::numeric(10,1), score_health::numeric(10,1),
+                  rank_composite, rank_revenue, rank_growth, total_ranked
+           FROM mv_charity_rankings
+           ${whereClause}
+           ORDER BY ${safeSort} ${sortDir}
+           LIMIT ${limit} OFFSET ${offset}`,
+      }),
+      supabase.rpc('exec_sql', {
+        query: `SELECT COUNT(*)::int as total FROM mv_charity_rankings ${whereClause}`,
+      }),
+    ]);
+
+    if (error) throw error;
+    if (countErr) throw countErr;
+
+    const total = (countData as Array<{ total: number }>)?.[0]?.total ?? 0;
+
+    const response = NextResponse.json({ results: data || [], total, limit, offset });
+    response.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+    return response;
+  } catch (error) {
+    console.error('Rankings error:', error);
+    return NextResponse.json({ error: 'Failed to fetch rankings' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/data/route.ts
+++ b/apps/web/src/app/api/data/route.ts
@@ -84,6 +84,7 @@ export async function GET(request: Request) {
       },
       health: '/api/data/health',
       export: '/api/data/export?type=foundations&format=csv',
+      catalog: '/api/data/catalog',
       docs: 'All endpoints support limit, offset, and format (json/csv) params.',
     }));
   }


### PR DESCRIPTION
## Summary
- Adds three public data sub-routes: \`/api/data/board-power\`, \`/api/data/catalog\`, \`/api/data/rankings\`
- Enriches \`/api/data\` and \`/api/data/data-health\` with additional facets aligned to \`mv_entity_power_index\` and \`mv_person_influence\`

Part of the post-Goods V1 dirty-tree carve program (phase 2, bucket: data-api).

## Test plan
- [x] typecheck clean (\`cd apps/web && npx tsc --noEmit\`)
- [ ] CI green (type check, unit/integration, e2e, Vercel preview)
- [ ] Spot-check \`/api/data/catalog\` returns dataset list
- [ ] Spot-check \`/api/data/rankings\` returns top entities by power_score