### PR TITLE
feat(ops): pilots + validation-reviews APIs

### DIFF
--- a/apps/web/src/app/api/ops/claims/route.ts
+++ b/apps/web/src/app/api/ops/claims/route.ts
@@ -1,24 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 import { sendEmail } from '@/lib/gmail';
 import { findContactByEmail, addTagToContact, removeTagFromContact } from '@/lib/ghl';
 
 export const dynamic = 'force-dynamic';
 
-const ADMIN_EMAILS = ['benjamin@act.place', 'hello@civicgraph.au'];
-
-async function checkAdmin() {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return null;
-  if (!ADMIN_EMAILS.includes(user.email || '')) return null;
-  return user;
-}
-
 export async function GET() {
-  const admin = await checkAdmin();
-  if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const db = getServiceSupabase();
   const { data, error } = await db
@@ -71,8 +61,8 @@ export async function GET() {
 }
 
 export async function PUT(request: NextRequest) {
-  const admin = await checkAdmin();
-  if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const body = await request.json();
   const { claim_id, status, admin_notes } = body;

--- a/apps/web/src/app/api/ops/health/route.ts
+++ b/apps/web/src/app/api/ops/health/route.ts
@@ -5,6 +5,19 @@ import { getServiceSupabase } from '@/lib/supabase';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
 
+function canonicalSourceSql(): string {
+  return `COALESCE(
+    NULLIF(discovery_method, ''),
+    CASE
+      WHEN source = 'foundation_program' THEN NULL
+      WHEN COALESCE(source_id, '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN NULL
+      ELSE NULLIF(source_id, '')
+    END,
+    source,
+    'unknown'
+  )`;
+}
+
 // Wrap a promise with a timeout — returns fallback instead of hanging forever
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function safe(p: PromiseLike<any>, ms = 15000): Promise<any> {
@@ -20,6 +33,7 @@ export async function GET() {
   if (auth.error) return auth.error;
 
   const db = getServiceSupabase();
+  const grantCanonicalSource = canonicalSourceSql();
 
   try {
     // All queries in one parallel batch — RPCs are instant, filtered counts are best-effort
@@ -31,6 +45,10 @@ export async function GET() {
       grantsWithDesc, grantsEnriched, grantsEmbedded, grantsOpen,
       foundationsProfiled, foundationsWithWebsite,
       seEnriched,
+      grantSemanticsSummary,
+      grantSemanticsSources,
+      grantSourceIdentitySummary,
+      grantSourceIdentitySources,
       // Breakdowns + recent runs
       sourceBreakdownResult, confidenceBreakdownResult,
       recentRuns, recentDiscoveryRuns,
@@ -59,6 +77,88 @@ export async function GET() {
         .not('website', 'is', null), 10000),
       safe(db.from('social_enterprises').select('*', { count: 'exact', head: true })
         .not('enriched_at', 'is', null), 10000),
+      safe(db.rpc('exec_sql', { query: `
+        SELECT
+          COUNT(*) FILTER (WHERE status IS NULL) AS status_null_total,
+          COUNT(*) FILTER (WHERE application_status IS NULL) AS application_status_null_total,
+          COUNT(*) FILTER (WHERE status = 'open' AND closes_at < CURRENT_DATE) AS open_past_deadline_total,
+          COUNT(*) FILTER (WHERE source = 'ghl_sync' AND status = 'unknown') AS ghl_sync_unknown_total
+        FROM grant_opportunities
+      ` }), 10000),
+      safe(db.rpc('exec_sql', { query: `
+        SELECT
+          ${grantCanonicalSource} AS source,
+          COUNT(*) FILTER (WHERE status IS NULL) AS status_null,
+          COUNT(*) FILTER (WHERE application_status IS NULL) AS application_status_null,
+          COUNT(*) FILTER (WHERE status = 'open' AND closes_at < CURRENT_DATE) AS open_past_deadline,
+          (
+            COUNT(*) FILTER (WHERE status IS NULL)
+            + COUNT(*) FILTER (WHERE application_status IS NULL)
+            + COUNT(*) FILTER (WHERE status = 'open' AND closes_at < CURRENT_DATE)
+          ) AS total_issues
+        FROM grant_opportunities
+        GROUP BY ${grantCanonicalSource}
+        HAVING (
+          COUNT(*) FILTER (WHERE status IS NULL)
+          + COUNT(*) FILTER (WHERE application_status IS NULL)
+          + COUNT(*) FILTER (WHERE status = 'open' AND closes_at < CURRENT_DATE)
+        ) > 0
+        ORDER BY total_issues DESC, source ASC
+        LIMIT 10
+      ` }), 10000),
+      safe(db.rpc('exec_sql', { query: `
+        SELECT
+          COUNT(*) FILTER (
+            WHERE discovered_by = 'grant_engine'
+              AND COALESCE(discovery_method, '') <> ''
+              AND COALESCE(source_id, '') = ''
+          ) AS blank_source_id_total,
+          COUNT(*) FILTER (
+            WHERE discovered_by = 'grant_engine'
+              AND COALESCE(discovery_method, '') <> ''
+              AND COALESCE(source_id, '') <> ''
+              AND source_id NOT LIKE '%::duplicate::%'
+              AND source_id <> discovery_method
+          ) AS canonical_mismatch_total,
+          COUNT(*) FILTER (
+            WHERE discovered_by = 'grant_engine'
+              AND source_id LIKE '%::duplicate::%'
+              AND status = 'duplicate'
+          ) AS duplicate_shadow_total
+        FROM grant_opportunities
+      ` }), 10000),
+      safe(db.rpc('exec_sql', { query: `
+        SELECT
+          discovery_method AS source,
+          COUNT(*) FILTER (WHERE COALESCE(source_id, '') = '') AS blank_source_id,
+          COUNT(*) FILTER (
+            WHERE COALESCE(source_id, '') <> ''
+              AND source_id NOT LIKE '%::duplicate::%'
+              AND source_id <> discovery_method
+          ) AS canonical_mismatch,
+          (
+            COUNT(*) FILTER (WHERE COALESCE(source_id, '') = '')
+            + COUNT(*) FILTER (
+              WHERE COALESCE(source_id, '') <> ''
+                AND source_id NOT LIKE '%::duplicate::%'
+                AND source_id <> discovery_method
+            )
+          ) AS total_issues
+        FROM grant_opportunities
+        WHERE discovered_by = 'grant_engine'
+          AND COALESCE(discovery_method, '') <> ''
+        GROUP BY discovery_method
+        HAVING (
+          COUNT(*) FILTER (WHERE COALESCE(source_id, '') = '')
+          + COUNT(*) FILTER (
+            WHERE COALESCE(source_id, '') <> ''
+              AND source_id NOT LIKE '%::duplicate::%'
+              AND source_id <> discovery_method
+          )
+        ) > 0
+        ORDER BY total_issues DESC, source ASC
+        LIMIT 10
+      ` }), 10000),
       // Breakdowns
       safe(db.rpc('get_grant_source_breakdown'), 8000),
       safe(db.rpc('get_foundation_confidence_breakdown'), 8000),
@@ -103,6 +203,45 @@ export async function GET() {
     const dcData = donorContractorStats.data ?? [];
     const dcTotalDonated = dcData.reduce((s: number, r: { total_donated: number }) => s + (r.total_donated || 0), 0);
     const dcTotalContracts = dcData.reduce((s: number, r: { total_contract_value: number }) => s + (r.total_contract_value || 0), 0);
+    const gsRows = grantSemanticsSummary.data ?? [];
+    const gs = Array.isArray(gsRows) && gsRows.length > 0 ? gsRows[0] : {};
+    const grantSemantics = {
+      statusNull: Number(gs.status_null_total ?? 0),
+      applicationStatusNull: Number(gs.application_status_null_total ?? 0),
+      openPastDeadline: Number(gs.open_past_deadline_total ?? 0),
+      ghlUnknown: Number(gs.ghl_sync_unknown_total ?? 0),
+      topIssueSources: (grantSemanticsSources.data ?? []).map((row: {
+        source: string;
+        status_null: number | string;
+        application_status_null: number | string;
+        open_past_deadline: number | string;
+        total_issues: number | string;
+      }) => ({
+        source: row.source,
+        statusNull: Number(row.status_null ?? 0),
+        applicationStatusNull: Number(row.application_status_null ?? 0),
+        openPastDeadline: Number(row.open_past_deadline ?? 0),
+        totalIssues: Number(row.total_issues ?? 0),
+      })),
+    };
+    const gsiRows = grantSourceIdentitySummary.data ?? [];
+    const gsi = Array.isArray(gsiRows) && gsiRows.length > 0 ? gsiRows[0] : {};
+    const sourceIdentity = {
+      blankSourceId: Number(gsi.blank_source_id_total ?? 0),
+      canonicalMismatch: Number(gsi.canonical_mismatch_total ?? 0),
+      duplicateShadows: Number(gsi.duplicate_shadow_total ?? 0),
+      topIssueSources: (grantSourceIdentitySources.data ?? []).map((row: {
+        source: string;
+        blank_source_id: number | string;
+        canonical_mismatch: number | string;
+        total_issues: number | string;
+      }) => ({
+        source: row.source,
+        blankSourceId: Number(row.blank_source_id ?? 0),
+        canonicalMismatch: Number(row.canonical_mismatch ?? 0),
+        totalIssues: Number(row.total_issues ?? 0),
+      })),
+    };
 
     const dataFreshness = [
       { dataset: 'Grants', table: 'grant_opportunities', count: tcount('grant_opportunities'), lastUpdated: tfresh('grant_opportunities') },
@@ -168,6 +307,8 @@ export async function GET() {
           enriched: seEnriched.count ?? 0,
         },
       },
+      grantSemantics,
+      sourceIdentity,
       entityGraph: {
         totalEntities: tcount('gs_entities'),
         totalRelationships: tcount('gs_relationships'),

--- a/apps/web/src/app/api/ops/pilots/[pilotId]/route.ts
+++ b/apps/web/src/app/api/ops/pilots/[pilotId]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getServiceSupabase } from '@/lib/supabase';
+import { resolvePilotLinks, sanitizePilotParticipantInput } from '@/lib/pilot-participants';
+
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ pilotId: string }> }) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  const { pilotId } = await params;
+  const body = await request.json();
+  const input = sanitizePilotParticipantInput(body);
+  const db = getServiceSupabase();
+
+  const updatePayload: Record<string, unknown> = {
+    ...(input.participant_name !== null ? { participant_name: input.participant_name } : {}),
+    ...(input.email !== null ? { email: input.email } : {}),
+    ...(input.organization_name !== null ? { organization_name: input.organization_name } : {}),
+    ...(input.role_title !== null ? { role_title: input.role_title } : {}),
+    ...(body.cohort !== undefined ? { cohort: input.cohort } : {}),
+    ...(body.stage !== undefined ? { stage: input.stage } : {}),
+    ...(body.payment_intent !== undefined ? { payment_intent: input.payment_intent } : {}),
+    ...(body.sean_ellis_response !== undefined ? { sean_ellis_response: input.sean_ellis_response } : {}),
+    ...(body.pilot_source !== undefined ? { pilot_source: input.pilot_source } : {}),
+    ...(body.funding_task !== undefined ? { funding_task: input.funding_task } : {}),
+    ...(body.notes !== undefined ? { notes: input.notes } : {}),
+    ...(body.last_contact_at !== undefined ? { last_contact_at: input.last_contact_at } : {}),
+    ...(body.onboarding_at !== undefined ? { onboarding_at: input.onboarding_at } : {}),
+    ...(body.observed_session_at !== undefined ? { observed_session_at: input.observed_session_at } : {}),
+    ...(body.closeout_at !== undefined ? { closeout_at: input.closeout_at } : {}),
+    updated_at: new Date().toISOString(),
+  };
+
+  if (input.email) {
+    const { linkedUserId, linkedOrgProfileId } = await resolvePilotLinks(input.email);
+    updatePayload.linked_user_id = linkedUserId;
+    updatePayload.linked_org_profile_id = linkedOrgProfileId;
+  }
+
+  const { data, error } = await db
+    .from('pilot_participants')
+    .update(updatePayload)
+    .eq('id', pilotId)
+    .select('*')
+    .single();
+
+  if (error) {
+    const status = error.code === '23505' ? 409 : 500;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  return NextResponse.json({ pilot: data });
+}

--- a/apps/web/src/app/api/ops/pilots/route.ts
+++ b/apps/web/src/app/api/ops/pilots/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getServiceSupabase } from '@/lib/supabase';
+import { resolvePilotLinks, sanitizePilotParticipantInput } from '@/lib/pilot-participants';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+  const { user } = auth;
+
+  const body = await request.json();
+  const input = sanitizePilotParticipantInput(body);
+
+  if (!input.participant_name || !input.email) {
+    return NextResponse.json({ error: 'Participant name and email are required.' }, { status: 400 });
+  }
+
+  const { linkedUserId, linkedOrgProfileId } = await resolvePilotLinks(input.email);
+  const db = getServiceSupabase();
+
+  const { data, error } = await db
+    .from('pilot_participants')
+    .insert({
+      owner_user_id: user.id,
+      linked_user_id: linkedUserId,
+      linked_org_profile_id: linkedOrgProfileId,
+      participant_name: input.participant_name,
+      email: input.email,
+      organization_name: input.organization_name,
+      role_title: input.role_title,
+      cohort: input.cohort,
+      stage: input.stage,
+      payment_intent: input.payment_intent,
+      sean_ellis_response: input.sean_ellis_response,
+      pilot_source: input.pilot_source,
+      funding_task: input.funding_task,
+      notes: input.notes,
+      last_contact_at: input.last_contact_at,
+      onboarding_at: input.onboarding_at,
+      observed_session_at: input.observed_session_at,
+      closeout_at: input.closeout_at,
+      updated_at: new Date().toISOString(),
+    })
+    .select('*')
+    .single();
+
+  if (error) {
+    const status = error.code === '23505' ? 409 : 500;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  return NextResponse.json({ pilot: data });
+}

--- a/apps/web/src/app/api/ops/route.ts
+++ b/apps/web/src/app/api/ops/route.ts
@@ -1,16 +1,225 @@
 import { NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { PILOT_PAYMENT_INTENTS, PILOT_STAGES } from '@/lib/pilot-participants';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  // Auth check
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+const PILOT_COHORTS = ['consultant', 'nonprofit', 'other'] as const;
+const PILOT_THRESHOLDS = {
+  profileReadyRate: 80,
+  shortlistRate: 60,
+  pipelineRate: 40,
+  alertRate: 50,
+  weeklyActiveRate: 70,
+  paymentIntentRate: 30,
+  paidOrCommittedRate: 20,
+  seanEllisRate: 40,
+} as const;
+const DATA_REVIEW_THRESHOLDS = {
+  grantPrecision: 70,
+  foundationPrecision: 75,
+  openNowTrust: 85,
+  grantSample: 100,
+  foundationSample: 50,
+} as const;
+
+function rate(numerator: number, denominator: number) {
+  if (denominator <= 0) return 0;
+  return Number(((numerator / denominator) * 100).toFixed(1));
+}
+
+function buildPilotCohortMetrics(rows: Array<{
+  cohort: string;
+  stage: string;
+  payment_intent: string;
+  sean_ellis_response: string;
+  activation: {
+    linkedAccount: boolean;
+    weeklyActive: boolean;
+    profileReady: boolean;
+    shortlistStarted: boolean;
+    pipelineStarted: boolean;
+    alertCreated: boolean;
+  };
+}>) {
+  const total = rows.length;
+  const linkedAccounts = rows.filter((pilot) => pilot.activation.linkedAccount).length;
+  const weeklyActive = rows.filter((pilot) => pilot.activation.weeklyActive).length;
+  const profileReady = rows.filter((pilot) => pilot.activation.profileReady).length;
+  const shortlistStarted = rows.filter((pilot) => pilot.activation.shortlistStarted).length;
+  const pipelineStarted = rows.filter((pilot) => pilot.activation.pipelineStarted).length;
+  const alertCreated = rows.filter((pilot) => pilot.activation.alertCreated).length;
+  const strongYes = rows.filter((pilot) => pilot.payment_intent === 'strong_yes').length;
+  const conditionalYes = rows.filter((pilot) => pilot.payment_intent === 'conditional_yes').length;
+  const paid = rows.filter((pilot) => pilot.stage === 'paid').length;
+  const paidOrCommitted = rows.filter((pilot) => pilot.stage === 'paid' || ['strong_yes', 'conditional_yes'].includes(pilot.payment_intent)).length;
+  const veryDisappointed = rows.filter((pilot) => pilot.sean_ellis_response === 'very_disappointed').length;
+
+  return {
+    total,
+    linkedAccounts,
+    weeklyActive,
+    profileReady,
+    shortlistStarted,
+    pipelineStarted,
+    alertCreated,
+    strongYes,
+    conditionalYes,
+    paid,
+    paidOrCommitted,
+    veryDisappointed,
+    weeklyActiveRate: rate(weeklyActive, total),
+    profileReadyRate: rate(profileReady, total),
+    shortlistRate: rate(shortlistStarted, total),
+    pipelineRate: rate(pipelineStarted, total),
+    alertRate: rate(alertCreated, total),
+    paymentIntentRate: rate(strongYes + conditionalYes, total),
+    paidOrCommittedRate: rate(paidOrCommitted, total),
+    paidRate: rate(paid, total),
+    seanEllisRate: rate(veryDisappointed, total),
+  };
+}
+
+function pickPilotAttention(pilot: {
+  id: string;
+  participant_name: string;
+  organization_name: string | null;
+  cohort: string;
+  stage: string;
+  payment_intent: string;
+  updated_at: string;
+  last_contact_at: string | null;
+  closeout_at: string | null;
+  activation: {
+    linkedAccount: boolean;
+    profileReady: boolean;
+    shortlistStarted: boolean;
+    pipelineStarted: boolean;
+    alertCreated: boolean;
+  };
+}) {
+  const lastTouch = pilot.last_contact_at || pilot.updated_at;
+  const daysSinceTouch = Math.floor((Date.now() - new Date(lastTouch).getTime()) / (24 * 60 * 60 * 1000));
+
+  if (['strong_yes', 'conditional_yes'].includes(pilot.payment_intent) && !['paid', 'declined'].includes(pilot.stage)) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'high',
+      reason: 'Commercial follow-up due',
+      detail: 'Participant has positive payment intent but is not yet closed.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
   }
+
+  if (['invited', 'scheduled', 'onboarded', 'active'].includes(pilot.stage) && !pilot.activation.linkedAccount) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'high',
+      reason: 'No linked product account',
+      detail: 'Pilot has progressed beyond lead stage but does not map to a user account yet.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
+  }
+
+  if (['onboarded', 'active'].includes(pilot.stage) && !pilot.activation.profileReady) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'high',
+      reason: 'Onboarded but no profile',
+      detail: 'Linked account exists but has not reached profile-ready.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
+  }
+
+  if (pilot.activation.profileReady && !pilot.activation.shortlistStarted) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'medium',
+      reason: 'Profile ready, no shortlist',
+      detail: 'Participant got through setup but has not shortlisted a grant.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
+  }
+
+  if (pilot.activation.shortlistStarted && !pilot.activation.pipelineStarted) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'medium',
+      reason: 'Shortlisted, no pipeline movement',
+      detail: 'Participant found grants but has not moved one into active work.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
+  }
+
+  if (pilot.activation.pipelineStarted && !pilot.activation.alertCreated) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'medium',
+      reason: 'Pipeline active, no alerts',
+      detail: 'Participant is using the tracker but has not enabled ongoing monitoring.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
+  }
+
+  if (['completed', 'active'].includes(pilot.stage) && !pilot.closeout_at && daysSinceTouch >= 7) {
+    return {
+      pilotId: pilot.id,
+      participant_name: pilot.participant_name,
+      organization_name: pilot.organization_name,
+      cohort: pilot.cohort,
+      stage: pilot.stage,
+      payment_intent: pilot.payment_intent,
+      severity: 'low',
+      reason: 'No recent follow-up',
+      detail: 'Pilot may need a close-out or review check-in.',
+      daysSinceTouch,
+      updated_at: pilot.updated_at,
+    };
+  }
+
+  return null;
+}
+
+export async function GET() {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const db = getServiceSupabase();
 
@@ -28,7 +237,16 @@ export async function GET() {
       foundationPrograms,
       seTotal,
       seEnriched,
+      paidProfiles,
+      activeTrials,
+      expiringTrials,
+      atRiskProfiles,
+      scheduledChurnProfiles,
+      billingProfiles,
+      pilotParticipants,
+      validationReviews,
       recentRuns,
+      recentProductEvents,
     ] = await Promise.all([
       db.from('grant_opportunities').select('*', { count: 'exact', head: true }),
       db.from('grant_opportunities').select('*', { count: 'exact', head: true }).not('embedding', 'is', null),
@@ -43,11 +261,333 @@ export async function GET() {
       db.from('foundation_programs').select('*', { count: 'exact', head: true }),
       db.from('social_enterprises').select('*', { count: 'exact', head: true }),
       db.from('social_enterprises').select('*', { count: 'exact', head: true }).not('enriched_at', 'is', null),
+      db.from('org_profiles').select('*', { count: 'exact', head: true }).neq('subscription_plan', 'community'),
+      db.from('org_profiles').select('*', { count: 'exact', head: true }).eq('subscription_status', 'trialing'),
+      db.from('org_profiles').select('*', { count: 'exact', head: true })
+        .eq('subscription_status', 'trialing')
+        .not('subscription_trial_end', 'is', null)
+        .lte('subscription_trial_end', new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString())
+        .gte('subscription_trial_end', new Date().toISOString()),
+      db.from('org_profiles').select('*', { count: 'exact', head: true }).in('subscription_status', ['past_due', 'unpaid']),
+      db.from('org_profiles').select('*', { count: 'exact', head: true }).eq('subscription_cancel_at_period_end', true),
+      db.from('org_profiles')
+        .select('id, name, subscription_plan, subscription_status, subscription_trial_end, subscription_current_period_end, subscription_cancel_at_period_end')
+        .neq('subscription_plan', 'community')
+        .order('subscription_trial_end', { ascending: true, nullsFirst: false })
+        .order('subscription_current_period_end', { ascending: true, nullsFirst: false })
+        .limit(50),
+      db.from('pilot_participants')
+        .select('*')
+        .order('updated_at', { ascending: false })
+        .limit(50),
+      db.from('validation_reviews')
+        .select('*')
+        .gte('review_date', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10))
+        .order('review_date', { ascending: false })
+        .limit(1000),
       db.from('agent_runs')
         .select('*')
         .order('completed_at', { ascending: false })
         .limit(20),
+      db.from('product_events')
+        .select('event_type, user_id, created_at, metadata')
+        .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()),
     ]);
+
+    const productEventRows = recentProductEvents.data ?? [];
+    const usersByEvent = productEventRows.reduce<Record<string, Set<string>>>((acc, row: { event_type: string; user_id: string }) => {
+      if (!acc[row.event_type]) acc[row.event_type] = new Set();
+      acc[row.event_type].add(row.user_id);
+      return acc;
+    }, {});
+    const weeklyActiveUserIds = new Set(
+      productEventRows
+        .filter((row: { created_at: string }) => new Date(row.created_at).getTime() >= Date.now() - 7 * 24 * 60 * 60 * 1000)
+        .map((row: { user_id: string }) => row.user_id)
+    );
+
+    const productFunnel = {
+      windowDays: 30,
+      profileReadyUsers: usersByEvent.profile_ready?.size ?? 0,
+      firstShortlistUsers: usersByEvent.first_grant_shortlisted?.size ?? 0,
+      pipelineStartedUsers: usersByEvent.pipeline_started?.size ?? 0,
+      firstAlertUsers: usersByEvent.first_alert_created?.size ?? 0,
+      alertClickUsers: usersByEvent.alert_clicked?.size ?? 0,
+      checkoutStartedUsers: usersByEvent.checkout_started?.size ?? 0,
+      trialStartedUsers: usersByEvent.subscription_trial_started?.size ?? 0,
+      billingReminderUsers: usersByEvent.billing_reminder_sent?.size ?? 0,
+      billingReminderClickUsers: usersByEvent.billing_reminder_clicked?.size ?? 0,
+      billingPortalUsers: usersByEvent.billing_portal_opened?.size ?? 0,
+      activatedUsers: usersByEvent.subscription_activated?.size ?? 0,
+    };
+
+    const pilotRows = (pilotParticipants.data ?? []) as Array<{
+      id: string;
+      participant_name: string;
+      email: string;
+      organization_name: string | null;
+      role_title: string | null;
+      cohort: string;
+      stage: string;
+      payment_intent: string;
+      sean_ellis_response: string;
+      pilot_source: string | null;
+      funding_task: string | null;
+      notes: string | null;
+      linked_user_id: string | null;
+      linked_org_profile_id: string | null;
+      created_at: string;
+      updated_at: string;
+      last_contact_at: string | null;
+      onboarding_at: string | null;
+      observed_session_at: string | null;
+      closeout_at: string | null;
+    }>;
+
+    const eventsByUser = productEventRows.reduce<Record<string, Set<string>>>((acc, row: { event_type: string; user_id: string }) => {
+      if (!acc[row.user_id]) acc[row.user_id] = new Set();
+      acc[row.user_id].add(row.event_type);
+      return acc;
+    }, {});
+
+    const pilots = pilotRows.map((pilot) => {
+      const userEvents = pilot.linked_user_id ? eventsByUser[pilot.linked_user_id] : undefined;
+      const activation = {
+        linkedAccount: Boolean(pilot.linked_user_id),
+        weeklyActive: pilot.linked_user_id ? weeklyActiveUserIds.has(pilot.linked_user_id) : false,
+        profileReady: userEvents?.has('profile_ready') ?? false,
+        shortlistStarted: userEvents?.has('first_grant_shortlisted') ?? false,
+        pipelineStarted: userEvents?.has('pipeline_started') ?? false,
+        alertCreated: userEvents?.has('first_alert_created') ?? false,
+        checkoutStarted: userEvents?.has('checkout_started') ?? false,
+        activated: userEvents?.has('subscription_activated') ?? false,
+      };
+      return {
+        ...pilot,
+        activation,
+      };
+    });
+
+    const pilotSummary = {
+      total: pilots.length,
+      consultants: pilots.filter((pilot) => pilot.cohort === 'consultant').length,
+      nonprofits: pilots.filter((pilot) => pilot.cohort === 'nonprofit').length,
+      active: pilots.filter((pilot) => ['onboarded', 'active'].includes(pilot.stage)).length,
+      completed: pilots.filter((pilot) => ['completed', 'paid', 'declined'].includes(pilot.stage)).length,
+      paid: pilots.filter((pilot) => pilot.stage === 'paid').length,
+      strongYes: pilots.filter((pilot) => pilot.payment_intent === 'strong_yes').length,
+      conditionalYes: pilots.filter((pilot) => pilot.payment_intent === 'conditional_yes').length,
+      linkedAccounts: pilots.filter((pilot) => pilot.activation.linkedAccount).length,
+      profileReady: pilots.filter((pilot) => pilot.activation.profileReady).length,
+      shortlistStarted: pilots.filter((pilot) => pilot.activation.shortlistStarted).length,
+      pipelineStarted: pilots.filter((pilot) => pilot.activation.pipelineStarted).length,
+      alertCreated: pilots.filter((pilot) => pilot.activation.alertCreated).length,
+      weeklyActive: pilots.filter((pilot) => pilot.activation.weeklyActive).length,
+      veryDisappointed: pilots.filter((pilot) => pilot.sean_ellis_response === 'very_disappointed').length,
+      paymentSignals: PILOT_PAYMENT_INTENTS.reduce<Record<string, number>>((acc, intent) => {
+        acc[intent] = pilots.filter((pilot) => pilot.payment_intent === intent).length;
+        return acc;
+      }, {}),
+      stageCounts: PILOT_STAGES.reduce<Record<string, number>>((acc, stage) => {
+        acc[stage] = pilots.filter((pilot) => pilot.stage === stage).length;
+        return acc;
+      }, {}),
+    };
+
+    const pilotCohorts = PILOT_COHORTS.map((cohort) => {
+      const rows = pilots.filter((pilot) => pilot.cohort === cohort);
+      return {
+        cohort,
+        ...buildPilotCohortMetrics(rows),
+      };
+    });
+
+    const overallPilotMetrics = buildPilotCohortMetrics(pilots);
+    const pilotBenchmarks = [
+      { key: 'weeklyActiveRate', label: 'Weekly active', current: overallPilotMetrics.weeklyActiveRate, target: PILOT_THRESHOLDS.weeklyActiveRate },
+      { key: 'profileReadyRate', label: 'Profile ready', current: overallPilotMetrics.profileReadyRate, target: PILOT_THRESHOLDS.profileReadyRate },
+      { key: 'shortlistRate', label: 'First shortlist', current: overallPilotMetrics.shortlistRate, target: PILOT_THRESHOLDS.shortlistRate },
+      { key: 'pipelineRate', label: 'Pipeline started', current: overallPilotMetrics.pipelineRate, target: PILOT_THRESHOLDS.pipelineRate },
+      { key: 'alertRate', label: 'First alert created', current: overallPilotMetrics.alertRate, target: PILOT_THRESHOLDS.alertRate },
+      { key: 'paymentIntentRate', label: 'Payment intent', current: overallPilotMetrics.paymentIntentRate, target: PILOT_THRESHOLDS.paymentIntentRate },
+      { key: 'paidOrCommittedRate', label: 'Paid or committed', current: overallPilotMetrics.paidOrCommittedRate, target: PILOT_THRESHOLDS.paidOrCommittedRate },
+      { key: 'seanEllisRate', label: 'Sean Ellis', current: overallPilotMetrics.seanEllisRate, target: PILOT_THRESHOLDS.seanEllisRate },
+    ].map((metric) => ({
+      ...metric,
+      passing: metric.current >= metric.target,
+      gap: Number((metric.current - metric.target).toFixed(1)),
+    }));
+
+    const benchmarkPassCount = pilotBenchmarks.filter((metric) => metric.passing).length;
+    const consultantMetrics = pilotCohorts.find((cohort) => cohort.cohort === 'consultant') ?? null;
+    const nonprofitMetrics = pilotCohorts.find((cohort) => cohort.cohort === 'nonprofit') ?? null;
+    const strongerCohort = consultantMetrics && nonprofitMetrics
+      ? (
+        consultantMetrics.total > 0 && nonprofitMetrics.total > 0
+          ? (
+            consultantMetrics.paidOrCommittedRate > nonprofitMetrics.paidOrCommittedRate + 10
+              ? 'consultant'
+              : nonprofitMetrics.paidOrCommittedRate > consultantMetrics.paidOrCommittedRate + 10
+                ? 'nonprofit'
+                : null
+          )
+          : null
+      )
+      : null;
+
+    let pilotRecommendation = 'Add pilot participants to start measuring activation and willingness to pay.';
+    let pilotDecisionStatus: 'insufficient_data' | 'pass' | 'mixed' | 'failing' = 'insufficient_data';
+
+    if (pilots.length >= 3) {
+      if (benchmarkPassCount >= 6) {
+        pilotDecisionStatus = 'pass';
+        pilotRecommendation = 'Pilot signal is strong enough to keep selling the current wedge. Focus on converting active users to paid.';
+      } else if (benchmarkPassCount >= 3) {
+        pilotDecisionStatus = 'mixed';
+        pilotRecommendation = 'Pilot signal is mixed. Keep testing, but prioritize the weakest activation steps before broader rollout.';
+      } else {
+        pilotDecisionStatus = 'failing';
+        pilotRecommendation = 'Pilot signal is weak. Fix trust and activation before pushing more top-of-funnel growth.';
+      }
+
+      if (strongerCohort === 'consultant') {
+        pilotRecommendation += ' Consultants currently outperform nonprofits, so they should stay the primary wedge.';
+      } else if (strongerCohort === 'nonprofit') {
+        pilotRecommendation += ' Nonprofit funding teams currently outperform consultants, so review the ICP focus.';
+      }
+    }
+
+    const pilotAttention = pilots
+      .map((pilot) => pickPilotAttention(pilot))
+      .filter(Boolean)
+      .sort((a, b) => {
+        const severityWeight = { high: 0, medium: 1, low: 2 };
+        const severityDiff = severityWeight[a!.severity as keyof typeof severityWeight] - severityWeight[b!.severity as keyof typeof severityWeight];
+        if (severityDiff !== 0) return severityDiff;
+        return b!.daysSinceTouch - a!.daysSinceTouch;
+      })
+      .slice(0, 10);
+
+    const reviewRows = (validationReviews.data ?? []) as Array<{
+      review_date: string;
+      record_type: 'grant' | 'foundation';
+      status: 'correct' | 'usable_but_incomplete' | 'wrong_noisy';
+      issue_type: string | null;
+      source: string | null;
+      open_now_correct: boolean | null;
+    }>;
+
+    const recentReviewDate = reviewRows[0]?.review_date ?? null;
+    const grantRows = reviewRows.filter((row) => row.record_type === 'grant');
+    const foundationRows = reviewRows.filter((row) => row.record_type === 'foundation');
+    const positiveGrantRows = grantRows.filter((row) => row.status !== 'wrong_noisy').length;
+    const positiveFoundationRows = foundationRows.filter((row) => row.status !== 'wrong_noisy').length;
+    const openNowRows = grantRows.filter((row) => row.open_now_correct !== null);
+    const openNowCorrect = openNowRows.filter((row) => row.open_now_correct === true).length;
+
+    const issueCounts = reviewRows.reduce<Record<string, number>>((acc, row) => {
+      const key = row.issue_type || 'none';
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+
+    const sourceNoiseCounts = reviewRows
+      .filter((row) => row.status === 'wrong_noisy' && row.source)
+      .reduce<Record<string, number>>((acc, row) => {
+        const key = row.source as string;
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+      }, {});
+
+    const dataReview = {
+      windowDays: 30,
+      reviewCount: reviewRows.length,
+      recentReviewDate,
+      grantRows: grantRows.length,
+      foundationRows: foundationRows.length,
+      grantPrecision: rate(positiveGrantRows, grantRows.length),
+      foundationPrecision: rate(positiveFoundationRows, foundationRows.length),
+      openNowTrust: rate(openNowCorrect, openNowRows.length),
+      topIssues: Object.entries(issueCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([issue, count]) => ({ issue, count })),
+      noisySources: Object.entries(sourceNoiseCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([source, count]) => ({ source, count })),
+    };
+
+    const dataReviewBenchmarks = [
+      { key: 'grantPrecision', label: 'Grant precision', current: dataReview.grantPrecision, target: DATA_REVIEW_THRESHOLDS.grantPrecision, unit: '%' },
+      { key: 'foundationPrecision', label: 'Foundation precision', current: dataReview.foundationPrecision, target: DATA_REVIEW_THRESHOLDS.foundationPrecision, unit: '%' },
+      { key: 'openNowTrust', label: 'Open-now trust', current: dataReview.openNowTrust, target: DATA_REVIEW_THRESHOLDS.openNowTrust, unit: '%' },
+      { key: 'grantSample', label: 'Grant review sample', current: dataReview.grantRows, target: DATA_REVIEW_THRESHOLDS.grantSample, unit: 'rows' },
+      { key: 'foundationSample', label: 'Foundation review sample', current: dataReview.foundationRows, target: DATA_REVIEW_THRESHOLDS.foundationSample, unit: 'rows' },
+    ].map((metric) => ({
+      ...metric,
+      passing: metric.current >= metric.target,
+      gap: Number((metric.current - metric.target).toFixed(1)),
+    }));
+
+    const dataReviewBenchmarkPassCount = dataReviewBenchmarks.filter((metric) => metric.passing).length;
+    const hasFullReviewSample = dataReview.grantRows >= DATA_REVIEW_THRESHOLDS.grantSample && dataReview.foundationRows >= DATA_REVIEW_THRESHOLDS.foundationSample;
+    const hasAnyReviewData = dataReview.reviewCount > 0;
+    const reviewIsStale = recentReviewDate
+      ? (Date.now() - new Date(recentReviewDate).getTime()) > 14 * 24 * 60 * 60 * 1000
+      : true;
+
+    let dataReviewDecisionStatus: 'insufficient_data' | 'pass' | 'mixed' | 'failing' = 'insufficient_data';
+    let dataReviewRecommendation = 'Import a reviewed scorecard to measure trust before making growth decisions.';
+
+    if (hasAnyReviewData) {
+      const trustFailing = dataReview.grantPrecision < DATA_REVIEW_THRESHOLDS.grantPrecision
+        || dataReview.foundationPrecision < DATA_REVIEW_THRESHOLDS.foundationPrecision
+        || dataReview.openNowTrust < DATA_REVIEW_THRESHOLDS.openNowTrust;
+
+      if (trustFailing) {
+        dataReviewDecisionStatus = 'failing';
+        dataReviewRecommendation = 'Trust metrics are below threshold. Pause growth work and fix the highest-noise sources before scaling.';
+      } else if (!hasFullReviewSample) {
+        dataReviewDecisionStatus = 'mixed';
+        dataReviewRecommendation = 'Trust metrics look positive, but the review sample is still too small. Finish the full weekly sample before treating this as proven.';
+      } else if (reviewIsStale) {
+        dataReviewDecisionStatus = 'mixed';
+        dataReviewRecommendation = 'Trust metrics are currently passing, but the latest review is stale. Run a fresh weekly review before using this as a go-to-market signal.';
+      } else {
+        dataReviewDecisionStatus = 'pass';
+        dataReviewRecommendation = 'Trust metrics are strong enough to support continued pilot and growth work. Keep monitoring the noisy sources table weekly.';
+      }
+    }
+
+    const upgradeSourceCounts = productEventRows.reduce<Record<string, { viewed: number; clicked: number; started: number; activated: number }>>((acc, row: {
+      event_type: string;
+      metadata: Record<string, unknown> | null;
+    }) => {
+      const source = typeof row.metadata?.source === 'string' && row.metadata.source.length > 0
+        ? row.metadata.source
+        : 'unknown';
+      if (!acc[source]) acc[source] = { viewed: 0, clicked: 0, started: 0, activated: 0 };
+      if (row.event_type === 'upgrade_prompt_viewed') acc[source].viewed += 1;
+      if (row.event_type === 'upgrade_cta_clicked') acc[source].clicked += 1;
+      if (row.event_type === 'checkout_started') acc[source].started += 1;
+      if (row.event_type === 'subscription_activated') acc[source].activated += 1;
+      return acc;
+    }, {});
+
+    const now = Date.now();
+    const trialWindowEnd = now + 7 * 24 * 60 * 60 * 1000;
+    const upcomingBillingProfiles = (billingProfiles.data ?? [])
+      .filter((profile: {
+        subscription_status: string | null;
+        subscription_trial_end: string | null;
+        subscription_cancel_at_period_end: boolean | null;
+      }) => {
+        const trialEnd = profile.subscription_trial_end ? new Date(profile.subscription_trial_end).getTime() : null;
+        const isExpiringTrial = profile.subscription_status === 'trialing' && trialEnd !== null && trialEnd >= now && trialEnd <= trialWindowEnd;
+        return isExpiringTrial || profile.subscription_cancel_at_period_end || ['past_due', 'unpaid'].includes(profile.subscription_status || '');
+      })
+      .slice(0, 8);
 
     return NextResponse.json({
       health: {
@@ -71,7 +611,42 @@ export async function GET() {
           total: seTotal.count ?? 0,
           enriched: seEnriched.count ?? 0,
         },
+        billing: {
+          paidProfiles: paidProfiles.count ?? 0,
+          activeTrials: activeTrials.count ?? 0,
+          expiringTrials: expiringTrials.count ?? 0,
+          atRisk: atRiskProfiles.count ?? 0,
+          scheduledChurn: scheduledChurnProfiles.count ?? 0,
+          trialStarts30d: usersByEvent.subscription_trial_started?.size ?? 0,
+          remindersSent30d: usersByEvent.billing_reminder_sent?.size ?? 0,
+          reminderClicks30d: usersByEvent.billing_reminder_clicked?.size ?? 0,
+          portalOpens30d: usersByEvent.billing_portal_opened?.size ?? 0,
+        },
       },
+      dataReview,
+      dataReviewBenchmarks,
+      dataReviewDecision: {
+        status: dataReviewDecisionStatus,
+        recommendation: dataReviewRecommendation,
+        benchmarkPassCount: dataReviewBenchmarkPassCount,
+        benchmarkTotal: dataReviewBenchmarks.length,
+        reviewIsStale,
+      },
+      productFunnel,
+      pilotSummary,
+      pilotBenchmarks,
+      pilotDecision: {
+        status: pilotDecisionStatus,
+        recommendation: pilotRecommendation,
+        benchmarkPassCount,
+        benchmarkTotal: pilotBenchmarks.length,
+        strongerCohort,
+      },
+      pilotCohorts,
+      pilotAttention,
+      pilots,
+      upgradeSources: upgradeSourceCounts,
+      upcomingBillingProfiles,
       recentRuns: recentRuns.data ?? [],
       lastUpdated: new Date().toISOString(),
     });

--- a/apps/web/src/app/api/ops/validation-reviews/import/route.ts
+++ b/apps/web/src/app/api/ops/validation-reviews/import/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getServiceSupabase } from '@/lib/supabase';
+import { parseValidationReviewCsv } from '@/lib/validation-reviews';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  const contentType = request.headers.get('content-type') || '';
+  if (!contentType.includes('multipart/form-data')) {
+    return NextResponse.json({ error: 'Expected multipart/form-data upload.' }, { status: 400 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'No CSV file uploaded.' }, { status: 400 });
+  }
+
+  if (file.size > 2 * 1024 * 1024) {
+    return NextResponse.json({ error: 'CSV file is too large. Max 2MB.' }, { status: 400 });
+  }
+
+  const csvText = await file.text();
+  const { rowsParsed, validRows } = parseValidationReviewCsv(csvText);
+
+  if (rowsParsed === 0) {
+    return NextResponse.json({ error: 'CSV contained no review rows.' }, { status: 400 });
+  }
+
+  if (validRows.length === 0) {
+    return NextResponse.json({ error: 'CSV rows were present but none were valid review rows.' }, { status: 400 });
+  }
+
+  const db = getServiceSupabase();
+  const { error } = await db
+    .from('validation_reviews')
+    .upsert(validRows, { onConflict: 'row_key' });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    imported: validRows.length,
+    rowsParsed,
+  });
+}

--- a/apps/web/src/app/api/ops/validation-reviews/template/route.ts
+++ b/apps/web/src/app/api/ops/validation-reviews/template/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+
+const TEMPLATE = 'review_date,reviewer,record_type,surface,source,record_id,record_name,status,issue_type,url_works,open_now_correct,deadline_correct,amount_correct,provider_correct,match_relevance_score,relationship_signal_score,actionability_score,notes,recommended_fix,owner\n';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  return new NextResponse(TEMPLATE, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="grantscope-data-review-scorecard-template.csv"',
+    },
+  });
+}

--- a/apps/web/src/lib/pilot-participants.ts
+++ b/apps/web/src/lib/pilot-participants.ts
@@ -1,0 +1,116 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const PILOT_COHORTS = ['consultant', 'nonprofit', 'other'] as const;
+export type PilotCohort = (typeof PILOT_COHORTS)[number];
+
+export const PILOT_STAGES = ['lead', 'invited', 'scheduled', 'onboarded', 'active', 'completed', 'paid', 'declined'] as const;
+export type PilotStage = (typeof PILOT_STAGES)[number];
+
+export const PILOT_PAYMENT_INTENTS = ['unknown', 'strong_yes', 'conditional_yes', 'not_now', 'no_budget', 'no_fit'] as const;
+export type PilotPaymentIntent = (typeof PILOT_PAYMENT_INTENTS)[number];
+
+export const PILOT_SEAN_ELLIS_RESPONSES = ['unknown', 'very_disappointed', 'somewhat_disappointed', 'not_disappointed'] as const;
+export type PilotSeanEllisResponse = (typeof PILOT_SEAN_ELLIS_RESPONSES)[number];
+
+export type PilotParticipantInput = {
+  participant_name?: unknown;
+  email?: unknown;
+  organization_name?: unknown;
+  role_title?: unknown;
+  cohort?: unknown;
+  stage?: unknown;
+  payment_intent?: unknown;
+  sean_ellis_response?: unknown;
+  pilot_source?: unknown;
+  funding_task?: unknown;
+  notes?: unknown;
+  last_contact_at?: unknown;
+  onboarding_at?: unknown;
+  observed_session_at?: unknown;
+  closeout_at?: unknown;
+};
+
+function cleanText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function cleanTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export function normalizePilotEmail(value: unknown): string | null {
+  const cleaned = cleanText(value);
+  return cleaned ? cleaned.toLowerCase() : null;
+}
+
+export function asPilotCohort(value: unknown): PilotCohort {
+  return PILOT_COHORTS.includes(value as PilotCohort) ? (value as PilotCohort) : 'consultant';
+}
+
+export function asPilotStage(value: unknown): PilotStage {
+  return PILOT_STAGES.includes(value as PilotStage) ? (value as PilotStage) : 'lead';
+}
+
+export function asPilotPaymentIntent(value: unknown): PilotPaymentIntent {
+  return PILOT_PAYMENT_INTENTS.includes(value as PilotPaymentIntent) ? (value as PilotPaymentIntent) : 'unknown';
+}
+
+export function asPilotSeanEllisResponse(value: unknown): PilotSeanEllisResponse {
+  return PILOT_SEAN_ELLIS_RESPONSES.includes(value as PilotSeanEllisResponse)
+    ? (value as PilotSeanEllisResponse)
+    : 'unknown';
+}
+
+export function sanitizePilotParticipantInput(input: PilotParticipantInput) {
+  return {
+    participant_name: cleanText(input.participant_name),
+    email: normalizePilotEmail(input.email),
+    organization_name: cleanText(input.organization_name),
+    role_title: cleanText(input.role_title),
+    cohort: asPilotCohort(input.cohort),
+    stage: asPilotStage(input.stage),
+    payment_intent: asPilotPaymentIntent(input.payment_intent),
+    sean_ellis_response: asPilotSeanEllisResponse(input.sean_ellis_response),
+    pilot_source: cleanText(input.pilot_source),
+    funding_task: cleanText(input.funding_task),
+    notes: cleanText(input.notes),
+    last_contact_at: cleanTimestamp(input.last_contact_at),
+    onboarding_at: cleanTimestamp(input.onboarding_at),
+    observed_session_at: cleanTimestamp(input.observed_session_at),
+    closeout_at: cleanTimestamp(input.closeout_at),
+  };
+}
+
+export async function resolvePilotLinks(email: string) {
+  const db = getServiceSupabase();
+
+  const { data: profile } = await db
+    .from('profiles')
+    .select('id, primary_organization_id')
+    .ilike('email', email)
+    .maybeSingle();
+
+  const linkedUserId = profile?.id ?? null;
+  let linkedOrgProfileId = profile?.primary_organization_id ?? null;
+
+  if (!linkedOrgProfileId && linkedUserId) {
+    const { data: orgProfile } = await db
+      .from('org_profiles')
+      .select('id')
+      .eq('user_id', linkedUserId)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    linkedOrgProfileId = orgProfile?.id ?? null;
+  }
+
+  return { linkedUserId, linkedOrgProfileId };
+}

--- a/apps/web/src/lib/validation-reviews.ts
+++ b/apps/web/src/lib/validation-reviews.ts
@@ -1,0 +1,135 @@
+import { parse } from 'csv-parse/sync';
+
+export type ValidationReviewRow = {
+  review_date: string;
+  reviewer: string | null;
+  row_key: string;
+  record_type: 'grant' | 'foundation';
+  surface: string | null;
+  source: string | null;
+  record_id: string | null;
+  record_name: string | null;
+  status: 'correct' | 'usable_but_incomplete' | 'wrong_noisy';
+  issue_type: string | null;
+  url_works: boolean | null;
+  open_now_correct: boolean | null;
+  deadline_correct: boolean | null;
+  amount_correct: boolean | null;
+  provider_correct: boolean | null;
+  match_relevance_score: number | null;
+  relationship_signal_score: number | null;
+  actionability_score: number | null;
+  notes: string | null;
+  recommended_fix: string | null;
+  owner: string | null;
+  updated_at: string;
+};
+
+function cleanText(value: unknown): string | null {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function cleanBoolean(value: unknown): boolean | null {
+  const normalized = cleanText(value)?.toLowerCase();
+  if (!normalized) return null;
+  if (['yes', 'y', 'true', '1'].includes(normalized)) return true;
+  if (['no', 'n', 'false', '0'].includes(normalized)) return false;
+  return null;
+}
+
+function cleanNumber(value: unknown): number | null {
+  const normalized = cleanText(value);
+  if (!normalized) return null;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function cleanDate(value: unknown): string | null {
+  const normalized = cleanText(value);
+  if (!normalized) return null;
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeRecordType(value: unknown): 'grant' | 'foundation' | null {
+  const normalized = cleanText(value)?.toLowerCase();
+  if (normalized === 'grant' || normalized === 'foundation') return normalized;
+  return null;
+}
+
+function normalizeStatus(value: unknown): ValidationReviewRow['status'] | null {
+  const normalized = cleanText(value)?.toLowerCase();
+  if (!normalized) return null;
+  if (normalized === 'correct') return 'correct';
+  if (normalized === 'usable_but_incomplete' || normalized === 'usable but incomplete') return 'usable_but_incomplete';
+  if (normalized === 'wrong_noisy' || normalized === 'wrong/noisy' || normalized === 'wrong noisy') return 'wrong_noisy';
+  return null;
+}
+
+function buildRowKey(row: Omit<ValidationReviewRow, 'row_key' | 'updated_at'>) {
+  const parts = [
+    row.review_date || 'undated',
+    row.reviewer || 'unknown-reviewer',
+    row.record_type || 'unknown-record',
+    row.surface || 'unknown-surface',
+    row.source || 'unknown-source',
+    row.record_id || row.record_name || row.notes || Math.random().toString(36).slice(2, 10),
+  ];
+  return parts
+    .join('::')
+    .toLowerCase()
+    .replace(/[^a-z0-9:._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 240);
+}
+
+export function parseValidationReviewCsv(csvText: string) {
+  const rows = parse(csvText, { columns: true, skip_empty_lines: true, trim: true }) as Array<Record<string, unknown>>;
+
+  const validRows: ValidationReviewRow[] = rows
+    .map((row) => {
+      const review_date = cleanDate(row.review_date);
+      const record_type = normalizeRecordType(row.record_type);
+      const status = normalizeStatus(row.status);
+
+      if (!review_date || !record_type || !status) return null;
+
+      const normalizedRow = {
+        review_date,
+        reviewer: cleanText(row.reviewer),
+        record_type,
+        surface: cleanText(row.surface),
+        source: cleanText(row.source),
+        record_id: cleanText(row.record_id),
+        record_name: cleanText(row.record_name),
+        status,
+        issue_type: cleanText(row.issue_type),
+        url_works: cleanBoolean(row.url_works),
+        open_now_correct: cleanBoolean(row.open_now_correct),
+        deadline_correct: cleanBoolean(row.deadline_correct),
+        amount_correct: cleanBoolean(row.amount_correct),
+        provider_correct: cleanBoolean(row.provider_correct),
+        match_relevance_score: cleanNumber(row.match_relevance_score),
+        relationship_signal_score: cleanNumber(row.relationship_signal_score),
+        actionability_score: cleanNumber(row.actionability_score),
+        notes: cleanText(row.notes),
+        recommended_fix: cleanText(row.recommended_fix),
+        owner: cleanText(row.owner),
+      } satisfies Omit<ValidationReviewRow, 'row_key' | 'updated_at'>;
+
+      return {
+        ...normalizedRow,
+        updated_at: new Date().toISOString(),
+        row_key: buildRowKey(normalizedRow),
+      } satisfies ValidationReviewRow;
+    })
+    .filter((row): row is ValidationReviewRow => row !== null);
+
+  return {
+    rowsParsed: rows.length,
+    validRows,
+  };
+}


### PR DESCRIPTION
## Summary
- New \`/api/ops/pilots\` + \`/api/ops/pilots/[pilotId]\` for pilot participant CRUD.
- New \`/api/ops/validation-reviews/{import,template}\` for CSV-based review intake.
- Enriches existing \`/api/ops/{claims,health,root}\` to surface pilot + review status.
- New libs: \`lib/pilot-participants.ts\`, \`lib/validation-reviews.ts\`.

Part of phase 2 dirty-tree carve (bucket: validation-pilots).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] \`GET /api/ops/pilots\` lists current pilots
- [ ] \`GET /api/ops/validation-reviews/template\` returns CSV template