### PR TITLE
feat(mission-control): frontier + runtime-sweeps + layout + MC API enrichments

### DIFF
--- a/apps/web/src/app/api/mission-control/discoveries/[id]/route.ts
+++ b/apps/web/src/app/api/mission-control/discoveries/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -8,9 +8,8 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const { id } = await params;
   const body = await request.json();

--- a/apps/web/src/app/api/mission-control/frontier/[frontierId]/route.ts
+++ b/apps/web/src/app/api/mission-control/frontier/[frontierId]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ frontierId: string }> }
+) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+  const { user } = auth;
+
+  const { frontierId } = await params;
+  const body = await request.json().catch(() => null);
+
+  if (body?.action !== 'reenable') {
+    return NextResponse.json({ error: 'Unsupported action' }, { status: 400 });
+  }
+
+  const svc = getServiceSupabase();
+  const { data: frontierRow, error: fetchError } = await svc
+    .from('source_frontier')
+    .select('id, metadata')
+    .eq('id', frontierId)
+    .maybeSingle();
+
+  if (fetchError) {
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+
+  if (!frontierRow) {
+    return NextResponse.json({ error: 'Frontier row not found' }, { status: 404 });
+  }
+
+  const checkedAt = new Date().toISOString();
+  const metadata = {
+    ...(frontierRow.metadata || {}),
+    auto_disabled_reason: null,
+    auto_disabled_at: null,
+    auto_disabled_status: null,
+    auto_disabled_failure_count: null,
+    manually_reenabled_at: checkedAt,
+    manually_reenabled_by: user.email || user.id,
+  };
+
+  const { data: updatedRow, error: updateError } = await svc
+    .from('source_frontier')
+    .update({
+      enabled: true,
+      failure_count: 0,
+      last_http_status: null,
+      last_error: null,
+      next_check_at: checkedAt,
+      metadata,
+      updated_at: checkedAt,
+    })
+    .eq('id', frontierId)
+    .select('id, enabled, next_check_at, metadata')
+    .single();
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ frontier: updatedRow });
+}

--- a/apps/web/src/app/api/mission-control/query/route.ts
+++ b/apps/web/src/app/api/mission-control/query/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -8,11 +8,8 @@ export const maxDuration = 15;
 const BLOCKED_PATTERNS = /\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|EXECUTE|COPY|VACUUM|REINDEX)\b/i;
 
 export async function POST(request: NextRequest) {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const body = await request.json();
   const sql = (body.sql ?? '').trim();

--- a/apps/web/src/app/api/mission-control/registry/route.ts
+++ b/apps/web/src/app/api/mission-control/registry/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { AGENTS, CATEGORIES } from '@/lib/agent-registry';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const agents = Object.entries(AGENTS).map(([id, def]) => ({
     id,

--- a/apps/web/src/app/api/mission-control/runtime-sweeps/[agentId]/route.ts
+++ b/apps/web/src/app/api/mission-control/runtime-sweeps/[agentId]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+  const { user } = auth;
+
+  const { agentId } = await params;
+  const body = await request.json().catch(() => null);
+  const rawCursor = body?.cursor;
+
+  if (!Number.isInteger(rawCursor) || rawCursor < 0) {
+    return NextResponse.json({ error: 'Cursor must be a non-negative integer' }, { status: 400 });
+  }
+
+  const svc = getServiceSupabase();
+  const { data: runtimeState, error: fetchError } = await svc
+    .from('agent_runtime_state')
+    .select('agent_id, state')
+    .eq('agent_id', agentId)
+    .maybeSingle();
+
+  if (fetchError) {
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+
+  if (!runtimeState?.state || typeof runtimeState.state !== 'object') {
+    return NextResponse.json({ error: 'Runtime sweep state not found' }, { status: 404 });
+  }
+
+  const state = runtimeState.state as Record<string, unknown>;
+  const candidateCount = Number(state.fullSweepCandidateCount || 0);
+  if (!Number.isInteger(candidateCount) || candidateCount <= 0) {
+    return NextResponse.json({ error: 'Sweep candidate count is not available' }, { status: 400 });
+  }
+
+  if (rawCursor >= candidateCount) {
+    return NextResponse.json(
+      { error: `Cursor must be between 0 and ${candidateCount - 1}` },
+      { status: 400 }
+    );
+  }
+
+  const nextState = {
+    ...state,
+    fullSweepCursor: rawCursor,
+    fullSweepCursorManuallySetAt: new Date().toISOString(),
+    fullSweepCursorManuallySetBy: user.email || user.id,
+  };
+
+  const { data: updatedState, error: updateError } = await svc
+    .from('agent_runtime_state')
+    .update({
+      state: nextState,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('agent_id', agentId)
+    .select('agent_id, state')
+    .single();
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ runtimeSweep: updatedState });
+}

--- a/apps/web/src/app/api/mission-control/schedules/[id]/route.ts
+++ b/apps/web/src/app/api/mission-control/schedules/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -8,9 +8,8 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const { id } = await params;
   const body = await request.json();

--- a/apps/web/src/app/api/mission-control/schedules/route.ts
+++ b/apps/web/src/app/api/mission-control/schedules/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const svc = getServiceSupabase();
   const { data, error } = await svc

--- a/apps/web/src/app/api/mission-control/tasks/[id]/cancel/route.ts
+++ b/apps/web/src/app/api/mission-control/tasks/[id]/cancel/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -8,9 +8,8 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const { id } = await params;
   const svc = getServiceSupabase();

--- a/apps/web/src/app/api/mission-control/tasks/route.ts
+++ b/apps/web/src/app/api/mission-control/tasks/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServer } from '@/lib/supabase-server';
+import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 import { AGENTS } from '@/lib/agent-registry';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
 
   const { searchParams } = request.nextUrl;
   const status = searchParams.get('status');
@@ -32,9 +31,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const supabase = await createSupabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+  const { user } = auth;
 
   const body = await request.json();
   const { agent_id, priority, params } = body;
@@ -45,6 +44,23 @@ export async function POST(request: NextRequest) {
 
   const agent = AGENTS[agent_id];
   const svc = getServiceSupabase();
+
+  const { data: existingTask, error: existingError } = await svc
+    .from('agent_tasks')
+    .select('id, agent_id, status, priority, created_at')
+    .eq('agent_id', agent_id)
+    .in('status', ['pending', 'running'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 500 });
+  }
+
+  if (existingTask) {
+    return NextResponse.json({ task: existingTask, existing: true }, { status: 409 });
+  }
 
   const { data, error } = await svc
     .from('agent_tasks')
@@ -59,5 +75,5 @@ export async function POST(request: NextRequest) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  return NextResponse.json({ task: data }, { status: 201 });
+  return NextResponse.json({ task: data, existing: false }, { status: 201 });
 }

--- a/apps/web/src/app/mission-control/layout.tsx
+++ b/apps/web/src/app/mission-control/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+import { requireAdminPage } from '@/lib/admin-auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function MissionControlLayout({ children }: { children: ReactNode }) {
+  await requireAdminPage('/mission-control');
+  return children;
+}


### PR DESCRIPTION
## Summary
- New \`/api/mission-control/frontier/[frontierId]\` route for frontier discovery drill-in.
- New \`/api/mission-control/runtime-sweeps/[agentId]\` for per-agent sweep history.
- New \`/mission-control/layout.tsx\` shared shell.
- Enriches existing MC APIs: \`discoveries/[id]\`, \`query\`, \`registry\`, \`schedules\`, \`schedules/[id]\`, \`tasks\`, \`tasks/[id]/cancel\`.

Part of phase 2 dirty-tree carve (bucket: mission-control).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] \`/mission-control\` renders with new layout
- [ ] Frontier + sweep drill-ins return expected payloads