### PR TITLE
feat(billing): stripe track/click + webhook enrichments + link tracking

### DIFF
--- a/apps/web/src/app/api/billing/checkout/route.ts
+++ b/apps/web/src/app/api/billing/checkout/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { recordProductEvents } from '@/lib/product-events'
 import { createSupabaseServer } from '@/lib/supabase-server'
 import { getServiceSupabase } from '@/lib/supabase'
 import { stripe, TIERS, type TierKey } from '@/lib/stripe'
@@ -12,7 +13,8 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { tier } = body as { tier: TierKey }
+    const { tier, source } = body as { tier: TierKey; source?: string }
+    const checkoutSource = typeof source === 'string' && source.trim().length > 0 ? source.trim().slice(0, 80) : 'unknown'
 
     if (!tier || !(tier in TIERS)) {
       return NextResponse.json({ error: 'Invalid tier' }, { status: 400 })
@@ -69,16 +71,33 @@ export async function POST(request: NextRequest) {
       metadata: {
         org_profile_id: profile.id,
         tier,
+        checkout_source: checkoutSource,
         platform: 'grantscope',
       },
       subscription_data: {
+        ...(tierConfig.trialDays ? { trial_period_days: tierConfig.trialDays } : {}),
         metadata: {
           org_profile_id: profile.id,
           tier,
+          checkout_source: checkoutSource,
           platform: 'grantscope',
         },
       },
     })
+
+    await recordProductEvents([
+      {
+        userId: user.id,
+        orgProfileId: profile.id,
+        eventType: 'checkout_started',
+        metadata: {
+          tier,
+          stripe_session_id: session.id,
+          source: checkoutSource,
+          trial_days: tierConfig.trialDays || 0,
+        },
+      },
+    ])
 
     return NextResponse.json({ url: session.url })
   } catch (error) {

--- a/apps/web/src/app/api/billing/portal/route.ts
+++ b/apps/web/src/app/api/billing/portal/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server'
+import { recordProductEvents } from '@/lib/product-events'
 import { createSupabaseServer } from '@/lib/supabase-server'
 import { getServiceSupabase } from '@/lib/supabase'
 import { stripe } from '@/lib/stripe'
 
-export async function POST() {
+export async function POST(request: Request) {
   try {
     const supabaseAuth = await createSupabaseServer()
     const { data: { user } } = await supabaseAuth.auth.getUser()
@@ -11,10 +12,15 @@ export async function POST() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    const body = await request.json().catch(() => null)
+    const source = typeof body?.source === 'string' && body.source.trim().length > 0
+      ? body.source.trim().slice(0, 80)
+      : 'profile_billing_panel'
+
     const supabase = getServiceSupabase()
     const { data: profile } = await supabase
       .from('org_profiles')
-      .select('stripe_customer_id')
+      .select('id, stripe_customer_id')
       .eq('user_id', user.id)
       .single()
 
@@ -25,8 +31,20 @@ export async function POST() {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3003'
     const session = await stripe.billingPortal.sessions.create({
       customer: profile.stripe_customer_id,
-      return_url: `${appUrl}/profile`,
+      return_url: `${appUrl}/profile?billing_source=${encodeURIComponent(source)}`,
     })
+
+    await recordProductEvents([
+      {
+        userId: user.id,
+        orgProfileId: profile.id,
+        eventType: 'billing_portal_opened',
+        metadata: {
+          source,
+          stripe_customer_id: profile.stripe_customer_id,
+        },
+      },
+    ])
 
     return NextResponse.json({ url: session.url })
   } catch (error) {

--- a/apps/web/src/app/api/billing/track/click/route.ts
+++ b/apps/web/src/app/api/billing/track/click/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { recordProductEvents } from '@/lib/product-events';
+import { resolveBillingReminderRedirect } from '@/lib/billing-link-tracking';
+import { getServiceSupabase } from '@/lib/supabase';
+
+type TrackingContext = {
+  userId: string | null;
+  orgProfileId: string | null;
+};
+
+async function resolveTrackingContext(request: NextRequest): Promise<TrackingContext> {
+  const orgProfileId = request.nextUrl.searchParams.get('orgProfileId');
+  const fallbackUserId = request.nextUrl.searchParams.get('userId');
+  const db = getServiceSupabase();
+
+  if (orgProfileId) {
+    const { data } = await db
+      .from('org_profiles')
+      .select('user_id')
+      .eq('id', orgProfileId)
+      .maybeSingle();
+
+    if (data?.user_id) {
+      return {
+        userId: data.user_id,
+        orgProfileId,
+      };
+    }
+  }
+
+  return {
+    userId: fallbackUserId,
+    orgProfileId,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const reminderType = request.nextUrl.searchParams.get('reminderType') || 'unknown';
+  const targetPath = request.nextUrl.searchParams.get('target');
+  const { userId, orgProfileId } = await resolveTrackingContext(request);
+
+  if (userId) {
+    await recordProductEvents([
+      {
+        userId,
+        orgProfileId,
+        eventType: 'billing_reminder_clicked',
+        metadata: {
+          source: 'billing_reminder_email',
+          reminder_type: reminderType,
+          target_path: targetPath || '/profile',
+        },
+      },
+    ]);
+  }
+
+  return NextResponse.redirect(resolveBillingReminderRedirect(targetPath), { status: 307 });
+}

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -1,9 +1,34 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { recordProductEvents } from '@/lib/product-events'
 import { stripe } from '@/lib/stripe'
 import { getServiceSupabase } from '@/lib/supabase'
 import type Stripe from 'stripe'
 
 export const runtime = 'nodejs'
+
+function toIsoTimestamp(value: number | null | undefined): string | null {
+  if (!value) return null
+  return new Date(value * 1000).toISOString()
+}
+
+function getSubscriptionPeriodEnd(subscription: Stripe.Subscription): number | null {
+  const periodEnds = subscription.items.data
+    .map((item) => item.current_period_end)
+    .filter((value): value is number => typeof value === 'number' && value > 0)
+
+  if (periodEnds.length === 0) return null
+  return Math.min(...periodEnds)
+}
+
+function getSubscriptionProfileUpdate(subscription: Stripe.Subscription, fallbackTier?: string) {
+  return {
+    subscription_plan: subscription.metadata?.tier || fallbackTier || undefined,
+    subscription_status: subscription.status,
+    subscription_trial_end: toIsoTimestamp(subscription.trial_end),
+    subscription_current_period_end: toIsoTimestamp(getSubscriptionPeriodEnd(subscription)),
+    subscription_cancel_at_period_end: subscription.cancel_at_period_end,
+  }
+}
 
 export async function POST(request: NextRequest) {
   const body = await request.text()
@@ -36,34 +61,102 @@ export async function POST(request: NextRequest) {
         const session = event.data.object as Stripe.Checkout.Session
         const orgProfileId = session.metadata?.org_profile_id
         const tier = session.metadata?.tier
+        const checkoutSource = session.metadata?.checkout_source || null
 
         if (orgProfileId && tier) {
+          let subscriptionStatus = 'active'
+          let subscriptionUpdate: ReturnType<typeof getSubscriptionProfileUpdate> | null = null
+          if (typeof session.subscription === 'string') {
+            const subscription = await stripe.subscriptions.retrieve(session.subscription)
+            subscriptionStatus = subscription.status
+            subscriptionUpdate = getSubscriptionProfileUpdate(subscription, tier)
+          }
+
           await supabase
             .from('org_profiles')
             .update({
-              subscription_plan: tier,
-              subscription_status: 'active',
               stripe_customer_id: session.customer as string,
+              subscription_plan: tier,
+              subscription_status: subscriptionStatus,
+              ...(subscriptionUpdate ?? {}),
             })
             .eq('id', orgProfileId)
+
+          const { data: profile } = await supabase
+            .from('org_profiles')
+            .select('user_id')
+            .eq('id', orgProfileId)
+            .maybeSingle()
+
+          if (profile?.user_id) {
+            const events: Parameters<typeof recordProductEvents>[0] = [
+              {
+                userId: profile.user_id,
+                orgProfileId,
+                eventType: 'subscription_activated',
+                metadata: {
+                  tier,
+                  subscription_status: subscriptionStatus,
+                  stripe_customer_id: session.customer as string,
+                  source: checkoutSource,
+                },
+              },
+            ]
+
+            if (subscriptionStatus === 'trialing') {
+              events.push({
+                userId: profile.user_id,
+                orgProfileId,
+                eventType: 'subscription_trial_started',
+                metadata: {
+                  tier,
+                  subscription_status: subscriptionStatus,
+                  source: checkoutSource,
+                  trial_end: subscriptionUpdate?.subscription_trial_end || null,
+                },
+              })
+            }
+
+            await recordProductEvents(events)
+          }
 
           console.log(`✅ CivicGraph subscription activated: org=${orgProfileId} tier=${tier}`)
         }
         break
       }
 
+      case 'customer.subscription.created':
       case 'customer.subscription.updated': {
         const subscription = event.data.object as Stripe.Subscription
         const orgProfileId = subscription.metadata?.org_profile_id
+        const checkoutSource = subscription.metadata?.checkout_source || null
 
         if (orgProfileId) {
           await supabase
             .from('org_profiles')
-            .update({
-              subscription_plan: subscription.metadata?.tier || undefined,
-              subscription_status: subscription.status,
-            })
+            .update(getSubscriptionProfileUpdate(subscription))
             .eq('id', orgProfileId)
+
+          const { data: profile } = await supabase
+            .from('org_profiles')
+            .select('user_id')
+            .eq('id', orgProfileId)
+            .maybeSingle()
+
+          if (profile?.user_id) {
+            await recordProductEvents([
+              {
+                userId: profile.user_id,
+                orgProfileId,
+                eventType: 'subscription_changed',
+                metadata: {
+                  tier: subscription.metadata?.tier || null,
+                  subscription_status: subscription.status,
+                  source: checkoutSource,
+                },
+              },
+            ])
+          }
 
           console.log(`🔄 CivicGraph subscription updated: org=${orgProfileId} status=${subscription.status}`)
         }
@@ -73,15 +166,42 @@ export async function POST(request: NextRequest) {
       case 'customer.subscription.deleted': {
         const subscription = event.data.object as Stripe.Subscription
         const orgProfileId = subscription.metadata?.org_profile_id
+        const checkoutSource = subscription.metadata?.checkout_source || null
 
         if (orgProfileId) {
+          const endedAt = toIsoTimestamp(subscription.ended_at || getSubscriptionPeriodEnd(subscription))
+
           await supabase
             .from('org_profiles')
             .update({
               subscription_plan: 'community',
-              subscription_status: 'cancelled',
+              subscription_status: subscription.status,
+              subscription_trial_end: null,
+              subscription_current_period_end: endedAt,
+              subscription_cancel_at_period_end: false,
             })
             .eq('id', orgProfileId)
+
+          const { data: profile } = await supabase
+            .from('org_profiles')
+            .select('user_id')
+            .eq('id', orgProfileId)
+            .maybeSingle()
+
+          if (profile?.user_id) {
+            await recordProductEvents([
+              {
+                userId: profile.user_id,
+                orgProfileId,
+                eventType: 'subscription_cancelled',
+                metadata: {
+                  previous_tier: subscription.metadata?.tier || null,
+                  subscription_status: subscription.status,
+                  source: checkoutSource,
+                },
+              },
+            ])
+          }
 
           console.log(`❌ CivicGraph subscription cancelled: org=${orgProfileId} → community`)
         }

--- a/apps/web/src/lib/billing-link-tracking.ts
+++ b/apps/web/src/lib/billing-link-tracking.ts
@@ -1,0 +1,34 @@
+import { buildAbsoluteAppUrl, getAppUrl } from '@/lib/app-url';
+
+type BillingReminderTrackParams = {
+  userId?: string | null;
+  orgProfileId?: string | null;
+  reminderType: string;
+  targetPath?: string;
+};
+
+export function normalizeBillingReminderTarget(targetPath?: string | null) {
+  if (!targetPath || !targetPath.startsWith('/')) {
+    return '/profile';
+  }
+
+  return targetPath;
+}
+
+export function buildBillingReminderClickUrl({
+  userId,
+  orgProfileId,
+  reminderType,
+  targetPath = '/profile',
+}: BillingReminderTrackParams) {
+  const url = new URL('/api/billing/track/click', getAppUrl());
+  url.searchParams.set('target', normalizeBillingReminderTarget(targetPath));
+  url.searchParams.set('reminderType', reminderType);
+  if (userId) url.searchParams.set('userId', userId);
+  if (orgProfileId) url.searchParams.set('orgProfileId', orgProfileId);
+  return url.toString();
+}
+
+export function resolveBillingReminderRedirect(targetPath?: string | null) {
+  return buildAbsoluteAppUrl(normalizeBillingReminderTarget(targetPath));
+}

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -4,71 +4,70 @@ export const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY)
   : null as unknown as Stripe
 
-// Annual discount: 2 months free = ~17% off
-export const ANNUAL_DISCOUNT = 0.17
-
 // Tier configuration — single source of truth
 // Cross-subsidy model: large orgs + foundations fund free community access
 export const TIERS = {
   community: {
     name: 'Community',
     tagline: 'Your work matters more than your budget',
-    description: 'For grassroots NFPs, First Nations orgs, and CLCs under $500K revenue',
+    description: 'For grassroots nonprofits, First Nations organisations, and small teams under $500K revenue',
     price: 0,
     stripePriceId: null,
     features: [
-      'Full grant search (14,000+ opportunities)',
-      'Foundation profiles (9,800+)',
-      'Save & track grants',
+      'Grant search',
+      'Foundation profiles',
+      'Save & shortlist grants',
       'Basic email alerts',
       '1 team member',
     ],
   },
   professional: {
     name: 'Professional',
-    tagline: 'Stop guessing, start winning',
-    description: 'For established NFPs and social enterprises',
+    tagline: 'Match. Monitor. Manage the pipeline.',
+    description: 'For grant consultants, freelance writers, and solo grants or fundraising leads',
     price: 79,
     stripePriceId: process.env.STRIPE_PRICE_PROFESSIONAL,
+    trialDays: 14,
     features: [
       'Everything in Community',
-      'AI grant writing assistant',
-      'Smart match scoring (0-100)',
-      'Custom alert rules',
+      'Org-fit grant matching',
+      'Advanced alerts and watchlists',
       'Pipeline tracking',
-      'Foundation relationship notes',
+      'Foundation prospect notes',
+      'Weekly digest',
       '5 team members',
     ],
   },
   organisation: {
     name: 'Organisation',
-    tagline: 'Your whole funding operation in one place',
-    description: 'For larger NFPs, peak bodies, and multi-program orgs',
+    tagline: 'Shared workflow for funding teams',
+    description: 'For grant teams, development teams, and advisory firms managing multiple active opportunities',
     price: 249,
     stripePriceId: process.env.STRIPE_PRICE_ORGANISATION,
+    trialDays: 14,
     features: [
       'Everything in Professional',
+      'Shared team workspace',
       'Org-wide pipeline dashboard',
-      'Bulk application tracking',
-      'Corporate & philanthropy CRM',
-      'Auto-match new grants to your mission',
+      'Board or client export reports',
       'Calendar integration',
-      'Board-ready export reports',
+      'Funder shortlist collaboration',
       '25 team members',
     ],
   },
   funder: {
     name: 'Funder',
-    tagline: 'See the whole system. Fund what works.',
-    description: 'For foundations, corporate giving, philanthropic advisors, and government',
+    tagline: 'Prospecting and portfolio intelligence',
+    description: 'For foundations, corporate giving, philanthropic advisors, and commissioners',
     price: 499,
     stripePriceId: process.env.STRIPE_PRICE_FUNDER,
+    trialDays: 14,
     features: [
       'Everything in Organisation',
-      'Portfolio view — who you fund, outcomes, geography',
+      'Portfolio intelligence',
       'Gap analysis — where money isn\'t going',
-      'Deal flow — discover aligned orgs',
-      'Data API access',
+      'Prospect discovery across entities',
+      'Read-only API access',
       'White-label option',
       'Unlimited team members',
     ],
@@ -79,6 +78,7 @@ export const TIERS = {
     description: 'For state/federal government, large foundations, and sector-wide deployments',
     price: 1999,
     stripePriceId: process.env.STRIPE_PRICE_ENTERPRISE,
+    trialDays: 0,
     features: [
       'Everything in Funder',
       'Full API access',


### PR DESCRIPTION
## Summary
- \`/api/billing/checkout\` emits \`upgrade_start\` product event + captures attribution.
- \`/api/billing/portal\` emits \`portal_open\` product event.
- \`/api/billing/webhook\` extended handlers for subscription lifecycle.
- New \`/api/billing/track/click\` tracks outbound billing CTA clicks.
- \`lib/stripe.ts\` — additional checkout helpers.
- New \`lib/billing-link-tracking.ts\` — per-click billing link resolver.

**Stacked on \`feat/alerts-infrastructure\` (PR #10)** because billing depends on \`product-events\`, \`start-checkout\`, and the \`AlertEntitlements\` subscription additions introduced there. Merge #10 first (or retarget this PR to main after #10 lands).

Part of phase 2 dirty-tree carve (bucket: billing).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] Checkout flow emits product events
- [ ] Webhook handles subscription events end-to-end