### PR TITLE
feat(auth): /auth/signup and /continue routes

### DIFF
--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation';
+
+function buildRegisterUrl(searchParams: Record<string, string | string[] | undefined>) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === 'string') {
+      params.set(key, value);
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        params.append(key, item);
+      }
+    }
+  }
+
+  const query = params.toString();
+  return query ? `/register?${query}` : '/register';
+}
+
+export default async function SignupAliasPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  redirect(buildRegisterUrl(await searchParams));
+}

--- a/apps/web/src/app/continue/page.tsx
+++ b/apps/web/src/app/continue/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServer } from '@/lib/supabase-server';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ContinuePage() {
+  const supabase = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login?redirect=%2Fcontinue');
+  }
+
+  const db = getServiceSupabase();
+  const [
+    { data: profile },
+    { count: savedGrantCount },
+    { count: savedFoundationCount },
+    { count: progressedGrantCount },
+  ] = await Promise.all([
+    db
+      .from('org_profiles')
+      .select('name, domains, geographic_focus')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+    db
+      .from('saved_grants')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id),
+    db
+      .from('saved_foundations')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id),
+    db
+      .from('saved_grants')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .neq('stage', 'discovered'),
+  ]);
+
+  const hasProfile = !!profile?.name;
+  const hasDomains = Array.isArray(profile?.domains) && profile.domains.length > 0;
+  const hasGeography = Array.isArray(profile?.geographic_focus) && profile.geographic_focus.length > 0;
+  const hasPipeline = (savedGrantCount || 0) > 0 || (savedFoundationCount || 0) > 0;
+  const hasShortlistedGrants = (savedGrantCount || 0) > 0;
+  const hasWorkedGrantPipeline = (progressedGrantCount || 0) > 0;
+
+  if (!hasProfile || !hasDomains || !hasGeography) {
+    redirect('/profile');
+  }
+
+  if (!hasPipeline) {
+    redirect('/profile/matches');
+  }
+
+  if (hasShortlistedGrants && !hasWorkedGrantPipeline) {
+    redirect('/tracker?onboarding=1');
+  }
+
+  redirect('/home');
+}


### PR DESCRIPTION
## Summary
- New \`/auth/signup\` route that forwards to \`/register\` preserving search params.
- New \`/continue\` route that resumes post-auth context (reads Supabase session, routes to org or onboarding).

Part of phase 2 dirty-tree carve (bucket: auth-continue).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] Visit \`/auth/signup?plan=funder\` → redirects to \`/register?plan=funder\`
- [ ] Visit \`/continue\` while authed → routes to current org/onboarding