### PR TITLE
feat(alerts): end-to-end alerts with notifications, tracking, scout + product-events infra

### DIFF
--- a/apps/web/src/app/alerts/page.tsx
+++ b/apps/web/src/app/alerts/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { createSupabaseBrowser } from '@/lib/supabase-browser';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { trackProductEvent } from '@/lib/product-events-client';
+import { startCheckoutForTier } from '@/lib/start-checkout';
+import { createSupabaseBrowser } from '@/lib/supabase-browser';
+import type { AlertFrequency, Tier } from '@/lib/subscription';
 
 interface MatchingGrant {
   id: string;
@@ -31,21 +34,319 @@ interface Alert {
   updated_at: string;
 }
 
+interface AlertActivity {
+  id: string;
+  notification_type: string;
+  status: string;
+  subject: string | null;
+  match_score: number | null;
+  match_signals: string[];
+  queued_at: string;
+  sent_at: string | null;
+  last_error: string | null;
+  alert: {
+    id: string;
+    name: string;
+    frequency: string;
+    enabled: boolean;
+  } | null;
+  grant: {
+    id: string;
+    name: string;
+    provider: string | null;
+    closes_at: string | null;
+  } | null;
+}
+
+interface QueueSummary {
+  queued: number;
+  sent: number;
+  failed: number;
+  cancelled: number;
+}
+
+interface AlertEntitlements {
+  maxAlerts: number;
+  frequencies: AlertFrequency[];
+  weeklyDigest: boolean;
+}
+
+interface AlertEventSummary {
+  notificationsQueued: number;
+  notificationsSent: number;
+  notificationsFailed: number;
+  digestsSent: number;
+  emailOpens: number;
+  grantClicks: number;
+  scoutRuns: number;
+  optimizationsApplied: number;
+}
+
+interface AlertPerformance {
+  queued: number;
+  sent: number;
+  failed: number;
+  digestsSent: number;
+  opens: number;
+  clicks: number;
+  tracked: number;
+  active: number;
+  submitted: number;
+  won: number;
+  openRate: number | null;
+  clickRate: number | null;
+  trackRate: number | null;
+  clickToTrackRate: number | null;
+  submissionRate: number | null;
+  winRate: number | null;
+  lastEventAt: string | null;
+  lastTrackedAt: string | null;
+  lastOptimizedAt: string | null;
+  lastOptimizationAction: string | null;
+  opensAfterOptimization: number;
+  sentAfterOptimization: number;
+  clicksAfterOptimization: number;
+  trackedAfterOptimization: number;
+  optimizationComparison: {
+    hasComparisonData: boolean;
+    enoughComparisonData: boolean;
+    before: {
+      sent: number;
+      opens: number;
+      clicks: number;
+      tracked: number;
+      openRate: number | null;
+      clickRate: number | null;
+      trackRate: number | null;
+    };
+    after: {
+      sent: number;
+      opens: number;
+      clicks: number;
+      tracked: number;
+      openRate: number | null;
+      clickRate: number | null;
+      trackRate: number | null;
+    };
+    delta: {
+      openRate: number | null;
+      clickRate: number | null;
+      trackRate: number | null;
+    };
+  } | null;
+  recommendation: {
+    key:
+      | 'keep_expand'
+      | 'working_pipeline'
+      | 'good_prospect_flow'
+      | 'clicks_not_converting'
+      | 'low_engagement'
+      | 'low_fit'
+      | 'no_recent_activity'
+      | 'monitor'
+      | 'optimization_improving'
+      | 'optimization_underperforming';
+    tone: 'success' | 'info' | 'warning' | 'neutral';
+    title: string;
+    detail: string;
+  };
+}
+
+interface AlertEvent {
+  id: number;
+  event_type: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+type ActionFeedback = {
+  tone: 'success' | 'error';
+  message: string;
+};
+
+type AlertOptimizationAction = 'pause' | 'slow_down' | 'clone_tighter';
+
 const FREQUENCIES = ['daily', 'weekly', 'monthly'];
 const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
 const CATEGORIES = ['Education', 'Health', 'Environment', 'Arts & Culture', 'Community', 'Indigenous', 'Research', 'Social Services'];
+
+const ALERT_STATUS_STYLES: Record<string, string> = {
+  queued: 'bg-amber-50 text-amber-700 border-amber-200',
+  sent: 'bg-green-100 text-green-700 border-green-200',
+  failed: 'bg-red-50 text-red-600 border-red-200',
+  cancelled: 'bg-gray-100 text-gray-500 border-gray-200',
+};
+
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${Math.max(mins, 0)}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function daysUntil(dateStr: string | null) {
+  if (!dateStr) return '—';
+  const diff = new Date(dateStr).getTime() - Date.now();
+  const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+  if (days < 0) return 'Closed';
+  if (days === 0) return 'Today';
+  if (days === 1) return '1 day';
+  return `${days} days`;
+}
+
+function formatMoney(n: number | null) {
+  return n == null ? '—' : `$${n.toLocaleString()}`;
+}
+
+const EMPTY_QUEUE_SUMMARY: QueueSummary = {
+  queued: 0,
+  sent: 0,
+  failed: 0,
+  cancelled: 0,
+};
+
+const EMPTY_EVENT_SUMMARY: AlertEventSummary = {
+  notificationsQueued: 0,
+  notificationsSent: 0,
+  notificationsFailed: 0,
+  digestsSent: 0,
+  emailOpens: 0,
+  grantClicks: 0,
+  scoutRuns: 0,
+  optimizationsApplied: 0,
+};
+
+function formatOptimizationAction(action: string | null) {
+  if (!action) return 'optimized';
+  if (action === 'clone_tighter') return 'cloned tighter';
+  if (action === 'slow_down') return 'slowed down';
+  if (action === 'pause') return 'paused';
+  return action.replace(/_/g, ' ');
+}
+
+function formatDelta(value: number | null) {
+  if (value == null) return '—';
+  if (value === 0) return '0 pts';
+  return `${value > 0 ? '+' : ''}${value} pts`;
+}
+
+function renderEventDetail(event: AlertEvent) {
+  if (event.event_type === 'optimization_applied') {
+    const action = typeof event.metadata?.action === 'string' ? event.metadata.action : null;
+    const recommendationTitle =
+      typeof event.metadata?.recommendation_title === 'string' ? event.metadata.recommendation_title : null;
+    const createdAlertName =
+      typeof event.metadata?.created_alert_name === 'string' ? event.metadata.created_alert_name : null;
+
+    if (action === 'clone_tighter' && createdAlertName) {
+      return `Created tighter variant: ${createdAlertName}${recommendationTitle ? ` from ${recommendationTitle}` : ''}`;
+    }
+
+    return `${formatOptimizationAction(action)}${recommendationTitle ? ` from ${recommendationTitle}` : ''}`;
+  }
+
+  return Object.keys(event.metadata || {}).length > 0 ? JSON.stringify(event.metadata) : 'No extra metadata';
+}
+
+function nextLowerFrequency(current: string) {
+  if (current === 'daily') return 'weekly';
+  if (current === 'weekly') return 'monthly';
+  return null;
+}
+
+function buildTighterVariantPayload(alert: Alert) {
+  const trimmedKeywords = alert.keywords.filter(Boolean).slice(0, 2);
+  const fallbackKeyword = trimmedKeywords.length > 0
+    ? trimmedKeywords
+    : alert.focus_areas[0]
+      ? [alert.focus_areas[0]]
+      : alert.categories[0]
+        ? [alert.categories[0]]
+        : [];
+
+  return {
+    name: `${alert.name} High Fit`,
+    frequency: alert.frequency,
+    categories: alert.categories.length > 1 ? alert.categories.slice(0, 1) : alert.categories,
+    focus_areas: alert.focus_areas.length > 1 ? alert.focus_areas.slice(0, 1) : alert.focus_areas,
+    states: alert.states.length > 1 ? alert.states.slice(0, 1) : alert.states,
+    min_amount: alert.min_amount,
+    max_amount: alert.max_amount,
+    keywords: fallbackKeyword,
+    entity_types: alert.entity_types,
+  };
+}
+
+function getOptimizationActions(
+  alert: Alert,
+  performance: AlertPerformance,
+  canClone: boolean
+): Array<{ action: AlertOptimizationAction; label: string }> {
+  if (
+    performance.recommendation.key === 'keep_expand'
+    || performance.recommendation.key === 'working_pipeline'
+    || performance.recommendation.key === 'good_prospect_flow'
+    || performance.recommendation.key === 'optimization_improving'
+  ) {
+    return canClone ? [{ action: 'clone_tighter', label: 'Clone High-Fit Variant' }] : [];
+  }
+
+  if (performance.recommendation.key === 'clicks_not_converting') {
+    const actions: Array<{ action: AlertOptimizationAction; label: string }> = [];
+    if (canClone) actions.push({ action: 'clone_tighter', label: 'Clone Tighter Variant' });
+    actions.push({ action: 'pause', label: 'Pause Alert' });
+    return actions;
+  }
+
+  if (performance.recommendation.key === 'low_engagement') {
+    const nextFrequency = nextLowerFrequency(alert.frequency);
+    return nextFrequency
+      ? [{ action: 'slow_down', label: `Switch to ${nextFrequency}` }]
+      : [{ action: 'pause', label: 'Pause Alert' }];
+  }
+
+  if (
+    performance.recommendation.key === 'low_fit'
+    || performance.recommendation.key === 'optimization_underperforming'
+  ) {
+    return [{ action: 'pause', label: 'Pause Alert' }];
+  }
+
+  return [];
+}
 
 export default function AlertsPage() {
   const [user, setUser] = useState<{ id: string } | null>(null);
   const [loading, setLoading] = useState(true);
   const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [recentActivity, setRecentActivity] = useState<AlertActivity[]>([]);
+  const [recentEvents, setRecentEvents] = useState<AlertEvent[]>([]);
+  const [queueSummary, setQueueSummary] = useState<QueueSummary>(EMPTY_QUEUE_SUMMARY);
+  const [eventSummary, setEventSummary] = useState<AlertEventSummary>(EMPTY_EVENT_SUMMARY);
+  const [alertPerformance, setAlertPerformance] = useState<Record<string, AlertPerformance>>({});
+  const [performanceWindowDays, setPerformanceWindowDays] = useState(30);
+  const [tier, setTier] = useState<Tier>('community');
+  const [entitlements, setEntitlements] = useState<AlertEntitlements>({ maxAlerts: 1, frequencies: ['weekly'], weeklyDigest: false });
+  const [usage, setUsage] = useState({ alerts: 0, activeAlerts: 0, remainingAlerts: 0 });
   const [showForm, setShowForm] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [scouting, setScouting] = useState(false);
+  const [delivering, setDelivering] = useState(false);
+  const [sendingDigest, setSendingDigest] = useState(false);
+  const [startingUpgrade, setStartingUpgrade] = useState(false);
+  const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+  const [pendingOptimization, setPendingOptimization] = useState<{ id: string; action: AlertOptimizationAction } | null>(null);
+  const [pendingToggleAlertId, setPendingToggleAlertId] = useState<string | null>(null);
+  const [pendingDeleteAlertId, setPendingDeleteAlertId] = useState<string | null>(null);
+  const [pendingTrackGrantId, setPendingTrackGrantId] = useState<string | null>(null);
+  const [pendingNotificationAction, setPendingNotificationAction] = useState<{ id: string; action: 'retry' | 'cancel' } | null>(null);
   const [expandedAlert, setExpandedAlert] = useState<string | null>(null);
   const [alertMatches, setAlertMatches] = useState<Record<string, MatchingGrant[]>>({});
   const [matchLoading, setMatchLoading] = useState<string | null>(null);
 
-  // Form state
   const [name, setName] = useState('');
   const [frequency, setFrequency] = useState('weekly');
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
@@ -53,6 +354,18 @@ export default function AlertsPage() {
   const [minAmount, setMinAmount] = useState('');
   const [maxAmount, setMaxAmount] = useState('');
   const [keywords, setKeywords] = useState('');
+
+  const pipelineImpactSummary = Object.values(alertPerformance).reduce(
+    (summary, performance) => {
+      summary.tracked += performance.tracked;
+      summary.active += performance.active;
+      summary.submitted += performance.submitted;
+      summary.won += performance.won;
+      return summary;
+    },
+    { tracked: 0, active: 0, submitted: 0, won: 0 }
+  );
+  const showCommunityUpsell = tier === 'community';
 
   useEffect(() => {
     const supabase = createSupabaseBrowser();
@@ -62,35 +375,82 @@ export default function AlertsPage() {
     });
   }, []);
 
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = window.setTimeout(() => setFeedback(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [feedback]);
+
+  useEffect(() => {
+    if (!user || !showCommunityUpsell) return;
+    void trackProductEvent('upgrade_prompt_viewed', {
+      source: 'alerts_page_upsell',
+      metadata: {
+        tier,
+        max_alerts: entitlements.maxAlerts,
+        weekly_digest: entitlements.weeklyDigest,
+      },
+      onceKey: 'alerts_page_upsell:viewed',
+    });
+  }, [user, showCommunityUpsell, tier, entitlements.maxAlerts, entitlements.weeklyDigest]);
+
   const fetchAlerts = useCallback(async () => {
     const res = await fetch('/api/alerts');
-    if (res.ok) {
-      const data = await res.json();
-      setAlerts(data.alerts || []);
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+      setFeedback({
+        tone: 'error',
+        message: data?.error || 'Could not load alerts.',
+      });
+      return;
     }
+
+    setAlerts(data?.alerts || []);
+    setRecentActivity(data?.recentActivity || []);
+    setAlertPerformance(data?.alertPerformance || {});
+    setPerformanceWindowDays(Number(data?.performanceWindowDays || 30));
+    setQueueSummary(data?.queueSummary || EMPTY_QUEUE_SUMMARY);
+    setRecentEvents(data?.recentEvents || []);
+    setEventSummary(data?.eventSummary || EMPTY_EVENT_SUMMARY);
+    setTier(data?.tier || 'community');
+    setEntitlements(data?.entitlements || { maxAlerts: 1, frequencies: ['weekly'], weeklyDigest: false });
+    setUsage(data?.usage || { alerts: 0, activeAlerts: 0, remainingAlerts: 0 });
   }, []);
 
   useEffect(() => {
-    if (user) fetchAlerts();
+    if (user) {
+      void fetchAlerts();
+    }
   }, [user, fetchAlerts]);
 
   async function createAlert(e: React.FormEvent) {
     e.preventDefault();
+    if (usage.alerts >= entitlements.maxAlerts) {
+      setFeedback({ tone: 'error', message: 'You have reached your alert limit for this plan.' });
+      return;
+    }
     setSaving(true);
-    const res = await fetch('/api/alerts', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: name || 'My Alert',
-        frequency,
-        categories: selectedCategories,
-        states: selectedStates,
-        min_amount: minAmount ? Number(minAmount) : null,
-        max_amount: maxAmount ? Number(maxAmount) : null,
-        keywords: keywords ? keywords.split(',').map(k => k.trim()).filter(Boolean) : [],
-      }),
-    });
-    if (res.ok) {
+
+    try {
+      const res = await fetch('/api/alerts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name || 'My Alert',
+          frequency,
+          categories: selectedCategories,
+          states: selectedStates,
+          min_amount: minAmount ? Number(minAmount) : null,
+          max_amount: maxAmount ? Number(maxAmount) : null,
+          keywords: keywords ? keywords.split(',').map(k => k.trim()).filter(Boolean) : [],
+        }),
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not create alert.');
+      }
+
       setShowForm(false);
       setName('');
       setFrequency('weekly');
@@ -99,24 +459,104 @@ export default function AlertsPage() {
       setMinAmount('');
       setMaxAmount('');
       setKeywords('');
-      fetchAlerts();
+      setFeedback({ tone: 'success', message: 'Alert created.' });
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not create alert.',
+      });
+    } finally {
+      setSaving(false);
     }
-    setSaving(false);
+  }
+
+  async function sendWeeklyDigest() {
+    setSendingDigest(true);
+
+    try {
+      const res = await fetch('/api/alerts/digest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force: true }),
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not send weekly digest.');
+      }
+
+      setFeedback({
+        tone: 'success',
+        message: data?.digestsSent > 0
+          ? `Sent ${data.digestsSent} weekly digest${data.digestsSent === 1 ? '' : 's'}.`
+          : 'No weekly digest was due yet. Run the scout first if you expected new matches.',
+      });
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not send weekly digest.',
+      });
+    } finally {
+      setSendingDigest(false);
+    }
   }
 
   async function toggleAlert(id: string, enabled: boolean) {
-    await fetch(`/api/alerts/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ enabled: !enabled }),
-    });
-    fetchAlerts();
+    setPendingToggleAlertId(id);
+
+    try {
+      const res = await fetch(`/api/alerts/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !enabled }),
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not update alert.');
+      }
+
+      setFeedback({
+        tone: 'success',
+        message: enabled ? 'Alert paused.' : 'Alert enabled.',
+      });
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not update alert.',
+      });
+    } finally {
+      setPendingToggleAlertId(null);
+    }
   }
 
   async function deleteAlert(id: string) {
     if (!confirm('Delete this alert?')) return;
-    await fetch(`/api/alerts/${id}`, { method: 'DELETE' });
-    fetchAlerts();
+    setPendingDeleteAlertId(id);
+
+    try {
+      const res = await fetch(`/api/alerts/${id}`, { method: 'DELETE' });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not delete alert.');
+      }
+
+      setFeedback({ tone: 'success', message: 'Alert deleted.' });
+      if (expandedAlert === id) {
+        setExpandedAlert(null);
+      }
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not delete alert.',
+      });
+    } finally {
+      setPendingDeleteAlertId(null);
+    }
   }
 
   async function viewMatches(alertId: string) {
@@ -124,38 +564,274 @@ export default function AlertsPage() {
       setExpandedAlert(null);
       return;
     }
+
     setExpandedAlert(alertId);
     if (alertMatches[alertId]) return;
+
     setMatchLoading(alertId);
-    const res = await fetch(`/api/alerts/matches?alertId=${alertId}`);
-    if (res.ok) {
-      const data = await res.json();
-      setAlertMatches(prev => ({ ...prev, [alertId]: data.grants || [] }));
+    try {
+      const res = await fetch(`/api/alerts/matches?alertId=${alertId}`);
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not load matches.');
+      }
+      setAlertMatches((prev) => ({ ...prev, [alertId]: data?.grants || [] }));
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not load matches.',
+      });
+    } finally {
+      setMatchLoading(null);
     }
-    setMatchLoading(null);
   }
 
-  async function trackGrant(grantId: string) {
-    await fetch(`/api/tracker/${grantId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ stage: 'discovered' }),
-    });
+  async function trackGrant(grantId: string, options?: { alertId?: string | null; notificationId?: string | null }) {
+    setPendingTrackGrantId(grantId);
+
+    try {
+      const sourceAlertPreferenceId =
+        options?.alertId && Number.isFinite(Number(options.alertId)) ? Number(options.alertId) : null;
+      const res = await fetch(`/api/tracker/${grantId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          stage: 'discovered',
+          ...(sourceAlertPreferenceId !== null ? { source_alert_preference_id: sourceAlertPreferenceId } : {}),
+          ...(options?.notificationId ? { source_notification_id: options.notificationId } : {}),
+          ...(sourceAlertPreferenceId !== null || options?.notificationId ? { source_attribution_type: 'manual' } : {}),
+        }),
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not add grant to tracker.');
+      }
+
+      setFeedback({ tone: 'success', message: 'Grant added to your tracker.' });
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not add grant to tracker.',
+      });
+    } finally {
+      setPendingTrackGrantId(null);
+    }
   }
 
-  if (loading) return (
-    <div className="flex items-center justify-center min-h-[40vh]">
-      <div className="text-sm font-black text-bauhaus-muted uppercase tracking-widest">Loading...</div>
-    </div>
-  );
+  async function updateNotification(notificationId: string, action: 'retry' | 'cancel') {
+    setPendingNotificationAction({ id: notificationId, action });
+
+    try {
+      const res = await fetch('/api/alerts/notifications', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notificationId, action }),
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not update notification.');
+      }
+
+      setFeedback({
+        tone: 'success',
+        message: action === 'retry'
+          ? 'Notification re-queued for delivery.'
+          : 'Notification dismissed from the queue.',
+      });
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not update notification.',
+      });
+    } finally {
+      setPendingNotificationAction(null);
+    }
+  }
+
+  async function deliverQueuedNow() {
+    setDelivering(true);
+
+    try {
+      const res = await fetch('/api/alerts/deliver', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit: 25 }),
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not deliver queued notifications.');
+      }
+
+      const sent = Number(data?.sent || 0);
+      const cancelled = Number(data?.cancelled || 0);
+      setFeedback({
+        tone: 'success',
+        message: sent > 0
+          ? `Delivered ${sent} queued notification${sent === 1 ? '' : 's'}.`
+          : cancelled > 0
+            ? `${cancelled} queued notification${cancelled === 1 ? '' : 's'} cancelled.`
+            : 'No queued grant notifications were ready to send.',
+      });
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not deliver queued notifications.',
+      });
+    } finally {
+      setDelivering(false);
+    }
+  }
+
+  async function runScoutNow() {
+    setScouting(true);
+
+    try {
+      const res = await fetch('/api/alerts/scout', {
+        method: 'POST',
+      });
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error || 'Could not run the grant scout.');
+      }
+
+      setFeedback({
+        tone: 'success',
+        message:
+          `Scanned ${data?.profilesScanned || 0} profile${data?.profilesScanned === 1 ? '' : 's'}, `
+          + `found ${data?.matchesFound || 0} match${data?.matchesFound === 1 ? '' : 'es'}, `
+          + `added ${data?.grantsAdded || 0} grant${data?.grantsAdded === 1 ? '' : 's'} to the tracker, `
+          + `and queued ${data?.notificationsQueued || 0} notification${data?.notificationsQueued === 1 ? '' : 's'}.`,
+      });
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not run the grant scout.',
+      });
+    } finally {
+      setScouting(false);
+    }
+  }
+
+  async function applyOptimization(alert: Alert, performance: AlertPerformance, action: AlertOptimizationAction) {
+    setPendingOptimization({ id: alert.id, action });
+
+    try {
+      if (action === 'pause') {
+        const res = await fetch(`/api/alerts/${alert.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            enabled: false,
+            optimization_event: {
+              action,
+              recommendation_title: performance.recommendation.title,
+              previous_frequency: alert.frequency,
+              next_frequency: null,
+            },
+          }),
+        });
+        const data = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(data?.error || 'Could not pause alert.');
+        }
+        setFeedback({ tone: 'success', message: 'Alert paused.' });
+      }
+
+      if (action === 'slow_down') {
+        const frequency = nextLowerFrequency(alert.frequency);
+        if (!frequency) {
+          throw new Error('This alert is already at the slowest frequency.');
+        }
+        const res = await fetch(`/api/alerts/${alert.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            frequency,
+            optimization_event: {
+              action,
+              recommendation_title: performance.recommendation.title,
+              previous_frequency: alert.frequency,
+              next_frequency: frequency,
+            },
+          }),
+        });
+        const data = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(data?.error || 'Could not update alert frequency.');
+        }
+        setFeedback({ tone: 'success', message: `Alert frequency changed to ${frequency}.` });
+      }
+
+      if (action === 'clone_tighter') {
+        if (usage.alerts >= entitlements.maxAlerts) {
+          throw new Error('You have reached your alert limit for this plan.');
+        }
+
+        const res = await fetch('/api/alerts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...buildTighterVariantPayload(alert),
+            optimization_source_alert_id: Number(alert.id),
+            optimization_action: action,
+            optimization_recommendation_title: performance.recommendation.title,
+          }),
+        });
+        const data = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(data?.error || 'Could not clone alert.');
+        }
+        setFeedback({
+          tone: 'success',
+          message:
+            performance.recommendation.key === 'keep_expand'
+              ? 'Created a high-fit variant from this winning alert.'
+              : 'Created a tighter alert variant for higher-fit matches.',
+        });
+      }
+
+      await fetchAlerts();
+    } catch (error) {
+      setFeedback({
+        tone: 'error',
+        message: error instanceof Error ? error.message : 'Could not apply alert optimization.',
+      });
+    } finally {
+      setPendingOptimization(null);
+    }
+  }
+
+  async function upgradeToProfessional() {
+    setStartingUpgrade(true);
+    const result = await startCheckoutForTier('professional', 'alerts_page_upsell');
+    if (!result.ok) {
+      setFeedback({ tone: 'error', message: result.error });
+      setStartingUpgrade(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh]">
+        <div className="text-sm font-black text-bauhaus-muted uppercase tracking-widest">Loading...</div>
+      </div>
+    );
+  }
 
   if (!user) {
     return (
       <div className="min-h-screen bg-white flex items-center justify-center">
         <div className="border-4 border-bauhaus-black p-12 text-center max-w-md">
           <h1 className="text-3xl font-black uppercase tracking-widest mb-4">Sign In Required</h1>
-          <p className="text-bauhaus-muted mb-6">Create grant alerts to get notified about new opportunities matching your criteria.</p>
-          <Link href="/auth/login" className="inline-block bg-bauhaus-black text-white px-8 py-3 font-bold uppercase tracking-wider hover:bg-bauhaus-red transition-colors">
+          <p className="text-bauhaus-muted mb-6">Create grant alerts and manage your delivery queue from one place.</p>
+          <Link href="/login?next=/alerts" className="inline-block bg-bauhaus-black text-white px-8 py-3 font-bold uppercase tracking-wider hover:bg-bauhaus-red transition-colors">
             Sign In
           </Link>
         </div>
@@ -164,253 +840,885 @@ export default function AlertsPage() {
   }
 
   return (
-    <div className="max-w-4xl">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-4xl font-black uppercase tracking-widest">Grant Alerts</h1>
-            <p className="text-bauhaus-muted mt-1">Get notified when grants match your criteria</p>
+    <div className="max-w-5xl">
+      <div className="flex items-start justify-between gap-4 flex-wrap mb-8">
+        <div>
+          <h1 className="text-4xl font-black uppercase tracking-widest">Grant Alerts</h1>
+          <p className="text-bauhaus-muted mt-1">
+            Build alerts, inspect the delivery queue, and send queued notifications without leaving the workspace.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-widest">
+            <span className="px-2 py-1 border border-bauhaus-black text-bauhaus-black">{tier} plan</span>
+            <span className="px-2 py-1 border border-bauhaus-black/20 text-bauhaus-muted">
+              {usage.alerts}/{entitlements.maxAlerts} alerts used
+            </span>
+            <span className="px-2 py-1 border border-bauhaus-black/20 text-bauhaus-muted">
+              {entitlements.frequencies.join(' / ')} frequencies
+            </span>
+            <span className={`px-2 py-1 border ${entitlements.weeklyDigest ? 'border-green-600 text-green-700' : 'border-bauhaus-black/20 text-bauhaus-muted'}`}>
+              {entitlements.weeklyDigest ? 'Weekly digest included' : 'Weekly digest locked'}
+            </span>
           </div>
+        </div>
+        <div className="flex gap-2 flex-wrap">
           <button
+            type="button"
+            onClick={() => void runScoutNow()}
+            disabled={scouting}
+            className="bg-bauhaus-red text-white px-5 py-3 font-bold uppercase tracking-wider hover:bg-red-700 transition-colors disabled:opacity-50"
+          >
+            {scouting ? 'Scouting...' : 'Run Scout Now'}
+          </button>
+          <button
+            type="button"
+            onClick={() => void deliverQueuedNow()}
+            disabled={delivering || queueSummary.queued === 0}
+            className="bg-bauhaus-blue text-white px-5 py-3 font-bold uppercase tracking-wider hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            {delivering ? 'Delivering...' : 'Deliver Queued Now'}
+          </button>
+          <button
+            type="button"
+            onClick={() => void sendWeeklyDigest()}
+            disabled={sendingDigest || !entitlements.weeklyDigest}
+            className="border-2 border-bauhaus-black px-5 py-3 font-bold uppercase tracking-wider hover:bg-gray-100 transition-colors disabled:opacity-50"
+          >
+            {sendingDigest ? 'Sending...' : 'Send Weekly Digest'}
+          </button>
+          <button
+            type="button"
             onClick={() => setShowForm(!showForm)}
-            className="bg-bauhaus-black text-white px-6 py-3 font-bold uppercase tracking-wider hover:bg-bauhaus-red transition-colors"
+            disabled={!showForm && usage.alerts >= entitlements.maxAlerts}
+            className="bg-bauhaus-black text-white px-6 py-3 font-bold uppercase tracking-wider hover:bg-bauhaus-red transition-colors disabled:opacity-50"
           >
             {showForm ? 'Cancel' : '+ New Alert'}
           </button>
         </div>
+      </div>
 
-        {/* Create Form */}
-        {showForm && (
-          <form onSubmit={createAlert} className="border-4 border-bauhaus-black p-6 mb-8">
-            <h2 className="text-xl font-black uppercase tracking-wider mb-4">New Alert</h2>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-              <div>
-                <label className="block text-xs font-bold uppercase tracking-wider mb-1">Name</label>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={e => setName(e.target.value)}
-                  placeholder="e.g. Indigenous Health Grants"
-                  className="w-full border-2 border-bauhaus-black px-3 py-2"
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-bold uppercase tracking-wider mb-1">Frequency</label>
-                <select
-                  value={frequency}
-                  onChange={e => setFrequency(e.target.value)}
-                  className="w-full border-2 border-bauhaus-black px-3 py-2"
-                >
-                  {FREQUENCIES.map(f => (
-                    <option key={f} value={f}>{f.charAt(0).toUpperCase() + f.slice(1)}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            <div className="mb-4">
-              <label className="block text-xs font-bold uppercase tracking-wider mb-1">Categories</label>
-              <div className="flex flex-wrap gap-2">
-                {CATEGORIES.map(cat => (
-                  <button
-                    key={cat}
-                    type="button"
-                    onClick={() => setSelectedCategories(prev =>
-                      prev.includes(cat) ? prev.filter(c => c !== cat) : [...prev, cat]
-                    )}
-                    className={`px-3 py-1 border-2 text-sm font-bold uppercase tracking-wider transition-colors ${
-                      selectedCategories.includes(cat)
-                        ? 'border-bauhaus-red bg-bauhaus-red text-white'
-                        : 'border-bauhaus-black hover:bg-gray-100'
-                    }`}
-                  >
-                    {cat}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="mb-4">
-              <label className="block text-xs font-bold uppercase tracking-wider mb-1">States</label>
-              <div className="flex flex-wrap gap-2">
-                {STATES.map(s => (
-                  <button
-                    key={s}
-                    type="button"
-                    onClick={() => setSelectedStates(prev =>
-                      prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]
-                    )}
-                    className={`px-3 py-1 border-2 text-sm font-bold uppercase tracking-wider transition-colors ${
-                      selectedStates.includes(s)
-                        ? 'border-bauhaus-blue bg-bauhaus-blue text-white'
-                        : 'border-bauhaus-black hover:bg-gray-100'
-                    }`}
-                  >
-                    {s}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-              <div>
-                <label className="block text-xs font-bold uppercase tracking-wider mb-1">Min Amount</label>
-                <input
-                  type="number"
-                  value={minAmount}
-                  onChange={e => setMinAmount(e.target.value)}
-                  placeholder="$0"
-                  className="w-full border-2 border-bauhaus-black px-3 py-2"
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-bold uppercase tracking-wider mb-1">Max Amount</label>
-                <input
-                  type="number"
-                  value={maxAmount}
-                  onChange={e => setMaxAmount(e.target.value)}
-                  placeholder="No limit"
-                  className="w-full border-2 border-bauhaus-black px-3 py-2"
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-bold uppercase tracking-wider mb-1">Keywords</label>
-                <input
-                  type="text"
-                  value={keywords}
-                  onChange={e => setKeywords(e.target.value)}
-                  placeholder="housing, climate, youth"
-                  className="w-full border-2 border-bauhaus-black px-3 py-2"
-                />
-              </div>
-            </div>
-
+      {!entitlements.weeklyDigest && (
+        <div className="mb-6 border-2 border-bauhaus-black bg-bauhaus-yellow/10 px-4 py-3">
+          <p className="text-sm font-bold text-bauhaus-black">
+            Weekly grant digests unlock on Professional and above.
+          </p>
+          <div className="mt-2 flex gap-3 flex-wrap items-center">
             <button
-              type="submit"
-              disabled={saving}
-              className="bg-bauhaus-red text-white px-6 py-3 font-bold uppercase tracking-wider hover:bg-red-700 transition-colors disabled:opacity-50"
+              type="button"
+              onClick={() => void upgradeToProfessional()}
+              disabled={startingUpgrade}
+              className="text-xs font-black uppercase tracking-widest text-bauhaus-blue hover:underline disabled:opacity-50"
             >
-              {saving ? 'Creating...' : 'Create Alert'}
+              {startingUpgrade ? 'Starting checkout…' : 'Upgrade to Professional'}
             </button>
-          </form>
-        )}
+            <Link href="/pricing" className="text-xs font-black uppercase tracking-widest text-bauhaus-blue hover:underline">
+              Compare plans &rarr;
+            </Link>
+          </div>
+        </div>
+      )}
 
-        {/* Alerts List */}
-        {alerts.length === 0 ? (
-          <div className="border-2 border-dashed border-bauhaus-black/20 p-8 text-center">
-            <p className="text-2xl font-black uppercase tracking-widest text-gray-400 mb-2">No Alerts Yet</p>
-            <p className="text-bauhaus-muted">Create your first alert to start receiving grant notifications.</p>
+      {showCommunityUpsell && (
+        <section className="mb-8 border-4 border-bauhaus-black bg-bauhaus-blue text-white p-6">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="max-w-2xl">
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-white/70">Professional Alerting</div>
+              <h2 className="mt-2 text-2xl font-black uppercase tracking-wider">Turn Alerts Into A Real Monitoring Product</h2>
+              <p className="mt-3 text-sm text-white/80 leading-relaxed">
+                Community gives you one weekly alert. Professional unlocks daily alerting, up to 10 saved alerts,
+                weekly digest delivery, and a stronger prospecting loop for teams that need funding work to stay live.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-widest">
+                <span className="border border-white/30 px-2 py-1">10 alerts</span>
+                <span className="border border-white/30 px-2 py-1">Daily / Weekly / Monthly</span>
+                <span className="border border-white/30 px-2 py-1">Weekly digest</span>
+                <span className="border border-white/30 px-2 py-1">Advanced watchlists</span>
+              </div>
+            </div>
+            <div className="flex gap-3 shrink-0">
+              <button
+                type="button"
+                onClick={() => void upgradeToProfessional()}
+                disabled={startingUpgrade}
+                className="bg-white px-5 py-3 font-black uppercase tracking-wider text-bauhaus-blue transition-colors hover:bg-bauhaus-yellow disabled:opacity-50"
+              >
+                {startingUpgrade ? 'Starting…' : 'Upgrade Now'}
+              </button>
+              <Link
+                href="/pricing"
+                className="border-2 border-white px-5 py-3 font-black uppercase tracking-wider text-white transition-colors hover:bg-white hover:text-bauhaus-blue"
+              >
+                View Plans
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {feedback && (
+        <div
+          className={`mb-6 border-2 px-4 py-3 text-sm font-bold rounded ${
+            feedback.tone === 'error'
+              ? 'border-red-500 bg-red-50 text-red-700'
+              : 'border-green-600 bg-green-50 text-green-700'
+          }`}
+          role={feedback.tone === 'error' ? 'alert' : 'status'}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-0 mb-8 border-4 border-bauhaus-black">
+        <div className="p-4 border-r-2 border-bauhaus-black/10 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Active Alerts</div>
+          <div className="text-2xl font-black text-bauhaus-black">{alerts.filter((alert) => alert.enabled).length}</div>
+        </div>
+        <div className="p-4 md:border-r-2 border-bauhaus-black/10 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Queued</div>
+          <div className="text-2xl font-black text-bauhaus-blue">{queueSummary.queued}</div>
+        </div>
+        <div className="p-4 border-r-2 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Failed</div>
+          <div className="text-2xl font-black text-bauhaus-red">{queueSummary.failed}</div>
+        </div>
+        <div className="p-4">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Delivered</div>
+          <div className="text-2xl font-black text-bauhaus-black">{queueSummary.sent}</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-0 mb-8 border-4 border-bauhaus-black">
+        <div className="p-4 border-r-2 border-bauhaus-black/10 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Queued This Week</div>
+          <div className="text-2xl font-black text-bauhaus-blue">{eventSummary.notificationsQueued}</div>
+        </div>
+        <div className="p-4 border-r-2 border-bauhaus-black/10 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Sent This Week</div>
+          <div className="text-2xl font-black text-bauhaus-black">{eventSummary.notificationsSent}</div>
+        </div>
+        <div className="p-4 border-r-2 border-bauhaus-black/10 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Failed This Week</div>
+          <div className="text-2xl font-black text-bauhaus-red">{eventSummary.notificationsFailed}</div>
+        </div>
+        <div className="p-4 border-r-2 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Digests Sent</div>
+          <div className="text-2xl font-black text-bauhaus-black">{eventSummary.digestsSent}</div>
+        </div>
+        <div className="p-4 border-r-2 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Email Opens</div>
+          <div className="text-2xl font-black text-bauhaus-black">{eventSummary.emailOpens}</div>
+        </div>
+        <div className="p-4">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Grant Clicks</div>
+          <div className="text-2xl font-black text-bauhaus-blue">{eventSummary.grantClicks}</div>
+        </div>
+        <div className="p-4 col-span-1 md:col-span-3 border-t-2 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Scout Runs</div>
+          <div className="text-2xl font-black text-bauhaus-black">{eventSummary.scoutRuns}</div>
+        </div>
+        <div className="p-4 col-span-1 md:col-span-3 border-t-2 md:border-l-2 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Optimizations</div>
+          <div className="text-2xl font-black text-bauhaus-black">{eventSummary.optimizationsApplied}</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-0 mb-8 border-4 border-bauhaus-black">
+        <div className="p-4 border-r-2 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Tracked From Alerts</div>
+          <div className="text-2xl font-black text-bauhaus-black">{pipelineImpactSummary.tracked}</div>
+        </div>
+        <div className="p-4 md:border-r-2 border-b-2 md:border-b-0 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Active Pipeline</div>
+          <div className="text-2xl font-black text-bauhaus-blue">{pipelineImpactSummary.active}</div>
+        </div>
+        <div className="p-4 border-r-2 border-bauhaus-black/10">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Submitted</div>
+          <div className="text-2xl font-black text-amber-700">{pipelineImpactSummary.submitted}</div>
+        </div>
+        <div className="p-4">
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Won</div>
+          <div className="text-2xl font-black text-green-700">{pipelineImpactSummary.won}</div>
+        </div>
+      </div>
+
+      <section className="border-4 border-bauhaus-black p-6 mb-8">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-blue">Delivery Queue</div>
+            <h2 className="text-xl font-black uppercase tracking-wider mt-2">Recent Alert Activity</h2>
+            <p className="text-sm text-bauhaus-muted mt-2 max-w-2xl">
+              See what has been queued, sent, or failed, then retry or dismiss specific items before the next automated delivery pass.
+            </p>
+          </div>
+          <Link
+            href="/home/watchlist"
+            className="text-xs font-black uppercase tracking-widest text-bauhaus-muted hover:text-bauhaus-black transition-colors"
+          >
+            Open Watchlist &rarr;
+          </Link>
+        </div>
+
+        {recentActivity.length === 0 ? (
+          <div className="border-2 border-dashed border-bauhaus-black/20 p-6 mt-6">
+            <p className="text-lg font-black uppercase tracking-widest text-gray-400 mb-2">No Queue Activity Yet</p>
+            <p className="text-bauhaus-muted">
+              Your alerts are ready. Once the scout queues grant matches, they will appear here with delivery status and actions.
+            </p>
           </div>
         ) : (
-          <div className="space-y-4">
-            {alerts.map(alert => (
-              <div key={alert.id} className="border-2 border-bauhaus-black p-4">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3 mb-2">
-                      <h3 className="text-lg font-black uppercase tracking-wider">{alert.name}</h3>
-                      <span className={`px-2 py-0.5 text-xs font-bold uppercase ${
-                        alert.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-500'
-                      }`}>
-                        {alert.enabled ? 'Active' : 'Paused'}
-                      </span>
-                      <span className="px-2 py-0.5 text-xs font-bold uppercase bg-bauhaus-blue text-white">
-                        {alert.frequency}
-                      </span>
-                    </div>
-
-                    <div className="flex flex-wrap gap-1 mb-2">
-                      {alert.categories?.map(c => (
-                        <span key={c} className="px-2 py-0.5 text-xs border border-bauhaus-black">{c}</span>
-                      ))}
-                      {alert.states?.map(s => (
-                        <span key={s} className="px-2 py-0.5 text-xs border border-bauhaus-blue text-bauhaus-blue">{s}</span>
-                      ))}
-                      {alert.keywords?.map(k => (
-                        <span key={k} className="px-2 py-0.5 text-xs bg-gray-100">{k}</span>
-                      ))}
-                    </div>
-
-                    {(alert.min_amount || alert.max_amount) && (
-                      <p className="text-sm text-bauhaus-muted">
-                        Amount: {alert.min_amount ? `$${alert.min_amount.toLocaleString()}` : '$0'}
-                        {' — '}
-                        {alert.max_amount ? `$${alert.max_amount.toLocaleString()}` : 'No limit'}
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="flex items-center gap-2 ml-4">
-                    <button
-                      onClick={() => viewMatches(alert.id)}
-                      className={`px-3 py-1 text-xs font-bold uppercase tracking-wider border-2 transition-colors ${
-                        expandedAlert === alert.id
-                          ? 'border-bauhaus-blue bg-bauhaus-blue text-white'
-                          : 'border-bauhaus-blue text-bauhaus-blue hover:bg-blue-50'
-                      }`}
-                    >
-                      {expandedAlert === alert.id ? 'Hide' : 'View Matches'}
-                    </button>
-                    <button
-                      onClick={() => toggleAlert(alert.id, alert.enabled)}
-                      className={`px-3 py-1 text-xs font-bold uppercase tracking-wider border-2 transition-colors ${
-                        alert.enabled
-                          ? 'border-gray-400 text-gray-600 hover:bg-gray-100'
-                          : 'border-green-600 text-green-600 hover:bg-green-50'
-                      }`}
-                    >
-                      {alert.enabled ? 'Pause' : 'Enable'}
-                    </button>
-                    <button
-                      onClick={() => deleteAlert(alert.id)}
-                      className="px-3 py-1 text-xs font-bold uppercase tracking-wider border-2 border-red-500 text-red-500 hover:bg-red-50 transition-colors"
-                    >
-                      Delete
-                    </button>
-                  </div>
-                </div>
-
-                {/* Matching Grants */}
-                {expandedAlert === alert.id && (
-                  <div className="mt-3 border-t-2 border-bauhaus-black/10 pt-3">
-                    {matchLoading === alert.id ? (
-                      <p className="text-xs font-black text-bauhaus-muted uppercase tracking-widest">Loading matches...</p>
-                    ) : (alertMatches[alert.id]?.length || 0) === 0 ? (
-                      <p className="text-sm text-bauhaus-muted">No matching grants found for this alert&apos;s criteria.</p>
-                    ) : (
-                      <div className="space-y-2">
-                        <p className="text-[10px] font-black uppercase tracking-wider text-bauhaus-muted mb-2">
-                          {alertMatches[alert.id].length} Matching Grant{alertMatches[alert.id].length !== 1 ? 's' : ''}
-                        </p>
-                        {alertMatches[alert.id].map(grant => (
-                          <div key={grant.id} className="flex items-center justify-between border-2 border-gray-200 px-3 py-2">
-                            <div className="flex-1 min-w-0">
-                              <a href={`/grants/${grant.id}`} className="font-bold text-sm hover:text-bauhaus-blue truncate block">{grant.name}</a>
-                              <div className="text-xs text-bauhaus-muted flex items-center gap-2">
-                                <span>{grant.provider}</span>
-                                {grant.amount_max && <span className="font-black tabular-nums">Up to ${grant.amount_max.toLocaleString()}</span>}
-                                {grant.closes_at && (
-                                  <span>Closes {new Date(grant.closes_at).toLocaleDateString()}</span>
-                                )}
-                              </div>
-                            </div>
-                            <button
-                              onClick={() => trackGrant(grant.id)}
-                              className="ml-3 px-3 py-1 text-[10px] font-black uppercase tracking-wider border-2 border-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors flex-shrink-0"
-                            >
-                              Track
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
+          <div className="space-y-3 mt-6">
+            {recentActivity.map((activity) => (
+              <AlertActivityRow
+                key={activity.id}
+                activity={activity}
+                onRetry={
+                  activity.status === 'failed' || activity.status === 'cancelled'
+                    ? () => void updateNotification(activity.id, 'retry')
+                    : undefined
+                }
+                onDismiss={
+                  activity.status === 'queued' || activity.status === 'failed'
+                    ? () => void updateNotification(activity.id, 'cancel')
+                    : undefined
+                }
+                retrying={pendingNotificationAction?.id === activity.id && pendingNotificationAction.action === 'retry'}
+                dismissing={pendingNotificationAction?.id === activity.id && pendingNotificationAction.action === 'cancel'}
+              />
             ))}
           </div>
         )}
+      </section>
+
+      {recentEvents.length > 0 && (
+        <section className="border-4 border-bauhaus-black p-6 mb-8">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-blue">System Events</div>
+          <h2 className="text-xl font-black uppercase tracking-wider mt-2">Recent Alert Operations</h2>
+          <div className="mt-4 space-y-2">
+            {recentEvents.slice(0, 8).map((event) => (
+              <div key={event.id} className="border-2 border-gray-200 px-3 py-2 flex items-center justify-between gap-4">
+                <div>
+                  <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                    {event.event_type.replace(/_/g, ' ')}
+                  </div>
+                  <div className="text-sm text-bauhaus-black">
+                    {renderEventDetail(event)}
+                  </div>
+                </div>
+                <div className="text-xs text-bauhaus-muted">{timeAgo(event.created_at)}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {showForm && (
+        <form onSubmit={createAlert} className="border-4 border-bauhaus-black p-6 mb-8">
+          <h2 className="text-xl font-black uppercase tracking-wider mb-4">New Alert</h2>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider mb-1">Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Indigenous Health Grants"
+                className="w-full border-2 border-bauhaus-black px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider mb-1">Frequency</label>
+              <select
+                value={frequency}
+                onChange={(e) => setFrequency(e.target.value)}
+                className="w-full border-2 border-bauhaus-black px-3 py-2"
+              >
+                {FREQUENCIES.filter((item) => entitlements.frequencies.includes(item as AlertFrequency)).map((item) => (
+                  <option key={item} value={item}>{item.charAt(0).toUpperCase() + item.slice(1)}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-xs font-bold uppercase tracking-wider mb-1">Categories</label>
+            <div className="flex flex-wrap gap-2">
+              {CATEGORIES.map((category) => (
+                <button
+                  key={category}
+                  type="button"
+                  onClick={() => setSelectedCategories((prev) =>
+                    prev.includes(category) ? prev.filter((value) => value !== category) : [...prev, category]
+                  )}
+                  className={`px-3 py-1 border-2 text-sm font-bold uppercase tracking-wider transition-colors ${
+                    selectedCategories.includes(category)
+                      ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                      : 'border-bauhaus-black hover:bg-gray-100'
+                  }`}
+                >
+                  {category}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-xs font-bold uppercase tracking-wider mb-1">States</label>
+            <div className="flex flex-wrap gap-2">
+              {STATES.map((state) => (
+                <button
+                  key={state}
+                  type="button"
+                  onClick={() => setSelectedStates((prev) =>
+                    prev.includes(state) ? prev.filter((value) => value !== state) : [...prev, state]
+                  )}
+                  className={`px-3 py-1 border-2 text-sm font-bold uppercase tracking-wider transition-colors ${
+                    selectedStates.includes(state)
+                      ? 'border-bauhaus-blue bg-bauhaus-blue text-white'
+                      : 'border-bauhaus-black hover:bg-gray-100'
+                  }`}
+                >
+                  {state}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider mb-1">Min Amount</label>
+              <input
+                type="number"
+                value={minAmount}
+                onChange={(e) => setMinAmount(e.target.value)}
+                placeholder="$0"
+                className="w-full border-2 border-bauhaus-black px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider mb-1">Max Amount</label>
+              <input
+                type="number"
+                value={maxAmount}
+                onChange={(e) => setMaxAmount(e.target.value)}
+                placeholder="No limit"
+                className="w-full border-2 border-bauhaus-black px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider mb-1">Keywords</label>
+              <input
+                type="text"
+                value={keywords}
+                onChange={(e) => setKeywords(e.target.value)}
+                placeholder="housing, climate, youth"
+                className="w-full border-2 border-bauhaus-black px-3 py-2"
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={saving}
+            className="bg-bauhaus-red text-white px-6 py-3 font-bold uppercase tracking-wider hover:bg-red-700 transition-colors disabled:opacity-50"
+          >
+            {saving ? 'Creating...' : 'Create Alert'}
+          </button>
+        </form>
+      )}
+
+      {alerts.length === 0 ? (
+        <div className="border-2 border-dashed border-bauhaus-black/20 p-8 text-center">
+          <p className="text-2xl font-black uppercase tracking-widest text-gray-400 mb-2">No Alerts Yet</p>
+          <p className="text-bauhaus-muted">Create your first alert to start receiving grant notifications.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {alerts.map((alert) => (
+            <div key={alert.id} className="border-2 border-bauhaus-black p-4">
+              {(() => {
+                const performance = alertPerformance[alert.id];
+                const optimizationActions = performance
+                  ? getOptimizationActions(alert, performance, usage.alerts < entitlements.maxAlerts)
+                  : [];
+                return (
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-3 mb-2 flex-wrap">
+                    <h3 className="text-lg font-black uppercase tracking-wider">{alert.name}</h3>
+                    <span className={`px-2 py-0.5 text-xs font-bold uppercase ${
+                      alert.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-500'
+                    }`}>
+                      {alert.enabled ? 'Active' : 'Paused'}
+                    </span>
+                    <span className="px-2 py-0.5 text-xs font-bold uppercase bg-bauhaus-blue text-white">
+                      {alert.frequency}
+                    </span>
+                  </div>
+
+                  <div className="flex flex-wrap gap-1 mb-2">
+                    {alert.categories?.map((category) => (
+                      <span key={category} className="px-2 py-0.5 text-xs border border-bauhaus-black">{category}</span>
+                    ))}
+                    {alert.states?.map((state) => (
+                      <span key={state} className="px-2 py-0.5 text-xs border border-bauhaus-blue text-bauhaus-blue">{state}</span>
+                    ))}
+                    {alert.keywords?.map((keyword) => (
+                      <span key={keyword} className="px-2 py-0.5 text-xs bg-gray-100">{keyword}</span>
+                    ))}
+                  </div>
+
+                  {(alert.min_amount || alert.max_amount) && (
+                    <p className="text-sm text-bauhaus-muted">
+                      Amount: {alert.min_amount ? formatMoney(alert.min_amount) : '$0'}
+                      {' — '}
+                      {alert.max_amount ? formatMoney(alert.max_amount) : 'No limit'}
+                    </p>
+                  )}
+
+                  <div className="mt-3 border-t-2 border-bauhaus-black/10 pt-3">
+                    <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
+                      Last {performanceWindowDays} Days
+                    </div>
+                    {performance ? (
+                      <>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-blue/20 text-bauhaus-blue">
+                            {performance.sent} sent
+                          </span>
+                          <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-black/20 text-bauhaus-black">
+                            {performance.opens} opens
+                          </span>
+                          <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-black/20 text-bauhaus-black">
+                            {performance.clicks} clicks
+                          </span>
+                          <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-black/20 text-bauhaus-muted">
+                            {performance.digestsSent} digests
+                          </span>
+                          {performance.failed > 0 ? (
+                            <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-red-200 text-red-600">
+                              {performance.failed} failed
+                            </span>
+                          ) : null}
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-4 text-xs text-bauhaus-muted">
+                          <span>
+                            Open rate: <span className="font-black text-bauhaus-black">{performance.openRate != null ? `${performance.openRate}%` : '—'}</span>
+                          </span>
+                          <span>
+                            Click rate: <span className="font-black text-bauhaus-black">{performance.clickRate != null ? `${performance.clickRate}%` : '—'}</span>
+                          </span>
+                          <span>
+                            Track rate: <span className="font-black text-bauhaus-black">{performance.trackRate != null ? `${performance.trackRate}%` : '—'}</span>
+                          </span>
+                          <span>
+                            Click→track: <span className="font-black text-bauhaus-black">{performance.clickToTrackRate != null ? `${performance.clickToTrackRate}%` : '—'}</span>
+                          </span>
+                          <span>
+                            Submit rate: <span className="font-black text-bauhaus-black">{performance.submissionRate != null ? `${performance.submissionRate}%` : '—'}</span>
+                          </span>
+                          <span>
+                            Win rate: <span className="font-black text-bauhaus-black">{performance.winRate != null ? `${performance.winRate}%` : '—'}</span>
+                          </span>
+                          {performance.lastEventAt ? (
+                            <span>
+                              Last activity: <span className="font-black text-bauhaus-black">{timeAgo(performance.lastEventAt)}</span>
+                            </span>
+                          ) : null}
+                        </div>
+                        <div className="mt-3 border-t border-bauhaus-black/10 pt-3">
+                          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
+                            Pipeline Impact
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-black/20 text-bauhaus-black">
+                              {performance.tracked} tracked
+                            </span>
+                            <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-blue/20 text-bauhaus-blue">
+                              {performance.active} active
+                            </span>
+                            <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-amber-300 text-amber-700">
+                              {performance.submitted} submitted
+                            </span>
+                            <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-green-300 text-green-700">
+                              {performance.won} won
+                            </span>
+                          </div>
+                          {performance.lastTrackedAt ? (
+                            <div className="mt-2 text-xs text-bauhaus-muted">
+                              Last tracked grant:{' '}
+                              <span className="font-black text-bauhaus-black">{timeAgo(performance.lastTrackedAt)}</span>
+                            </div>
+                          ) : null}
+                          {performance.lastOptimizedAt ? (
+                            <div className="mt-2 text-xs text-bauhaus-muted">
+                              Last optimized:{' '}
+                              <span className="font-black text-bauhaus-black">
+                                {timeAgo(performance.lastOptimizedAt)}
+                              </span>
+                              {performance.lastOptimizationAction ? (
+                                <>
+                                  {' '}via{' '}
+                                  <span className="font-black text-bauhaus-black">
+                                    {formatOptimizationAction(performance.lastOptimizationAction)}
+                                  </span>
+                                </>
+                              ) : null}
+                            </div>
+                          ) : null}
+                          {performance.lastOptimizedAt ? (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-black/20 text-bauhaus-black">
+                                {performance.sentAfterOptimization} sent since
+                              </span>
+                              <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-bauhaus-blue/20 text-bauhaus-blue">
+                                {performance.clicksAfterOptimization} clicks since
+                              </span>
+                              <span className="px-2 py-1 text-[10px] font-black uppercase tracking-widest border border-green-300 text-green-700">
+                                {performance.trackedAfterOptimization} tracked since
+                              </span>
+                            </div>
+                          ) : null}
+                          {performance.optimizationComparison ? (
+                            <div className="mt-3 border-t border-bauhaus-black/10 pt-3">
+                              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
+                                Before vs After
+                              </div>
+                              {performance.optimizationComparison.hasComparisonData ? (
+                                <>
+                                  {!performance.optimizationComparison.enoughComparisonData ? (
+                                    <p className="mt-2 text-xs text-bauhaus-muted">
+                                      Optimization was logged, but there is not enough send volume on both sides yet for a strong comparison.
+                                    </p>
+                                  ) : null}
+                                  <div className="mt-2 grid grid-cols-1 md:grid-cols-3 gap-2 text-xs">
+                                    <div className="border border-bauhaus-black/10 p-3">
+                                      <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Open Rate</div>
+                                      <div className="mt-1 font-black text-bauhaus-black">
+                                        {performance.optimizationComparison.before.openRate != null ? `${performance.optimizationComparison.before.openRate}%` : '—'}
+                                        {' → '}
+                                        {performance.optimizationComparison.after.openRate != null ? `${performance.optimizationComparison.after.openRate}%` : '—'}
+                                      </div>
+                                      <div className={`mt-1 text-[10px] font-black uppercase tracking-widest ${
+                                        (performance.optimizationComparison.delta.openRate ?? 0) > 0
+                                          ? 'text-green-700'
+                                          : (performance.optimizationComparison.delta.openRate ?? 0) < 0
+                                            ? 'text-red-600'
+                                            : 'text-bauhaus-muted'
+                                      }`}>
+                                        {formatDelta(performance.optimizationComparison.delta.openRate)}
+                                      </div>
+                                    </div>
+                                    <div className="border border-bauhaus-black/10 p-3">
+                                      <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Click Rate</div>
+                                      <div className="mt-1 font-black text-bauhaus-black">
+                                        {performance.optimizationComparison.before.clickRate != null ? `${performance.optimizationComparison.before.clickRate}%` : '—'}
+                                        {' → '}
+                                        {performance.optimizationComparison.after.clickRate != null ? `${performance.optimizationComparison.after.clickRate}%` : '—'}
+                                      </div>
+                                      <div className={`mt-1 text-[10px] font-black uppercase tracking-widest ${
+                                        (performance.optimizationComparison.delta.clickRate ?? 0) > 0
+                                          ? 'text-green-700'
+                                          : (performance.optimizationComparison.delta.clickRate ?? 0) < 0
+                                            ? 'text-red-600'
+                                            : 'text-bauhaus-muted'
+                                      }`}>
+                                        {formatDelta(performance.optimizationComparison.delta.clickRate)}
+                                      </div>
+                                    </div>
+                                    <div className="border border-bauhaus-black/10 p-3">
+                                      <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Track Rate</div>
+                                      <div className="mt-1 font-black text-bauhaus-black">
+                                        {performance.optimizationComparison.before.trackRate != null ? `${performance.optimizationComparison.before.trackRate}%` : '—'}
+                                        {' → '}
+                                        {performance.optimizationComparison.after.trackRate != null ? `${performance.optimizationComparison.after.trackRate}%` : '—'}
+                                      </div>
+                                      <div className={`mt-1 text-[10px] font-black uppercase tracking-widest ${
+                                        (performance.optimizationComparison.delta.trackRate ?? 0) > 0
+                                          ? 'text-green-700'
+                                          : (performance.optimizationComparison.delta.trackRate ?? 0) < 0
+                                            ? 'text-red-600'
+                                            : 'text-bauhaus-muted'
+                                      }`}>
+                                        {formatDelta(performance.optimizationComparison.delta.trackRate)}
+                                      </div>
+                                    </div>
+                                  </div>
+                                </>
+                              ) : (
+                                <p className="mt-2 text-xs text-bauhaus-muted">
+                                  No post-optimization delivery or tracking activity yet.
+                                </p>
+                              )}
+                            </div>
+                          ) : null}
+                          <div className="mt-3 border-t border-bauhaus-black/10 pt-3">
+                            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
+                              Recommendation
+                            </div>
+                            <div className="mt-2 flex items-start gap-3 flex-wrap">
+                              <span
+                                className={`px-2 py-1 text-[10px] font-black uppercase tracking-widest border ${
+                                  performance.recommendation.tone === 'success'
+                                    ? 'border-green-300 text-green-700'
+                                    : performance.recommendation.tone === 'info'
+                                      ? 'border-bauhaus-blue/20 text-bauhaus-blue'
+                                      : performance.recommendation.tone === 'warning'
+                                        ? 'border-amber-300 text-amber-700'
+                                        : 'border-bauhaus-black/20 text-bauhaus-muted'
+                                }`}
+                              >
+                                {performance.recommendation.title}
+                              </span>
+                              <p className="text-xs text-bauhaus-muted max-w-2xl">
+                                {performance.recommendation.detail}
+                              </p>
+                            </div>
+                            {optimizationActions.length > 0 ? (
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                {optimizationActions.map((item) => (
+                                  <button
+                                    key={item.action}
+                                    type="button"
+                                    onClick={() => void applyOptimization(alert, performance, item.action)}
+                                    disabled={pendingOptimization?.id === alert.id}
+                                    className="px-3 py-1 text-[10px] font-black uppercase tracking-wider border-2 border-bauhaus-black text-bauhaus-black hover:bg-gray-100 transition-colors disabled:opacity-50"
+                                  >
+                                    {pendingOptimization?.id === alert.id && pendingOptimization.action === item.action
+                                      ? 'Applying...'
+                                      : item.label}
+                                  </button>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                      </>
+                    ) : (
+                      <p className="mt-2 text-xs text-bauhaus-muted">
+                        No recent delivery or engagement yet for this alert.
+                      </p>
+                    )}
+                    {showCommunityUpsell && performance.recommendation.key !== 'keep_expand' ? (
+                      <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-3">
+                        <p className="text-xs text-bauhaus-muted">
+                          Need more signal? Professional unlocks more alerts, daily frequency, and weekly digest delivery.
+                        </p>
+                        <div className="mt-2 flex gap-3 flex-wrap">
+                          <button
+                            type="button"
+                            onClick={() => void upgradeToProfessional()}
+                            disabled={startingUpgrade}
+                            className="text-[11px] font-black uppercase tracking-widest text-bauhaus-blue hover:underline disabled:opacity-50"
+                          >
+                            {startingUpgrade ? 'Starting checkout…' : 'Upgrade'}
+                          </button>
+                          <Link href="/pricing" className="text-[11px] font-black uppercase tracking-widest text-bauhaus-muted hover:text-bauhaus-black">
+                            Compare plans
+                          </Link>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void viewMatches(alert.id)}
+                    className={`px-3 py-1 text-xs font-bold uppercase tracking-wider border-2 transition-colors ${
+                      expandedAlert === alert.id
+                        ? 'border-bauhaus-blue bg-bauhaus-blue text-white'
+                        : 'border-bauhaus-blue text-bauhaus-blue hover:bg-blue-50'
+                    }`}
+                  >
+                    {expandedAlert === alert.id ? 'Hide' : 'View Matches'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void toggleAlert(alert.id, alert.enabled)}
+                    disabled={pendingToggleAlertId === alert.id}
+                    className={`px-3 py-1 text-xs font-bold uppercase tracking-wider border-2 transition-colors disabled:opacity-50 ${
+                      alert.enabled
+                        ? 'border-gray-400 text-gray-600 hover:bg-gray-100'
+                        : 'border-green-600 text-green-600 hover:bg-green-50'
+                    }`}
+                  >
+                    {pendingToggleAlertId === alert.id ? 'Saving...' : alert.enabled ? 'Pause' : 'Enable'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void deleteAlert(alert.id)}
+                    disabled={pendingDeleteAlertId === alert.id}
+                    className="px-3 py-1 text-xs font-bold uppercase tracking-wider border-2 border-red-500 text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
+                  >
+                    {pendingDeleteAlertId === alert.id ? 'Deleting...' : 'Delete'}
+                  </button>
+                </div>
+              </div>
+                );
+              })()}
+
+              {expandedAlert === alert.id && (
+                <div className="mt-3 border-t-2 border-bauhaus-black/10 pt-3">
+                  {matchLoading === alert.id ? (
+                    <p className="text-xs font-black text-bauhaus-muted uppercase tracking-widest">Loading matches...</p>
+                  ) : (alertMatches[alert.id]?.length || 0) === 0 ? (
+                    <p className="text-sm text-bauhaus-muted">No matching grants found for this alert&apos;s criteria.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      <p className="text-[10px] font-black uppercase tracking-wider text-bauhaus-muted mb-2">
+                        {alertMatches[alert.id].length} Matching Grant{alertMatches[alert.id].length !== 1 ? 's' : ''}
+                      </p>
+                      {alertMatches[alert.id].map((grant) => (
+                        <div key={grant.id} className="flex items-center justify-between gap-3 border-2 border-gray-200 px-3 py-2">
+                          <div className="flex-1 min-w-0">
+                            <Link href={`/grants/${grant.id}`} className="font-bold text-sm hover:text-bauhaus-blue truncate block">
+                              {grant.name}
+                            </Link>
+                            <div className="text-xs text-bauhaus-muted flex items-center gap-2 flex-wrap">
+                              <span>{grant.provider}</span>
+                              {grant.amount_max && <span className="font-black tabular-nums">Up to {formatMoney(grant.amount_max)}</span>}
+                              {grant.closes_at && <span>Closes {new Date(grant.closes_at).toLocaleDateString()}</span>}
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => void trackGrant(grant.id, { alertId: alert.id })}
+                            disabled={pendingTrackGrantId === grant.id}
+                            className="ml-3 px-3 py-1 text-[10px] font-black uppercase tracking-wider border-2 border-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors disabled:opacity-50 flex-shrink-0"
+                          >
+                            {pendingTrackGrantId === grant.id ? 'Saving...' : 'Track'}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AlertActivityRow({
+  activity,
+  retrying,
+  dismissing,
+  onRetry,
+  onDismiss,
+}: {
+  activity: AlertActivity;
+  retrying?: boolean;
+  dismissing?: boolean;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+}) {
+  const statusLabel = activity.status === 'sent'
+    ? 'Sent'
+    : activity.status === 'failed'
+      ? 'Failed'
+      : activity.status === 'cancelled'
+        ? 'Cancelled'
+        : 'Queued';
+  const activityTime = activity.sent_at || activity.queued_at;
+
+  return (
+    <div className="border-2 border-gray-200 p-4 hover:border-bauhaus-black transition-colors">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className={`text-[10px] px-2 py-0.5 font-bold uppercase rounded-sm border ${ALERT_STATUS_STYLES[activity.status] || ALERT_STATUS_STYLES.cancelled}`}>
+              {statusLabel}
+            </span>
+            {activity.alert?.name ? (
+              <span className="text-[10px] px-2 py-0.5 font-bold uppercase bg-bauhaus-black text-white rounded-sm">
+                {activity.alert.name}
+              </span>
+            ) : null}
+            {activity.match_score != null ? (
+              <span className="text-[10px] px-2 py-0.5 font-bold uppercase bg-bauhaus-blue/10 text-bauhaus-blue rounded-sm">
+                {activity.match_score}% match
+              </span>
+            ) : null}
+          </div>
+
+          <div className="mt-2">
+            {activity.grant ? (
+              <Link
+                href={`/grants/${activity.grant.id}`}
+                className="font-bold text-sm hover:text-bauhaus-red transition-colors line-clamp-1"
+              >
+                {activity.grant.name}
+              </Link>
+            ) : (
+              <div className="font-bold text-sm line-clamp-1">{activity.subject || 'Grant alert activity'}</div>
+            )}
+            <div className="text-xs text-bauhaus-muted mt-1">
+              {activity.alert?.name || 'Grant alert'}
+              {(activity.grant?.provider || activity.subject) ? ` · ${activity.grant?.provider || activity.subject}` : ''}
+            </div>
+          </div>
+
+          {activity.match_signals.length > 0 ? (
+            <div className="flex gap-1 mt-2 flex-wrap">
+              {activity.match_signals.slice(0, 4).map((signal) => (
+                <span key={signal} className="text-[10px] px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded">
+                  {signal}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {activity.last_error ? (
+            <div className="mt-2 text-xs text-red-600">
+              {activity.last_error}
+            </div>
+          ) : null}
+
+          <div className="mt-3 flex gap-2 flex-wrap">
+            {activity.grant?.id ? (
+              <Link
+                href={`/grants/${activity.grant.id}`}
+                className="text-[10px] px-2.5 py-1 font-black uppercase tracking-widest border border-bauhaus-black text-bauhaus-black hover:bg-gray-100 transition-colors"
+              >
+                View Grant
+              </Link>
+            ) : null}
+            {onRetry ? (
+              <button
+                type="button"
+                onClick={onRetry}
+                disabled={retrying}
+                className="text-[10px] px-2.5 py-1 font-black uppercase tracking-widest border border-bauhaus-blue text-bauhaus-blue hover:bg-bauhaus-blue/5 transition-colors disabled:opacity-50"
+              >
+                {retrying ? 'Retrying...' : 'Retry Delivery'}
+              </button>
+            ) : null}
+            {onDismiss ? (
+              <button
+                type="button"
+                onClick={onDismiss}
+                disabled={dismissing}
+                className="text-[10px] px-2.5 py-1 font-black uppercase tracking-widest border border-bauhaus-black text-bauhaus-muted hover:text-bauhaus-black hover:bg-gray-100 transition-colors disabled:opacity-50"
+              >
+                {dismissing ? 'Dismissing...' : 'Dismiss'}
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="shrink-0 text-right">
+          <div className="text-xs text-bauhaus-muted">{timeAgo(activityTime)}</div>
+          {activity.grant?.closes_at ? (
+            <div className={`mt-1 text-xs font-bold ${daysUntil(activity.grant.closes_at) === 'Closed' ? 'text-red-500' : 'text-bauhaus-muted'}`}>
+              {daysUntil(activity.grant.closes_at)}
+            </div>
+          ) : null}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/api/alerts/[id]/route.ts
+++ b/apps/web/src/app/api/alerts/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireModule } from '@/lib/api-auth';
+import { recordAlertEvents } from '@/lib/alert-events';
+import { getAlertEntitlements } from '@/lib/subscription';
 import { getServiceSupabase } from '@/lib/supabase';
 
 /**
@@ -8,28 +10,91 @@ import { getServiceSupabase } from '@/lib/supabase';
  */
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const auth = await requireModule('tracker');
+  const auth = await requireModule('grants');
   if (auth.error) return auth.error;
-  const { user } = auth;
+  const { user, tier } = auth;
 
   const { id } = await params;
   const body = await request.json();
+  const entitlements = getAlertEntitlements(tier);
+  const optimizationEvent = body.optimization_event as
+    | {
+      action?: string;
+      recommendation_title?: string;
+      previous_frequency?: string | null;
+      next_frequency?: string | null;
+    }
+    | undefined;
+
+  const updatePayload = {
+    ...(body.name !== undefined ? { name: body.name } : {}),
+    ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+    ...(body.frequency !== undefined ? { frequency: body.frequency } : {}),
+    ...(body.categories !== undefined ? { categories: body.categories } : {}),
+    ...(body.focus_areas !== undefined ? { focus_areas: body.focus_areas } : {}),
+    ...(body.states !== undefined ? { states: body.states } : {}),
+    ...(body.min_amount !== undefined ? { min_amount: body.min_amount } : {}),
+    ...(body.max_amount !== undefined ? { max_amount: body.max_amount } : {}),
+    ...(body.keywords !== undefined ? { keywords: body.keywords } : {}),
+    ...(body.entity_types !== undefined ? { entity_types: body.entity_types } : {}),
+    updated_at: new Date().toISOString(),
+  };
+
+  if (body.frequency && !entitlements.frequencies.includes(body.frequency)) {
+    return NextResponse.json(
+      {
+        error: 'This alert frequency is not available on your current plan.',
+        tier,
+        allowed_frequencies: entitlements.frequencies,
+        upgrade_url: '/pricing',
+      },
+      { status: 403 }
+    );
+  }
 
   const db = getServiceSupabase();
   const { data, error } = await db
     .from('alert_preferences')
-    .update({ ...body, updated_at: new Date().toISOString() })
+    .update(updatePayload)
     .eq('id', id)
     .eq('user_id', user.id)
     .select()
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await recordAlertEvents([
+    {
+      userId: user.id,
+      alertPreferenceId: data.id,
+      eventType: 'alert_updated',
+      metadata: {
+        frequency: data.frequency,
+        enabled: data.enabled,
+      },
+    },
+    ...(optimizationEvent
+      ? [{
+        userId: user.id,
+        alertPreferenceId: data.id,
+        eventType: 'optimization_applied' as const,
+        metadata: {
+          action: optimizationEvent.action || null,
+          recommendation_title: optimizationEvent.recommendation_title || null,
+          previous_frequency: optimizationEvent.previous_frequency || null,
+          next_frequency: optimizationEvent.next_frequency || null,
+          result_enabled: data.enabled,
+          result_frequency: data.frequency,
+        },
+      }]
+      : []),
+  ]);
+
   return NextResponse.json({ alert: data });
 }
 
 export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const auth = await requireModule('tracker');
+  const auth = await requireModule('grants');
   if (auth.error) return auth.error;
   const { user } = auth;
 
@@ -42,5 +107,14 @@ export async function DELETE(_request: NextRequest, { params }: { params: Promis
     .eq('user_id', user.id);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await recordAlertEvents([
+    {
+      userId: user.id,
+      alertPreferenceId: Number(id),
+      eventType: 'alert_deleted',
+      metadata: {},
+    },
+  ]);
   return NextResponse.json({ deleted: true });
 }

--- a/apps/web/src/app/api/alerts/deliver/route.ts
+++ b/apps/web/src/app/api/alerts/deliver/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireModule } from '@/lib/api-auth';
+import { deliverQueuedGrantNotifications } from '@/lib/grant-notifications';
+
+export async function POST(request: NextRequest) {
+  const auth = await requireModule('grants');
+  if (auth.error) return auth.error;
+  const { user } = auth;
+
+  const body = await request.json().catch(() => null);
+  const requestedLimit = typeof body?.limit === 'number' ? body.limit : 25;
+  const limit = Math.min(Math.max(Math.floor(requestedLimit), 1), 50);
+
+  try {
+    const result = await deliverQueuedGrantNotifications({
+      userId: user.id,
+      limit,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      ...result,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to deliver queued notifications.' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/alerts/digest/route.ts
+++ b/apps/web/src/app/api/alerts/digest/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireModule } from '@/lib/api-auth';
+import { sendGrantAlertDigests } from '@/lib/grant-alert-digests';
+import { getAlertEntitlements } from '@/lib/subscription';
+
+export async function POST(request: NextRequest) {
+  const auth = await requireModule('grants');
+  if (auth.error) return auth.error;
+  const { user, tier } = auth;
+
+  const entitlements = getAlertEntitlements(tier);
+  if (!entitlements.weeklyDigest) {
+    return NextResponse.json(
+      {
+        error: 'Weekly grant digests are available on the Professional plan and above.',
+        tier,
+        upgrade_url: '/pricing',
+      },
+      { status: 403 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const force = body?.force === true;
+
+  try {
+    const result = await sendGrantAlertDigests({
+      userId: user.id,
+      force,
+      dryRun: false,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      ...result,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to send weekly digest.' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/alerts/matches/route.ts
+++ b/apps/web/src/app/api/alerts/matches/route.ts
@@ -7,7 +7,7 @@ import { getServiceSupabase } from '@/lib/supabase';
  * Returns grant_opportunities matching an alert's criteria.
  */
 export async function GET(request: NextRequest) {
-  const auth = await requireModule('tracker');
+  const auth = await requireModule('grants');
   if (auth.error) return auth.error;
   const { user } = auth;
 

--- a/apps/web/src/app/api/alerts/notifications/route.ts
+++ b/apps/web/src/app/api/alerts/notifications/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireModule } from '@/lib/api-auth';
+import { recordAlertEvents } from '@/lib/alert-events';
+import { getServiceSupabase } from '@/lib/supabase';
+
+type NotificationAction = 'retry' | 'cancel';
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireModule('grants');
+  if (auth.error) return auth.error;
+  const { user } = auth;
+
+  const body = await request.json().catch(() => null);
+  const notificationId = typeof body?.notificationId === 'string' ? body.notificationId : '';
+  const action: NotificationAction = body?.action === 'cancel' ? 'cancel' : 'retry';
+
+  if (!notificationId) {
+    return NextResponse.json({ error: 'notificationId is required' }, { status: 400 });
+  }
+
+  const serviceDb = getServiceSupabase();
+  const { data: notification, error: notificationError } = await serviceDb
+    .from('grant_notification_outbox')
+    .select('id, user_id, alert_preference_id, grant_id, status, queued_at, attempt_count')
+    .eq('user_id', user.id)
+    .eq('id', notificationId)
+    .maybeSingle();
+
+  if (notificationError) {
+    return NextResponse.json({ error: notificationError.message }, { status: 500 });
+  }
+
+  if (!notification) {
+    return NextResponse.json({ error: 'Notification not found.' }, { status: 404 });
+  }
+
+  if (notification.status === 'sent') {
+    return NextResponse.json({ error: 'Sent notifications cannot be changed.' }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const nextState = action === 'cancel'
+    ? {
+        status: 'cancelled',
+        queued_at: notification.queued_at,
+        sent_at: null,
+        last_attempted_at: now,
+        last_error: 'Dismissed by user',
+        external_message_id: null,
+      }
+    : {
+        status: 'queued',
+        queued_at: now,
+        sent_at: null,
+        attempt_count: 0,
+        last_attempted_at: null,
+        last_error: null,
+        external_message_id: null,
+      };
+
+  const { data: updatedNotification, error: updateError } = await serviceDb
+    .from('grant_notification_outbox')
+    .update(nextState)
+    .eq('user_id', user.id)
+    .eq('id', notificationId)
+    .select('id, grant_id, alert_preference_id, status, queued_at, sent_at, attempt_count, last_attempted_at, last_error, external_message_id')
+    .single();
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  await recordAlertEvents([
+    {
+      userId: user.id,
+      alertPreferenceId: updatedNotification.alert_preference_id ?? notification.alert_preference_id ?? null,
+      notificationId: updatedNotification.id,
+      grantId: updatedNotification.grant_id ?? notification.grant_id ?? null,
+      eventType: action === 'cancel' ? 'notification_cancelled' : 'notification_requeued',
+      metadata: {
+        action,
+        status: updatedNotification.status,
+      },
+    },
+  ]);
+
+  return NextResponse.json({
+    ok: true,
+    action,
+    notification: updatedNotification,
+  });
+}

--- a/apps/web/src/app/api/alerts/route.ts
+++ b/apps/web/src/app/api/alerts/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireModule } from '@/lib/api-auth';
+import { recordProductEvents } from '@/lib/product-events';
+import {
+  buildAlertPerformanceSnapshot,
+  type AlertPerformanceEventRow,
+  type AttributedSavedGrantRow,
+} from '@/lib/alert-performance';
+import { recordAlertEvents } from '@/lib/alert-events';
+import { getAlertEntitlements } from '@/lib/subscription';
 import { getServiceSupabase } from '@/lib/supabase';
 
 /**
@@ -8,36 +16,248 @@ import { getServiceSupabase } from '@/lib/supabase';
  */
 
 export async function GET() {
-  const auth = await requireModule('tracker');
+  const auth = await requireModule('grants');
   if (auth.error) return auth.error;
-  const { user } = auth;
+  const { user, tier } = auth;
 
   const db = getServiceSupabase();
-  const { data, error } = await db
-    .from('alert_preferences')
-    .select('*')
-    .eq('user_id', user.id)
-    .order('created_at', { ascending: false });
+  const performanceWindowDays = 30;
+  const performanceWindowStart = new Date(Date.now() - performanceWindowDays * 24 * 60 * 60 * 1000).toISOString();
+  const [
+    { data: alerts, error: alertsError },
+    { data: recentAlertRows, error: recentAlertsError },
+    { count: queuedCount, error: queuedCountError },
+    { count: sentCount, error: sentCountError },
+    { count: failedCount, error: failedCountError },
+    { count: cancelledCount, error: cancelledCountError },
+    { data: recentEvents, error: recentEventsError },
+    { data: performanceEvents, error: performanceEventsError },
+    { data: attributedSavedGrants, error: attributedSavedGrantsError },
+  ] = await Promise.all([
+    db.from('alert_preferences')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false }),
+    db.from('grant_notification_outbox')
+      .select('id, grant_id, alert_preference_id, notification_type, status, subject, match_score, match_signals, queued_at, sent_at, last_error')
+      .eq('user_id', user.id)
+      .order('queued_at', { ascending: false })
+      .limit(20),
+    db.from('grant_notification_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('status', 'queued'),
+    db.from('grant_notification_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('status', 'sent'),
+    db.from('grant_notification_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('status', 'failed'),
+    db.from('grant_notification_outbox')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('status', 'cancelled'),
+    db.from('alert_events')
+      .select('id, event_type, metadata, created_at')
+      .eq('user_id', user.id)
+      .gte('created_at', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
+      .order('created_at', { ascending: false })
+      .limit(50),
+    db.from('alert_events')
+      .select('alert_preference_id, event_type, created_at, metadata')
+      .eq('user_id', user.id)
+      .not('alert_preference_id', 'is', null)
+      .gte('created_at', performanceWindowStart)
+      .order('created_at', { ascending: false })
+      .limit(500),
+    db.from('saved_grants')
+      .select('source_alert_preference_id, stage, created_at, updated_at, source_attributed_at')
+      .eq('user_id', user.id)
+      .not('source_alert_preference_id', 'is', null),
+  ]);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ alerts: data });
+  const firstError =
+    alertsError
+    || recentAlertsError
+    || queuedCountError
+    || sentCountError
+    || failedCountError
+    || cancelledCountError
+    || recentEventsError
+    || performanceEventsError
+    || attributedSavedGrantsError;
+
+  if (firstError) {
+    return NextResponse.json({ error: firstError.message }, { status: 500 });
+  }
+
+  const grantIds = [...new Set((recentAlertRows || []).map((row: { grant_id: string | null }) => row.grant_id).filter(Boolean))] as string[];
+
+  const { data: alertGrants, error: alertGrantsError } = grantIds.length > 0
+    ? await db
+      .from('grant_opportunities')
+      .select('id, name, provider, closes_at')
+      .in('id', grantIds)
+    : { data: [], error: null };
+
+  if (alertGrantsError) {
+    return NextResponse.json({ error: alertGrantsError.message }, { status: 500 });
+  }
+
+  const alertsById = new Map(
+    (alerts || []).map((alert: { id: string | number; name: string; frequency: string; enabled: boolean }) => [
+      String(alert.id),
+      { id: String(alert.id), name: alert.name, frequency: alert.frequency, enabled: alert.enabled },
+    ])
+  );
+
+  const grantsById = new Map(
+    (alertGrants || []).map((grant: { id: string; name: string; provider: string | null; closes_at: string | null }) => [
+      grant.id,
+      grant,
+    ])
+  );
+
+  const recentActivity = (recentAlertRows || []).map((row: {
+    id: string;
+    grant_id: string | null;
+    alert_preference_id: string | number | null;
+    notification_type: string;
+    status: string;
+    subject: string | null;
+    match_score: number | null;
+    match_signals: string[] | null;
+    queued_at: string;
+    sent_at: string | null;
+    last_error: string | null;
+  }) => ({
+    id: row.id,
+    notification_type: row.notification_type,
+    status: row.status,
+    subject: row.subject,
+    match_score: row.match_score,
+    match_signals: row.match_signals || [],
+    queued_at: row.queued_at,
+    sent_at: row.sent_at,
+    last_error: row.last_error,
+    alert: row.alert_preference_id ? alertsById.get(String(row.alert_preference_id)) || null : null,
+    grant: row.grant_id ? grantsById.get(row.grant_id) || null : null,
+  }));
+
+  const entitlements = getAlertEntitlements(tier);
+  const eventRows = (recentEvents || []) as Array<{
+    id: number;
+    event_type: string;
+    metadata: Record<string, unknown> | null;
+    created_at: string;
+  }>;
+  const eventSummary = eventRows.reduce(
+    (summary, event) => {
+      if (event.event_type === 'notification_queued') summary.notificationsQueued += 1;
+      if (event.event_type === 'notification_sent') summary.notificationsSent += 1;
+      if (event.event_type === 'notification_failed') summary.notificationsFailed += 1;
+      if (event.event_type === 'digest_sent') summary.digestsSent += 1;
+      if (event.event_type === 'notification_opened' || event.event_type === 'digest_opened') summary.emailOpens += 1;
+      if (event.event_type === 'notification_clicked' || event.event_type === 'digest_clicked') summary.grantClicks += 1;
+      if (event.event_type === 'scout_run') summary.scoutRuns += 1;
+      if (event.event_type === 'optimization_applied') summary.optimizationsApplied += 1;
+      return summary;
+    },
+    {
+      notificationsQueued: 0,
+      notificationsSent: 0,
+      notificationsFailed: 0,
+      digestsSent: 0,
+      emailOpens: 0,
+      grantClicks: 0,
+      scoutRuns: 0,
+      optimizationsApplied: 0,
+    }
+  );
+
+  const normalizedAlertPerformance = buildAlertPerformanceSnapshot({
+    performanceEvents: (performanceEvents || []) as AlertPerformanceEventRow[],
+    attributedSavedGrants: (attributedSavedGrants || []) as AttributedSavedGrantRow[],
+  });
+
+  return NextResponse.json({
+    alerts: alerts || [],
+    recentActivity,
+    alertPerformance: normalizedAlertPerformance,
+    performanceWindowDays,
+    tier,
+    entitlements,
+    usage: {
+      alerts: alerts?.length || 0,
+      activeAlerts: alerts?.filter((alert: { enabled: boolean }) => alert.enabled).length || 0,
+      remainingAlerts: Math.max(entitlements.maxAlerts - (alerts?.length || 0), 0),
+    },
+    queueSummary: {
+      queued: queuedCount || 0,
+      sent: sentCount || 0,
+      failed: failedCount || 0,
+      cancelled: cancelledCount || 0,
+    },
+    eventSummary,
+    recentEvents: eventRows,
+  });
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await requireModule('tracker');
+  const auth = await requireModule('grants');
   if (auth.error) return auth.error;
-  const { user } = auth;
+  const { user, tier } = auth;
 
   const body = await request.json();
   const { name, frequency, categories, focus_areas, states, min_amount, max_amount, keywords, entity_types } = body;
+  const optimizationSourceAlertId = body.optimization_source_alert_id != null ? Number(body.optimization_source_alert_id) : null;
+  const optimizationAction = typeof body.optimization_action === 'string' ? body.optimization_action : null;
+  const optimizationRecommendationTitle = typeof body.optimization_recommendation_title === 'string'
+    ? body.optimization_recommendation_title
+    : null;
+  const entitlements = getAlertEntitlements(tier);
+  const requestedFrequency = frequency || 'weekly';
+
+  if (!entitlements.frequencies.includes(requestedFrequency)) {
+    return NextResponse.json(
+      {
+        error: 'This alert frequency is not available on your current plan.',
+        tier,
+        allowed_frequencies: entitlements.frequencies,
+        upgrade_url: '/pricing',
+      },
+      { status: 403 }
+    );
+  }
 
   const db = getServiceSupabase();
+  const { count: alertCount, error: alertCountError } = await db
+    .from('alert_preferences')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', user.id);
+
+  if (alertCountError) return NextResponse.json({ error: alertCountError.message }, { status: 500 });
+
+  if ((alertCount || 0) >= entitlements.maxAlerts) {
+    return NextResponse.json(
+      {
+        error: 'You have reached your alert limit for this plan.',
+        tier,
+        max_alerts: entitlements.maxAlerts,
+        upgrade_url: '/pricing',
+      },
+      { status: 403 }
+    );
+  }
+
   const { data, error } = await db
     .from('alert_preferences')
     .insert({
       user_id: user.id,
       name: name || 'My Alert',
-      frequency: frequency || 'weekly',
+      frequency: requestedFrequency,
       categories: categories || [],
       focus_areas: focus_areas || [],
       states: states || [],
@@ -50,5 +270,46 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await recordAlertEvents([
+    {
+      userId: user.id,
+      alertPreferenceId: data.id,
+      eventType: 'alert_created',
+      metadata: {
+        frequency: data.frequency,
+        tier,
+      },
+    },
+    ...(optimizationSourceAlertId
+      ? [{
+        userId: user.id,
+        alertPreferenceId: optimizationSourceAlertId,
+        eventType: 'optimization_applied' as const,
+        metadata: {
+          action: optimizationAction || 'clone_tighter',
+          recommendation_title: optimizationRecommendationTitle,
+          created_alert_id: data.id,
+          created_alert_name: data.name,
+          result: 'created_variant',
+        },
+      }]
+      : []),
+  ]);
+
+  if ((alertCount || 0) === 0) {
+    await recordProductEvents([
+      {
+        userId: user.id,
+        eventType: 'first_alert_created',
+        metadata: {
+          alert_id: data.id,
+          frequency: data.frequency,
+          tier,
+        },
+      },
+    ]);
+  }
+
   return NextResponse.json({ alert: data }, { status: 201 });
 }

--- a/apps/web/src/app/api/alerts/scout/route.ts
+++ b/apps/web/src/app/api/alerts/scout/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { requireModule } from '@/lib/api-auth';
+import { runGrantScoutForUser } from '@/lib/grant-scout';
+
+export async function POST() {
+  const auth = await requireModule('grants');
+  if (auth.error) return auth.error;
+  const { user } = auth;
+
+  try {
+    const result = await runGrantScoutForUser(user.id);
+
+    if (result.profilesScanned === 0) {
+      return NextResponse.json(
+        { error: 'Complete your organisation profile before running the grant scout.' },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      ...result,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to run grant scout.' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/alerts/track/click/route.ts
+++ b/apps/web/src/app/api/alerts/track/click/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { recordAlertEvents, type AlertEventType } from '@/lib/alert-events';
+import { resolveAlertTrackRedirect } from '@/lib/alert-link-tracking';
+import { recordProductEvents } from '@/lib/product-events';
+import { getServiceSupabase } from '@/lib/supabase';
+
+type TrackingContext = {
+  userId: string | null;
+  alertPreferenceId: number | null;
+  notificationId: string | null;
+  grantId: string | null;
+};
+
+async function resolveTrackingContext(request: NextRequest) {
+  const source = request.nextUrl.searchParams.get('source');
+  const notificationId = request.nextUrl.searchParams.get('notificationId');
+  const alertIdParam = request.nextUrl.searchParams.get('alertId');
+  const grantId = request.nextUrl.searchParams.get('grantId');
+  const fallbackUserId = request.nextUrl.searchParams.get('userId');
+  const alertPreferenceId = alertIdParam ? Number(alertIdParam) : null;
+  const db = getServiceSupabase();
+
+  if (source === 'notification' && notificationId) {
+    const { data } = await db
+      .from('grant_notification_outbox')
+      .select('user_id, alert_preference_id, grant_id')
+      .eq('id', notificationId)
+      .maybeSingle();
+
+    if (data?.user_id) {
+      return {
+        source,
+        context: {
+          userId: data.user_id,
+          alertPreferenceId: data.alert_preference_id ?? alertPreferenceId,
+          notificationId,
+          grantId: data.grant_id ?? grantId,
+        } satisfies TrackingContext,
+      };
+    }
+  }
+
+  if (source === 'digest' && alertPreferenceId != null) {
+    const { data } = await db
+      .from('alert_preferences')
+      .select('user_id')
+      .eq('id', alertPreferenceId)
+      .maybeSingle();
+
+    if (data?.user_id) {
+      return {
+        source,
+        context: {
+          userId: data.user_id,
+          alertPreferenceId,
+          notificationId: notificationId || null,
+          grantId: grantId || null,
+        } satisfies TrackingContext,
+      };
+    }
+  }
+
+  return {
+    source,
+    context: {
+      userId: fallbackUserId,
+      alertPreferenceId,
+      notificationId: notificationId || null,
+      grantId: grantId || null,
+    } satisfies TrackingContext,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { source, context } = await resolveTrackingContext(request);
+  const targetPath = request.nextUrl.searchParams.get('target');
+  const eventType: AlertEventType | null =
+    source === 'notification'
+      ? 'notification_clicked'
+      : source === 'digest'
+        ? 'digest_clicked'
+        : null;
+
+  if (eventType && context.userId) {
+    await recordAlertEvents([
+      {
+        userId: context.userId,
+        alertPreferenceId: context.alertPreferenceId,
+        notificationId: context.notificationId,
+        grantId: context.grantId,
+        eventType,
+        metadata: {
+          source,
+          targetPath: targetPath || '/alerts',
+        },
+      },
+    ]);
+
+    await recordProductEvents([
+      {
+        userId: context.userId,
+        eventType: 'alert_clicked',
+        metadata: {
+          source,
+          alert_preference_id: context.alertPreferenceId,
+          notification_id: context.notificationId,
+          grant_id: context.grantId,
+          target_path: targetPath || '/alerts',
+        },
+      },
+    ]);
+  }
+
+  return NextResponse.redirect(resolveAlertTrackRedirect(targetPath), { status: 307 });
+}

--- a/apps/web/src/app/api/alerts/track/open/route.ts
+++ b/apps/web/src/app/api/alerts/track/open/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { recordAlertEvents, type AlertEventType } from '@/lib/alert-events';
+import { getServiceSupabase } from '@/lib/supabase';
+
+const PIXEL_GIF = Buffer.from(
+  'R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+  'base64'
+);
+
+type TrackingContext = {
+  userId: string | null;
+  alertPreferenceId: number | null;
+  notificationId: string | null;
+  grantId: string | null;
+};
+
+async function resolveTrackingContext(request: NextRequest) {
+  const source = request.nextUrl.searchParams.get('source');
+  const notificationId = request.nextUrl.searchParams.get('notificationId');
+  const alertIdParam = request.nextUrl.searchParams.get('alertId');
+  const grantId = request.nextUrl.searchParams.get('grantId');
+  const fallbackUserId = request.nextUrl.searchParams.get('userId');
+  const alertPreferenceId = alertIdParam ? Number(alertIdParam) : null;
+  const db = getServiceSupabase();
+
+  if (source === 'notification' && notificationId) {
+    const { data } = await db
+      .from('grant_notification_outbox')
+      .select('user_id, alert_preference_id, grant_id')
+      .eq('id', notificationId)
+      .maybeSingle();
+
+    if (data?.user_id) {
+      return {
+        source,
+        context: {
+          userId: data.user_id,
+          alertPreferenceId: data.alert_preference_id ?? alertPreferenceId,
+          notificationId,
+          grantId: data.grant_id ?? grantId,
+        } satisfies TrackingContext,
+      };
+    }
+  }
+
+  if (source === 'digest' && alertPreferenceId != null) {
+    const { data } = await db
+      .from('alert_preferences')
+      .select('user_id')
+      .eq('id', alertPreferenceId)
+      .maybeSingle();
+
+    if (data?.user_id) {
+      return {
+        source,
+        context: {
+          userId: data.user_id,
+          alertPreferenceId,
+          notificationId: notificationId || null,
+          grantId: grantId || null,
+        } satisfies TrackingContext,
+      };
+    }
+  }
+
+  return {
+    source,
+    context: {
+      userId: fallbackUserId,
+      alertPreferenceId,
+      notificationId: notificationId || null,
+      grantId: grantId || null,
+    } satisfies TrackingContext,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { source, context } = await resolveTrackingContext(request);
+  const eventType: AlertEventType | null =
+    source === 'notification'
+      ? 'notification_opened'
+      : source === 'digest'
+        ? 'digest_opened'
+        : null;
+
+  if (eventType && context.userId) {
+    await recordAlertEvents([
+      {
+        userId: context.userId,
+        alertPreferenceId: context.alertPreferenceId,
+        notificationId: context.notificationId,
+        grantId: context.grantId,
+        eventType,
+        metadata: { source },
+      },
+    ]);
+  }
+
+  return new NextResponse(PIXEL_GIF, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/gif',
+      'Content-Length': String(PIXEL_GIF.byteLength),
+      'Cache-Control': 'no-store, max-age=0',
+    },
+  });
+}

--- a/apps/web/src/lib/alert-attribution.ts
+++ b/apps/web/src/lib/alert-attribution.ts
@@ -1,0 +1,57 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+export type SavedGrantAttributionType =
+  | 'notification_clicked'
+  | 'digest_clicked'
+  | 'scout_auto'
+  | 'manual';
+
+export type SavedGrantAttribution = {
+  alertPreferenceId: number | null;
+  notificationId: string | null;
+  attributionType: SavedGrantAttributionType;
+  attributedAt: string;
+};
+
+type ServiceDb = ReturnType<typeof getServiceSupabase>;
+
+const ATTRIBUTION_EVENT_TYPES: SavedGrantAttributionType[] = [
+  'notification_clicked',
+  'digest_clicked',
+];
+
+export async function resolveRecentAlertAttribution(
+  db: ServiceDb,
+  userId: string,
+  grantId: string,
+  lookbackDays: number = 30
+): Promise<SavedGrantAttribution | null> {
+  const windowStart = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data, error } = await db
+    .from('alert_events')
+    .select('alert_preference_id, notification_id, event_type, created_at')
+    .eq('user_id', userId)
+    .eq('grant_id', grantId)
+    .in('event_type', ATTRIBUTION_EVENT_TYPES)
+    .not('alert_preference_id', 'is', null)
+    .gte('created_at', windowStart)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data?.event_type) {
+    return null;
+  }
+
+  return {
+    alertPreferenceId: data.alert_preference_id ?? null,
+    notificationId: data.notification_id ?? null,
+    attributionType: data.event_type as SavedGrantAttributionType,
+    attributedAt: data.created_at || new Date().toISOString(),
+  };
+}

--- a/apps/web/src/lib/alert-events.ts
+++ b/apps/web/src/lib/alert-events.ts
@@ -1,0 +1,51 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+export type AlertEventType =
+  | 'alert_created'
+  | 'alert_updated'
+  | 'alert_deleted'
+  | 'optimization_applied'
+  | 'scout_run'
+  | 'notification_queued'
+  | 'notification_requeued'
+  | 'notification_sent'
+  | 'notification_failed'
+  | 'notification_cancelled'
+  | 'notification_opened'
+  | 'notification_clicked'
+  | 'digest_sent'
+  | 'digest_failed'
+  | 'digest_opened'
+  | 'digest_clicked'
+  | 'delivery_run';
+
+type AlertEventInput = {
+  userId: string;
+  eventType: AlertEventType;
+  alertPreferenceId?: number | null;
+  notificationId?: string | null;
+  grantId?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export async function recordAlertEvents(events: AlertEventInput[]) {
+  if (events.length === 0) return;
+
+  const db = getServiceSupabase();
+  const rows = events.map((event) => ({
+    user_id: event.userId,
+    alert_preference_id: event.alertPreferenceId ?? null,
+    notification_id: event.notificationId ?? null,
+    grant_id: event.grantId ?? null,
+    event_type: event.eventType,
+    metadata: event.metadata ?? {},
+  }));
+
+  const { error } = await db
+    .from('alert_events')
+    .insert(rows);
+
+  if (error) {
+    console.error('[alert-events] insert failed:', error);
+  }
+}

--- a/apps/web/src/lib/alert-link-tracking.ts
+++ b/apps/web/src/lib/alert-link-tracking.ts
@@ -1,0 +1,58 @@
+import { buildAbsoluteAppUrl, getAppUrl } from '@/lib/app-url';
+
+type AlertTrackSource = 'digest' | 'notification';
+
+type AlertTrackParams = {
+  source: AlertTrackSource;
+  targetPath?: string;
+  userId?: string | null;
+  alertPreferenceId?: number | null;
+  notificationId?: string | null;
+  grantId?: string | null;
+};
+
+export function normalizeAlertTrackTarget(targetPath?: string | null) {
+  if (!targetPath || !targetPath.startsWith('/')) {
+    return '/alerts';
+  }
+
+  return targetPath;
+}
+
+export function buildAlertTrackClickUrl({
+  source,
+  targetPath = '/alerts',
+  userId,
+  alertPreferenceId,
+  notificationId,
+  grantId,
+}: AlertTrackParams) {
+  const url = new URL('/api/alerts/track/click', getAppUrl());
+  url.searchParams.set('source', source);
+  url.searchParams.set('target', normalizeAlertTrackTarget(targetPath));
+  if (userId) url.searchParams.set('userId', userId);
+  if (alertPreferenceId != null) url.searchParams.set('alertId', String(alertPreferenceId));
+  if (notificationId) url.searchParams.set('notificationId', notificationId);
+  if (grantId) url.searchParams.set('grantId', grantId);
+  return url.toString();
+}
+
+export function buildAlertTrackOpenUrl({
+  source,
+  userId,
+  alertPreferenceId,
+  notificationId,
+  grantId,
+}: Omit<AlertTrackParams, 'targetPath'>) {
+  const url = new URL('/api/alerts/track/open', getAppUrl());
+  url.searchParams.set('source', source);
+  if (userId) url.searchParams.set('userId', userId);
+  if (alertPreferenceId != null) url.searchParams.set('alertId', String(alertPreferenceId));
+  if (notificationId) url.searchParams.set('notificationId', notificationId);
+  if (grantId) url.searchParams.set('grantId', grantId);
+  return url.toString();
+}
+
+export function resolveAlertTrackRedirect(targetPath?: string | null) {
+  return buildAbsoluteAppUrl(normalizeAlertTrackTarget(targetPath));
+}

--- a/apps/web/src/lib/alert-performance.ts
+++ b/apps/web/src/lib/alert-performance.ts
@@ -1,0 +1,411 @@
+export type AlertRecommendationKey =
+  | 'keep_expand'
+  | 'working_pipeline'
+  | 'good_prospect_flow'
+  | 'clicks_not_converting'
+  | 'low_engagement'
+  | 'low_fit'
+  | 'no_recent_activity'
+  | 'monitor'
+  | 'optimization_improving'
+  | 'optimization_underperforming';
+
+export type AlertOptimizationComparison = {
+  hasComparisonData: boolean;
+  enoughComparisonData: boolean;
+  before: {
+    sent: number;
+    opens: number;
+    clicks: number;
+    tracked: number;
+    openRate: number | null;
+    clickRate: number | null;
+    trackRate: number | null;
+  };
+  after: {
+    sent: number;
+    opens: number;
+    clicks: number;
+    tracked: number;
+    openRate: number | null;
+    clickRate: number | null;
+    trackRate: number | null;
+  };
+  delta: {
+    openRate: number | null;
+    clickRate: number | null;
+    trackRate: number | null;
+  };
+};
+
+export type AlertRecommendation = {
+  key: AlertRecommendationKey;
+  tone: 'success' | 'info' | 'warning' | 'neutral';
+  title: string;
+  detail: string;
+};
+
+export type AlertPerformanceEventRow = {
+  alert_preference_id: number | null;
+  event_type: string;
+  created_at: string;
+  metadata: Record<string, unknown> | null;
+};
+
+export type AttributedSavedGrantRow = {
+  source_alert_preference_id: number | null;
+  stage: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  source_attributed_at: string | null;
+};
+
+type AlertPerformanceAccumulator = {
+  queued: number;
+  sent: number;
+  failed: number;
+  digestsSent: number;
+  opens: number;
+  clicks: number;
+  tracked: number;
+  active: number;
+  submitted: number;
+  won: number;
+  lastEventAt: string | null;
+  lastTrackedAt: string | null;
+  lastOptimizedAt: string | null;
+  lastOptimizationAction: string | null;
+  opensAfterOptimization: number;
+  sentAfterOptimization: number;
+  clicksAfterOptimization: number;
+  trackedAfterOptimization: number;
+};
+
+export type AlertPerformanceMetrics = AlertPerformanceAccumulator & {
+  openRate: number | null;
+  clickRate: number | null;
+  trackRate: number | null;
+  clickToTrackRate: number | null;
+  submissionRate: number | null;
+  winRate: number | null;
+  optimizationComparison: AlertOptimizationComparison | null;
+  recommendation: AlertRecommendation;
+};
+
+const ACTIVE_STAGES = new Set(['researching', 'pursuing', 'negotiating']);
+const SUBMITTED_STAGES = new Set(['submitted']);
+const WON_STAGES = new Set(['approved', 'successful', 'realized']);
+
+function createAccumulator(): AlertPerformanceAccumulator {
+  return {
+    queued: 0,
+    sent: 0,
+    failed: 0,
+    digestsSent: 0,
+    opens: 0,
+    clicks: 0,
+    tracked: 0,
+    active: 0,
+    submitted: 0,
+    won: 0,
+    lastEventAt: null,
+    lastTrackedAt: null,
+    lastOptimizedAt: null,
+    lastOptimizationAction: null,
+    opensAfterOptimization: 0,
+    sentAfterOptimization: 0,
+    clicksAfterOptimization: 0,
+    trackedAfterOptimization: 0,
+  };
+}
+
+export function rate(numerator: number, denominator: number) {
+  return denominator > 0 ? Math.round((numerator / denominator) * 100) : null;
+}
+
+export function describeOptimizationChange(comparison: AlertOptimizationComparison) {
+  const parts: string[] = [];
+  if (comparison.delta.clickRate != null && comparison.delta.clickRate !== 0) {
+    parts.push(`click rate ${comparison.delta.clickRate > 0 ? 'up' : 'down'} ${Math.abs(comparison.delta.clickRate)} pts`);
+  }
+  if (comparison.delta.trackRate != null && comparison.delta.trackRate !== 0) {
+    parts.push(`track rate ${comparison.delta.trackRate > 0 ? 'up' : 'down'} ${Math.abs(comparison.delta.trackRate)} pts`);
+  }
+  if (comparison.delta.openRate != null && comparison.delta.openRate !== 0) {
+    parts.push(`open rate ${comparison.delta.openRate > 0 ? 'up' : 'down'} ${Math.abs(comparison.delta.openRate)} pts`);
+  }
+  return parts.slice(0, 2).join(', ');
+}
+
+export function buildAlertRecommendation(
+  metrics: Pick<AlertPerformanceMetrics, 'sent' | 'opens' | 'clicks' | 'tracked' | 'submitted' | 'won'>,
+  comparison: AlertOptimizationComparison | null
+): AlertRecommendation {
+  if (comparison?.enoughComparisonData) {
+    const clickDelta = comparison.delta.clickRate ?? 0;
+    const trackDelta = comparison.delta.trackRate ?? 0;
+    const changeSummary = describeOptimizationChange(comparison);
+
+    if (trackDelta >= 5 || clickDelta >= 10) {
+      return {
+        key: 'optimization_improving',
+        tone: 'success',
+        title: 'Optimization improving',
+        detail: changeSummary
+          ? `The last optimization is working: ${changeSummary}. Keep this version active and consider a tighter follow-on variant.`
+          : 'The last optimization is improving engagement. Keep this version active and monitor submissions.',
+      };
+    }
+
+    if (trackDelta <= -5 || clickDelta <= -10) {
+      return {
+        key: 'optimization_underperforming',
+        tone: 'warning',
+        title: 'Optimization underperforming',
+        detail: changeSummary
+          ? `The last optimization made results worse: ${changeSummary}. Pause this version or tighten the criteria again.`
+          : 'The last optimization is underperforming. Pause this version or tighten the criteria again.',
+      };
+    }
+  }
+
+  if (metrics.won > 0) {
+    return {
+      key: 'keep_expand',
+      tone: 'success',
+      title: 'Keep and expand',
+      detail: 'This alert has already produced wins. Keep it active and consider a tighter high-fit variant.',
+    };
+  }
+
+  if (metrics.submitted > 0) {
+    return {
+      key: 'working_pipeline',
+      tone: 'success',
+      title: 'Working pipeline',
+      detail: 'This alert is generating applications. Keep it active and watch the click-to-track rate.',
+    };
+  }
+
+  if (metrics.tracked >= 3) {
+    return {
+      key: 'good_prospect_flow',
+      tone: 'info',
+      title: 'Good prospect flow',
+      detail: 'People are tracking grants from this alert. Keep it active while you watch for submissions.',
+    };
+  }
+
+  if (metrics.clicks >= 3 && metrics.tracked === 0) {
+    return {
+      key: 'clicks_not_converting',
+      tone: 'warning',
+      title: 'Clicks not converting',
+      detail: 'Recipients are opening grant links but not tracking them. Tighten keywords, geography, or amount filters.',
+    };
+  }
+
+  if (metrics.sent >= 8 && metrics.opens <= 1) {
+    return {
+      key: 'low_engagement',
+      tone: 'warning',
+      title: 'Low engagement',
+      detail: 'This alert is sending often without opens. Lower frequency or rename it so it feels more distinct.',
+    };
+  }
+
+  if (metrics.sent >= 8 && metrics.clicks <= 1) {
+    return {
+      key: 'low_fit',
+      tone: 'warning',
+      title: 'Low fit',
+      detail: 'This alert is being delivered but rarely clicked. Tighten the criteria or pause it if it stays noisy.',
+    };
+  }
+
+  if (metrics.sent === 0 && metrics.tracked === 0) {
+    return {
+      key: 'no_recent_activity',
+      tone: 'neutral',
+      title: 'No recent activity',
+      detail: 'No recent sends or tracked grants in the last 30 days. Keep it active until more data accumulates.',
+    };
+  }
+
+  return {
+    key: 'monitor',
+    tone: 'neutral',
+    title: 'Monitor',
+    detail: 'This alert needs a little more data before there is a strong recommendation.',
+  };
+}
+
+function normalizeAccumulator(metrics: AlertPerformanceAccumulator): AlertPerformanceMetrics {
+  const sentBeforeOptimization = Math.max(metrics.sent - metrics.sentAfterOptimization, 0);
+  const opensBeforeOptimization = Math.max(metrics.opens - metrics.opensAfterOptimization, 0);
+  const clicksBeforeOptimization = Math.max(metrics.clicks - metrics.clicksAfterOptimization, 0);
+  const trackedBeforeOptimization = Math.max(metrics.tracked - metrics.trackedAfterOptimization, 0);
+
+  const beforeOpenRate = rate(opensBeforeOptimization, sentBeforeOptimization);
+  const afterOpenRate = rate(metrics.opensAfterOptimization, metrics.sentAfterOptimization);
+  const beforeClickRate = rate(clicksBeforeOptimization, sentBeforeOptimization);
+  const afterClickRate = rate(metrics.clicksAfterOptimization, metrics.sentAfterOptimization);
+  const beforeTrackRate = rate(trackedBeforeOptimization, sentBeforeOptimization);
+  const afterTrackRate = rate(metrics.trackedAfterOptimization, metrics.sentAfterOptimization);
+
+  const hasOptimization = Boolean(metrics.lastOptimizedAt);
+  const hasComparisonData = hasOptimization && (sentBeforeOptimization > 0 || metrics.sentAfterOptimization > 0);
+  const enoughComparisonData = sentBeforeOptimization >= 3 && metrics.sentAfterOptimization >= 3;
+  const optimizationComparison: AlertOptimizationComparison | null = hasOptimization
+    ? {
+      hasComparisonData,
+      enoughComparisonData,
+      before: {
+        sent: sentBeforeOptimization,
+        opens: opensBeforeOptimization,
+        clicks: clicksBeforeOptimization,
+        tracked: trackedBeforeOptimization,
+        openRate: beforeOpenRate,
+        clickRate: beforeClickRate,
+        trackRate: beforeTrackRate,
+      },
+      after: {
+        sent: metrics.sentAfterOptimization,
+        opens: metrics.opensAfterOptimization,
+        clicks: metrics.clicksAfterOptimization,
+        tracked: metrics.trackedAfterOptimization,
+        openRate: afterOpenRate,
+        clickRate: afterClickRate,
+        trackRate: afterTrackRate,
+      },
+      delta: {
+        openRate:
+          beforeOpenRate != null && afterOpenRate != null
+            ? afterOpenRate - beforeOpenRate
+            : null,
+        clickRate:
+          beforeClickRate != null && afterClickRate != null
+            ? afterClickRate - beforeClickRate
+            : null,
+        trackRate:
+          beforeTrackRate != null && afterTrackRate != null
+            ? afterTrackRate - beforeTrackRate
+            : null,
+      },
+    }
+    : null;
+
+  return {
+    ...metrics,
+    openRate: rate(metrics.opens, metrics.sent),
+    clickRate: rate(metrics.clicks, metrics.sent),
+    trackRate: rate(metrics.tracked, metrics.sent),
+    clickToTrackRate: rate(metrics.tracked, metrics.clicks),
+    submissionRate: rate(metrics.submitted, metrics.tracked),
+    winRate: rate(metrics.won, metrics.submitted),
+    optimizationComparison,
+    recommendation: buildAlertRecommendation(metrics, optimizationComparison),
+  };
+}
+
+export function createEmptyAlertPerformanceMetrics(): AlertPerformanceMetrics {
+  return normalizeAccumulator(createAccumulator());
+}
+
+export function buildAlertPerformanceSnapshot({
+  performanceEvents,
+  attributedSavedGrants,
+}: {
+  performanceEvents: AlertPerformanceEventRow[];
+  attributedSavedGrants: AttributedSavedGrantRow[];
+}): Record<string, AlertPerformanceMetrics> {
+  const alertPerformance = performanceEvents.reduce<Record<string, AlertPerformanceAccumulator>>((acc, event) => {
+    if (event.alert_preference_id == null) {
+      return acc;
+    }
+
+    const key = String(event.alert_preference_id);
+    const existing = acc[key] || createAccumulator();
+
+    if (event.event_type === 'notification_queued') existing.queued += 1;
+    if (event.event_type === 'notification_sent') existing.sent += 1;
+    if (event.event_type === 'notification_failed') existing.failed += 1;
+    if (event.event_type === 'digest_sent') existing.digestsSent += 1;
+    if (event.event_type === 'notification_opened' || event.event_type === 'digest_opened') existing.opens += 1;
+    if (event.event_type === 'notification_clicked' || event.event_type === 'digest_clicked') existing.clicks += 1;
+    if (event.event_type === 'optimization_applied') {
+      if (!existing.lastOptimizedAt || event.created_at > existing.lastOptimizedAt) {
+        existing.lastOptimizedAt = event.created_at;
+        existing.lastOptimizationAction = typeof event.metadata?.action === 'string' ? event.metadata.action : null;
+      }
+    } else if (!existing.lastEventAt || event.created_at > existing.lastEventAt) {
+      existing.lastEventAt = event.created_at;
+    }
+
+    acc[key] = existing;
+    return acc;
+  }, {});
+
+  for (const savedGrant of attributedSavedGrants) {
+    if (savedGrant.source_alert_preference_id == null) {
+      continue;
+    }
+
+    const key = String(savedGrant.source_alert_preference_id);
+    const existing = alertPerformance[key] || createAccumulator();
+
+    existing.tracked += 1;
+    if (savedGrant.stage && ACTIVE_STAGES.has(savedGrant.stage)) existing.active += 1;
+    if (savedGrant.stage && SUBMITTED_STAGES.has(savedGrant.stage)) existing.submitted += 1;
+    if (savedGrant.stage && WON_STAGES.has(savedGrant.stage)) existing.won += 1;
+
+    const trackedAt = savedGrant.source_attributed_at || savedGrant.created_at || savedGrant.updated_at;
+    if (trackedAt && (!existing.lastTrackedAt || trackedAt > existing.lastTrackedAt)) {
+      existing.lastTrackedAt = trackedAt;
+    }
+
+    alertPerformance[key] = existing;
+  }
+
+  for (const event of performanceEvents) {
+    if (event.alert_preference_id == null || event.event_type === 'optimization_applied') {
+      continue;
+    }
+
+    const key = String(event.alert_preference_id);
+    const existing = alertPerformance[key];
+    if (!existing?.lastOptimizedAt || event.created_at <= existing.lastOptimizedAt) {
+      continue;
+    }
+
+    if (event.event_type === 'notification_sent') existing.sentAfterOptimization += 1;
+    if (event.event_type === 'notification_opened' || event.event_type === 'digest_opened') {
+      existing.opensAfterOptimization += 1;
+    }
+    if (event.event_type === 'notification_clicked' || event.event_type === 'digest_clicked') {
+      existing.clicksAfterOptimization += 1;
+    }
+  }
+
+  for (const savedGrant of attributedSavedGrants) {
+    if (savedGrant.source_alert_preference_id == null) {
+      continue;
+    }
+
+    const key = String(savedGrant.source_alert_preference_id);
+    const existing = alertPerformance[key];
+    const trackedAt = savedGrant.source_attributed_at || savedGrant.created_at || savedGrant.updated_at;
+    if (!existing?.lastOptimizedAt || !trackedAt || trackedAt <= existing.lastOptimizedAt) {
+      continue;
+    }
+
+    existing.trackedAfterOptimization += 1;
+  }
+
+  return Object.fromEntries(
+    Object.entries(alertPerformance).map(([alertId, metrics]) => [
+      alertId,
+      normalizeAccumulator(metrics),
+    ])
+  );
+}

--- a/apps/web/src/lib/app-url.ts
+++ b/apps/web/src/lib/app-url.ts
@@ -1,0 +1,8 @@
+export function getAppUrl() {
+  return (process.env.NEXT_PUBLIC_APP_URL || 'https://civicgraph.au').replace(/\/+$/, '');
+}
+
+export function buildAbsoluteAppUrl(path: string) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return new URL(normalizedPath, getAppUrl()).toString();
+}

--- a/apps/web/src/lib/grant-alert-digests.ts
+++ b/apps/web/src/lib/grant-alert-digests.ts
@@ -1,0 +1,591 @@
+import {
+  buildAlertPerformanceSnapshot,
+  createEmptyAlertPerformanceMetrics,
+  type AlertPerformanceEventRow,
+  type AttributedSavedGrantRow,
+} from '@/lib/alert-performance';
+import { buildAlertTrackClickUrl, buildAlertTrackOpenUrl } from '@/lib/alert-link-tracking';
+import { sendEmail } from '@/lib/gmail';
+import { recordAlertEvents } from '@/lib/alert-events';
+import { getAlertEntitlements, resolveSubscriptionTier } from '@/lib/subscription';
+import { getServiceSupabase } from '@/lib/supabase';
+
+type DigestOptions = {
+  userId?: string;
+  dryRun?: boolean;
+  force?: boolean;
+};
+
+type OrgProfileRow = {
+  id: string;
+  user_id: string;
+  name: string | null;
+  notify_email: boolean | null;
+  subscription_plan: string | null;
+};
+
+type AlertRow = {
+  id: number;
+  name: string;
+  frequency: 'daily' | 'weekly' | 'monthly';
+  enabled: boolean;
+};
+
+type OutboxRow = {
+  id: string;
+  grant_id: string;
+  alert_preference_id: number | null;
+  status: string;
+  subject: string | null;
+  match_score: number | null;
+  match_signals: string[] | null;
+  created_at: string;
+  queued_at: string;
+  sent_at: string | null;
+  last_error: string | null;
+};
+
+type GrantRow = {
+  id: string;
+  name: string;
+  provider: string | null;
+  closes_at: string | null;
+};
+
+type DigestAlertInsight = {
+  alertName: string;
+  recommendationTitle: string;
+  recommendationDetail: string;
+  frequency: 'daily' | 'weekly' | 'monthly';
+};
+
+export type GrantAlertDigestResult = {
+  profilesConsidered: number;
+  profilesEligible: number;
+  digestsSent: number;
+  alertsIncluded: number;
+  grantsIncluded: number;
+  skippedNoProfile: number;
+  skippedTier: number;
+  skippedNoAlerts: number;
+  skippedNoChanges: number;
+  dryRun: boolean;
+};
+
+function fmtDate(date: string | null) {
+  return date ? new Date(date).toLocaleDateString('en-AU') : 'No deadline';
+}
+
+function timeAgo(date: string) {
+  const diff = Date.now() - new Date(date).getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days <= 0) return 'today';
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function buildDigestEmail({
+  profileName,
+  items,
+  alertInsights,
+  periodStart,
+  periodEnd,
+  trackingPixels,
+}: {
+  profileName: string;
+  items: Array<{
+    grantName: string;
+    provider: string | null;
+    alertName: string | null;
+    alertId: number | null;
+    score: number | null;
+    signals: string[];
+    closesAt: string | null;
+    createdAt: string;
+    status: string;
+    grantId: string;
+    trackedGrantUrl: string;
+  }>;
+  alertInsights: DigestAlertInsight[];
+  periodStart: string;
+  periodEnd: string;
+  trackingPixels: string[];
+}) {
+  const itemHtml = items.slice(0, 12).map((item) => `
+    <div style="border:2px solid #141414;padding:12px;margin-bottom:12px;">
+      <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start;">
+        <div>
+          <div style="font-weight:900;font-size:14px;line-height:1.3;">
+            <a href="${item.trackedGrantUrl}" style="color:#141414;text-decoration:none;">
+              ${escapeHtml(item.grantName)}
+            </a>
+          </div>
+          <div style="font-size:11px;color:#6b6b6b;margin-top:4px;">
+            ${escapeHtml(item.alertName || 'Grant match')}
+            ${item.provider ? ` · ${escapeHtml(item.provider)}` : ''}
+          </div>
+        </div>
+        ${item.score != null ? `
+          <div style="background:#1c47d1;color:#fff;padding:4px 8px;font-size:10px;font-weight:900;letter-spacing:0.1em;text-transform:uppercase;">
+            ${item.score}% match
+          </div>
+        ` : ''}
+      </div>
+      ${item.signals.length > 0 ? `
+        <div style="margin-top:8px;">
+          ${item.signals.slice(0, 4).map((signal) => `
+            <span style="display:inline-block;margin:0 6px 6px 0;padding:4px 6px;background:#f3f4f6;color:#4b5563;font-size:10px;border-radius:4px;">
+              ${escapeHtml(signal)}
+            </span>
+          `).join('')}
+        </div>
+      ` : ''}
+      <div style="margin-top:8px;font-size:11px;color:#6b6b6b;">
+        Deadline: ${escapeHtml(fmtDate(item.closesAt))} · Added ${escapeHtml(timeAgo(item.createdAt))} · Queue status: ${escapeHtml(item.status)}
+      </div>
+    </div>
+  `).join('');
+
+  const alertInsightHtml = alertInsights.length > 0
+    ? `
+      <div style="margin-bottom:20px;">
+        <div style="font-size:10px;font-weight:900;letter-spacing:0.1em;text-transform:uppercase;color:#6b6b6b;margin-bottom:10px;">
+          Alert Watch
+        </div>
+        ${alertInsights.map((insight) => `
+          <div style="border-left:4px solid #141414;padding:8px 0 8px 12px;margin-bottom:10px;">
+            <div style="font-size:13px;font-weight:800;">
+              ${escapeHtml(insight.alertName)} · ${escapeHtml(insight.recommendationTitle)}
+            </div>
+            <div style="font-size:11px;color:#6b6b6b;margin-top:4px;">
+              ${escapeHtml(insight.recommendationDetail)}
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    `
+    : '';
+
+  const body = [
+    `Weekly grant digest for ${profileName}`,
+    '',
+    `${items.length} grant match${items.length === 1 ? '' : 'es'} changed between ${new Date(periodStart).toLocaleDateString('en-AU')} and ${new Date(periodEnd).toLocaleDateString('en-AU')}.`,
+    ...(alertInsights.length > 0
+      ? [
+        '',
+        'Alert watch:',
+        ...alertInsights.map((insight) => `- ${insight.alertName} — ${insight.recommendationTitle}. ${insight.recommendationDetail}`),
+      ]
+      : []),
+    '',
+    ...items.slice(0, 12).flatMap((item, index) => ([
+      `${index + 1}. ${item.grantName}${item.provider ? ` — ${item.provider}` : ''}${item.score != null ? ` (${item.score}% match)` : ''}`,
+      `   Open: ${item.trackedGrantUrl}`,
+    ])),
+    '',
+    'Open CivicGraph to review the full alert queue and tracker.',
+  ].join('\n');
+
+  const html = `
+    <div style="max-width:640px;margin:0 auto;font-family:Helvetica,Arial,sans-serif;color:#141414;">
+      <div style="background:#141414;padding:16px 20px;margin-bottom:24px;">
+        <div style="color:#f2ce1e;font-weight:900;font-size:11px;letter-spacing:0.15em;text-transform:uppercase;">CivicGraph Weekly Grant Digest</div>
+      </div>
+      <div style="padding:0 20px 24px;">
+        <p style="font-size:14px;margin-bottom:8px;">Hi ${escapeHtml(profileName)},</p>
+        <p style="font-size:14px;margin-bottom:20px;">
+          Here are the grant matches that changed across your weekly alerts this week.
+        </p>
+        <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:20px;">
+          <div style="border:2px solid #141414;padding:10px 12px;min-width:160px;">
+            <div style="font-size:10px;font-weight:900;letter-spacing:0.1em;text-transform:uppercase;color:#6b6b6b;">Matches In Digest</div>
+            <div style="font-size:28px;font-weight:900;margin-top:4px;">${items.length}</div>
+          </div>
+          <div style="border:2px solid #141414;padding:10px 12px;min-width:160px;">
+            <div style="font-size:10px;font-weight:900;letter-spacing:0.1em;text-transform:uppercase;color:#6b6b6b;">Period</div>
+            <div style="font-size:13px;font-weight:700;margin-top:6px;">
+              ${escapeHtml(new Date(periodStart).toLocaleDateString('en-AU'))} - ${escapeHtml(new Date(periodEnd).toLocaleDateString('en-AU'))}
+            </div>
+          </div>
+        </div>
+        ${alertInsightHtml}
+        ${itemHtml}
+        <div style="margin-top:24px;padding-top:16px;border-top:3px solid #141414;">
+          <a href="https://civicgraph.au/alerts" style="display:inline-block;padding:10px 20px;background:#141414;color:#fff;text-decoration:none;font-weight:900;font-size:11px;text-transform:uppercase;letter-spacing:0.1em;">
+            Open Grant Alerts
+          </a>
+        </div>
+      </div>
+      ${trackingPixels.map((src) => `<img src="${src}" alt="" width="1" height="1" style="display:none;width:1px;height:1px;" />`).join('')}
+    </div>
+  `;
+
+  return {
+    subject: `CivicGraph Weekly Grant Digest — ${items.length} match${items.length === 1 ? '' : 'es'}`,
+    body,
+    html,
+  };
+}
+
+export async function sendGrantAlertDigests({
+  userId,
+  dryRun = false,
+  force = false,
+}: DigestOptions = {}): Promise<GrantAlertDigestResult> {
+  const db = getServiceSupabase();
+  let profileQuery = db
+    .from('org_profiles')
+    .select('id, user_id, name, notify_email, subscription_plan');
+
+  if (userId) {
+    profileQuery = profileQuery.eq('user_id', userId);
+  } else {
+    profileQuery = profileQuery.eq('notify_email', true);
+  }
+
+  const { data: profiles, error: profileError } = await profileQuery;
+  if (profileError) {
+    throw new Error(profileError.message);
+  }
+
+  if (!profiles?.length) {
+    return {
+      profilesConsidered: 0,
+      profilesEligible: 0,
+      digestsSent: 0,
+      alertsIncluded: 0,
+      grantsIncluded: 0,
+      skippedNoProfile: 0,
+      skippedTier: 0,
+      skippedNoAlerts: 0,
+      skippedNoChanges: 0,
+      dryRun,
+    };
+  }
+
+  const periodEnd = new Date().toISOString();
+  const periodStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const performanceWindowStart = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  let profilesEligible = 0;
+  let digestsSent = 0;
+  let alertsIncluded = 0;
+  let grantsIncluded = 0;
+  let skippedTier = 0;
+  let skippedNoAlerts = 0;
+  let skippedNoChanges = 0;
+
+  for (const profile of profiles as OrgProfileRow[]) {
+    const tier = resolveSubscriptionTier(profile.subscription_plan);
+    const entitlements = getAlertEntitlements(tier);
+
+    if (!entitlements.weeklyDigest) {
+      skippedTier++;
+      continue;
+    }
+
+    const { data: alerts, error: alertsError } = await db
+      .from('alert_preferences')
+      .select('id, name, frequency, enabled')
+      .eq('user_id', profile.user_id)
+      .eq('enabled', true)
+      .eq('frequency', 'weekly');
+
+    if (alertsError) {
+      throw new Error(alertsError.message);
+    }
+
+    if (!alerts?.length) {
+      skippedNoAlerts++;
+      continue;
+    }
+
+    const weeklyAlerts = alerts as AlertRow[];
+    const alertIds = weeklyAlerts.map((alert) => alert.id);
+    profilesEligible++;
+
+    const { data: recentDigestRows, error: recentDigestError } = await db
+      .from('alert_notifications')
+      .select('alert_id, sent_at, email_status')
+      .in('alert_id', alertIds)
+      .gte('sent_at', periodStart);
+
+    if (recentDigestError) {
+      throw new Error(recentDigestError.message);
+    }
+
+    const sentThisWeek = new Set(
+      (recentDigestRows || [])
+        .filter((row: { email_status: string }) => row.email_status === 'sent')
+        .map((row: { alert_id: number | null }) => row.alert_id)
+        .filter((value): value is number => typeof value === 'number')
+    );
+
+    const dueAlerts = force
+      ? weeklyAlerts
+      : weeklyAlerts.filter((alert) => !sentThisWeek.has(alert.id));
+
+    if (dueAlerts.length === 0) {
+      continue;
+    }
+
+    const dueAlertIds = dueAlerts.map((alert) => alert.id);
+
+    const [
+      { data: performanceEvents, error: performanceEventsError },
+      { data: attributedSavedGrants, error: attributedSavedGrantsError },
+    ] = await Promise.all([
+      db.from('alert_events')
+        .select('alert_preference_id, event_type, created_at, metadata')
+        .eq('user_id', profile.user_id)
+        .in('alert_preference_id', dueAlertIds)
+        .gte('created_at', performanceWindowStart)
+        .order('created_at', { ascending: false })
+        .limit(500),
+      db.from('saved_grants')
+        .select('source_alert_preference_id, stage, created_at, updated_at, source_attributed_at')
+        .eq('user_id', profile.user_id)
+        .in('source_alert_preference_id', dueAlertIds),
+    ]);
+
+    if (performanceEventsError) {
+      throw new Error(performanceEventsError.message);
+    }
+
+    if (attributedSavedGrantsError) {
+      throw new Error(attributedSavedGrantsError.message);
+    }
+
+    const alertPerformance = buildAlertPerformanceSnapshot({
+      performanceEvents: (performanceEvents || []) as AlertPerformanceEventRow[],
+      attributedSavedGrants: (attributedSavedGrants || []) as AttributedSavedGrantRow[],
+    });
+
+    const { data: outboxRows, error: outboxError } = await db
+      .from('grant_notification_outbox')
+      .select('id, grant_id, alert_preference_id, status, subject, match_score, match_signals, created_at, queued_at, sent_at, last_error')
+      .eq('user_id', profile.user_id)
+      .gte('created_at', periodStart)
+      .order('created_at', { ascending: false })
+      .limit(100);
+
+    if (outboxError) {
+      throw new Error(outboxError.message);
+    }
+
+    const rows = ((outboxRows || []) as OutboxRow[]).filter((row) =>
+      row.alert_preference_id == null || dueAlertIds.includes(row.alert_preference_id)
+    );
+
+    if (rows.length === 0) {
+      skippedNoChanges++;
+      continue;
+    }
+
+    const grantIds = [...new Set(rows.map((row) => row.grant_id))];
+    const { data: grants, error: grantsError } = await db
+      .from('grant_opportunities')
+      .select('id, name, provider, closes_at')
+      .in('id', grantIds);
+
+    if (grantsError) {
+      throw new Error(grantsError.message);
+    }
+
+    const grantMap = new Map((grants || []).map((grant) => [grant.id, grant as GrantRow]));
+    const alertMap = new Map(dueAlerts.map((alert) => [alert.id, alert]));
+    const recommendationPriority = (title: string) => {
+      switch (title) {
+        case 'Optimization underperforming':
+        case 'Low engagement':
+        case 'Low fit':
+        case 'Clicks not converting':
+          return 0;
+        case 'Optimization improving':
+        case 'Keep and expand':
+        case 'Working pipeline':
+        case 'Good prospect flow':
+          return 1;
+        default:
+          return 2;
+      }
+    };
+
+    const items = rows.map((row) => {
+      const grant = grantMap.get(row.grant_id);
+      const alert = row.alert_preference_id ? alertMap.get(row.alert_preference_id) : null;
+      return {
+        grantName: grant?.name || row.subject || 'Grant match',
+        provider: grant?.provider || null,
+        alertName: alert?.name || null,
+        alertId: alert?.id ?? row.alert_preference_id ?? null,
+        score: row.match_score,
+        signals: row.match_signals || [],
+        closesAt: grant?.closes_at || null,
+        createdAt: row.created_at,
+        status: row.status,
+        grantId: row.grant_id,
+        trackedGrantUrl: buildAlertTrackClickUrl({
+          source: 'digest',
+          userId: profile.user_id,
+          alertPreferenceId: alert?.id ?? row.alert_preference_id ?? null,
+          grantId: row.grant_id,
+          targetPath: `/grants/${row.grant_id}`,
+        }),
+      };
+    });
+
+    const alertInsights = dueAlerts
+      .map((alert) => {
+        const metrics = alertPerformance[String(alert.id)] || createEmptyAlertPerformanceMetrics();
+        return {
+          alertName: alert.name,
+          recommendationTitle: metrics.recommendation.title,
+          recommendationDetail: metrics.recommendation.detail,
+          frequency: alert.frequency,
+        };
+      })
+      .sort((a, b) => {
+        const priorityDelta = recommendationPriority(a.recommendationTitle) - recommendationPriority(b.recommendationTitle);
+        if (priorityDelta !== 0) return priorityDelta;
+        return a.alertName.localeCompare(b.alertName);
+      })
+      .slice(0, 3);
+
+    const digestEmail = buildDigestEmail({
+      profileName: profile.name || 'there',
+      items,
+      alertInsights,
+      periodStart,
+      periodEnd,
+      trackingPixels: [...new Set(dueAlerts.map((alert) => buildAlertTrackOpenUrl({
+        source: 'digest',
+        userId: profile.user_id,
+        alertPreferenceId: alert.id,
+      })))],
+    });
+
+    const digestSentAt = new Date().toISOString();
+
+    if (!dryRun) {
+      const { data: authUser, error: authUserError } = await db.auth.admin.getUserById(profile.user_id);
+      if (authUserError) {
+        throw new Error(authUserError.message);
+      }
+
+      const recipientEmail = authUser.user?.email;
+      if (!recipientEmail) {
+        skippedNoChanges++;
+        continue;
+      }
+
+      try {
+        await sendEmail({
+          to: recipientEmail,
+          subject: digestEmail.subject,
+          body: digestEmail.body,
+          html: digestEmail.html,
+          senderName: 'CivicGraph Alerts',
+        });
+
+        const alertNotificationRows = dueAlerts.map((alert) => ({
+          user_id: profile.user_id,
+          alert_id: alert.id,
+          grant_ids: items
+            .filter((item) => item.alertName === alert.name)
+            .map((item) => item.grantId),
+          match_count: items.filter((item) => item.alertName === alert.name).length,
+          sent_at: digestSentAt,
+          email_status: 'sent',
+        }));
+
+        if (alertNotificationRows.length > 0) {
+          const { error: notificationLogError } = await db
+            .from('alert_notifications')
+            .insert(alertNotificationRows);
+
+          if (notificationLogError) {
+            throw new Error(notificationLogError.message);
+          }
+        }
+
+        const { error: alertUpdateError } = await db
+          .from('alert_preferences')
+          .update({
+            last_sent_at: digestSentAt,
+            updated_at: digestSentAt,
+          })
+          .in('id', dueAlertIds);
+
+        if (alertUpdateError) {
+          throw new Error(alertUpdateError.message);
+        }
+
+        await recordAlertEvents(dueAlerts.map((alert) => ({
+          userId: profile.user_id,
+          alertPreferenceId: alert.id,
+          eventType: 'digest_sent',
+          metadata: {
+            tier,
+            grantCount: items.filter((item) => item.alertName === alert.name).length,
+            periodStart,
+            periodEnd,
+          },
+        })));
+      } catch (error) {
+        const digestError = error instanceof Error ? error.message : 'Digest delivery failed';
+
+        await db
+          .from('alert_notifications')
+          .insert(dueAlerts.map((alert) => ({
+            user_id: profile.user_id,
+            alert_id: alert.id,
+            grant_ids: [],
+            match_count: 0,
+            sent_at: digestSentAt,
+            email_status: 'failed',
+          })));
+
+        await recordAlertEvents(dueAlerts.map((alert) => ({
+          userId: profile.user_id,
+          alertPreferenceId: alert.id,
+          eventType: 'digest_failed',
+          metadata: {
+            tier,
+            periodStart,
+            periodEnd,
+            error: digestError,
+          },
+        })));
+
+        throw error;
+      }
+    }
+
+    digestsSent++;
+    alertsIncluded += dueAlerts.length;
+    grantsIncluded += items.length;
+  }
+
+  return {
+    profilesConsidered: profiles.length,
+    profilesEligible,
+    digestsSent,
+    alertsIncluded,
+    grantsIncluded,
+    skippedNoProfile: 0,
+    skippedTier,
+    skippedNoAlerts,
+    skippedNoChanges,
+    dryRun,
+  };
+}

--- a/apps/web/src/lib/grant-notifications.ts
+++ b/apps/web/src/lib/grant-notifications.ts
@@ -1,0 +1,313 @@
+import { buildAlertTrackClickUrl, buildAlertTrackOpenUrl } from '@/lib/alert-link-tracking';
+import { sendEmail } from '@/lib/gmail';
+import { recordAlertEvents } from '@/lib/alert-events';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const MAX_GRANT_NOTIFICATION_ATTEMPTS = 5;
+
+type DeliverGrantNotificationsOptions = {
+  limit?: number;
+  userId?: string;
+};
+
+type OutboxRow = {
+  id: string;
+  user_id: string;
+  grant_id: string;
+  alert_preference_id: number | null;
+  subject: string;
+  body: string | null;
+  match_score: number | null;
+  match_signals: string[] | null;
+  attempt_count: number;
+};
+
+type GrantRow = {
+  id: string;
+  name: string;
+  provider: string | null;
+  closes_at: string | null;
+  url: string | null;
+};
+
+function formatNotificationDeadline(date: string | null) {
+  return date ? new Date(date).toLocaleDateString('en-AU') : 'No deadline';
+}
+
+export async function deliverQueuedGrantNotifications({
+  limit = 50,
+  userId,
+}: DeliverGrantNotificationsOptions = {}) {
+  const serviceDb = getServiceSupabase();
+  const requestedLimit = Math.min(Math.max(Math.floor(limit), 1), 100);
+
+  let query = serviceDb
+    .from('grant_notification_outbox')
+    .select('id, user_id, grant_id, alert_preference_id, subject, body, match_score, match_signals, attempt_count')
+    .eq('status', 'queued')
+    .lt('attempt_count', MAX_GRANT_NOTIFICATION_ATTEMPTS)
+    .order('queued_at', { ascending: true })
+    .limit(requestedLimit);
+
+  if (userId) {
+    query = query.eq('user_id', userId);
+  }
+
+  const { data: queued, error } = await query;
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = (queued || []) as OutboxRow[];
+  if (rows.length === 0) {
+    return { queued: 0, sent: 0, failed: 0, cancelled: 0 };
+  }
+
+  const grantIds = [...new Set(rows.map((row) => row.grant_id))];
+  const { data: grants, error: grantsError } = await serviceDb
+    .from('grant_opportunities')
+    .select('id, name, provider, closes_at, url')
+    .in('id', grantIds);
+
+  if (grantsError) {
+    throw new Error(grantsError.message);
+  }
+
+  const grantsById = new Map((grants || []).map((grant) => [grant.id, grant as GrantRow]));
+
+  const userIds = [...new Set(rows.map((row) => row.user_id))];
+  const emailMap = new Map<string, string>();
+
+  for (const recipientUserId of userIds) {
+    const { data, error: userError } = await serviceDb.auth.admin.getUserById(recipientUserId);
+    if (userError) {
+      throw new Error(userError.message);
+    }
+    if (data?.user?.email) {
+      emailMap.set(recipientUserId, data.user.email);
+    }
+  }
+
+  let sent = 0;
+  let failed = 0;
+  let cancelled = 0;
+  const recordedEvents: Array<Parameters<typeof recordAlertEvents>[0][number]> = [];
+
+  for (const row of rows) {
+    const email = emailMap.get(row.user_id);
+    const attemptCount = (row.attempt_count || 0) + 1;
+    const attemptedAt = new Date().toISOString();
+
+    if (!email) {
+      const { error: cancelError } = await serviceDb
+        .from('grant_notification_outbox')
+        .update({
+          status: 'cancelled',
+          attempt_count: attemptCount,
+          last_attempted_at: attemptedAt,
+          last_error: 'No recipient email found',
+        })
+        .eq('id', row.id);
+
+      if (cancelError) {
+        throw new Error(cancelError.message);
+      }
+
+      cancelled++;
+      recordedEvents.push({
+        userId: row.user_id,
+        alertPreferenceId: row.alert_preference_id,
+        notificationId: row.id,
+        grantId: row.grant_id,
+        eventType: 'notification_cancelled',
+        metadata: {
+          reason: 'missing_email',
+        },
+      });
+      continue;
+    }
+
+    try {
+      const grant = grantsById.get(row.grant_id);
+      const trackedGrantUrl = buildAlertTrackClickUrl({
+        source: 'notification',
+        notificationId: row.id,
+        alertPreferenceId: row.alert_preference_id,
+        grantId: row.grant_id,
+        targetPath: `/grants/${row.grant_id}`,
+      });
+      const trackingPixelUrl = buildAlertTrackOpenUrl({
+        source: 'notification',
+        notificationId: row.id,
+        alertPreferenceId: row.alert_preference_id,
+        grantId: row.grant_id,
+      });
+      const body = [
+        `Grant: ${grant?.name || row.subject || 'Grant match'}`,
+        row.match_score != null ? `Match score: ${row.match_score}%` : null,
+        row.match_signals?.length ? `Signals: ${row.match_signals.join(', ')}` : null,
+        grant?.closes_at ? `Deadline: ${formatNotificationDeadline(grant.closes_at)}` : null,
+        grant?.url ? `Source page: ${grant.url}` : null,
+        '',
+        `Open in CivicGraph: ${trackedGrantUrl}`,
+      ].filter(Boolean).join('\n');
+      const html = `
+        <div style="max-width:640px;margin:0 auto;font-family:Helvetica,Arial,sans-serif;color:#141414;">
+          <div style="background:#141414;padding:16px 20px;margin-bottom:24px;">
+            <div style="color:#f2ce1e;font-weight:900;font-size:11px;letter-spacing:0.15em;text-transform:uppercase;">CivicGraph Grant Alert</div>
+          </div>
+          <div style="padding:0 20px 24px;">
+            <div style="font-weight:900;font-size:18px;line-height:1.3;">
+              <a href="${trackedGrantUrl}" style="color:#141414;text-decoration:none;">
+                ${grant?.name || row.subject || 'Grant match'}
+              </a>
+            </div>
+            <div style="font-size:12px;color:#6b6b6b;margin-top:6px;">
+              ${grant?.provider || 'CivicGraph match'}
+            </div>
+            <div style="margin-top:16px;display:flex;gap:12px;flex-wrap:wrap;">
+              ${row.match_score != null ? `<div style="border:2px solid #141414;padding:8px 10px;font-size:11px;font-weight:900;text-transform:uppercase;">${row.match_score}% match</div>` : ''}
+              ${grant?.closes_at ? `<div style="border:2px solid #141414;padding:8px 10px;font-size:11px;font-weight:700;">Deadline ${formatNotificationDeadline(grant.closes_at)}</div>` : ''}
+            </div>
+            ${row.match_signals?.length ? `
+              <div style="margin-top:16px;">
+                ${row.match_signals.slice(0, 4).map((signal) => `
+                  <span style="display:inline-block;margin:0 6px 6px 0;padding:4px 6px;background:#f3f4f6;color:#4b5563;font-size:10px;border-radius:4px;">
+                    ${signal}
+                  </span>
+                `).join('')}
+              </div>
+            ` : ''}
+            <div style="margin-top:20px;">
+              <a href="${trackedGrantUrl}" style="display:inline-block;padding:10px 20px;background:#141414;color:#fff;text-decoration:none;font-weight:900;font-size:11px;text-transform:uppercase;letter-spacing:0.1em;">
+                Open In CivicGraph
+              </a>
+            </div>
+            ${grant?.url ? `
+              <div style="margin-top:12px;font-size:11px;color:#6b6b6b;">
+                Source page: <a href="${grant.url}" style="color:#1c47d1;">${grant.url}</a>
+              </div>
+            ` : ''}
+          </div>
+          <img src="${trackingPixelUrl}" alt="" width="1" height="1" style="display:none;width:1px;height:1px;" />
+        </div>
+      `;
+
+      const result = await sendEmail({
+        to: email,
+        subject: `[CivicGraph] ${row.subject}`,
+        body,
+        html,
+        senderName: 'CivicGraph Grants',
+      });
+
+      const { error: sentError } = await serviceDb
+        .from('grant_notification_outbox')
+        .update({
+          status: 'sent',
+          sent_at: attemptedAt,
+          attempt_count: attemptCount,
+          last_attempted_at: attemptedAt,
+          last_error: null,
+          external_message_id: result.id,
+        })
+        .eq('id', row.id);
+
+      if (sentError) {
+        throw new Error(sentError.message);
+      }
+
+      if (row.alert_preference_id) {
+        const { error: alertError } = await serviceDb
+          .from('alert_preferences')
+          .update({
+            last_sent_at: attemptedAt,
+            updated_at: attemptedAt,
+          })
+          .eq('id', row.alert_preference_id);
+
+        if (alertError) {
+          throw new Error(alertError.message);
+        }
+      }
+
+      sent++;
+      recordedEvents.push({
+        userId: row.user_id,
+        alertPreferenceId: row.alert_preference_id,
+        notificationId: row.id,
+        grantId: row.grant_id,
+        eventType: 'notification_sent',
+        metadata: {
+          attemptCount,
+          scopedUser: userId || null,
+        },
+      });
+    } catch (error) {
+      const lastError = error instanceof Error ? error.message : 'Delivery failed';
+      const { error: failedUpdateError } = await serviceDb
+        .from('grant_notification_outbox')
+        .update({
+          status: attemptCount >= MAX_GRANT_NOTIFICATION_ATTEMPTS ? 'failed' : 'queued',
+          attempt_count: attemptCount,
+          last_attempted_at: attemptedAt,
+          last_error: lastError,
+        })
+        .eq('id', row.id);
+
+      if (failedUpdateError) {
+        throw new Error(failedUpdateError.message);
+      }
+
+      failed++;
+      recordedEvents.push({
+        userId: row.user_id,
+        alertPreferenceId: row.alert_preference_id,
+        notificationId: row.id,
+        grantId: row.grant_id,
+        eventType: 'notification_failed',
+        metadata: {
+          attemptCount,
+          error: lastError,
+          scopedUser: userId || null,
+        },
+      });
+    }
+  }
+
+  const summaryEvents = userId
+    ? [{
+        userId,
+        eventType: 'delivery_run' as const,
+        metadata: {
+          scopedUser: userId,
+          queued: rows.length,
+          sent,
+          failed,
+          cancelled,
+        },
+      }]
+    : [...new Set(rows.map((row) => row.user_id))].map((recipientUserId) => ({
+        userId: recipientUserId,
+        eventType: 'delivery_run' as const,
+        metadata: {
+          scopedUser: null,
+          queued: rows.filter((row) => row.user_id === recipientUserId).length,
+          sent: recordedEvents.filter((event) => event.userId === recipientUserId && event.eventType === 'notification_sent').length,
+          failed: recordedEvents.filter((event) => event.userId === recipientUserId && event.eventType === 'notification_failed').length,
+          cancelled: recordedEvents.filter((event) => event.userId === recipientUserId && event.eventType === 'notification_cancelled').length,
+        },
+      }));
+
+  await recordAlertEvents([
+    ...recordedEvents,
+    ...summaryEvents,
+  ]);
+
+  return {
+    queued: rows.length,
+    sent,
+    failed,
+    cancelled,
+  };
+}

--- a/apps/web/src/lib/grant-scout.ts
+++ b/apps/web/src/lib/grant-scout.ts
@@ -1,0 +1,457 @@
+import { getServiceSupabase } from '@/lib/supabase';
+import { recordAlertEvents } from '@/lib/alert-events';
+
+const MIN_SCORE = 65;
+const ALERT_MIN_SCORE = 50;
+
+type OrgProfile = {
+  id: string;
+  user_id: string;
+  name: string | null;
+  domains: string[] | null;
+  geographic_focus: string[] | null;
+  org_type: string | null;
+  annual_revenue: number | string | null;
+  mission: string | null;
+  projects: Array<{ name?: string | null }> | null;
+  notify_email: boolean | null;
+  notify_threshold: number | string | null;
+};
+
+type AlertPreference = {
+  id: number;
+  name: string;
+  categories: string[] | null;
+  focus_areas: string[] | null;
+  states: string[] | null;
+  min_amount: number | null;
+  max_amount: number | null;
+  keywords: string[] | null;
+};
+
+type GrantOpportunity = {
+  id: string;
+  name: string | null;
+  description: string | null;
+  amount_min: number | null;
+  amount_max: number | null;
+  deadline: string | null;
+  provider: string | null;
+  url: string | null;
+  categories: string[] | null;
+  focus_areas: string[] | null;
+  target_recipients: string[] | null;
+  geography: string | null;
+  source: string | null;
+  aligned_projects: string[] | null;
+};
+
+type ScoutGrant = GrantOpportunity & {
+  match_score: number;
+  match_signals: string[];
+};
+
+export type GrantScoutResult = {
+  profilesScanned: number;
+  grantsScored: number;
+  matchesFound: number;
+  grantsAdded: number;
+  notificationsQueued: number;
+  alertsUpdated: number;
+};
+
+function toArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function normalizeThreshold(value: number | string | null | undefined) {
+  const parsed = typeof value === 'string' ? Number(value) : value ?? NaN;
+  if (!Number.isFinite(parsed)) return MIN_SCORE;
+  return parsed <= 1 ? Math.round(parsed * 100) : parsed;
+}
+
+function scoreGrant(grant: GrantOpportunity, profile: OrgProfile) {
+  let score = 50;
+  const signals: string[] = [];
+
+  const orgDomains = toArray(profile.domains).map((domain) => domain.toLowerCase());
+  const grantCategories = toArray(grant.categories).map((category) => category.toLowerCase());
+  const grantFocusAreas = toArray(grant.focus_areas).map((focusArea) => focusArea.toLowerCase());
+  const allGrantTerms = [...grantCategories, ...grantFocusAreas];
+
+  const categoryOverlap = orgDomains.filter((domain) =>
+    allGrantTerms.some((term) => term.includes(domain) || domain.includes(term))
+  ).length;
+
+  if (categoryOverlap > 0) {
+    score += Math.min(categoryOverlap * 10, 25);
+    signals.push(`${categoryOverlap} category match${categoryOverlap > 1 ? 'es' : ''}`);
+  }
+
+  const orgGeo = toArray(profile.geographic_focus).map((geo) => geo.toLowerCase());
+  const grantGeo = (grant.geography || '').toLowerCase();
+  if (orgGeo.length > 0 && grantGeo) {
+    const geoMatch = orgGeo.some((geo) => grantGeo.includes(geo) || geo.includes(grantGeo));
+    if (geoMatch) {
+      score += 15;
+      signals.push('Geographic match');
+    }
+  }
+
+  const sourceState = {
+    'nsw-grants': 'nsw',
+    'vic-grants': 'vic',
+    'qld-grants': 'qld',
+    'sa-grants': 'sa',
+    'wa-grants': 'wa',
+    'tas-grants': 'tas',
+    'act-grants': 'act',
+    'nt-grants': 'nt',
+    grantconnect: 'national',
+  }[grant.source || ''];
+
+  if (sourceState && orgGeo.some((geo) => geo === sourceState || geo === 'national')) {
+    score += 10;
+    signals.push(`State match (${sourceState.toUpperCase()})`);
+  }
+
+  const annualRevenue = Number(profile.annual_revenue || 0);
+  if (annualRevenue > 0 && grant.amount_max) {
+    const ratio = grant.amount_max / annualRevenue;
+    if (ratio >= 0.01 && ratio <= 0.5) {
+      score += 10;
+      signals.push('Amount fits org size');
+    }
+  }
+
+  const orgType = (profile.org_type || '').toLowerCase();
+  const grantTargets = toArray(grant.target_recipients).map((target) => target.toLowerCase());
+  if (grantTargets.length > 0 && orgType) {
+    const recipientMatch = grantTargets.some((target) =>
+      target.includes(orgType)
+      || orgType.includes(target)
+      || (orgType.includes('charity') && target.includes('not-for-profit'))
+      || (orgType.includes('social_enterprise') && target.includes('not-for-profit'))
+    );
+    if (recipientMatch) {
+      score += 10;
+      signals.push('Target recipient match');
+    }
+  }
+
+  if (profile.mission && grant.description) {
+    const missionWords = profile.mission.toLowerCase().split(/\s+/).filter((word) => word.length > 4);
+    const description = grant.description.toLowerCase();
+    const missionHits = missionWords.filter((word) => description.includes(word)).length;
+    if (missionHits >= 3) {
+      score += Math.min(missionHits * 3, 15);
+      signals.push(`${missionHits} mission keywords`);
+    }
+  }
+
+  if (grant.deadline) {
+    const daysUntilDeadline = Math.ceil((new Date(grant.deadline).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+    if (daysUntilDeadline > 0 && daysUntilDeadline <= 30) {
+      score += 5;
+      signals.push('Closing soon');
+    }
+  }
+
+  const profileProjects = Array.isArray(profile.projects) ? profile.projects : [];
+  if (profileProjects.length > 0 && Array.isArray(grant.aligned_projects) && grant.aligned_projects.length > 0) {
+    const projectNames = profileProjects
+      .map((project) => project?.name?.toLowerCase())
+      .filter((name): name is string => Boolean(name));
+    const grantProjects = grant.aligned_projects.map((project) => project.toLowerCase());
+    const projectMatch = projectNames.some((projectName) =>
+      grantProjects.some((grantProject) => grantProject.includes(projectName) || projectName.includes(grantProject))
+    );
+    if (projectMatch) {
+      score += 10;
+      signals.push('Project alignment');
+    }
+  }
+
+  return { score: Math.min(score, 100), signals };
+}
+
+function matchesAlert(grant: GrantOpportunity, alert: AlertPreference) {
+  const alertTerms = [...toArray(alert.categories), ...toArray(alert.focus_areas)];
+  if (alertTerms.length > 0) {
+    const grantTerms = [...toArray(grant.categories), ...toArray(grant.focus_areas)].map((term) => term.toLowerCase());
+    const normalizedAlertTerms = alertTerms.map((term) => term.toLowerCase());
+    if (!normalizedAlertTerms.some((alertTerm) =>
+      grantTerms.some((grantTerm) => grantTerm.includes(alertTerm) || alertTerm.includes(grantTerm))
+    )) {
+      return false;
+    }
+  }
+
+  if (toArray(alert.states).length > 0) {
+    const sourceState = {
+      'nsw-grants': 'NSW',
+      'vic-grants': 'VIC',
+      'qld-grants': 'QLD',
+      'sa-grants': 'SA',
+      'wa-grants': 'WA',
+      'tas-grants': 'TAS',
+      'act-grants': 'ACT',
+      'nt-grants': 'NT',
+      grantconnect: 'National',
+    }[grant.source || ''];
+
+    if (sourceState) {
+      const alertStates = toArray(alert.states).map((state) => state.toLowerCase());
+      if (!alertStates.includes(sourceState.toLowerCase())) {
+        return false;
+      }
+    }
+  }
+
+  if (alert.min_amount && grant.amount_max && grant.amount_max < alert.min_amount) return false;
+  if (alert.max_amount && grant.amount_min && grant.amount_min > alert.max_amount) return false;
+
+  if (toArray(alert.keywords).length > 0) {
+    const text = `${grant.name || ''} ${grant.description || ''}`.toLowerCase();
+    if (!toArray(alert.keywords).some((keyword) => text.includes(keyword.toLowerCase()))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function alertSpecificity(alert: AlertPreference) {
+  return toArray(alert.categories).length
+    + toArray(alert.focus_areas).length
+    + toArray(alert.states).length
+    + toArray(alert.keywords).length
+    + (alert.min_amount ? 1 : 0)
+    + (alert.max_amount ? 1 : 0);
+}
+
+function findMatchingAlert(grant: GrantOpportunity, alerts: AlertPreference[]) {
+  return alerts.find((alert) => matchesAlert(grant, alert)) || null;
+}
+
+export async function runGrantScoutForUser(userId: string): Promise<GrantScoutResult> {
+  const db = getServiceSupabase();
+
+  const { data: profiles, error: profileError } = await db
+    .from('org_profiles')
+    .select('id, user_id, name, domains, geographic_focus, org_type, annual_revenue, mission, projects, notify_email, notify_threshold')
+    .eq('user_id', userId);
+
+  if (profileError) {
+    throw new Error(profileError.message);
+  }
+
+  if (!profiles?.length) {
+    return {
+      profilesScanned: 0,
+      grantsScored: 0,
+      matchesFound: 0,
+      grantsAdded: 0,
+      notificationsQueued: 0,
+      alertsUpdated: 0,
+    };
+  }
+
+  const now = new Date().toISOString().split('T')[0];
+  const { data: grants, error: grantError } = await db
+    .from('grant_opportunities')
+    .select('id, name, description, amount_min, amount_max, deadline, provider, url, categories, focus_areas, target_recipients, geography, source, aligned_projects')
+    .or(`deadline.is.null,deadline.gte.${now}`)
+    .order('created_at', { ascending: false })
+    .limit(500);
+
+  if (grantError) {
+    throw new Error(grantError.message);
+  }
+
+  let totalAdded = 0;
+  let totalMatches = 0;
+  let totalQueued = 0;
+  let totalAlertsUpdated = 0;
+
+  for (const profile of profiles as OrgProfile[]) {
+    const { data: alerts, error: alertsError } = await db
+      .from('alert_preferences')
+      .select('id, name, categories, focus_areas, states, min_amount, max_amount, keywords')
+      .eq('user_id', profile.user_id)
+      .eq('enabled', true);
+
+    if (alertsError) {
+      throw new Error(alertsError.message);
+    }
+
+    const enabledAlerts = [...((alerts || []) as AlertPreference[])].sort((a, b) => alertSpecificity(b) - alertSpecificity(a));
+
+    const scored = ((grants || []) as GrantOpportunity[])
+      .map((grant) => {
+        const { score, signals } = scoreGrant(grant, profile);
+        return { ...grant, match_score: score, match_signals: signals };
+      })
+      .sort((a, b) => b.match_score - a.match_score);
+
+    const highScoring = scored.filter((grant) => grant.match_score >= MIN_SCORE);
+    const alertMatches = scored.filter((grant) => grant.match_score >= ALERT_MIN_SCORE);
+    totalMatches += alertMatches.length;
+
+    const { data: existingSavedGrants, error: existingError } = await db
+      .from('saved_grants')
+      .select('grant_id')
+      .eq('user_id', profile.user_id);
+
+    if (existingError) {
+      throw new Error(existingError.message);
+    }
+
+    const existingIds = new Set((existingSavedGrants || []).map((row: { grant_id: string }) => row.grant_id));
+    const newGrants = highScoring.filter((grant) => !existingIds.has(grant.id));
+    const matchedAlertsByGrantId = new Map(
+      newGrants.map((grant) => [grant.id, findMatchingAlert(grant, enabledAlerts)])
+    );
+
+    if (newGrants.length > 0) {
+      const attributedAt = new Date().toISOString();
+      const rows = newGrants.map((grant) => {
+        const matchedAlert = matchedAlertsByGrantId.get(grant.id);
+        return {
+          user_id: profile.user_id,
+          org_profile_id: profile.id,
+          grant_id: grant.id,
+          stage: 'discovered',
+          notes: `Auto-discovered by Grant Scout. Score: ${grant.match_score}%. Signals: ${grant.match_signals.join(', ')}`,
+          source_alert_preference_id: matchedAlert?.id ?? null,
+          source_notification_id: null,
+          source_attribution_type: 'scout_auto' as const,
+          source_attributed_at: attributedAt,
+        };
+      });
+
+      const { error: insertError } = await db
+        .from('saved_grants')
+        .upsert(rows, { onConflict: 'user_id,grant_id' });
+
+      if (insertError) {
+        throw new Error(insertError.message);
+      }
+
+      totalAdded += newGrants.length;
+    }
+
+    const notifyThreshold = normalizeThreshold(profile.notify_threshold);
+    const shouldQueueNotifications = profile.notify_email !== false || enabledAlerts.length > 0;
+    const notifiable = shouldQueueNotifications
+      ? newGrants.filter((grant) => grant.match_score >= notifyThreshold)
+      : [];
+
+    if (notifiable.length > 0) {
+      const grantIds = notifiable.map((grant) => grant.id);
+      const { data: existingNotifications, error: existingNotificationsError } = await db
+        .from('grant_notification_outbox')
+        .select('grant_id')
+        .eq('user_id', profile.user_id)
+        .eq('notification_type', 'grant_match')
+        .in('status', ['queued', 'sent'])
+        .in('grant_id', grantIds);
+
+      if (existingNotificationsError) {
+        throw new Error(existingNotificationsError.message);
+      }
+
+      const notifiedGrantIds = new Set((existingNotifications || []).map((row: { grant_id: string }) => row.grant_id));
+      const rowsToInsert = notifiable
+        .filter((grant) => !notifiedGrantIds.has(grant.id))
+        .map((grant) => ({
+          alert_preference_id: matchedAlertsByGrantId.get(grant.id)?.id || null,
+          user_id: profile.user_id,
+          org_profile_id: profile.id,
+          grant_id: grant.id,
+          notification_type: 'grant_match',
+          subject: `New grant match: ${(grant.name || '').slice(0, 80)}`,
+          body: [
+            `Grant: ${grant.name || 'Untitled grant'}`,
+            `Match score: ${grant.match_score}%`,
+            `Signals: ${grant.match_signals.join(', ')}`,
+            grant.deadline ? `Deadline: ${grant.deadline}` : null,
+            grant.url ? `\nMore info: ${grant.url}` : null,
+            '',
+            'View in CivicGraph: https://civicgraph.au/grants',
+          ].filter(Boolean).join('\n'),
+          match_score: grant.match_score,
+          match_signals: grant.match_signals,
+        }));
+
+      if (rowsToInsert.length > 0) {
+        const { data: insertedNotifications, error: notificationError } = await db
+          .from('grant_notification_outbox')
+          .insert(rowsToInsert)
+          .select('id, alert_preference_id, grant_id');
+
+        if (notificationError) {
+          throw new Error(notificationError.message);
+        }
+
+        totalQueued += rowsToInsert.length;
+
+        await recordAlertEvents([
+          ...((insertedNotifications || []).map((notification: { id: string; alert_preference_id: number | null; grant_id: string }) => ({
+            userId: profile.user_id,
+            alertPreferenceId: notification.alert_preference_id,
+            notificationId: notification.id,
+            grantId: notification.grant_id,
+            eventType: 'notification_queued' as const,
+            metadata: {
+              source: 'grant_scout',
+            },
+          }))),
+        ]);
+      }
+    }
+
+    if (enabledAlerts.length > 0) {
+      const timestamp = new Date().toISOString();
+      for (const alert of enabledAlerts) {
+        const matches = alertMatches.filter((grant) => matchesAlert(grant, alert));
+        const { error: updateError } = await db
+          .from('alert_preferences')
+          .update({
+            match_count: matches.length,
+            last_matched_at: matches.length > 0 ? timestamp : null,
+            updated_at: timestamp,
+          })
+          .eq('id', alert.id);
+
+        if (updateError) {
+          throw new Error(updateError.message);
+        }
+      }
+
+      totalAlertsUpdated += enabledAlerts.length;
+    }
+
+    await recordAlertEvents([
+      {
+        userId: profile.user_id,
+        eventType: 'scout_run',
+        metadata: {
+          matchesFound: alertMatches.length,
+          grantsAdded: newGrants.length,
+          notificationsQueued: notifiable.length,
+          alertsUpdated: enabledAlerts.length,
+        },
+      },
+    ]);
+  }
+
+  return {
+    profilesScanned: profiles.length,
+    grantsScored: grants?.length || 0,
+    matchesFound: totalMatches,
+    grantsAdded: totalAdded,
+    notificationsQueued: totalQueued,
+    alertsUpdated: totalAlertsUpdated,
+  };
+}

--- a/apps/web/src/lib/product-events-client.ts
+++ b/apps/web/src/lib/product-events-client.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import type { ProductEventType } from '@/lib/product-events';
+
+type TrackOptions = {
+  source: string;
+  metadata?: Record<string, unknown>;
+  onceKey?: string;
+};
+
+export async function trackProductEvent(eventType: ProductEventType, options: TrackOptions) {
+  const { source, metadata, onceKey } = options;
+
+  if (typeof window !== 'undefined' && onceKey) {
+    const storageKey = `cg:product-event:${onceKey}`;
+    if (window.sessionStorage.getItem(storageKey)) {
+      return;
+    }
+    window.sessionStorage.setItem(storageKey, '1');
+  }
+
+  try {
+    await fetch('/api/product-events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType,
+        source,
+        metadata: metadata || {},
+      }),
+    });
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/apps/web/src/lib/product-events.ts
+++ b/apps/web/src/lib/product-events.ts
@@ -1,0 +1,60 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+export type ProductEventType =
+  | 'profile_ready'
+  | 'first_grant_shortlisted'
+  | 'pipeline_started'
+  | 'first_alert_created'
+  | 'alert_clicked'
+  | 'upgrade_prompt_viewed'
+  | 'upgrade_cta_clicked'
+  | 'checkout_started'
+  | 'subscription_trial_started'
+  | 'subscription_activated'
+  | 'subscription_changed'
+  | 'subscription_cancelled'
+  | 'billing_portal_opened'
+  | 'billing_reminder_clicked'
+  | 'billing_reminder_sent';
+
+type ProductEventInput = {
+  userId: string;
+  orgProfileId?: string | null;
+  eventType: ProductEventType;
+  metadata?: Record<string, unknown> | null;
+};
+
+export async function recordProductEvents(events: ProductEventInput[]) {
+  if (events.length === 0) return;
+
+  const db = getServiceSupabase();
+  const now = new Date().toISOString();
+  const rows = events.map((event) => ({
+    user_id: event.userId,
+    org_profile_id: event.orgProfileId ?? null,
+    event_type: event.eventType,
+    metadata: event.metadata ?? {},
+    created_at: now,
+  }));
+
+  const { error } = await db.from('product_events').insert(rows);
+  if (error) {
+    console.error('[product-events] insert failed:', error);
+  }
+}
+
+export async function hasProductEvent(userId: string, eventType: ProductEventType) {
+  const db = getServiceSupabase();
+  const { count, error } = await db
+    .from('product_events')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .eq('event_type', eventType);
+
+  if (error) {
+    console.error('[product-events] existence check failed:', error);
+    return false;
+  }
+
+  return (count ?? 0) > 0;
+}

--- a/apps/web/src/lib/profile-alerts.ts
+++ b/apps/web/src/lib/profile-alerts.ts
@@ -1,0 +1,49 @@
+export const DEFAULT_PROFILE_ALERT_NAME = 'Profile Grant Alert';
+
+const SUPPORTED_STATE_CODES = new Set(['nsw', 'vic', 'qld', 'wa', 'sa', 'tas', 'act', 'nt']);
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+export function normalizeAlertStates(geographicFocus: string[] = []): string[] {
+  return unique(
+    geographicFocus.flatMap((value) => {
+      const normalized = value.toLowerCase().trim();
+      if (!normalized) return [];
+      if (normalized === 'national') return ['National'];
+      if (SUPPORTED_STATE_CODES.has(normalized)) return [normalized.toUpperCase()];
+      return [];
+    })
+  );
+}
+
+export function buildProfileAlertPreference({
+  domains = [],
+  geographicFocus = [],
+  notifyEmail = true,
+}: {
+  domains?: string[];
+  geographicFocus?: string[];
+  notifyEmail?: boolean;
+}) {
+  const normalizedDomains = unique(domains);
+  const normalizedStates = normalizeAlertStates(geographicFocus);
+  const hasSignal = normalizedDomains.length > 0 || normalizedStates.length > 0;
+
+  return {
+    hasSignal,
+    values: {
+      name: DEFAULT_PROFILE_ALERT_NAME,
+      enabled: notifyEmail && hasSignal,
+      frequency: 'weekly' as const,
+      categories: normalizedDomains,
+      focus_areas: normalizedDomains,
+      states: normalizedStates,
+      min_amount: null as number | null,
+      max_amount: null as number | null,
+      keywords: [] as string[],
+      entity_types: [] as string[],
+    },
+  };
+}

--- a/apps/web/src/lib/start-checkout.ts
+++ b/apps/web/src/lib/start-checkout.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { trackProductEvent } from '@/lib/product-events-client';
+import type { TierKey } from '@/lib/stripe';
+
+type StartCheckoutResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export async function startCheckoutForTier(tier: TierKey, source = 'unknown'): Promise<StartCheckoutResult> {
+  try {
+    await trackProductEvent('upgrade_cta_clicked', {
+      source,
+      metadata: { tier },
+    });
+
+    const res = await fetch('/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tier, billing: 'monthly', source }),
+    });
+
+    const data = await res.json().catch(() => null);
+
+    if (data?.url) {
+      window.location.href = data.url;
+      return { ok: true };
+    }
+
+    if (res.status === 401) {
+      window.location.href = `/register?plan=${tier}`;
+      return { ok: true };
+    }
+
+    if (res.status === 400 && data?.error === 'Create an organisation profile first') {
+      window.location.href = '/profile?next=/alerts';
+      return { ok: true };
+    }
+
+    return { ok: false, error: data?.error || 'Could not start checkout.' };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : 'Could not start checkout.',
+    };
+  }
+}

--- a/apps/web/src/lib/subscription.ts
+++ b/apps/web/src/lib/subscription.ts
@@ -18,6 +18,14 @@ export type Module =
   | 'governed-proof'   // Outcome evidence, community voice (pilot)
   | 'api';             // Programmatic access
 
+export type AlertFrequency = 'daily' | 'weekly' | 'monthly';
+
+export interface AlertEntitlements {
+  maxAlerts: number;
+  frequencies: AlertFrequency[];
+  weeklyDigest: boolean;
+}
+
 /** Which tier unlocks which modules */
 const TIER_MODULES: Record<Tier, Module[]> = {
   community:     ['grants', 'research'],
@@ -29,6 +37,34 @@ const TIER_MODULES: Record<Tier, Module[]> = {
 
 const TIER_ORDER: Tier[] = ['community', 'professional', 'organisation', 'funder', 'enterprise'];
 
+const TIER_ALERTS: Record<Tier, AlertEntitlements> = {
+  community: {
+    maxAlerts: 1,
+    frequencies: ['weekly'],
+    weeklyDigest: false,
+  },
+  professional: {
+    maxAlerts: 10,
+    frequencies: ['daily', 'weekly', 'monthly'],
+    weeklyDigest: true,
+  },
+  organisation: {
+    maxAlerts: 25,
+    frequencies: ['daily', 'weekly', 'monthly'],
+    weeklyDigest: true,
+  },
+  funder: {
+    maxAlerts: 100,
+    frequencies: ['daily', 'weekly', 'monthly'],
+    weeklyDigest: true,
+  },
+  enterprise: {
+    maxAlerts: 1000,
+    frequencies: ['daily', 'weekly', 'monthly'],
+    weeklyDigest: true,
+  },
+};
+
 export function tierRank(tier: Tier): number {
   return TIER_ORDER.indexOf(tier);
 }
@@ -39,6 +75,10 @@ export function hasModule(tier: Tier, module: Module): boolean {
 
 export function getModules(tier: Tier): Module[] {
   return TIER_MODULES[tier];
+}
+
+export function getAlertEntitlements(tier: Tier): AlertEntitlements {
+  return TIER_ALERTS[tier];
 }
 
 /** Minimum tier required for a module */


### PR DESCRIPTION
## Summary
- Full alerts pipeline: UI (\`/alerts\`), CRUD + list + [id] + matches APIs, delivery (\`deliver\`, \`digest\`, \`notifications\`, \`scout\`), and open/click tracking.
- New alert infra libs: \`alert-{attribution,events,link-tracking,performance}\`, \`profile-alerts\`.
- Alert engine libs: \`grant-alert-digests\`, \`grant-notifications\`, \`grant-scout\`.
- Shared telemetry: \`product-events\`, \`product-events-client\`, \`start-checkout\`, \`app-url\` (used downstream by billing + mission-control carves).
- \`subscription.ts\`: adds \`AlertFrequency\`, \`AlertEntitlements\`, \`getAlertEntitlements\` (additive — new per-tier alert limits).

Part of phase 2 dirty-tree carve (bucket: alerts + shared telemetry).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] \`/alerts\` page loads and reflects tier entitlements
- [ ] \`POST /api/alerts\` creates an alert; \`/api/alerts/digest\` delivers weekly digest