### PR TITLE
feat(foundations): 5 new foundation pages + compare + backlog + review-set

### DIFF
--- a/apps/web/src/app/foundations/[id]/giving-chart.tsx
+++ b/apps/web/src/app/foundations/[id]/giving-chart.tsx
@@ -5,7 +5,13 @@ interface GivingHistoryChartProps {
 }
 
 export function GivingHistoryChart({ history }: GivingHistoryChartProps) {
-  const sorted = [...history].sort((a, b) => a.year - b.year);
+  const normalized = Array.from(
+    history.reduce((map, entry) => {
+      map.set(entry.year, (map.get(entry.year) ?? 0) + Number(entry.amount ?? 0));
+      return map;
+    }, new Map<number, number>())
+  ).map(([year, amount]) => ({ year, amount }));
+  const sorted = normalized.sort((a, b) => a.year - b.year);
   const maxAmount = Math.max(...sorted.map(h => h.amount));
 
   function formatMoney(amount: number): string {

--- a/apps/web/src/app/foundations/[id]/page.tsx
+++ b/apps/web/src/app/foundations/[id]/page.tsx
@@ -39,6 +39,7 @@ interface FoundationDetail {
   notable_grants: string[] | null;
   board_members: string[] | null;
   enriched_at: string | null;
+  last_scraped_at: string | null;
   scraped_urls: string[] | null;
   created_at: string;
 }
@@ -56,6 +57,29 @@ interface ProgramRow {
   program_type: string | null;
   eligibility: string | null;
   application_process: string | null;
+  scraped_at: string | null;
+}
+
+interface ProgramYearRow {
+  id: string;
+  report_year: number | null;
+  fiscal_year: string | null;
+  summary: string | null;
+  reported_amount: number | null;
+  source_report_url: string | null;
+  metadata: Record<string, unknown> | null;
+  partners: Array<{ name?: string; role?: string }> | null;
+  places: Array<{ name?: string; type?: string }> | null;
+  foundation_programs:
+    | {
+        name: string;
+        program_type: string | null;
+      }
+    | Array<{
+    name: string;
+    program_type: string | null;
+      }>
+    | null;
 }
 
 interface LinkedGrant {
@@ -97,6 +121,38 @@ interface SimilarFoundation {
   type: string | null;
 }
 
+interface BoardRoleRow {
+  person_name: string;
+  role_type: string | null;
+  person_entity_id: string | null;
+  source: string | null;
+  confidence: string | null;
+}
+
+const SNOW_FOUNDATION_ID = 'd242967e-0e68-4367-9785-06cf0ec7485e';
+const PRF_FOUNDATION_ID = '4ee5baca-c898-4318-ae2b-d79b95379cc7';
+const MINDEROO_FOUNDATION_ID = '8f8704be-d6e8-40f3-b561-ac6630ce5b36';
+const RIO_TINTO_FOUNDATION_ID = '85f0de43-d004-4122-83a6-287eeecc4da9';
+const IAN_POTTER_FOUNDATION_ID = 'b9e090e5-1672-48ff-815a-2a6314ebe033';
+const ECSTRA_FOUNDATION_ID = '25b80b63-416e-4aaa-b470-2f8dc6fa835f';
+
+const PUBLIC_REVIEW_ROUTE_MAP: Record<string, string> = {
+  [SNOW_FOUNDATION_ID]: '/snow-foundation',
+  [PRF_FOUNDATION_ID]: '/foundations/prf',
+  [MINDEROO_FOUNDATION_ID]: '/foundations/minderoo',
+  [RIO_TINTO_FOUNDATION_ID]: '/foundations/rio-tinto',
+  [IAN_POTTER_FOUNDATION_ID]: '/foundations/ian-potter',
+  [ECSTRA_FOUNDATION_ID]: '/foundations/ecstra',
+};
+
+const REVIEW_SET_COMPARE_TARGETS = [
+  { id: SNOW_FOUNDATION_ID, label: 'Compare with Snow' },
+  { id: PRF_FOUNDATION_ID, label: 'Compare with PRF' },
+  { id: MINDEROO_FOUNDATION_ID, label: 'Compare with Minderoo' },
+  { id: IAN_POTTER_FOUNDATION_ID, label: 'Compare with Ian Potter' },
+  { id: ECSTRA_FOUNDATION_ID, label: 'Compare with ECSTRA' },
+];
+
 function formatMoney(amount: number | null): string {
   if (!amount) return 'Unknown';
   if (amount >= 1000000000) return `$${(amount / 1000000000).toFixed(1)}B`;
@@ -116,6 +172,23 @@ function typeLabel(type: string | null): string {
   return type ? labels[type] || type : 'Foundation';
 }
 
+function formatDateWithRecency(value: string | null): string {
+  if (!value) return 'Unknown';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  const exact = date.toLocaleDateString('en-AU', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  const daysAgo = Math.max(0, Math.floor((Date.now() - date.getTime()) / 86_400_000));
+
+  if (daysAgo === 0) return `${exact} (today)`;
+  if (daysAgo === 1) return `${exact} (1 day ago)`;
+  return `${exact} (${daysAgo} days ago)`;
+}
+
 function confidenceBadge(c: string) {
   if (c === 'high') return { cls: 'border-money bg-money-light text-money', label: 'High' };
   if (c === 'medium') return { cls: 'border-bauhaus-yellow bg-warning-light text-bauhaus-black', label: 'Medium' };
@@ -132,9 +205,40 @@ function programTypeBadge(type: string | null) {
   }
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function getProgramYearFoundationProgram(row: ProgramYearRow) {
+  if (Array.isArray(row.foundation_programs)) return row.foundation_programs[0] ?? null;
+  return row.foundation_programs ?? null;
+}
+
+function sourceLabel(value: string | null | undefined) {
+  if (!value) return 'Unknown source';
+  return value.replace(/_/g, ' ');
+}
+
+function buildCompareTargets(foundationId: string) {
+  return REVIEW_SET_COMPARE_TARGETS.filter((target) => target.id !== foundationId);
+}
+
+function normalizeGivingHistory(history: Array<{ year: number; amount: number }> | null | undefined) {
+  if (!history || history.length === 0) return [];
+
+  const byYear = new Map<number, number>();
+  for (const entry of history) {
+    byYear.set(entry.year, (byYear.get(entry.year) ?? 0) + Number(entry.amount ?? 0));
+  }
+
+  return Array.from(byYear.entries())
+    .map(([year, amount]) => ({ year, amount }))
+    .sort((left, right) => left.year - right.year);
+}
+
+function getPublicReviewHref(foundationId: string) {
+  return PUBLIC_REVIEW_ROUTE_MAP[foundationId] || null;
+}
+
+function Section({ title, children, id }: { title: string; children: React.ReactNode; id?: string }) {
   return (
-    <section className="mb-8">
+    <section id={id} className="mb-8">
       <h2 className="text-sm font-black text-bauhaus-black mb-3 pb-2 border-b-4 border-bauhaus-black uppercase tracking-widest">
         {title}
       </h2>
@@ -147,14 +251,20 @@ export default async function FoundationDetailPage({ params }: { params: Promise
   const { id } = await params;
   const supabase = getServiceSupabase();
 
-  const [{ data: foundation }, { data: programs }, { data: linkedGrants }] = await Promise.all([
+  const [{ data: foundation }, { data: programs }, { data: linkedGrants }, { data: programYears }] = await Promise.all([
     supabase.from('foundations').select('*').eq('id', id).single(),
     supabase.from('foundation_programs').select('*').eq('foundation_id', id).in('status', ['open', 'closed']).order('deadline', { ascending: true, nullsFirst: false }),
     supabase.from('grant_opportunities').select('id, name, amount_min, amount_max, closes_at, program_type, source, description').eq('foundation_id', id).order('closes_at', { ascending: true, nullsFirst: false }),
+    supabase
+      .from('foundation_program_years')
+      .select('id, report_year, fiscal_year, summary, reported_amount, source_report_url, metadata, partners, places, foundation_programs(name, program_type)')
+      .eq('foundation_id', id)
+      .order('report_year', { ascending: false, nullsFirst: false }),
   ]);
 
   if (!foundation) notFound();
   const f = foundation as FoundationDetail;
+  const givingHistory = normalizeGivingHistory(f.giving_history);
 
   // Fetch ACNC financials, similar foundations, and matching grants in parallel
   interface MatchingGrant {
@@ -166,7 +276,7 @@ export default async function FoundationDetailPage({ params }: { params: Promise
     categories: string[];
   }
 
-  const [{ data: acncData }, { data: similarData }, { data: matchingData }] = await Promise.all([
+  const [{ data: acncData }, { data: similarData }, { data: matchingData }, { data: boardRoleData }] = await Promise.all([
     supabase.from('acnc_ais')
       .select('abn, charity_name, ais_year, total_revenue, total_expenses, total_assets, grants_donations_au, grants_donations_intl, net_surplus_deficit, donations_and_bequests, revenue_from_investments, employee_expenses, net_assets_liabilities, charity_size, fin_report_from, fin_report_to')
       .eq('abn', f.acnc_abn)
@@ -188,6 +298,17 @@ export default async function FoundationDetailPage({ params }: { params: Promise
           .order('closes_at', { ascending: true })
           .limit(8)
       : Promise.resolve({ data: [] }),
+    (() => {
+      const query = supabase
+        .from('person_roles')
+        .select('person_name, role_type, person_entity_id, source, confidence')
+        .is('cessation_date', null)
+        .order('role_type', { ascending: true })
+        .order('person_name', { ascending: true });
+      return f.acnc_abn
+        ? query.eq('company_abn', f.acnc_abn)
+        : query.eq('company_name', f.name);
+    })(),
   ]);
 
   const allAcnc: AcncFinancials[] = (acncData || []) as AcncFinancials[];
@@ -206,6 +327,15 @@ export default async function FoundationDetailPage({ params }: { params: Promise
 
   const similarFoundations = (similarData || []) as SimilarFoundation[];
   const matchingGrants = (matchingData || []) as MatchingGrant[];
+  const boardRoles = ((boardRoleData || []) as BoardRoleRow[]).sort((a, b) => {
+    const order = (value: string | null) => {
+      if (value === 'chair') return 0;
+      if (value === 'director') return 1;
+      return 2;
+    };
+    const rank = order(a.role_type) - order(b.role_type);
+    return rank !== 0 ? rank : a.person_name.localeCompare(b.person_name);
+  });
 
   // Optional: check if logged-in user's org has pipeline items with this foundation
   interface PipelineContext {
@@ -249,8 +379,18 @@ export default async function FoundationDetailPage({ params }: { params: Promise
 
   const badge = confidenceBadge(f.profile_confidence);
   const allPrograms = programs as ProgramRow[] || [];
+  const allProgramYears = (programYears || []) as ProgramYearRow[];
   const allLinkedGrants = (linkedGrants || []) as LinkedGrant[];
+  const compareTargets = buildCompareTargets(f.id);
+  const publicReviewHref = getPublicReviewHref(f.id);
   const hasFinancials = f.parent_company || f.asx_code || f.endowment_size || f.revenue_sources?.length > 0 || f.giving_ratio;
+  const openProgramCount = allPrograms.filter((program) => program.status === 'open').length;
+  const closedProgramCount = allPrograms.filter((program) => program.status === 'closed').length;
+  const latestProgramScrapedAt = allPrograms.reduce<string | null>((latest, program) => {
+    if (!program.scraped_at) return latest;
+    if (!latest) return program.scraped_at;
+    return new Date(program.scraped_at).getTime() > new Date(latest).getTime() ? program.scraped_at : latest;
+  }, null);
 
   // Group programs by type
   const programsByType = allPrograms.reduce((acc, p) => {
@@ -293,6 +433,31 @@ export default async function FoundationDetailPage({ params }: { params: Promise
           <a href={`https://www.acnc.gov.au/charity/charities?search=${encodeURIComponent(f.acnc_abn)}`} target="_blank" rel="noopener noreferrer" className="text-bauhaus-blue hover:text-bauhaus-red text-xs font-black uppercase tracking-wider">
             ACNC Register &rarr;
           </a>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+          {publicReviewHref && (
+            <Link
+              href={publicReviewHref}
+              className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+            >
+              Open review route
+            </Link>
+          )}
+          {compareTargets.map((target) => (
+            <Link
+              key={target.id}
+              href={`/foundations/compare?left=${f.id}&right=${target.id}`}
+              className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+            >
+              {target.label}
+            </Link>
+          ))}
+          <Link
+            href="/foundations/compare"
+            className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open compare surface
+          </Link>
         </div>
       </div>
 
@@ -406,16 +571,16 @@ export default async function FoundationDetailPage({ params }: { params: Promise
             </Section>
           )}
 
-          {f.giving_history && f.giving_history.length > 1 && (
+          {givingHistory.length > 1 && (
             <Section title="Giving History">
-              <GivingHistoryChart history={f.giving_history} />
+              <GivingHistoryChart history={givingHistory} />
             </Section>
           )}
 
-          {f.giving_history && f.giving_history.length === 1 && (
+          {givingHistory.length === 1 && (
             <Section title="Giving History">
               <div className="flex gap-3 flex-wrap">
-                {f.giving_history.map(entry => (
+                {givingHistory.map(entry => (
                   <div key={entry.year} className="bg-white border-4 border-bauhaus-black px-4 py-3 text-center">
                     <div className="text-xs text-bauhaus-muted font-black">{entry.year}</div>
                     <div className="text-lg font-black text-bauhaus-black tabular-nums">{formatMoney(entry.amount)}</div>
@@ -424,6 +589,8 @@ export default async function FoundationDetailPage({ params }: { params: Promise
               </div>
             </Section>
           )}
+
+          <div id="program-history" className="scroll-mt-24" />
 
           {acncFinancials.length > 0 && (
             <Section title="ACNC Financial History">
@@ -497,7 +664,13 @@ export default async function FoundationDetailPage({ params }: { params: Promise
           )}
 
           {allPrograms.length > 0 && (
-            <Section title={`Programs & Opportunities (${allPrograms.length})`}>
+            <Section id="programs-opportunities" title={`Programs & Opportunities (${allPrograms.length})`}>
+              <p className="mb-4 text-xs font-medium text-bauhaus-muted">
+                {openProgramCount} open
+                {closedProgramCount > 0 ? ` · ${closedProgramCount} closed` : ''}
+                {' · '}sorted by deadline
+                {latestProgramScrapedAt ? ` · last checked ${formatDateWithRecency(latestProgramScrapedAt)}` : ''}
+              </p>
               {/* Program type summary */}
               {Object.keys(programsByType).length > 1 && (
                 <div className="flex gap-2 mb-4 flex-wrap">
@@ -543,6 +716,79 @@ export default async function FoundationDetailPage({ params }: { params: Promise
                         {p.deadline && <span>Closes {new Date(p.deadline).toLocaleDateString('en-AU')}</span>}
                         {p.url && <a href={p.url} target="_blank" rel="noopener noreferrer" className="text-bauhaus-blue hover:text-bauhaus-red uppercase tracking-wider">Apply &rarr;</a>}
                       </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </Section>
+          )}
+
+          {allProgramYears.length > 0 && (
+            <Section title={`Program History (${allProgramYears.length})`}>
+              <p className="mb-4 text-xs font-medium text-bauhaus-muted">
+                Year-specific program memory with visible provenance. This is the bridge between open opportunities and recurring portfolio strands.
+              </p>
+              <div className="space-y-3">
+                {allProgramYears.map((row) => {
+                  const foundationProgram = getProgramYearFoundationProgram(row);
+                  const badge = programTypeBadge(foundationProgram?.program_type || 'program');
+                  const partnerLabel = (row.partners || [])
+                    .map((partner) => partner.name)
+                    .filter(Boolean)
+                    .join(', ');
+                  const placeLabel = (row.places || [])
+                    .map((place) => place.name)
+                    .filter(Boolean)
+                    .join(', ');
+                  const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+
+                  return (
+                    <div key={row.id} className="bg-white border-4 border-bauhaus-black p-4">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                            {row.fiscal_year || row.report_year || 'Program year'}
+                          </div>
+                          <h3 className="mt-1 text-lg font-black text-bauhaus-black">
+                            {foundationProgram?.name || 'Unnamed program'}
+                          </h3>
+                        </div>
+                        <div className="flex gap-1.5 flex-wrap">
+                          <span className={`text-[11px] font-black px-2 py-0.5 uppercase tracking-wider border-2 ${badge.cls}`}>
+                            {badge.label}
+                          </span>
+                          {row.reported_amount != null ? (
+                            <span className="text-[11px] font-black px-2 py-0.5 uppercase tracking-wider border-2 border-money bg-money-light text-money">
+                              {formatMoney(row.reported_amount)}
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                      {row.summary ? (
+                        <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                          {row.summary}
+                        </p>
+                      ) : null}
+                      {(partnerLabel || placeLabel || source || row.source_report_url) && (
+                        <div className="mt-3 flex flex-wrap gap-4 text-xs font-bold text-bauhaus-muted">
+                          {partnerLabel ? <span>Partners: {partnerLabel}</span> : null}
+                          {placeLabel ? <span>Places: {placeLabel}</span> : null}
+                          {source ? <span>Source: {sourceLabel(source)}</span> : null}
+                          {row.source_report_url ? (
+                            <span>
+                              Evidence:{' '}
+                              <a
+                                href={row.source_report_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-bauhaus-red hover:text-bauhaus-blue underline decoration-bauhaus-red underline-offset-4"
+                              >
+                                open source
+                              </a>
+                            </span>
+                          ) : null}
+                        </div>
+                      )}
                     </div>
                   );
                 })}
@@ -665,7 +911,38 @@ export default async function FoundationDetailPage({ params }: { params: Promise
             </div>
           )}
 
-          {f.board_members && f.board_members.length > 0 && (
+          <div id="board-leadership" className="scroll-mt-24" />
+
+          {boardRoles.length > 0 && (
+            <div className="bg-white border-4 border-bauhaus-black p-4">
+              <h3 className="text-xs font-black text-bauhaus-black mb-3 uppercase tracking-widest">Board &amp; Leadership</h3>
+              <div className="space-y-2">
+                {boardRoles.map((member) => (
+                  <div key={`${member.person_name}-${member.role_type || 'unknown'}`} className="flex items-start justify-between gap-3 border-b-2 border-bauhaus-black/10 pb-2 last:border-b-0 last:pb-0">
+                    <div className="min-w-0">
+                      <Link
+                        href={`/person/${encodeURIComponent(member.person_name)}`}
+                        className="text-sm font-black text-bauhaus-black hover:text-bauhaus-blue"
+                      >
+                        {member.person_name}
+                      </Link>
+                      <div className="mt-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                        {(member.role_type || 'role').replace(/_/g, ' ')}
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-right text-[10px] font-black uppercase tracking-[0.14em] text-bauhaus-muted">
+                      {member.source === 'acnc_register' ? 'ACNC' : member.source || 'Linked'}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3 border-t-2 border-bauhaus-black/20 pt-3 text-[10px] font-bold uppercase tracking-[0.16em] text-bauhaus-muted">
+                Linked from structured person roles rather than unstructured foundation summary text.
+              </div>
+            </div>
+          )}
+
+          {boardRoles.length === 0 && f.board_members && f.board_members.length > 0 && (
             <div className="bg-white border-4 border-bauhaus-black p-4">
               <h3 className="text-xs font-black text-bauhaus-black mb-3 uppercase tracking-widest">Board &amp; Leadership</h3>
               <div className="space-y-1.5">
@@ -678,6 +955,8 @@ export default async function FoundationDetailPage({ params }: { params: Promise
               </div>
             </div>
           )}
+
+          <div id="matching-grants" className="scroll-mt-24" />
 
           {matchingGrants.length > 0 && (
             <div className="bg-white border-4 border-bauhaus-black p-4">
@@ -706,12 +985,22 @@ export default async function FoundationDetailPage({ params }: { params: Promise
               <h3 className="text-xs font-black text-bauhaus-black mb-3 uppercase tracking-widest">Similar Foundations</h3>
               <div className="space-y-2">
                 {similarFoundations.map(sf => (
-                  <a key={sf.id} href={`/foundations/${sf.id}`} className="block hover:bg-bauhaus-canvas p-2 -mx-2 transition-colors border-b-2 border-bauhaus-black/10 last:border-0">
-                    <div className="text-sm font-bold text-bauhaus-black leading-tight">{sf.name.length > 45 ? sf.name.slice(0, 45) + '\u2026' : sf.name}</div>
-                    <div className="text-xs text-bauhaus-muted mt-0.5 font-medium">
-                      {sf.total_giving_annual ? formatMoney(sf.total_giving_annual) + '/yr' : typeLabel(sf.type)}
+                  <div key={sf.id} className="border-b-2 border-bauhaus-black/10 py-2 last:border-0">
+                    <Link href={`/foundations/${sf.id}`} className="block -mx-2 px-2 py-1 transition-colors hover:bg-bauhaus-canvas">
+                      <div className="text-sm font-bold text-bauhaus-black leading-tight">{sf.name.length > 45 ? sf.name.slice(0, 45) + '\u2026' : sf.name}</div>
+                      <div className="text-xs text-bauhaus-muted mt-0.5 font-medium">
+                        {sf.total_giving_annual ? formatMoney(sf.total_giving_annual) + '/yr' : typeLabel(sf.type)}
+                      </div>
+                    </Link>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                      <Link
+                        href={`/foundations/compare?left=${f.id}&right=${sf.id}`}
+                        className="border-2 border-bauhaus-blue/25 bg-link-light px-2 py-1 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                      >
+                        Compare now
+                      </Link>
                     </div>
-                  </a>
+                  </div>
                 ))}
               </div>
             </div>
@@ -720,9 +1009,14 @@ export default async function FoundationDetailPage({ params }: { params: Promise
           <div className="bg-bauhaus-canvas border-4 border-bauhaus-black p-4 text-xs text-bauhaus-muted space-y-1.5 font-medium">
             <h3 className="text-xs font-black text-bauhaus-black mb-2 uppercase tracking-widest">Data Sources</h3>
             <div>Profile quality: <span className={`font-black ${f.profile_confidence === 'high' ? 'text-money' : f.profile_confidence === 'medium' ? 'text-bauhaus-yellow' : 'text-bauhaus-muted'}`}>{f.profile_confidence}</span></div>
-            {f.enriched_at && <div>Last profiled: {new Date(f.enriched_at).toLocaleDateString('en-AU', { year: 'numeric', month: 'long', day: 'numeric' })}</div>}
+            {f.enriched_at && <div>Foundation profile updated: {formatDateWithRecency(f.enriched_at)}</div>}
+            {latestProgramScrapedAt && <div>Grant/program scan updated: {formatDateWithRecency(latestProgramScrapedAt)}</div>}
+            {!latestProgramScrapedAt && f.last_scraped_at && <div>Website scan updated: {formatDateWithRecency(f.last_scraped_at)}</div>}
+            {latestProgramScrapedAt && f.enriched_at && new Date(latestProgramScrapedAt).getTime() > new Date(f.enriched_at).getTime() && (
+              <div>Program discovery is newer than the foundation profile summary.</div>
+            )}
             {f.scraped_urls && f.scraped_urls.length > 0 && <div>Website pages scraped: {f.scraped_urls.length}</div>}
-            <div>Added: {new Date(f.created_at).toLocaleDateString('en-AU', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+            <div>Added: {formatDateWithRecency(f.created_at)}</div>
             <a href={`https://www.acnc.gov.au/charity/charities?search=${encodeURIComponent(f.acnc_abn)}`} target="_blank" rel="noopener noreferrer" className="text-bauhaus-blue hover:text-bauhaus-red block mt-2 font-black uppercase tracking-wider">
               View on ACNC Register &rarr;
             </a>

--- a/apps/web/src/app/foundations/backlog/page.tsx
+++ b/apps/web/src/app/foundations/backlog/page.tsx
@@ -1,0 +1,921 @@
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+interface BacklogRow {
+  id: string;
+  name: string;
+  type: string | null;
+  total_giving_annual: number | null;
+  board_roles: number;
+  verified_grants: number;
+  raw_grant_edges: number;
+  raw_grant_datasets: number;
+  current_program_count: number;
+  year_memory_count: number;
+  verified_source_backed_count: number;
+}
+
+interface BacklogSearchParams {
+  left?: string;
+  right?: string;
+  queue?: string;
+  status?: string;
+}
+
+interface FoundationOption {
+  id: string;
+  name: string;
+  type: string | null;
+  total_giving_annual: number | null;
+}
+
+interface PairAlternative {
+  foundationId: string;
+  foundationName: string;
+  foundationType: string | null;
+  candidateId: string;
+  candidateName: string;
+  candidateType: string | null;
+}
+
+type QueueKind = 'grants' | 'year_memory' | 'source_backed' | 'operator';
+
+type QueueStatus = {
+  key: string;
+  label: string;
+  detail: string;
+  priority: number;
+  tone: 'green' | 'amber' | 'red' | 'slate';
+};
+
+const GRANTMAKER_TYPES = [
+  'private_ancillary_fund',
+  'public_ancillary_fund',
+  'trust',
+  'corporate_foundation',
+  'grantmaker',
+  'foundation',
+];
+
+const BACKLOG_QUEUE_META: Record<string, { label: string; detail: string }> = {
+  'missing-verified-grants': {
+    label: 'Missing verified grants',
+    detail: 'This compare pair sent you into the grant-evidence queue first.',
+  },
+  'missing-year-memory': {
+    label: 'Missing year memory',
+    detail: 'This compare pair needs recurring program-year memory before it becomes a stronger operational read.',
+  },
+  'missing-source-backed-memory': {
+    label: 'Missing source-backed memory',
+    detail: 'This compare pair already has some memory structure, but it still needs official provenance.',
+  },
+  'operator-exclusions': {
+    label: 'Operator exclusions',
+    detail: 'This compare pair is outside the benchmark grantmaker lane and belongs in the exclusion queue for now.',
+  },
+};
+
+const PAGE_QUEUE_SCAN_LIMIT = 50;
+
+const ACTIONABLE_GRANT_PIPELINE_FOUNDATION_IDS = new Set([
+  'b9e090e5-1672-48ff-815a-2a6314ebe033',
+  '8f8704be-d6e8-40f3-b561-ac6630ce5b36',
+  '25b80b63-416e-4aaa-b470-2f8dc6fa835f',
+  '85f0de43-d004-4122-83a6-287eeecc4da9',
+  'f5c80d75-6a66-4a0c-aa41-d1f3aa791f21',
+  '3af6cf86-f10c-488f-941f-00ab7bbad7f8',
+  '983f0037-da5f-43d4-b9ae-3ff8853d6727',
+  '77be5d6c-9e0b-4467-9300-e30e4ba480ee',
+  '95e902b1-9883-40da-8806-e38d202d8cdf',
+  '3ef014f7-76ea-48e6-932a-7ec133cc5342',
+  '4a6a3689-626b-4a26-b95c-ed67123cab36',
+  '686fc5c5-d211-441b-a424-020c7ee3fb1a',
+]);
+
+const BACKLOG_QUEUE_ORDER = [
+  'missing-verified-grants',
+  'missing-year-memory',
+  'missing-source-backed-memory',
+  'operator-exclusions',
+] as const;
+
+function buildSliceHref(params: BacklogSearchParams, queue: string) {
+  const search = new URLSearchParams();
+  if (params.left) search.set('left', params.left);
+  if (params.right) search.set('right', params.right);
+  search.set('queue', queue);
+  if (params.status) search.set('status', params.status);
+  return `/foundations/backlog?${search.toString()}#${queue}`;
+}
+
+function buildStatusHref(params: BacklogSearchParams, status?: string) {
+  const search = new URLSearchParams();
+  if (params.left) search.set('left', params.left);
+  if (params.right) search.set('right', params.right);
+  if (params.queue) search.set('queue', params.queue);
+  if (status) search.set('status', status);
+
+  const query = search.toString();
+  const hash = params.queue ? `#${params.queue}` : '';
+  return query ? `/foundations/backlog?${query}${hash}` : `/foundations/backlog${hash}`;
+}
+
+function buildBacklogQuery(comparableTypes: string, filter: string) {
+  return `WITH rel AS (
+            SELECT r.source_entity_id, COUNT(*)::int AS relationship_grants
+            FROM gs_relationships r
+            WHERE r.relationship_type = 'grant'
+              AND r.dataset = 'foundation_grantees'
+            GROUP BY r.source_entity_id
+          ),
+          fg AS (
+            SELECT foundation_id, COUNT(*)::int AS canonical_grants
+            FROM foundation_grantees
+            GROUP BY foundation_id
+          ),
+          board AS (
+            SELECT
+              COALESCE(NULLIF(company_abn, ''), company_name) AS foundation_key,
+              COUNT(*)::int AS board_roles
+            FROM person_roles
+            WHERE cessation_date IS NULL
+            GROUP BY COALESCE(NULLIF(company_abn, ''), company_name)
+          ),
+          programs AS (
+            SELECT foundation_id, COUNT(*)::int AS current_program_count
+            FROM foundation_programs
+            WHERE status IN ('open', 'ongoing', 'closed')
+            GROUP BY foundation_id
+          ),
+          raw_rel AS (
+            SELECT
+              source_entity_id,
+              COUNT(*)::int AS raw_grant_edges,
+              COUNT(DISTINCT dataset)::int AS raw_grant_datasets
+            FROM gs_relationships
+            WHERE relationship_type = 'grant'
+              AND dataset <> 'foundation_grantees'
+            GROUP BY source_entity_id
+          ),
+          yrs AS (
+            SELECT
+              foundation_id,
+              COUNT(*)::int AS year_memory_count,
+              COUNT(*) FILTER (
+                WHERE COALESCE(metadata->>'source', '') NOT ILIKE '%inferred%'
+              )::int AS verified_source_backed_count
+            FROM foundation_program_years
+            GROUP BY foundation_id
+          ),
+          candidate_rows AS (
+            SELECT
+              f.id,
+              f.name,
+              f.type,
+              f.total_giving_annual,
+              COALESCE(board.board_roles, 0) AS board_roles,
+              GREATEST(
+                COALESCE(fg.canonical_grants, 0),
+                COALESCE(rel.relationship_grants, 0)
+              ) AS verified_grants,
+              COALESCE(raw_rel.raw_grant_edges, 0) AS raw_grant_edges,
+              COALESCE(raw_rel.raw_grant_datasets, 0) AS raw_grant_datasets,
+              COALESCE(programs.current_program_count, 0) AS current_program_count,
+              COALESCE(yrs.year_memory_count, 0) AS year_memory_count,
+              COALESCE(yrs.verified_source_backed_count, 0) AS verified_source_backed_count
+            FROM foundations f
+            LEFT JOIN rel ON rel.source_entity_id = f.gs_entity_id
+            LEFT JOIN fg ON fg.foundation_id = f.id
+            LEFT JOIN board ON board.foundation_key = COALESCE(NULLIF(f.acnc_abn, ''), f.name)
+            LEFT JOIN programs ON programs.foundation_id = f.id
+            LEFT JOIN raw_rel ON raw_rel.source_entity_id = f.gs_entity_id
+            LEFT JOIN yrs ON yrs.foundation_id = f.id
+            WHERE f.total_giving_annual IS NOT NULL
+          )
+          SELECT *
+          FROM candidate_rows
+          WHERE ${filter}
+          ORDER BY total_giving_annual DESC NULLS LAST
+          LIMIT ${PAGE_QUEUE_SCAN_LIMIT}`;
+}
+
+function formatMoney(amount: number | null | undefined): string {
+  if (amount == null) return '—';
+  if (amount >= 1_000_000_000) return `$${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `$${Math.round(amount / 1_000)}K`;
+  return `$${Math.round(amount).toLocaleString('en-AU')}`;
+}
+
+function formatType(type: string | null | undefined): string {
+  if (!type) return 'Unknown';
+  return type
+    .replace(/_/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function isGrantmakerComparable(type: string | null | undefined) {
+  return GRANTMAKER_TYPES.includes(type || '');
+}
+
+function buildPairAlternatives(
+  pairRows: FoundationOption[],
+  options: FoundationOption[],
+): PairAlternative[] {
+  const currentIds = new Set(pairRows.map((row) => row.id));
+
+  return pairRows.flatMap((row) => {
+    if (!row.type) return [];
+
+    const candidate = options.find((option) =>
+      option.id !== row.id &&
+      !currentIds.has(option.id) &&
+      option.type === row.type,
+    );
+
+    if (!candidate) return [];
+
+    return [{
+      foundationId: row.id,
+      foundationName: row.name,
+      foundationType: row.type,
+      candidateId: candidate.id,
+      candidateName: candidate.name,
+      candidateType: candidate.type,
+    }];
+  });
+}
+
+function queueHref(row: BacklogRow, queue: 'grants' | 'year_memory' | 'source_backed' | 'operator') {
+  if (queue === 'grants') return `/foundations/${row.id}#matching-grants`;
+  if (queue === 'year_memory' || queue === 'source_backed') return `/foundations/${row.id}#program-history`;
+  return `/foundations/compare?left=${row.id}&right=d242967e-0e68-4367-9785-06cf0ec7485e`;
+}
+
+function queueStatus(row: BacklogRow, queue: QueueKind): QueueStatus {
+  if (queue === 'grants') {
+    if (ACTIONABLE_GRANT_PIPELINE_FOUNDATION_IDS.has(row.id)) {
+      return {
+        key: 'actionable',
+        label: 'Actionable now',
+        detail: 'A verified-grant pipeline already exists for this foundation.',
+        priority: 0,
+        tone: 'green',
+      };
+    }
+
+    if (row.raw_grant_edges > 0) {
+      return {
+        key: 'blocked_pipeline',
+        label: 'Blocked on pipeline',
+        detail: `Raw grant dataset exists (${row.raw_grant_edges} edges across ${row.raw_grant_datasets} dataset${row.raw_grant_datasets === 1 ? '' : 's'}), but no canonical backfill pipeline is configured yet.`,
+        priority: 1,
+        tone: 'amber',
+      };
+    }
+
+    return {
+      key: 'blocked_raw_data',
+      label: 'Blocked on raw data',
+      detail: 'No raw grant dataset exists yet for canonical verified-grant backfill.',
+      priority: 2,
+      tone: 'red',
+    };
+  }
+
+  if (queue === 'year_memory') {
+    if (row.current_program_count > 0) {
+      return {
+        key: 'actionable',
+        label: 'Actionable now',
+        detail: `Seedable current program rows are present (${row.current_program_count}).`,
+        priority: 0,
+        tone: 'green',
+      };
+    }
+
+    return {
+      key: 'blocked_public_surface',
+      label: 'Blocked on public program surface',
+      detail: 'No current public program surface was found to seed program-year memory.',
+      priority: 1,
+      tone: 'red',
+    };
+  }
+
+  if (queue === 'source_backed') {
+    return {
+      key: 'needs_provenance',
+      label: 'Needs provenance pass',
+      detail: 'Program memory exists, but official provenance is still missing.',
+      priority: 0,
+      tone: 'amber',
+    };
+  }
+
+  return {
+    key: 'outside_benchmark_lane',
+    label: 'Outside benchmark lane',
+    detail: 'This foundation currently sits outside the benchmark grantmaker lane.',
+    priority: 0,
+    tone: 'slate',
+  };
+}
+
+function sortBacklogRows(rows: BacklogRow[], queue: QueueKind, statusFilter?: string) {
+  return [...rows]
+    .filter((row) => !statusFilter || queueStatus(row, queue).key === statusFilter)
+    .sort((left, right) => {
+      const leftStatus = queueStatus(left, queue);
+      const rightStatus = queueStatus(right, queue);
+
+      if (leftStatus.priority !== rightStatus.priority) {
+        return leftStatus.priority - rightStatus.priority;
+      }
+
+      return (right.total_giving_annual || 0) - (left.total_giving_annual || 0);
+    })
+    .slice(0, 12);
+}
+
+function countRowsByStatus(rows: BacklogRow[], queue: QueueKind) {
+  return rows.reduce<Record<string, number>>((acc, row) => {
+    const key = queueStatus(row, queue).key;
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function statusToneClassName(tone: QueueStatus['tone']) {
+  if (tone === 'green') return 'border-bauhaus-blue/25 bg-link-light text-bauhaus-blue';
+  if (tone === 'amber') return 'border-bauhaus-red/25 bg-bauhaus-red/5 text-bauhaus-red';
+  if (tone === 'red') return 'border-bauhaus-red bg-white text-bauhaus-red';
+  return 'border-bauhaus-black/20 bg-white text-bauhaus-black';
+}
+
+function QueueSection({
+  id,
+  title,
+  detail,
+  rows,
+  queue,
+  active,
+  statusSummary,
+}: {
+  id: string;
+  title: string;
+  detail: string;
+  rows: BacklogRow[];
+  queue: QueueKind;
+  active?: boolean;
+  statusSummary: Array<{ key: string; label: string; tone: QueueStatus['tone']; count: number; href: string; active: boolean }>;
+}) {
+  return (
+    <section
+      id={id}
+      className={`scroll-mt-24 p-6 ${active ? 'border-4 border-bauhaus-red bg-bauhaus-red/5' : 'border-4 border-bauhaus-black bg-white'}`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">{title}</div>
+        {active ? (
+          <span className="border-2 border-bauhaus-red bg-white px-2 py-1 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-red">
+            Active slice
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-3 max-w-4xl text-sm font-medium leading-relaxed text-bauhaus-muted">{detail}</p>
+      <div className="mt-4">
+        <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Queue status mix</div>
+        <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+          {statusSummary.map((status) => (
+            <a
+              key={status.key}
+              href={status.href}
+              className={`border-2 px-2.5 py-1 transition-colors ${
+                status.active
+                  ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                  : `${statusToneClassName(status.tone)} hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white`
+              }`}
+            >
+              {status.label} ({status.count})
+            </a>
+          ))}
+        </div>
+      </div>
+      {rows.length === 0 ? (
+        <div className="mt-5 border-2 border-dashed border-bauhaus-black/20 bg-bauhaus-canvas p-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+            No foundations match this status filter in this queue.
+          </div>
+        </div>
+      ) : (
+      <div className="mt-5 grid gap-4">
+        {rows.map((row, index) => (
+          <div key={row.id} className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+            {(() => {
+              const status = queueStatus(row, queue);
+              const statusClassName = statusToneClassName(status.tone);
+
+              return (
+                <>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  #{index + 1} · {formatType(row.type)}
+                </div>
+                <div className="mt-1 text-lg font-black text-bauhaus-black">{row.name}</div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <div className={`border-2 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${statusClassName}`}>
+                  {status.label}
+                </div>
+                <div className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">
+                  {formatMoney(row.total_giving_annual)}
+                </div>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              <span className="border-2 border-bauhaus-black/20 px-2.5 py-1 text-bauhaus-black">
+                {row.board_roles} governance
+              </span>
+              <span className="border-2 border-bauhaus-black/20 px-2.5 py-1 text-bauhaus-black">
+                {row.verified_grants} verified grants
+              </span>
+              <span className="border-2 border-bauhaus-black/20 px-2.5 py-1 text-bauhaus-black">
+                {row.year_memory_count} year memory
+              </span>
+              <span className="border-2 border-bauhaus-black/20 px-2.5 py-1 text-bauhaus-black">
+                {row.verified_source_backed_count} source-backed
+              </span>
+            </div>
+            <p className="mt-4 max-w-3xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+              <span className="font-black uppercase tracking-[0.14em] text-bauhaus-black">Blocked:</span>{' '}
+              {status.detail}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              <Link
+                href={queueHref(row, queue)}
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Open next step
+              </Link>
+              <Link
+                href={`/foundations/${row.id}`}
+                className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+              >
+                Open profile
+              </Link>
+            </div>
+                </>
+              );
+            })()}
+          </div>
+        ))}
+      </div>
+      )}
+    </section>
+  );
+}
+
+export default async function FoundationsBacklogPage({ searchParams }: { searchParams: Promise<BacklogSearchParams> }) {
+  const params = await searchParams;
+  const activeStatus = params.status || null;
+  const supabase = getServiceSupabase();
+  const comparableTypes = GRANTMAKER_TYPES.map((type) => `'${type}'`).join(',');
+  const [missingVerifiedGrantsResult, missingYearMemoryResult, missingSourceBackedResult, operatorExclusionsResult] =
+    await Promise.all([
+      supabase.rpc('exec_sql', {
+        query: buildBacklogQuery(
+          comparableTypes,
+          `type IN (${comparableTypes}) AND board_roles > 0 AND verified_grants = 0`,
+        ),
+      }),
+      supabase.rpc('exec_sql', {
+        query: buildBacklogQuery(
+          comparableTypes,
+          `type IN (${comparableTypes}) AND board_roles > 0 AND year_memory_count = 0`,
+        ),
+      }),
+      supabase.rpc('exec_sql', {
+        query: buildBacklogQuery(
+          comparableTypes,
+          `type IN (${comparableTypes}) AND year_memory_count > 0 AND verified_source_backed_count = 0`,
+        ),
+      }),
+      supabase.rpc('exec_sql', {
+        query: buildBacklogQuery(
+          comparableTypes,
+          `(type IS NULL OR type NOT IN (${comparableTypes})) AND board_roles > 0`,
+        ),
+      }),
+    ]);
+
+  const missingVerifiedGrantsRows = (missingVerifiedGrantsResult.data || []) as BacklogRow[];
+  const missingYearMemoryRows = (missingYearMemoryResult.data || []) as BacklogRow[];
+  const missingSourceBackedRows = (missingSourceBackedResult.data || []) as BacklogRow[];
+  const operatorExclusionsRows = (operatorExclusionsResult.data || []) as BacklogRow[];
+  const missingVerifiedGrants = sortBacklogRows(
+    missingVerifiedGrantsRows,
+    'grants',
+    activeStatus || undefined,
+  );
+  const missingYearMemory = sortBacklogRows(
+    missingYearMemoryRows,
+    'year_memory',
+    activeStatus || undefined,
+  );
+  const missingSourceBacked = sortBacklogRows(
+    missingSourceBackedRows,
+    'source_backed',
+    activeStatus || undefined,
+  );
+  const operatorExclusions = sortBacklogRows(
+    operatorExclusionsRows,
+    'operator',
+    activeStatus || undefined,
+  );
+  const rowsByQueue = {
+    'missing-verified-grants': { rows: missingVerifiedGrantsRows, queue: 'grants' as const },
+    'missing-year-memory': { rows: missingYearMemoryRows, queue: 'year_memory' as const },
+    'missing-source-backed-memory': { rows: missingSourceBackedRows, queue: 'source_backed' as const },
+    'operator-exclusions': { rows: operatorExclusionsRows, queue: 'operator' as const },
+  };
+  const statusCountScope = params.queue && params.queue in rowsByQueue
+    ? [rowsByQueue[params.queue as keyof typeof rowsByQueue]]
+    : Object.values(rowsByQueue);
+  const statusCounts = statusCountScope.reduce<Record<string, number>>((acc, item) => {
+    const counts = countRowsByStatus(item.rows, item.queue);
+    Object.entries(counts).forEach(([key, value]) => {
+      acc[key] = (acc[key] || 0) + value;
+    });
+    return acc;
+  }, {});
+  const totalStatusCount = statusCountScope.reduce((sum, item) => sum + item.rows.length, 0);
+  const comparePairIds = [params.left, params.right].filter(Boolean) as string[];
+  const compareBackHref =
+    comparePairIds.length === 2 ? `/foundations/compare?left=${comparePairIds[0]}&right=${comparePairIds[1]}` : null;
+  const activeQueueMeta = params.queue ? BACKLOG_QUEUE_META[params.queue] : null;
+  const pairSlicePivots = comparePairIds.length === 2
+    ? BACKLOG_QUEUE_ORDER.map((queue) => ({
+        queue,
+        label: BACKLOG_QUEUE_META[queue].label,
+        href: buildSliceHref(params, queue),
+        active: params.queue === queue,
+      }))
+    : [];
+  const statusChips = [
+    { key: null, label: 'All statuses', count: totalStatusCount },
+    { key: 'actionable', label: 'Actionable now', count: statusCounts.actionable || 0 },
+    { key: 'blocked_raw_data', label: 'Blocked on raw data', count: statusCounts.blocked_raw_data || 0 },
+    { key: 'blocked_pipeline', label: 'Blocked on pipeline', count: statusCounts.blocked_pipeline || 0 },
+    { key: 'blocked_public_surface', label: 'Blocked on public program surface', count: statusCounts.blocked_public_surface || 0 },
+    { key: 'needs_provenance', label: 'Needs provenance pass', count: statusCounts.needs_provenance || 0 },
+    { key: 'outside_benchmark_lane', label: 'Outside benchmark lane', count: statusCounts.outside_benchmark_lane || 0 },
+  ] as const;
+  const queueStatusSummaries = {
+    grants: [
+      {
+        key: 'actionable',
+        label: 'Actionable now',
+        tone: 'green' as const,
+        count: countRowsByStatus(missingVerifiedGrantsRows, 'grants').actionable || 0,
+        href: buildStatusHref({ ...params, queue: 'missing-verified-grants' }, 'actionable'),
+        active: params.queue === 'missing-verified-grants' && activeStatus === 'actionable',
+      },
+      {
+        key: 'blocked_pipeline',
+        label: 'Blocked on pipeline',
+        tone: 'amber' as const,
+        count: countRowsByStatus(missingVerifiedGrantsRows, 'grants').blocked_pipeline || 0,
+        href: buildStatusHref({ ...params, queue: 'missing-verified-grants' }, 'blocked_pipeline'),
+        active: params.queue === 'missing-verified-grants' && activeStatus === 'blocked_pipeline',
+      },
+      {
+        key: 'blocked_raw_data',
+        label: 'Blocked on raw data',
+        tone: 'red' as const,
+        count: countRowsByStatus(missingVerifiedGrantsRows, 'grants').blocked_raw_data || 0,
+        href: buildStatusHref({ ...params, queue: 'missing-verified-grants' }, 'blocked_raw_data'),
+        active: params.queue === 'missing-verified-grants' && activeStatus === 'blocked_raw_data',
+      },
+    ],
+    year_memory: [
+      {
+        key: 'actionable',
+        label: 'Actionable now',
+        tone: 'green' as const,
+        count: countRowsByStatus(missingYearMemoryRows, 'year_memory').actionable || 0,
+        href: buildStatusHref({ ...params, queue: 'missing-year-memory' }, 'actionable'),
+        active: params.queue === 'missing-year-memory' && activeStatus === 'actionable',
+      },
+      {
+        key: 'blocked_public_surface',
+        label: 'Blocked on public program surface',
+        tone: 'red' as const,
+        count: countRowsByStatus(missingYearMemoryRows, 'year_memory').blocked_public_surface || 0,
+        href: buildStatusHref({ ...params, queue: 'missing-year-memory' }, 'blocked_public_surface'),
+        active: params.queue === 'missing-year-memory' && activeStatus === 'blocked_public_surface',
+      },
+    ],
+    source_backed: [
+      {
+        key: 'needs_provenance',
+        label: 'Needs provenance pass',
+        tone: 'amber' as const,
+        count: countRowsByStatus(missingSourceBackedRows, 'source_backed').needs_provenance || 0,
+        href: buildStatusHref({ ...params, queue: 'missing-source-backed-memory' }, 'needs_provenance'),
+        active: params.queue === 'missing-source-backed-memory' && activeStatus === 'needs_provenance',
+      },
+    ],
+    operator: [
+      {
+        key: 'outside_benchmark_lane',
+        label: 'Outside benchmark lane',
+        tone: 'slate' as const,
+        count: countRowsByStatus(operatorExclusionsRows, 'operator').outside_benchmark_lane || 0,
+        href: buildStatusHref({ ...params, queue: 'operator-exclusions' }, 'outside_benchmark_lane'),
+        active: params.queue === 'operator-exclusions' && activeStatus === 'outside_benchmark_lane',
+      },
+    ],
+  };
+  let comparePairNames: string[] = [];
+  let comparePairRows: FoundationOption[] = [];
+  let pairAlternatives: PairAlternative[] = [];
+
+  if (comparePairIds.length === 2) {
+    const [{ data: pairRows }, { data: compareOptions }] = await Promise.all([
+      supabase
+        .from('foundations')
+        .select('id, name, type, total_giving_annual')
+        .in('id', comparePairIds),
+      supabase
+        .from('foundations')
+        .select('id, name, type, total_giving_annual')
+        .order('total_giving_annual', { ascending: false, nullsFirst: false })
+        .limit(150),
+    ]);
+
+    comparePairRows = comparePairIds
+      .map((id) => (pairRows || []).find((row) => row.id === id))
+      .filter(Boolean) as FoundationOption[];
+
+    comparePairNames = comparePairRows
+      .map((row) => row.name)
+      .filter(Boolean) as string[];
+
+    if (
+      comparePairRows.length === 2 &&
+      comparePairRows.every((row) => !isGrantmakerComparable(row.type))
+    ) {
+      pairAlternatives = buildPairAlternatives(comparePairRows, (compareOptions || []) as FoundationOption[]);
+    }
+  }
+
+  return (
+    <div className="pb-16">
+      <section className="border-b-4 border-bauhaus-black pb-10">
+        <Link
+          href="/foundations"
+          className="text-xs font-black uppercase tracking-[0.35em] text-bauhaus-muted transition-colors hover:text-bauhaus-black"
+        >
+          ← Back to foundations
+        </Link>
+        <div className="mt-4 text-xs font-black uppercase tracking-[0.35em] text-bauhaus-red">Reviewability backlog</div>
+        <h1 className="mt-4 text-4xl font-black leading-[0.9] text-bauhaus-black sm:text-6xl">
+          Batch upgrade
+          <br />
+          queue
+        </h1>
+        <p className="mt-5 max-w-4xl text-lg font-medium leading-relaxed text-bauhaus-muted">
+          This is the compounding work surface: rank the highest-value foundations by missing layer,
+          batch the real upgrade jobs, and separate non-grantmaker institutions out of the benchmark lane.
+        </p>
+        {compareBackHref ? (
+          <div className="mt-5 border-l-4 border-bauhaus-blue bg-link-light/40 px-4 py-3">
+            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-blue">Opened from compare pair</div>
+            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+              {comparePairNames.length === 2
+                ? `${comparePairNames[0]} vs ${comparePairNames[1]} sent you here.`
+                : 'A live compare pair sent you here.'}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              <a
+                href={compareBackHref}
+                className="border-2 border-bauhaus-blue/25 bg-white px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Return to compare
+              </a>
+            </div>
+          </div>
+        ) : null}
+        {activeQueueMeta ? (
+          <div className="mt-5 border-l-4 border-bauhaus-red bg-bauhaus-red/5 px-4 py-3">
+            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-red">Current backlog slice</div>
+            <div className="mt-2 text-sm font-black uppercase tracking-[0.16em] text-bauhaus-black">
+              {activeQueueMeta.label}
+            </div>
+            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">{activeQueueMeta.detail}</p>
+            {params.queue ? (
+              <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                <a
+                  href={`#${params.queue}`}
+                  className="border-2 border-bauhaus-red/25 bg-white px-3 py-2 text-bauhaus-red transition-colors hover:border-bauhaus-red hover:bg-bauhaus-red hover:text-white"
+                >
+                  Jump to active slice
+                </a>
+              </div>
+            ) : null}
+            {pairSlicePivots.length > 1 ? (
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  Keep this pair, change slice
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                  {pairSlicePivots.map((pivot) => (
+                    <a
+                      key={pivot.queue}
+                      href={pivot.href}
+                      className={`px-3 py-2 transition-colors ${
+                        pivot.active
+                          ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                          : 'border-2 border-bauhaus-black/20 bg-white text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+                      }`}
+                    >
+                      {pivot.label}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            {pairAlternatives.length > 0 ? (
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  Better-fit compare next
+                </div>
+                <div className="mt-3 space-y-3">
+                  {pairAlternatives.map((alternative) => (
+                    <div key={`${alternative.foundationId}-${alternative.candidateId}`} className="border-l-4 border-bauhaus-blue pl-3">
+                      <div className="text-xs font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                        {alternative.foundationName} → {formatType(alternative.candidateType)}
+                      </div>
+                      <p className="mt-1 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                        Compare {alternative.foundationName} with {alternative.candidateName} instead if you want a more type-aligned read from this backlog lane.
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                        <a
+                          href={`/foundations/compare?left=${alternative.foundationId}&right=${alternative.candidateId}&from=backlog&backlog_queue=${params.queue || 'operator-exclusions'}&backlog_left=${params.left || ''}&backlog_right=${params.right || ''}`}
+                          className="border-2 border-bauhaus-blue/25 bg-white px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                        >
+                          Open {alternative.foundationName} vs {alternative.candidateName}
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="mt-6 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.25em]">
+          <span className="border-2 border-bauhaus-black px-3 py-2 text-bauhaus-black">
+            {missingVerifiedGrants.length} grant-layer targets
+          </span>
+          <span className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-bauhaus-blue">
+            {missingYearMemory.length} year-memory targets
+          </span>
+          <span className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red">
+            {operatorExclusions.length} operator exclusions
+          </span>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+          <Link
+            href="/foundations/review-set"
+            className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open review set
+          </Link>
+          <Link
+            href="/foundations/compare"
+            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+          >
+            Open compare surface
+          </Link>
+        </div>
+        <div className="mt-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Jump to backlog slice</div>
+          <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+            <a
+              href={comparePairIds.length === 2 ? buildSliceHref(params, 'missing-verified-grants') : '#missing-verified-grants'}
+              className={`px-3 py-2 transition-colors ${
+                params.queue === 'missing-verified-grants'
+                  ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                  : 'border-2 border-bauhaus-black/20 bg-white text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+              }`}
+            >
+              Missing verified grants
+            </a>
+            <a
+              href={comparePairIds.length === 2 ? buildSliceHref(params, 'missing-year-memory') : '#missing-year-memory'}
+              className={`px-3 py-2 transition-colors ${
+                params.queue === 'missing-year-memory'
+                  ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                  : 'border-2 border-bauhaus-blue/25 bg-link-light text-bauhaus-blue hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white'
+              }`}
+            >
+              Missing year memory
+            </a>
+            <a
+              href={comparePairIds.length === 2 ? buildSliceHref(params, 'missing-source-backed-memory') : '#missing-source-backed-memory'}
+              className={`px-3 py-2 transition-colors ${
+                params.queue === 'missing-source-backed-memory'
+                  ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                  : 'border-2 border-bauhaus-black/20 bg-bauhaus-canvas text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+              }`}
+            >
+              Missing source-backed memory
+            </a>
+            <a
+              href={comparePairIds.length === 2 ? buildSliceHref(params, 'operator-exclusions') : '#operator-exclusions'}
+              className={`px-3 py-2 transition-colors ${
+                params.queue === 'operator-exclusions'
+                  ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                  : 'border-2 border-bauhaus-red/25 bg-bauhaus-red/5 text-bauhaus-red hover:border-bauhaus-red hover:bg-bauhaus-red hover:text-white'
+              }`}
+            >
+              Operator exclusions
+            </a>
+          </div>
+        </div>
+        <div className="mt-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Filter by queue status</div>
+          <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+            {statusChips.map((chip) => {
+              const active = activeStatus === chip.key || (!activeStatus && chip.key === null);
+              return (
+                <a
+                  key={chip.label}
+                  href={buildStatusHref(params, chip.key || undefined)}
+                  className={`px-3 py-2 transition-colors ${
+                    active
+                      ? 'border-2 border-bauhaus-red bg-white text-bauhaus-red'
+                      : 'border-2 border-bauhaus-black/20 bg-white text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+                  }`}
+                >
+                  {chip.label} ({chip.count})
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <div className="mt-10 grid gap-6">
+        <QueueSection
+          id="missing-verified-grants"
+          title="Missing verified grants"
+          detail="Highest-capital grantmaker-like foundations with governance visibility but no canonical verified grant layer. This is the fastest queue for making compare and review surfaces more truthful."
+          rows={missingVerifiedGrants}
+          queue="grants"
+          active={params.queue === 'missing-verified-grants'}
+          statusSummary={queueStatusSummaries.grants}
+        />
+
+        <QueueSection
+          id="missing-year-memory"
+          title="Missing year memory"
+          detail="Grantmaker-like foundations that already have governance visibility but no recurring program-year layer yet. This queue compounds compare quality once seeded."
+          rows={missingYearMemory}
+          queue="year_memory"
+          active={params.queue === 'missing-year-memory'}
+          statusSummary={queueStatusSummaries.year_memory}
+        />
+
+        <QueueSection
+          id="missing-source-backed-memory"
+          title="Missing source-backed memory"
+          detail="Foundations with year-memory rows already present, but still missing official source-backed provenance. This is the cleanup queue after initial seeding."
+          rows={missingSourceBacked}
+          queue="source_backed"
+          active={params.queue === 'missing-source-backed-memory'}
+          statusSummary={queueStatusSummaries.source_backed}
+        />
+
+        <QueueSection
+          id="operator-exclusions"
+          title="Operator exclusions"
+          detail="High-visibility institutions that should not be pushed through the philanthropic benchmark lane without stronger evidence that they are real grantmakers. Use this queue to avoid bad comparisons."
+          rows={operatorExclusions}
+          queue="operator"
+          active={params.queue === 'operator-exclusions'}
+          statusSummary={queueStatusSummaries.operator}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/foundations/compare/page.tsx
+++ b/apps/web/src/app/foundations/compare/page.tsx
@@ -1,0 +1,1716 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Foundation Compare | CivicGraph',
+  description: 'Compare two foundations across annual giving, governance, open programs, and recurring year-memory.',
+};
+
+const DEFAULT_FOUNDATION_IDS = [
+  'd242967e-0e68-4367-9785-06cf0ec7485e',
+  '4ee5baca-c898-4318-ae2b-d79b95379cc7',
+];
+
+const MINDEROO_FOUNDATION_ID = '8f8704be-d6e8-40f3-b561-ac6630ce5b36';
+const RIO_TINTO_FOUNDATION_ID = '85f0de43-d004-4122-83a6-287eeecc4da9';
+const IAN_POTTER_FOUNDATION_ID = 'b9e090e5-1672-48ff-815a-2a6314ebe033';
+const ECSTRA_FOUNDATION_ID = '25b80b63-416e-4aaa-b470-2f8dc6fa835f';
+const REVIEW_SET_IDS = [
+  DEFAULT_FOUNDATION_IDS[0],
+  DEFAULT_FOUNDATION_IDS[1],
+  MINDEROO_FOUNDATION_ID,
+  RIO_TINTO_FOUNDATION_ID,
+  IAN_POTTER_FOUNDATION_ID,
+  ECSTRA_FOUNDATION_ID,
+];
+
+const SPECIAL_ROUTE_MAP: Record<string, string> = {
+  'd242967e-0e68-4367-9785-06cf0ec7485e': '/snow-foundation',
+  '4ee5baca-c898-4318-ae2b-d79b95379cc7': '/foundations/prf',
+  '8f8704be-d6e8-40f3-b561-ac6630ce5b36': '/foundations/minderoo',
+  '85f0de43-d004-4122-83a6-287eeecc4da9': '/foundations/rio-tinto',
+  'b9e090e5-1672-48ff-815a-2a6314ebe033': '/foundations/ian-potter',
+  '25b80b63-416e-4aaa-b470-2f8dc6fa835f': '/foundations/ecstra',
+};
+
+const FOUNDATION_LABEL_MAP: Record<string, string> = {
+  'd242967e-0e68-4367-9785-06cf0ec7485e': 'Snow',
+  '4ee5baca-c898-4318-ae2b-d79b95379cc7': 'PRF',
+  '8f8704be-d6e8-40f3-b561-ac6630ce5b36': 'Minderoo',
+  '85f0de43-d004-4122-83a6-287eeecc4da9': 'Rio Tinto',
+  'b9e090e5-1672-48ff-815a-2a6314ebe033': 'Ian Potter',
+  '25b80b63-416e-4aaa-b470-2f8dc6fa835f': 'ECSTRA',
+};
+
+const CORE_BENCHMARK_IDS = REVIEW_SET_IDS;
+const BACKLOG_QUEUE_LABELS: Record<string, string> = {
+  'missing-verified-grants': 'Missing verified grants',
+  'missing-year-memory': 'Missing year memory',
+  'missing-source-backed-memory': 'Missing source-backed memory',
+  'operator-exclusions': 'Operator exclusions',
+};
+
+interface SearchParams {
+  ids?: string;
+  left?: string;
+  right?: string;
+  from?: string;
+  backlog_queue?: string;
+  backlog_left?: string;
+  backlog_right?: string;
+}
+
+interface FoundationRow {
+  id: string;
+  name: string;
+  acnc_abn: string;
+  type: string | null;
+  description: string | null;
+  website: string | null;
+  total_giving_annual: number | null;
+  thematic_focus: string[] | null;
+  geographic_focus: string[] | null;
+  profile_confidence: string;
+  giving_philosophy: string | null;
+}
+
+interface FoundationOption {
+  id: string;
+  name: string;
+  type: string | null;
+  total_giving_annual: number | null;
+}
+
+interface ProgramYearRow {
+  id: string;
+  report_year: number | null;
+  fiscal_year: string | null;
+  summary: string | null;
+  reported_amount: number | null;
+  source_report_url: string | null;
+  partners: Array<{ name?: string; role?: string }> | null;
+  places: Array<{ name?: string; type?: string }> | null;
+  metadata: Record<string, unknown> | null;
+  foundation_programs:
+    | {
+        name: string;
+        program_type: string | null;
+      }
+    | Array<{
+        name: string;
+        program_type: string | null;
+      }>
+    | null;
+}
+
+interface FoundationCardData {
+  foundation: FoundationRow;
+  openProgramCount: number;
+  totalProgramCount: number;
+  boardRoleCount: number;
+  verifiedGrantCount: number;
+  yearMemoryCount: number;
+  latestProgramYears: ProgramYearRow[];
+  inferredYearMemoryCount: number;
+  reportBackedYearMemoryCount: number;
+  reviewReadiness: 'stable' | 'developing' | 'early';
+}
+
+interface CountRow {
+  count: number;
+}
+
+interface ComparePreset {
+  label: string;
+  left: string;
+  right: string;
+}
+
+interface ComparisonHighlight {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+interface ReviewEstimate {
+  status: 'ready' | 'close' | 'not_yet';
+  label: string;
+  detail: string;
+}
+
+interface StabilityAction {
+  label: string;
+  detail: string;
+  href?: string;
+}
+
+interface PrimaryReviewAction {
+  label: string;
+  detail: string;
+  href?: string;
+}
+
+interface ReviewProgress {
+  completed: number;
+  total: number;
+  missing: string[];
+}
+
+interface PairChecklistItem {
+  label: string;
+  done: boolean;
+  href?: string;
+}
+
+interface PairContext {
+  badge: string;
+  title: string;
+  detail: string;
+}
+
+interface PairExecutionLane {
+  label: string;
+  detail: string;
+  links: Array<{
+    label: string;
+    href: string;
+  }>;
+}
+
+interface BenchmarkFit {
+  label: string;
+  detail: string;
+}
+
+interface TypeAlignedAlternative {
+  foundationId: string;
+  foundationLabel: string;
+  candidateId: string;
+  candidateLabel: string;
+  candidateType: string | null;
+}
+
+interface PairBacklogLane {
+  label: string;
+  detail: string;
+  href: string;
+}
+
+function isGrantmakerComparable(type: string | null | undefined) {
+  return [
+    'private_ancillary_fund',
+    'public_ancillary_fund',
+    'trust',
+    'corporate_foundation',
+    'grantmaker',
+    'foundation',
+  ].includes(type || '');
+}
+
+function formatFoundationType(type: string | null | undefined) {
+  if (!type) return 'unknown';
+  return type
+    .replace(/_/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function buildBenchmarkFit(card: FoundationCardData): BenchmarkFit {
+  const typeLabel = formatFoundationType(card.foundation.type);
+
+  if (!isGrantmakerComparable(card.foundation.type)) {
+    return {
+      label: 'Outside benchmark lane',
+      detail: `${typeLabel} profile. Use this as institutional context unless a real grantmaker layer is verified.`,
+    };
+  }
+
+  if (card.reviewReadiness === 'stable') {
+    return {
+      label: 'Benchmark-ready grantmaker',
+      detail: `${typeLabel} with enough evidence depth for stable philanthropic review.`,
+    };
+  }
+
+  if (card.reviewReadiness === 'developing') {
+    return {
+      label: 'Grantmaker in build',
+      detail: `${typeLabel} with some review structure in place, but still missing part of the verified evidence stack.`,
+    };
+  }
+
+  return {
+    label: 'Grantmaker candidate',
+    detail: `${typeLabel} profile, but still too thin for benchmark review without more verified evidence.`,
+  };
+}
+
+function buildTypeAlignedAlternatives(
+  cards: FoundationCardData[],
+  options: FoundationOption[],
+): TypeAlignedAlternative[] {
+  if (cards.length < 2) return [];
+
+  const currentIds = new Set(cards.map((card) => card.foundation.id));
+
+  return cards.flatMap((card) => {
+    if (!card.foundation.type) return [];
+
+    const candidate = options.find((option) =>
+      option.id !== card.foundation.id &&
+      !currentIds.has(option.id) &&
+      option.type === card.foundation.type,
+    );
+
+    if (!candidate) return [];
+
+    return [{
+      foundationId: card.foundation.id,
+      foundationLabel: FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name,
+      candidateId: candidate.id,
+      candidateLabel: FOUNDATION_LABEL_MAP[candidate.id] || candidate.name,
+      candidateType: candidate.type,
+    }];
+  });
+}
+
+function formatMoney(amount: number | null | undefined): string {
+  if (amount == null) return '—';
+  if (amount >= 1_000_000_000) return `$${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `$${Math.round(amount / 1_000)}K`;
+  return `$${Math.round(amount).toLocaleString('en-AU')}`;
+}
+
+function formatRatio(numerator: number, denominator: number) {
+  if (!numerator || !denominator) return null;
+  return `${(numerator / denominator).toFixed(1)}x`;
+}
+
+function labelise(value: string | null | undefined) {
+  if (!value) return 'Program';
+  return value.replace(/_/g, ' ');
+}
+
+function getProgramYearFoundationProgram(row: ProgramYearRow) {
+  if (Array.isArray(row.foundation_programs)) return row.foundation_programs[0] ?? null;
+  return row.foundation_programs ?? null;
+}
+
+function getDemoHref(foundationId: string) {
+  return SPECIAL_ROUTE_MAP[foundationId] || `/foundations/${foundationId}`;
+}
+
+function buildCompareHref(left: string, right: string) {
+  return `/foundations/compare?left=${left}&right=${right}`;
+}
+
+function resolveFoundationIds(pairedIds: string[], requestedIds: string[]) {
+  const baseIds =
+    pairedIds.length === 2
+      ? pairedIds
+      : requestedIds.length === 2
+        ? requestedIds
+        : DEFAULT_FOUNDATION_IDS;
+
+  const [leftId, rightId] = baseIds;
+  if (!leftId || !rightId) return DEFAULT_FOUNDATION_IDS;
+
+  if (leftId !== rightId) return [leftId, rightId];
+
+  if (leftId === DEFAULT_FOUNDATION_IDS[0]) return DEFAULT_FOUNDATION_IDS;
+  if (leftId === DEFAULT_FOUNDATION_IDS[1]) return [DEFAULT_FOUNDATION_IDS[1], DEFAULT_FOUNDATION_IDS[0]];
+  return [leftId, DEFAULT_FOUNDATION_IDS[0]];
+}
+
+function signalSummary(card: FoundationCardData) {
+  const signals = [];
+  if (card.boardRoleCount > 0) signals.push(`${card.boardRoleCount} governance roles`);
+  if (card.verifiedGrantCount > 0) signals.push(`${card.verifiedGrantCount} verified grants`);
+  if (card.yearMemoryCount > 0) signals.push(`${card.yearMemoryCount} year-memory rows`);
+  if (card.openProgramCount > 0) signals.push(`${card.openProgramCount} open programs`);
+  return signals;
+}
+
+function getPivotTargets(foundationId: string) {
+  return CORE_BENCHMARK_IDS
+    .filter((candidateId) => candidateId !== foundationId)
+    .map((candidateId) => ({
+      id: candidateId,
+      label: FOUNDATION_LABEL_MAP[candidateId] || 'Benchmark',
+    }));
+}
+
+function buildPairContext(cards: FoundationCardData[]): PairContext | null {
+  if (cards.length < 2) return null;
+
+  const inBenchmarkSet = cards.filter((card) => REVIEW_SET_IDS.includes(card.foundation.id)).length;
+  const governanceCount = cards.filter((card) => card.boardRoleCount > 0).length;
+  const grantCount = cards.filter((card) => card.verifiedGrantCount > 0).length;
+  const yearMemoryCount = cards.filter((card) => card.yearMemoryCount > 0).length;
+  const allNonGrantmaker = cards.every((card) => !isGrantmakerComparable(card.foundation.type));
+
+  if (allNonGrantmaker) {
+    return {
+      badge: 'Operator pair',
+      title: 'This pair is made up of operating institutions, not established grantmaker routes.',
+      detail:
+        `Use it carefully: the current types are ${cards.map((card) => formatFoundationType(card.foundation.type)).join(' and ')}, so this comparison is better for institutional profile reading than for philanthropic benchmark review.`,
+    };
+  }
+
+  if (inBenchmarkSet === 2) {
+    return {
+      badge: 'Benchmark pair',
+      title: 'This pair sits inside the live review benchmark set.',
+      detail:
+        'Use it to read real stability differences across proven public review routes, not just profile similarity.',
+    };
+  }
+
+  if (inBenchmarkSet === 1) {
+    return {
+      badge: 'Bridge pair',
+      title: 'This pair crosses a benchmark foundation with a non-benchmark candidate.',
+      detail:
+        'Use it to see what evidence is already present on the candidate side and what still separates it from the stable review set.',
+    };
+  }
+
+  if (governanceCount === 2 && grantCount === 0 && yearMemoryCount === 0) {
+    return {
+      badge: 'Governance-first pair',
+      title: 'This pair is currently legible at the governance layer, but thin everywhere else.',
+      detail:
+        'It is useful for shortlist or prospect comparison, but not yet for stable philanthropic review because neither side has a verified grant layer or recurring year-memory.',
+    };
+  }
+
+  return {
+    badge: 'Candidate pair',
+    title: 'This pair is outside the benchmark set and should be treated as exploratory.',
+    detail:
+      'Use it to spot the next data lifts: verified grants, recurring year-memory, and source-backed program memory.',
+  };
+}
+
+function buildSharedPairGaps(cards: FoundationCardData[]) {
+  if (cards.length < 2) return [] as string[];
+
+  const sharedChecks = [
+    {
+      label: 'Verified grant layer',
+      missing: cards.every((card) => card.verifiedGrantCount === 0),
+    },
+    {
+      label: 'Recurring year memory',
+      missing: cards.every((card) => card.yearMemoryCount === 0),
+    },
+    {
+      label: 'Verified source-backed memory',
+      missing: cards.every((card) => card.reportBackedYearMemoryCount === 0),
+    },
+  ];
+
+  return sharedChecks.filter((check) => check.missing).map((check) => check.label);
+}
+
+function buildBacklogHref(cards: FoundationCardData[]) {
+  if (cards.length < 2) return '/foundations/backlog';
+
+  const buildParams = (queue?: string) => {
+    const params = new URLSearchParams({
+      left: cards[0].foundation.id,
+      right: cards[1].foundation.id,
+    });
+    if (queue) params.set('queue', queue);
+    return params.toString();
+  };
+  const withPair = (queue?: string, hash?: string) =>
+    `/foundations/backlog?${buildParams(queue)}${hash ? `#${hash}` : ''}`;
+
+  if (isOperatorPair(cards)) return withPair('operator-exclusions', 'operator-exclusions');
+  if (cards.every((card) => card.verifiedGrantCount === 0)) {
+    return withPair('missing-verified-grants', 'missing-verified-grants');
+  }
+  if (cards.every((card) => card.yearMemoryCount === 0)) {
+    return withPair('missing-year-memory', 'missing-year-memory');
+  }
+  if (cards.every((card) => card.reportBackedYearMemoryCount === 0)) {
+    return withPair('missing-source-backed-memory', 'missing-source-backed-memory');
+  }
+
+  return withPair();
+}
+
+function buildBacklogLane(cards: FoundationCardData[]): PairBacklogLane {
+  const href = buildBacklogHref(cards);
+
+  if (href.endsWith('#operator-exclusions')) {
+    return {
+      label: 'Operator exclusions',
+      detail:
+        'This pair is being sent to the exclusion queue because both sides currently read as non-grantmaker institutions. Treat it as institutional context unless a real philanthropic layer emerges.',
+      href,
+    };
+  }
+
+  if (href.endsWith('#missing-verified-grants')) {
+    return {
+      label: 'Missing verified grants',
+      detail:
+        'This pair shares a missing grant layer, so the next useful batch queue is verified grants rather than more compare-page interpretation.',
+      href,
+    };
+  }
+
+  if (href.endsWith('#missing-year-memory')) {
+    return {
+      label: 'Missing year memory',
+      detail:
+        'This pair needs recurring program-year memory on both sides before it becomes a stronger operating comparison.',
+      href,
+    };
+  }
+
+  if (href.endsWith('#missing-source-backed-memory')) {
+    return {
+      label: 'Missing source-backed memory',
+      detail:
+        'This pair already has some year memory, but it still needs official source-backed provenance before the review can harden.',
+      href,
+    };
+  }
+
+  return {
+    label: 'General backlog',
+    detail:
+      'This pair does not collapse neatly into one missing layer, so the full backlog is the right next surface.',
+    href,
+  };
+}
+
+function buildBacklogReturnHref(params: SearchParams) {
+  if (
+    params.from !== 'backlog' ||
+    !params.backlog_left ||
+    !params.backlog_right ||
+    !params.backlog_queue
+  ) {
+    return null;
+  }
+
+  const search = new URLSearchParams({
+    left: params.backlog_left,
+    right: params.backlog_right,
+    queue: params.backlog_queue,
+  });
+
+  return `/foundations/backlog?${search.toString()}#${params.backlog_queue}`;
+}
+
+function getGapHref(card: FoundationCardData, gap: 'grants' | 'year-memory' | 'source-backed') {
+  if (gap === 'grants') {
+    if (card.foundation.id === DEFAULT_FOUNDATION_IDS[1]) return '/foundations/prf#how-prf-funds';
+    if (card.foundation.id === DEFAULT_FOUNDATION_IDS[0]) return '/snow-foundation#year-memory';
+    return `${getDemoHref(card.foundation.id)}#matching-grants`;
+  }
+
+  if (card.foundation.id === DEFAULT_FOUNDATION_IDS[1]) return '/foundations/prf#program-year-memory';
+  if (card.foundation.id === DEFAULT_FOUNDATION_IDS[0]) return '/snow-foundation#year-memory';
+  return `${getDemoHref(card.foundation.id)}#program-history`;
+}
+
+function buildSharedPairExecutionLanes(cards: FoundationCardData[]): PairExecutionLane[] {
+  if (cards.length < 2) return [];
+
+  if (cards.every((card) => !isGrantmakerComparable(card.foundation.type))) {
+    return [
+      {
+        label: 'Validate grantmaker fit before further review',
+        detail:
+          'Open both profiles first and confirm these organizations should be treated as philanthropic funders at all. If not, keep them out of the benchmark review lane and use this compare view only for institutional context.',
+        links: cards.map((card) => ({
+          label: FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name,
+          href: getDemoHref(card.foundation.id),
+        })),
+      },
+    ];
+  }
+
+  const lanes: PairExecutionLane[] = [];
+
+  if (cards.every((card) => card.verifiedGrantCount === 0)) {
+    lanes.push({
+      label: 'Build the verified grant layer on both sides',
+      detail:
+        'Open each foundation on its grant surface and backfill real grantee or grant-relationship evidence before treating this pair as more than governance-only.',
+      links: cards.map((card) => ({
+        label: FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name,
+        href: getGapHref(card, 'grants'),
+      })),
+    });
+  }
+
+  if (cards.every((card) => card.yearMemoryCount === 0)) {
+    lanes.push({
+      label: 'Seed recurring year memory on both sides',
+      detail:
+        'Open each foundation on program history and create year-memory rows so recurring strands can be compared as operating memory instead of profile text.',
+      links: cards.map((card) => ({
+        label: FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name,
+        href: getGapHref(card, 'year-memory'),
+      })),
+    });
+  }
+
+  if (cards.every((card) => card.reportBackedYearMemoryCount === 0)) {
+    lanes.push({
+      label: 'Promote both sides to verified source-backed memory',
+      detail:
+        'Once year-memory exists, replace inferred or absent rows with official source-backed program memory so the pair can move toward stable review.',
+      links: cards.map((card) => ({
+        label: FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name,
+        href: getGapHref(card, 'source-backed'),
+      })),
+    });
+  }
+
+  return lanes;
+}
+
+function buildComparisonHighlights(cards: FoundationCardData[]): ComparisonHighlight[] {
+  if (cards.length < 2) return [];
+
+  const [left, right] = cards;
+  const leftGiving = left.foundation.total_giving_annual || 0;
+  const rightGiving = right.foundation.total_giving_annual || 0;
+  const givingLeader = leftGiving >= rightGiving ? left : right;
+  const givingFollower = givingLeader.foundation.id === left.foundation.id ? right : left;
+  const givingRatio = formatRatio(
+    Math.max(leftGiving, rightGiving),
+    Math.min(leftGiving, rightGiving),
+  );
+
+  const governanceLeader = left.boardRoleCount >= right.boardRoleCount ? left : right;
+  const governanceFollower = governanceLeader.foundation.id === left.foundation.id ? right : left;
+
+  const yearMemoryLeader = left.yearMemoryCount >= right.yearMemoryCount ? left : right;
+  const yearMemoryFollower = yearMemoryLeader.foundation.id === left.foundation.id ? right : left;
+
+  const verifiedLeader = left.verifiedGrantCount >= right.verifiedGrantCount ? left : right;
+  const verifiedFollower = verifiedLeader.foundation.id === left.foundation.id ? right : left;
+  const typeMismatch = left.foundation.type !== right.foundation.type;
+
+  const highlights: ComparisonHighlight[] = [
+    {
+      label: 'Annual giving gap',
+      value:
+        leftGiving === rightGiving
+          ? 'Parity'
+          : `${FOUNDATION_LABEL_MAP[givingLeader.foundation.id] || givingLeader.foundation.name} leads`,
+      detail:
+        leftGiving === rightGiving
+          ? `Both foundations currently surface ${formatMoney(leftGiving)} in annual giving.`
+          : `${formatMoney(givingLeader.foundation.total_giving_annual)} vs ${formatMoney(givingFollower.foundation.total_giving_annual)}${givingRatio ? ` · ${givingRatio}` : ''}.`,
+    },
+    {
+      label: 'Governance visibility',
+      value:
+        left.boardRoleCount === right.boardRoleCount
+          ? 'Parity'
+          : `${FOUNDATION_LABEL_MAP[governanceLeader.foundation.id] || governanceLeader.foundation.name} leads`,
+      detail:
+        left.boardRoleCount === right.boardRoleCount
+          ? `Both sides currently expose ${left.boardRoleCount} governance roles.`
+          : `${governanceLeader.boardRoleCount} roles vs ${governanceFollower.boardRoleCount}.`,
+    },
+    {
+      label: 'Recurring year memory',
+      value:
+        left.yearMemoryCount === right.yearMemoryCount
+          ? 'Parity'
+          : `${FOUNDATION_LABEL_MAP[yearMemoryLeader.foundation.id] || yearMemoryLeader.foundation.name} leads`,
+      detail:
+        left.yearMemoryCount === right.yearMemoryCount
+          ? `Both sides currently surface ${left.yearMemoryCount} year-memory rows.`
+          : `${yearMemoryLeader.yearMemoryCount} rows vs ${yearMemoryFollower.yearMemoryCount}.`,
+    },
+    {
+      label: 'Verified grant layer',
+      value:
+        left.verifiedGrantCount === right.verifiedGrantCount
+          ? 'Parity'
+          : `${FOUNDATION_LABEL_MAP[verifiedLeader.foundation.id] || verifiedLeader.foundation.name} leads`,
+      detail:
+        left.verifiedGrantCount === right.verifiedGrantCount
+          ? `Both sides currently surface ${left.verifiedGrantCount} verified grant rows.`
+          : `${verifiedLeader.verifiedGrantCount} verified grants vs ${verifiedFollower.verifiedGrantCount}.`,
+    },
+  ];
+
+  if (typeMismatch) {
+    highlights.unshift({
+      label: 'Institution type',
+      value: 'Type mismatch',
+      detail: `${left.foundation.name} is ${formatFoundationType(left.foundation.type)} while ${right.foundation.name} is ${formatFoundationType(right.foundation.type)}.`,
+    });
+  }
+
+  return highlights;
+}
+
+function sourceLabel(value: string | null | undefined) {
+  if (!value) return 'Unknown source';
+  return value.replace(/_/g, ' ');
+}
+
+function deriveReviewReadiness(card: FoundationCardData): FoundationCardData['reviewReadiness'] {
+  if (
+    card.boardRoleCount > 0 &&
+    card.yearMemoryCount > 0 &&
+    card.verifiedGrantCount > 0 &&
+    card.reportBackedYearMemoryCount > 0
+  ) {
+    return 'stable';
+  }
+
+  if (card.boardRoleCount > 0 && card.yearMemoryCount > 0) {
+    return 'developing';
+  }
+
+  return 'early';
+}
+
+function readinessLabel(value: FoundationCardData['reviewReadiness']) {
+  if (value === 'stable') return 'Stable review';
+  if (value === 'developing') return 'Developing review';
+  return 'Early review';
+}
+
+function buildStabilityActions(card: FoundationCardData): StabilityAction[] {
+  const actions: StabilityAction[] = [];
+  const foundationRoute = getDemoHref(card.foundation.id);
+  const governanceHref = card.foundation.id === DEFAULT_FOUNDATION_IDS[0] ? '/snow-foundation#governance-graph' : foundationRoute;
+  const verifiedLayerHref = card.foundation.id === DEFAULT_FOUNDATION_IDS[0] ? '/snow-foundation#year-memory' : foundationRoute;
+
+  if (card.boardRoleCount === 0) {
+    actions.push({
+      label: 'Backfill governance roles',
+      detail: 'Add or reconcile board and leadership visibility so the foundation is legible at the people layer.',
+      href: governanceHref,
+    });
+  }
+
+  if (card.verifiedGrantCount === 0) {
+    actions.push({
+      label: 'Build the verified grant layer',
+      detail: 'Link report-backed grantees or relationship rows so the review is not relying only on program surfaces.',
+      href: card.foundation.id === DEFAULT_FOUNDATION_IDS[1] ? '/foundations/prf#how-prf-funds' : foundationRoute,
+    });
+  }
+
+  if (card.yearMemoryCount === 0) {
+    actions.push({
+      label: 'Seed recurring year memory',
+      detail: 'Create program-year rows so recurring strands can be reviewed across years instead of only as static profile text.',
+      href: foundationRoute,
+    });
+  }
+
+  if (card.inferredYearMemoryCount > 0 && card.reportBackedYearMemoryCount === 0) {
+    actions.push({
+      label: 'Convert inferred rows to verified source-backed rows',
+      detail: `Replace the current ${card.inferredYearMemoryCount} inferred year-memory rows with official source-backed program memory.`,
+      href: card.foundation.id === DEFAULT_FOUNDATION_IDS[1] ? '/foundations/prf#program-year-memory' : foundationRoute,
+    });
+  } else if (card.inferredYearMemoryCount > 0) {
+    actions.push({
+      label: 'Reduce inferred memory',
+      detail: `The foundation still has ${card.inferredYearMemoryCount} inferred year-memory rows that should be verified in a later pass.`,
+      href: foundationRoute,
+    });
+  }
+
+  if (actions.length === 0) {
+    actions.push({
+      label: 'Maintain the verified layer',
+      detail: 'This foundation is stable enough for review. The next job is upkeep rather than core backfill.',
+      href: verifiedLayerHref,
+    });
+  }
+
+  return actions;
+}
+
+function buildReviewProgress(card: FoundationCardData): ReviewProgress {
+  const checks = [
+    { ok: card.boardRoleCount > 0, label: 'governance visibility' },
+    { ok: card.verifiedGrantCount > 0, label: 'verified grant layer' },
+    { ok: card.yearMemoryCount > 0, label: 'year-memory rows' },
+    { ok: card.reportBackedYearMemoryCount > 0, label: 'verified source-backed memory' },
+  ];
+
+  return {
+    completed: checks.filter((check) => check.ok).length,
+    total: checks.length,
+    missing: checks.filter((check) => !check.ok).map((check) => check.label),
+  };
+}
+
+function isOperatorPair(cards: FoundationCardData[]) {
+  return cards.length >= 2 && cards.every((card) => !isGrantmakerComparable(card.foundation.type));
+}
+
+function buildInstitutionalContextChecklist(cards: FoundationCardData[]): PairChecklistItem[] {
+  return cards.flatMap((card) => {
+    const foundationLabel = FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name;
+
+    return [
+      {
+        label: `${foundationLabel}: institution type classified`,
+        done: Boolean(card.foundation.type),
+        href: getDemoHref(card.foundation.id),
+      },
+      {
+        label: `${foundationLabel}: governance visibility`,
+        done: card.boardRoleCount > 0,
+        href: getDemoHref(card.foundation.id),
+      },
+    ];
+  });
+}
+
+function buildPrimaryReviewAction(cards: FoundationCardData[]): PrimaryReviewAction | null {
+  if (cards.length === 0) return null;
+
+  if (isOperatorPair(cards)) {
+    return {
+      label: 'Validate institutional fit before benchmark review',
+      detail:
+        'Open the two institutional profiles first. This pair belongs in contextual comparison unless you can show a real grantmaker layer on both sides.',
+      href: cards[0] ? getDemoHref(cards[0].foundation.id) : undefined,
+    };
+  }
+
+  const priorityOrder: Array<FoundationCardData['reviewReadiness']> = ['early', 'developing'];
+  const target =
+    priorityOrder
+      .map((status) => cards.find((card) => card.reviewReadiness === status))
+      .find(Boolean) || null;
+
+  if (!target) {
+    return {
+      label: 'Review the strongest verified route',
+      detail: 'This pair is stable enough for review. Use the detailed route to audit the current evidence layer and keep it maintained.',
+      href: cards[0] ? getDemoHref(cards[0].foundation.id) : undefined,
+    };
+  }
+
+  const [firstAction] = buildStabilityActions(target);
+  if (!firstAction) return null;
+
+  return {
+    label: `${FOUNDATION_LABEL_MAP[target.foundation.id] || target.foundation.name}: ${firstAction.label}`,
+    detail: firstAction.detail,
+    href: firstAction.href,
+  };
+}
+
+function buildPairChecklist(cards: FoundationCardData[]): PairChecklistItem[] {
+  return cards.flatMap((card) => {
+    const foundationLabel = FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name;
+    const progress = buildReviewProgress(card);
+
+    const baseChecks: PairChecklistItem[] = [
+      {
+        label: `${foundationLabel}: governance visibility`,
+        done: card.boardRoleCount > 0,
+        href: card.boardRoleCount > 0 ? getDemoHref(card.foundation.id) : buildStabilityActions(card).find((action) => action.label === 'Backfill governance roles')?.href,
+      },
+      {
+        label: `${foundationLabel}: verified grant layer`,
+        done: card.verifiedGrantCount > 0,
+        href:
+          card.verifiedGrantCount > 0
+            ? getDemoHref(card.foundation.id)
+            : buildStabilityActions(card).find((action) => action.label === 'Build the verified grant layer')?.href,
+      },
+      {
+        label: `${foundationLabel}: verified source-backed memory`,
+        done: card.reportBackedYearMemoryCount > 0,
+        href:
+          card.reportBackedYearMemoryCount > 0
+            ? getDemoHref(card.foundation.id)
+            : buildStabilityActions(card).find((action) => action.label === 'Convert inferred rows to verified source-backed rows')?.href,
+      },
+    ];
+
+    if (progress.total === progress.completed && !baseChecks.some((check) => !check.done)) {
+      return baseChecks;
+    }
+
+    return baseChecks;
+  });
+}
+
+function buildReviewEstimate(cards: FoundationCardData[]): ReviewEstimate {
+  if (cards.length < 2) {
+    return {
+      status: 'not_yet',
+      label: 'Unclear pair',
+      detail: 'The compare surface needs two valid foundations before review stability can be assessed.',
+    };
+  }
+
+  if (isOperatorPair(cards)) {
+    return {
+      status: 'not_yet',
+      label: 'Outside benchmark review lane',
+      detail:
+        'This pair is made up of operating institutions rather than established grantmaker routes. Treat it as institutional context unless a true philanthropic funding layer is verified on both sides.',
+    };
+  }
+
+  const stableCount = cards.filter((card) => card.reviewReadiness === 'stable').length;
+  const developingCount = cards.filter((card) => card.reviewReadiness === 'developing').length;
+
+  if (stableCount === 2) {
+    return {
+      status: 'ready',
+      label: 'Ready for stable review now',
+      detail: 'Both sides have governance visibility, recurring year memory, and at least some verified source-backed evidence. This is good enough for serious review.',
+    };
+  }
+
+  if (stableCount === 1 && developingCount === 1) {
+    return {
+      status: 'close',
+      label: 'One more verification pass',
+      detail: 'This pair is close. One side is already stable, while the other still needs verified source-backed program memory or verified grant evidence to stop feeling inferred.',
+    };
+  }
+
+  if (developingCount === 2) {
+    return {
+      status: 'close',
+      label: '1 to 2 focused passes',
+      detail: 'Both sides are reviewable, but not fully stable. The next lift is converting inferred program memory into verified source-backed rows and filling the verified grant layer.',
+    };
+  }
+
+  return {
+    status: 'not_yet',
+    label: 'Needs more build before stable review',
+    detail: 'The current pair still lacks enough verified evidence depth. Governance and year memory exist in places, but the review would still lean too heavily on inferred data.',
+  };
+}
+
+const COMPARE_PRESETS: ComparePreset[] = [
+  { label: 'Snow vs PRF', left: DEFAULT_FOUNDATION_IDS[0], right: DEFAULT_FOUNDATION_IDS[1] },
+  { label: 'Snow vs Minderoo', left: DEFAULT_FOUNDATION_IDS[0], right: MINDEROO_FOUNDATION_ID },
+  { label: 'Snow vs Ian Potter', left: DEFAULT_FOUNDATION_IDS[0], right: IAN_POTTER_FOUNDATION_ID },
+  { label: 'Snow vs ECSTRA', left: DEFAULT_FOUNDATION_IDS[0], right: ECSTRA_FOUNDATION_ID },
+  { label: 'Snow vs Rio Tinto', left: DEFAULT_FOUNDATION_IDS[0], right: RIO_TINTO_FOUNDATION_ID },
+  { label: 'PRF vs Minderoo', left: DEFAULT_FOUNDATION_IDS[1], right: MINDEROO_FOUNDATION_ID },
+  { label: 'PRF vs Ian Potter', left: DEFAULT_FOUNDATION_IDS[1], right: IAN_POTTER_FOUNDATION_ID },
+  { label: 'PRF vs ECSTRA', left: DEFAULT_FOUNDATION_IDS[1], right: ECSTRA_FOUNDATION_ID },
+  { label: 'PRF vs Rio Tinto', left: DEFAULT_FOUNDATION_IDS[1], right: RIO_TINTO_FOUNDATION_ID },
+  { label: 'Minderoo vs Ian Potter', left: MINDEROO_FOUNDATION_ID, right: IAN_POTTER_FOUNDATION_ID },
+  { label: 'Minderoo vs ECSTRA', left: MINDEROO_FOUNDATION_ID, right: ECSTRA_FOUNDATION_ID },
+  { label: 'Minderoo vs Rio Tinto', left: MINDEROO_FOUNDATION_ID, right: RIO_TINTO_FOUNDATION_ID },
+  { label: 'Ian Potter vs Rio Tinto', left: IAN_POTTER_FOUNDATION_ID, right: RIO_TINTO_FOUNDATION_ID },
+  { label: 'Ian Potter vs ECSTRA', left: IAN_POTTER_FOUNDATION_ID, right: ECSTRA_FOUNDATION_ID },
+  { label: 'ECSTRA vs Rio Tinto', left: ECSTRA_FOUNDATION_ID, right: RIO_TINTO_FOUNDATION_ID },
+];
+
+async function getFoundationCardData(supabase: ReturnType<typeof getServiceSupabase>, foundation: FoundationRow): Promise<FoundationCardData> {
+  const [openPrograms, totalPrograms, boardRoles, foundationGranteeTableCount, { data: verifiedGrantRows }, yearMemory] = await Promise.all([
+    supabase
+      .from('foundation_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundation.id)
+      .eq('status', 'open'),
+    supabase
+      .from('foundation_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundation.id)
+      .in('status', ['open', 'closed', 'ongoing']),
+    (() => {
+      const query = supabase
+        .from('person_roles')
+        .select('person_name', { count: 'exact', head: true })
+        .is('cessation_date', null);
+      return foundation.acnc_abn
+        ? query.eq('company_abn', foundation.acnc_abn)
+        : query.eq('company_name', foundation.name);
+    })(),
+    supabase
+      .from('foundation_grantees')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundation.id),
+    supabase.rpc('exec_sql', {
+      query: `SELECT COUNT(*)::int AS count
+              FROM gs_relationships r
+              JOIN gs_entities s ON s.id = r.source_entity_id
+              WHERE s.abn = '${foundation.acnc_abn}'
+                AND r.relationship_type = 'grant'
+                AND r.dataset = 'foundation_grantees'`,
+    }),
+    supabase
+      .from('foundation_program_years')
+      .select('id, report_year, fiscal_year, summary, reported_amount, source_report_url, partners, places, metadata, foundation_programs(name, program_type)', { count: 'exact' })
+      .eq('foundation_id', foundation.id)
+      .order('report_year', { ascending: false, nullsFirst: false }),
+  ]);
+
+  const allProgramYears = (yearMemory.data || []) as ProgramYearRow[];
+  const latestProgramYears = allProgramYears.slice(0, 4);
+  const inferredYearMemoryCount = allProgramYears.filter((row) => {
+    const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+    return source?.includes('inferred');
+  }).length;
+  const reportBackedYearMemoryCount = allProgramYears.filter((row) => {
+    const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+    return !!source && !source.includes('inferred');
+  }).length;
+  const relationshipGrantCount = Number(((verifiedGrantRows as CountRow[] | null)?.[0]?.count) || 0);
+  const verifiedGrantCount = Math.max(foundationGranteeTableCount.count || 0, relationshipGrantCount);
+
+  const draftCard: FoundationCardData = {
+    foundation,
+    openProgramCount: openPrograms.count || 0,
+    totalProgramCount: totalPrograms.count || 0,
+    boardRoleCount: boardRoles.count || 0,
+    verifiedGrantCount,
+    yearMemoryCount: yearMemory.count || 0,
+    latestProgramYears,
+    inferredYearMemoryCount,
+    reportBackedYearMemoryCount,
+    reviewReadiness: 'early',
+  };
+
+  return {
+    ...draftCard,
+    reviewReadiness: deriveReviewReadiness(draftCard),
+  };
+}
+
+export default async function FoundationComparePage({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const params = await searchParams;
+  const pairedIds = [params.left, params.right].map(value => value?.trim()).filter(Boolean) as string[];
+  const backlogPairIds = [params.backlog_left, params.backlog_right].map(value => value?.trim()).filter(Boolean) as string[];
+  const requestedIds = (params.ids || '')
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean)
+    .slice(0, 2);
+  const foundationIds = resolveFoundationIds(pairedIds, requestedIds);
+  const backlogReturnHref = buildBacklogReturnHref(params);
+  const backlogQueueLabel = params.backlog_queue ? BACKLOG_QUEUE_LABELS[params.backlog_queue] || 'Backlog slice' : 'Backlog slice';
+  const sourcePairHref =
+    backlogPairIds.length === 2 ? buildCompareHref(backlogPairIds[0], backlogPairIds[1]) : null;
+
+  const supabase = getServiceSupabase();
+  const [{ data: foundations }, { data: foundationOptions }, { data: backlogFoundations }] = await Promise.all([
+    supabase
+      .from('foundations')
+      .select('id, name, acnc_abn, type, description, website, total_giving_annual, thematic_focus, geographic_focus, profile_confidence, giving_philosophy')
+      .in('id', foundationIds),
+    supabase
+      .from('foundations')
+      .select('id, name, type, total_giving_annual')
+      .order('total_giving_annual', { ascending: false, nullsFirst: false })
+      .limit(150),
+    backlogPairIds.length === 2
+      ? supabase
+          .from('foundations')
+          .select('id, name')
+          .in('id', backlogPairIds)
+      : Promise.resolve({ data: [] }),
+  ]);
+
+  const orderedFoundations = foundationIds
+    .map(id => (foundations || []).find(row => row.id === id))
+    .filter(Boolean) as FoundationRow[];
+
+  const cards = await Promise.all(
+    orderedFoundations.map(foundation => getFoundationCardData(supabase, foundation)),
+  );
+  const compareOptions = (foundationOptions || []) as FoundationOption[];
+  const backlogPairNames = backlogPairIds
+    .map((id) => (backlogFoundations || []).find((row: { id: string; name: string }) => row.id === id)?.name)
+    .filter(Boolean) as string[];
+  const [leftFoundationId, rightFoundationId] = foundationIds;
+  const duplicateSelectionRequested =
+    pairedIds.length === 2 && pairedIds[0] === pairedIds[1];
+  const highlights = buildComparisonHighlights(cards);
+  const reviewEstimate = buildReviewEstimate(cards);
+  const primaryReviewAction = buildPrimaryReviewAction(cards);
+  const reviewProgress = cards.map((card) => ({
+    foundationId: card.foundation.id,
+    label: FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name,
+    progress: buildReviewProgress(card),
+  }));
+  const operatorPair = isOperatorPair(cards);
+  const pairChecklist = buildPairChecklist(cards);
+  const institutionalContextChecklist = buildInstitutionalContextChecklist(cards);
+  const pairContext = buildPairContext(cards);
+  const sharedPairGaps = buildSharedPairGaps(cards);
+  const sharedPairExecutionLanes = buildSharedPairExecutionLanes(cards);
+  const typeAlignedAlternatives = buildTypeAlignedAlternatives(cards, compareOptions);
+  const backlogHref = buildBacklogHref(cards);
+  const backlogLane = buildBacklogLane(cards);
+  const totalCompletedSignals = reviewProgress.reduce((sum, item) => sum + item.progress.completed, 0);
+  const totalSignals = reviewProgress.reduce((sum, item) => sum + item.progress.total, 0);
+  const remainingSignals = totalSignals - totalCompletedSignals;
+
+  return (
+    <div className="pb-16">
+      <section className="border-b-4 border-bauhaus-black pb-10">
+        <div className="text-xs font-black uppercase tracking-[0.35em] text-bauhaus-red">Public compare route</div>
+        <h1 className="mt-4 text-4xl font-black leading-[0.9] text-bauhaus-black sm:text-6xl">
+          Foundation
+          <br />
+          Compare
+        </h1>
+        <p className="mt-5 max-w-4xl text-lg font-medium leading-relaxed text-bauhaus-muted">
+          Compare two foundations across capital scale, governance visibility, open program surface,
+          and recurring year-memory. Snow and Paul Ramsay are the default pair because they show the
+          current best verified case and the first non-Snow replication case side by side.
+        </p>
+        {backlogReturnHref ? (
+          <div className="mt-5 border-l-4 border-bauhaus-blue bg-link-light/40 px-4 py-3">
+            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-blue">
+              Opened from backlog
+            </div>
+            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+              {backlogPairNames.length === 2
+                ? `${backlogPairNames[0]} vs ${backlogPairNames[1]} sent you here from ${backlogQueueLabel}.`
+                : `This compare view was opened from ${backlogQueueLabel}.`}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              <a
+                href={backlogReturnHref}
+                className="border-2 border-bauhaus-blue/25 bg-white px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Return to backlog
+              </a>
+              {sourcePairHref ? (
+                <a
+                  href={sourcePairHref}
+                  className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                >
+                  Open source pair
+                </a>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+        <div className="mt-6 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.25em]">
+          <span className="border-2 border-bauhaus-black px-3 py-2 text-bauhaus-black">Default: Snow vs PRF</span>
+          <span className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-bauhaus-blue">Reusable compare surface</span>
+          <span className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red">Side-by-side operator view</span>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+          <Link
+            href={buildCompareHref(DEFAULT_FOUNDATION_IDS[0], DEFAULT_FOUNDATION_IDS[1])}
+            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+          >
+            Reset to Snow vs PRF
+          </Link>
+          <Link
+            href="/foundations/review-set"
+            className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open review set
+          </Link>
+          <a
+            href={backlogHref}
+            className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open relevant backlog slice
+          </a>
+          <Link
+            href={buildCompareHref(rightFoundationId, leftFoundationId)}
+            className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Swap sides
+          </Link>
+          <Link
+            href="/foundations"
+            className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Browse directory
+          </Link>
+        </div>
+      </section>
+
+      <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Choose foundations</div>
+        {duplicateSelectionRequested ? (
+          <div className="mt-4 border-l-4 border-bauhaus-red bg-bauhaus-red/5 px-4 py-3 text-sm font-bold text-bauhaus-black">
+            Duplicate selection detected. The compare view reset the right side so you still land on two different foundations.
+          </div>
+        ) : null}
+        <div className="mt-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Benchmark pairs</div>
+          <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+            {COMPARE_PRESETS.map((preset) => (
+              <Link
+                key={preset.label}
+                href={buildCompareHref(preset.left, preset.right)}
+                className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+              >
+                {preset.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <form method="get" className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[1fr_1fr_auto]">
+          <label className="block">
+            <div className="mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Left side</div>
+            <select
+              name="left"
+              defaultValue={leftFoundationId}
+              className="w-full border-4 border-bauhaus-black bg-white px-4 py-3 text-sm font-black text-bauhaus-black focus:bg-bauhaus-yellow focus:outline-none"
+            >
+              {compareOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name} · {formatMoney(option.total_giving_annual)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <div className="mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Right side</div>
+            <select
+              name="right"
+              defaultValue={rightFoundationId}
+              className="w-full border-4 border-bauhaus-black bg-white px-4 py-3 text-sm font-black text-bauhaus-black focus:bg-bauhaus-yellow focus:outline-none"
+            >
+              {compareOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name} · {formatMoney(option.total_giving_annual)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex items-end">
+            <button
+              type="submit"
+              className="w-full border-4 border-bauhaus-black bg-bauhaus-red px-5 py-3 text-xs font-black uppercase tracking-[0.22em] text-white transition-colors hover:bg-bauhaus-black xl:w-auto"
+            >
+              Compare now
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {pairContext ? (
+        <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Current pair</div>
+              <div className="mt-2 text-2xl font-black text-bauhaus-black">{pairContext.badge}</div>
+              <p className="mt-3 max-w-4xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                <span className="font-black text-bauhaus-black">{pairContext.title}</span>{' '}
+                {pairContext.detail}
+              </p>
+              {sharedPairGaps.length > 0 ? (
+                <div className="mt-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Shared gaps in this pair</div>
+                  <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                    {sharedPairGaps.map((gap) => (
+                      <span
+                        key={gap}
+                        className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red"
+                      >
+                        {gap}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {sharedPairExecutionLanes.length > 0 ? (
+                <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Pair execution lane</div>
+                  <div className="mt-3 space-y-3">
+                    {sharedPairExecutionLanes.map((lane) => (
+                      <div key={lane.label} className="border-l-4 border-bauhaus-red pl-3">
+                        <div className="text-xs font-black uppercase tracking-[0.16em] text-bauhaus-black">{lane.label}</div>
+                        <p className="mt-1 text-sm font-medium leading-relaxed text-bauhaus-muted">{lane.detail}</p>
+                        <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                          {lane.links.map((link) => (
+                            <Link
+                              key={`${lane.label}-${link.label}`}
+                              href={link.href}
+                              className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                            >
+                              Open {link.label}
+                            </Link>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Backlog lane</div>
+                <div className="mt-2 text-sm font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                  {backlogLane.label}
+                </div>
+                <p className="mt-2 max-w-4xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                  {backlogLane.detail}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                  <a
+                    href={backlogLane.href}
+                    className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                  >
+                    Open {backlogLane.label}
+                  </a>
+                </div>
+              </div>
+              {operatorPair && typeAlignedAlternatives.length > 0 ? (
+                <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Better-fit compare next</div>
+                  <div className="mt-3 space-y-3">
+                    {typeAlignedAlternatives.map((alternative) => (
+                      <div key={`${alternative.foundationId}-${alternative.candidateId}`} className="border-l-4 border-bauhaus-blue pl-3">
+                        <div className="text-xs font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                          {alternative.foundationLabel} → {formatFoundationType(alternative.candidateType)}
+                        </div>
+                        <p className="mt-1 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                          Compare {alternative.foundationLabel} with {alternative.candidateLabel} instead if you want a more type-aligned read.
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                          <Link
+                            href={buildCompareHref(alternative.foundationId, alternative.candidateId)}
+                            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                          >
+                            Open {alternative.foundationLabel} vs {alternative.candidateLabel}
+                          </Link>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              {cards.map((card) => (
+                <Link
+                  key={`${card.foundation.id}-pair-route`}
+                  href={getDemoHref(card.foundation.id)}
+                  className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                >
+                  Open {FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name}
+                </Link>
+              ))}
+              <Link
+                href="/foundations/review-set"
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Open benchmark set
+              </Link>
+              <Link
+                href={buildCompareHref(DEFAULT_FOUNDATION_IDS[0], DEFAULT_FOUNDATION_IDS[1])}
+                className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+              >
+                Open strongest benchmark pair
+              </Link>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {highlights.length > 0 ? (
+        <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">At a glance</div>
+          <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {highlights.map((highlight) => (
+              <div key={highlight.label} className="border-2 border-bauhaus-black bg-bauhaus-canvas p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  {highlight.label}
+                </div>
+                <div className="mt-2 text-lg font-black text-bauhaus-black">{highlight.value}</div>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">{highlight.detail}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Review stability</div>
+        <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[0.9fr_1.1fr]">
+          <div className="border-2 border-bauhaus-black bg-bauhaus-canvas p-4">
+            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Current estimate</div>
+            <div className="mt-2 text-2xl font-black text-bauhaus-black">{reviewEstimate.label}</div>
+            <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">{reviewEstimate.detail}</p>
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Progress to stable review</div>
+                {operatorPair ? (
+                  <>
+                    <div className="mt-2 text-lg font-black text-bauhaus-black">Not applicable to benchmark review</div>
+                    <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                      This pair sits outside the philanthropic benchmark lane, so stable-review signal math would be misleading here.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <div className="mt-2 text-lg font-black text-bauhaus-black">
+                      {totalCompletedSignals}/{totalSignals} signals complete
+                    </div>
+                    <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                      {remainingSignals === 0
+                        ? 'No major stability gaps remain for this pair.'
+                        : `${remainingSignals} stability signal${remainingSignals === 1 ? '' : 's'} still missing across the pair.`}
+                    </p>
+                    <div className="mt-3 h-3 w-full overflow-hidden border-2 border-bauhaus-black bg-white">
+                      <div
+                        className="h-full bg-bauhaus-red transition-all"
+                        style={{ width: `${(totalCompletedSignals / totalSignals) * 100}%` }}
+                      />
+                    </div>
+                  </>
+                )}
+            </div>
+            {(operatorPair ? institutionalContextChecklist.length > 0 : pairChecklist.length > 0) ? (
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  {operatorPair ? 'Institutional context checks' : 'Pair checklist'}
+                </div>
+                <div className="mt-3 space-y-2">
+                  {(operatorPair ? institutionalContextChecklist : pairChecklist).map((item) => (
+                    <div key={item.label} className="flex items-start gap-3 text-sm font-medium text-bauhaus-muted">
+                      <span
+                        className={`mt-0.5 inline-flex h-5 w-5 items-center justify-center border-2 text-[10px] font-black ${
+                          item.done
+                            ? 'border-money bg-money-light text-money'
+                            : 'border-bauhaus-red bg-bauhaus-red/5 text-bauhaus-red'
+                        }`}
+                      >
+                        {item.done ? '✓' : '•'}
+                      </span>
+                      {item.href ? (
+                        <Link href={item.href} className="underline decoration-bauhaus-red underline-offset-4 hover:text-bauhaus-blue">
+                          {item.label}
+                        </Link>
+                      ) : (
+                        <span>{item.label}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            {primaryReviewAction ? (
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Recommended next move</div>
+                <div className="mt-2 text-sm font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                  {primaryReviewAction.label}
+                </div>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">{primaryReviewAction.detail}</p>
+                {primaryReviewAction.href ? (
+                  <Link
+                    href={primaryReviewAction.href}
+                    className="mt-3 inline-flex items-center border-2 border-bauhaus-red bg-bauhaus-red px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-white transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black"
+                  >
+                    Open next step
+                  </Link>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {cards.map((card) => (
+              <div key={`${card.foundation.id}-readiness`} className="border-2 border-bauhaus-black bg-white p-4">
+                {(() => {
+                  const benchmarkFit = buildBenchmarkFit(card);
+                  return (
+                    <div className="mb-4 border-b-2 border-bauhaus-black/10 pb-4">
+                      <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                        Benchmark fit
+                      </div>
+                      <div className="mt-2 text-sm font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                        {benchmarkFit.label}
+                      </div>
+                      <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                        {benchmarkFit.detail}
+                      </p>
+                    </div>
+                  );
+                })()}
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  {FOUNDATION_LABEL_MAP[card.foundation.id] || card.foundation.name}
+                </div>
+                <div className="mt-2 text-lg font-black text-bauhaus-black">
+                  {readinessLabel(card.reviewReadiness)}
+                </div>
+                <div className="mt-3 space-y-2 text-sm font-medium text-bauhaus-muted">
+                  <p>Governance roles: {card.boardRoleCount}</p>
+                  <p>Verified grants: {card.verifiedGrantCount}</p>
+                  <p>Year memory rows: {card.yearMemoryCount}</p>
+                  <p>Verified source-backed rows: {card.reportBackedYearMemoryCount}</p>
+                  <p>Inferred rows: {card.inferredYearMemoryCount}</p>
+                </div>
+                {(() => {
+                  const progress = buildReviewProgress(card);
+                  const nonGrantmaker = !isGrantmakerComparable(card.foundation.type);
+                  return (
+                    <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                      <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                        {nonGrantmaker ? 'Institutional context' : 'Completion'}
+                      </div>
+                      {nonGrantmaker ? (
+                        <>
+                          <div className="mt-2 text-lg font-black text-bauhaus-black">Benchmark review not applicable</div>
+                          <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                            This foundation is currently typed as {formatFoundationType(card.foundation.type)}, so the benchmark completion score is not the right readout.
+                          </p>
+                        </>
+                      ) : (
+                        <>
+                          <div className="mt-2 text-lg font-black text-bauhaus-black">
+                            {progress.completed}/{progress.total} stable signals
+                          </div>
+                          {progress.missing.length > 0 ? (
+                            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                              Missing: {progress.missing.join(', ')}.
+                            </p>
+                          ) : (
+                            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                              No major review-stability gaps remain.
+                            </p>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  );
+                })()}
+                <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">What to do next</div>
+                  <div className="mt-3 space-y-3">
+                    {buildStabilityActions(card).map((action) => (
+                      <div key={action.label} className="border-l-4 border-bauhaus-red pl-3">
+                        {action.href ? (
+                          <Link
+                            href={action.href}
+                            className="text-xs font-black uppercase tracking-[0.16em] text-bauhaus-black underline decoration-bauhaus-red underline-offset-4 transition-colors hover:text-bauhaus-blue"
+                          >
+                            {action.label}
+                          </Link>
+                        ) : (
+                          <div className="text-xs font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                            {action.label}
+                          </div>
+                        )}
+                        <p className="mt-1 text-sm font-medium leading-relaxed text-bauhaus-muted">{action.detail}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-6 xl:grid-cols-2">
+        {cards.map((card) => {
+          const foundation = card.foundation;
+          const signals = signalSummary(card);
+          const pivotTargets = getPivotTargets(foundation.id);
+
+          return (
+            <div key={foundation.id} className="border-4 border-bauhaus-black bg-white">
+              <div className="border-b-4 border-bauhaus-black bg-bauhaus-yellow px-6 py-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <div className="text-[10px] font-black uppercase tracking-[0.25em] text-bauhaus-black">
+                      {foundation.profile_confidence} confidence
+                    </div>
+                    <h2 className="mt-2 text-2xl font-black text-bauhaus-black">{foundation.name}</h2>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                      <span className="border-2 border-bauhaus-black/20 bg-white px-2.5 py-1 text-bauhaus-black">
+                        {formatFoundationType(foundation.type)}
+                      </span>
+                      <span className="border-2 border-bauhaus-black/20 bg-white px-2.5 py-1 text-bauhaus-muted">
+                        ABN {foundation.acnc_abn || '—'}
+                      </span>
+                    </div>
+                  </div>
+                  <Link
+                    href={getDemoHref(foundation.id)}
+                    className="border-2 border-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors"
+                  >
+                    Open route
+                  </Link>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-0 border-b-4 border-bauhaus-black md:grid-cols-4">
+                <div className="border-r-2 border-bauhaus-black p-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Annual giving</div>
+                  <div className="mt-2 text-2xl font-black text-bauhaus-black">{formatMoney(foundation.total_giving_annual)}</div>
+                </div>
+                <div className="border-r-2 border-bauhaus-black p-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Open programs</div>
+                  <div className="mt-2 text-2xl font-black text-bauhaus-black">{card.openProgramCount}</div>
+                </div>
+                <div className="border-r-2 border-bauhaus-black p-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Governance</div>
+                  <div className="mt-2 text-2xl font-black text-bauhaus-black">{card.boardRoleCount}</div>
+                </div>
+                <div className="p-4">
+                  <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Year memory</div>
+                  <div className="mt-2 text-2xl font-black text-bauhaus-black">{card.yearMemoryCount}</div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-6 p-6 xl:grid-cols-[0.95fr_1.05fr]">
+                <div>
+                  <div className="text-xs font-black uppercase tracking-[0.22em] text-bauhaus-red">Readiness signals</div>
+                  <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                    {signals.map(signal => (
+                      <span key={signal} className="border-2 border-bauhaus-black px-2 py-1 text-bauhaus-black">
+                        {signal}
+                      </span>
+                    ))}
+                    {signals.length === 0 ? (
+                      <span className="border-2 border-bauhaus-black/20 px-2 py-1 text-bauhaus-muted">No strong signals yet</span>
+                    ) : null}
+                  </div>
+                  {foundation.description ? (
+                    <p className="mt-4 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                      {foundation.description}
+                    </p>
+                  ) : null}
+                  {foundation.giving_philosophy ? (
+                    <div className="mt-4 border-l-4 border-bauhaus-red pl-3 text-sm font-bold leading-relaxed text-bauhaus-black">
+                      {foundation.giving_philosophy}
+                    </div>
+                  ) : null}
+                  <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                    {(foundation.thematic_focus || []).slice(0, 4).map((focus) => (
+                      <span key={focus} className="border-2 border-bauhaus-black/20 px-2 py-1 text-bauhaus-muted">
+                        {focus}
+                      </span>
+                    ))}
+                    {(foundation.geographic_focus || []).slice(0, 3).map((focus) => (
+                      <span key={focus} className="border-2 border-bauhaus-blue/20 px-2 py-1 text-bauhaus-blue">
+                        {focus}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="mt-4">
+                    <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                      Pivot compare
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                      {pivotTargets.map((target) => (
+                        <Link
+                          key={target.id}
+                          href={buildCompareHref(foundation.id, target.id)}
+                          className="border-2 border-bauhaus-blue/25 bg-link-light px-2 py-1 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                        >
+                          vs {target.label}
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="border-2 border-bauhaus-black bg-bauhaus-canvas p-4">
+                  <div className="text-xs font-black uppercase tracking-[0.22em] text-bauhaus-muted">Latest program year memory</div>
+                  <div className="mt-4 space-y-3">
+                    {card.latestProgramYears.map((row) => {
+                      const program = getProgramYearFoundationProgram(row);
+                      const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+                      const partnerLabel = (row.partners || []).map((partner) => partner.name).filter(Boolean).join(', ');
+                      const placeLabel = (row.places || []).map((place) => place.name).filter(Boolean).join(', ');
+
+                      return (
+                        <div key={row.id} className="border-b-2 border-bauhaus-black/10 pb-3 last:border-b-0 last:pb-0">
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                                {row.fiscal_year || row.report_year || 'Program year'}
+                              </div>
+                              <h3 className="mt-1 text-base font-black text-bauhaus-black">
+                                {program?.name || 'Unnamed program'}
+                              </h3>
+                            </div>
+                            <span className="border-2 border-bauhaus-black/20 bg-white px-2 py-1 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                              {labelise(program?.program_type || 'program')}
+                            </span>
+                          </div>
+                          {row.summary ? (
+                            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">{row.summary}</p>
+                          ) : null}
+                          <div className="mt-2 space-y-1 text-xs font-bold text-bauhaus-muted">
+                            {partnerLabel ? <p>Partners: {partnerLabel}</p> : null}
+                            {placeLabel ? <p>Places: {placeLabel}</p> : null}
+                            {source ? <p>Source: {sourceLabel(source)}</p> : null}
+                            {row.source_report_url ? (
+                              <p>
+                                Evidence:{' '}
+                                <a
+                                  href={row.source_report_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-bauhaus-red underline decoration-bauhaus-red underline-offset-4"
+                                >
+                                  open source
+                                </a>
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
+                      );
+                    })}
+                    {card.latestProgramYears.length === 0 ? (
+                      <div className="text-sm font-medium text-bauhaus-muted">No year-memory rows available yet.</div>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </section>
+
+      <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">How to use this</div>
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <div className="text-sm font-black text-bauhaus-black">1. Compare the capital posture</div>
+            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+              Start with annual giving, open programs, and governance visibility before you look at stories or relationships.
+            </p>
+          </div>
+          <div>
+            <div className="text-sm font-black text-bauhaus-black">2. Check year-memory depth</div>
+            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+              If recurring program rows exist, the foundation is ready for stronger portfolio tracking and annual review loops.
+            </p>
+          </div>
+          <div>
+            <div className="text-sm font-black text-bauhaus-black">3. Open the detailed route</div>
+            <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+              Use the detailed demo page only after the compare view has made the differences legible.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/foundations/ecstra/page.tsx
+++ b/apps/web/src/app/foundations/ecstra/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import { PublicFoundationReviewRoute } from '../public-review-route';
+
+const ECSTRA_FOUNDATION_ID = '25b80b63-416e-4aaa-b470-2f8dc6fa835f';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'ECSTRA Review Route | CivicGraph',
+  description: 'Public review route for ECSTRA Foundation with governance visibility, verified grants, and source-backed year-memory.',
+};
+
+export default async function EcstraReviewPage() {
+  return (
+    <PublicFoundationReviewRoute
+      foundationId={ECSTRA_FOUNDATION_ID}
+      heroTitle="ECSTRA Foundation review route"
+      heroDescription="This public route shows ECSTRA as a financial capability review case with governance visibility, verified grants, and official current program memory now live together."
+      compareTargets={[
+        { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare ECSTRA with Snow' },
+        { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare ECSTRA with PRF' },
+        { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare ECSTRA with Minderoo' },
+        { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare ECSTRA with Ian Potter' },
+      ]}
+    />
+  );
+}

--- a/apps/web/src/app/foundations/ian-potter/page.tsx
+++ b/apps/web/src/app/foundations/ian-potter/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import { PublicFoundationReviewRoute } from '../public-review-route';
+
+const IAN_POTTER_FOUNDATION_ID = 'b9e090e5-1672-48ff-815a-2a6314ebe033';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Ian Potter Review Route | CivicGraph',
+  description: 'Public review route for The Ian Potter Foundation with governance visibility, official grant history, and source-backed program memory.',
+};
+
+export default async function IanPotterReviewPage() {
+  return (
+    <PublicFoundationReviewRoute
+      foundationId={IAN_POTTER_FOUNDATION_ID}
+      heroTitle="Ian Potter Foundation review route"
+      heroDescription="This public route shows Ian Potter as a grant-rich, source-backed review case. Governance visibility, official current program memory, and the historical Ian Potter grants database are now live together."
+      compareTargets={[
+        { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare Ian Potter with Snow' },
+        { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare Ian Potter with PRF' },
+        { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare Ian Potter with Minderoo' },
+      ]}
+    />
+  );
+}

--- a/apps/web/src/app/foundations/minderoo/page.tsx
+++ b/apps/web/src/app/foundations/minderoo/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import { PublicFoundationReviewRoute } from '../public-review-route';
+
+const MINDEROO_FOUNDATION_ID = '8f8704be-d6e8-40f3-b561-ac6630ce5b36';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Minderoo Review Route | CivicGraph',
+  description: 'Public review route for Minderoo Foundation with governance visibility, verified grants, and source-backed year-memory.',
+};
+
+export default async function MinderooReviewPage() {
+  return (
+    <PublicFoundationReviewRoute
+      foundationId={MINDEROO_FOUNDATION_ID}
+      heroTitle="Minderoo Foundation review route"
+      heroDescription="This public route shows Minderoo as a source-backed review case with governance visibility, annual-report-backed grant evidence, and current year-memory now live on the same public surface."
+      compareTargets={[
+        { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare Minderoo with Snow' },
+        { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare Minderoo with PRF' },
+        { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare Minderoo with Ian Potter' },
+      ]}
+    />
+  );
+}

--- a/apps/web/src/app/foundations/page.tsx
+++ b/apps/web/src/app/foundations/page.tsx
@@ -29,6 +29,59 @@ interface FoundationPowerProfileRow {
   gatekeeping_score: number | null;
 }
 
+interface FoundationYearMemorySummaryRow {
+  foundation_id: string;
+  year_memory_count: number;
+  verified_source_backed_count: number;
+}
+
+interface FoundationReviewSummaryRow {
+  foundation_id: string;
+  board_roles: number;
+  table_grants: number;
+  relationship_grants: number;
+}
+
+interface ReviewBreakdownRow {
+  review_status: string;
+  count: number;
+}
+
+interface MissingSignalSummaryRow {
+  missing_governance: number;
+  missing_verified_grants: number;
+  missing_year_memory: number;
+  missing_source_backed: number;
+}
+
+interface CountRow {
+  count: number;
+}
+
+const SNOW_FOUNDATION_ID = 'd242967e-0e68-4367-9785-06cf0ec7485e';
+const PRF_FOUNDATION_ID = '4ee5baca-c898-4318-ae2b-d79b95379cc7';
+const MINDEROO_FOUNDATION_ID = '8f8704be-d6e8-40f3-b561-ac6630ce5b36';
+const RIO_TINTO_FOUNDATION_ID = '85f0de43-d004-4122-83a6-287eeecc4da9';
+const IAN_POTTER_FOUNDATION_ID = 'b9e090e5-1672-48ff-815a-2a6314ebe033';
+const ECSTRA_FOUNDATION_ID = '25b80b63-416e-4aaa-b470-2f8dc6fa835f';
+
+const PUBLIC_REVIEW_ROUTE_MAP: Record<string, string> = {
+  [SNOW_FOUNDATION_ID]: '/snow-foundation',
+  [PRF_FOUNDATION_ID]: '/foundations/prf',
+  [MINDEROO_FOUNDATION_ID]: '/foundations/minderoo',
+  [RIO_TINTO_FOUNDATION_ID]: '/foundations/rio-tinto',
+  [IAN_POTTER_FOUNDATION_ID]: '/foundations/ian-potter',
+  [ECSTRA_FOUNDATION_ID]: '/foundations/ecstra',
+};
+
+const REVIEW_SET_COMPARE_TARGETS = [
+  { id: SNOW_FOUNDATION_ID, label: 'Compare with Snow' },
+  { id: PRF_FOUNDATION_ID, label: 'Compare with PRF' },
+  { id: MINDEROO_FOUNDATION_ID, label: 'Compare with Minderoo' },
+  { id: IAN_POTTER_FOUNDATION_ID, label: 'Compare with Ian Potter' },
+  { id: ECSTRA_FOUNDATION_ID, label: 'Compare with ECSTRA' },
+];
+
 function formatGiving(amount: number | null): string {
   if (!amount) return 'Unknown';
   if (amount >= 1000000) return `$${(amount / 1000000).toFixed(1)}M`;
@@ -59,6 +112,120 @@ function opennessLabel(score: number | null | undefined) {
   return 'Mixed access';
 }
 
+function reviewStatusLabel({
+  boardRoles,
+  verifiedGrants,
+  yearMemory,
+  verifiedSourceBacked,
+}: {
+  boardRoles: number;
+  verifiedGrants: number;
+  yearMemory: number;
+  verifiedSourceBacked: number;
+}) {
+  const stableSignals = [
+    boardRoles > 0,
+    verifiedGrants > 0,
+    yearMemory > 0,
+    verifiedSourceBacked > 0,
+  ].filter(Boolean).length;
+
+  if (stableSignals === 4) {
+    return {
+      label: 'Stable review',
+      cls: 'border-money bg-money-light text-money',
+    };
+  }
+
+  if (stableSignals >= 2) {
+    return {
+      label: 'Developing review',
+      cls: 'border-bauhaus-yellow bg-warning-light text-bauhaus-black',
+    };
+  }
+
+  return {
+    label: 'Early review',
+    cls: 'border-bauhaus-black/20 bg-bauhaus-canvas text-bauhaus-muted',
+  };
+}
+
+function reviewSignals({
+  boardRoles,
+  verifiedGrants,
+  yearMemory,
+  verifiedSourceBacked,
+}: {
+  boardRoles: number;
+  verifiedGrants: number;
+  yearMemory: number;
+  verifiedSourceBacked: number;
+}) {
+  return [
+    { key: 'governance', label: 'Governance', active: boardRoles > 0 },
+    { key: 'grants', label: 'Verified grants', active: verifiedGrants > 0 },
+    { key: 'memory', label: 'Year memory', active: yearMemory > 0 },
+    { key: 'sources', label: 'Source-backed', active: verifiedSourceBacked > 0 },
+  ];
+}
+
+function missingReviewSignals({
+  boardRoles,
+  verifiedGrants,
+  yearMemory,
+  verifiedSourceBacked,
+}: {
+  boardRoles: number;
+  verifiedGrants: number;
+  yearMemory: number;
+  verifiedSourceBacked: number;
+}) {
+  return reviewSignals({
+    boardRoles,
+    verifiedGrants,
+    yearMemory,
+    verifiedSourceBacked,
+  })
+    .filter((signal) => !signal.active)
+    .map((signal) => signal.label);
+}
+
+function buildCompareTargets(foundationId: string) {
+  return REVIEW_SET_COMPARE_TARGETS.filter((target) => target.id !== foundationId);
+}
+
+function getPublicReviewHref(foundationId: string) {
+  return PUBLIC_REVIEW_ROUTE_MAP[foundationId] || null;
+}
+
+function nextMoveForFoundation(foundationId: string, missingSignals: string[]) {
+  if (missingSignals.includes('Year memory') || missingSignals.includes('Source-backed')) {
+    return {
+      label: 'Next move: build year memory',
+      href: `/foundations/${foundationId}#program-history`,
+    };
+  }
+
+  if (missingSignals.includes('Governance')) {
+    return {
+      label: 'Next move: link governance',
+      href: `/foundations/${foundationId}#board-leadership`,
+    };
+  }
+
+  if (missingSignals.includes('Verified grants')) {
+    return {
+      label: 'Next move: pressure-test grant layer',
+      href: `/foundations/compare?left=${foundationId}&right=${SNOW_FOUNDATION_ID}`,
+    };
+  }
+
+  return {
+    label: 'Open review path',
+    href: `/foundations/${foundationId}`,
+  };
+}
+
 const STATES = [
   { value: 'AU-National', label: 'National' },
   { value: 'AU-QLD', label: 'Queensland' },
@@ -81,6 +248,36 @@ interface SearchParams {
   geo?: string;
   giving_min?: string;
   giving_max?: string;
+  review?: string;
+  missing?: string;
+}
+
+function sqlString(value: string) {
+  return value.replace(/'/g, "''");
+}
+
+function buildReviewHref(baseParams: URLSearchParams, review: string) {
+  const params = new URLSearchParams(baseParams.toString());
+  if (review) {
+    params.set('review', review);
+  } else {
+    params.delete('review');
+  }
+
+  const queryString = params.toString();
+  return queryString ? `/foundations?${queryString}` : '/foundations';
+}
+
+function buildMissingHref(baseParams: URLSearchParams, missing: string) {
+  const params = new URLSearchParams(baseParams.toString());
+  if (missing) {
+    params.set('missing', missing);
+  } else {
+    params.delete('missing');
+  }
+
+  const queryString = params.toString();
+  return queryString ? `/foundations?${queryString}` : '/foundations';
 }
 
 export default async function FoundationsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
@@ -93,78 +290,356 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
   const geoFilter = params.geo || '';
   const givingMin = params.giving_min ? parseInt(params.giving_min, 10) : null;
   const givingMax = params.giving_max ? parseInt(params.giving_max, 10) : null;
+  const reviewFilter = params.review || '';
+  const missingFilter = params.missing || '';
   const page = parseInt(params.page || '1', 10);
   const pageSize = 25;
   const offset = (page - 1) * pageSize;
 
   const supabase = getServiceSupabase();
-  let dbQuery = supabase
-    .from('foundations')
-    .select('id, name, type, website, description, total_giving_annual, thematic_focus, geographic_focus, profile_confidence, enriched_at, created_at', { count: 'exact' });
+  const useReviewSqlPath = Boolean(reviewFilter) || Boolean(missingFilter) || sortBy === 'review';
+  let foundations: FoundationRow[] = [];
+  let count = 0;
+
+  const baseWhereClauses = ['TRUE'];
 
   if (query) {
-    dbQuery = dbQuery.or(`name.ilike.%${query}%,description.ilike.%${query}%`);
+    const escaped = sqlString(query);
+    baseWhereClauses.push(`(f.name ILIKE '%${escaped}%' OR COALESCE(f.description, '') ILIKE '%${escaped}%')`);
   }
   if (typeFilter) {
-    dbQuery = dbQuery.eq('type', typeFilter);
+    baseWhereClauses.push(`f.type = '${sqlString(typeFilter)}'`);
   }
   if (focusFilter) {
-    dbQuery = dbQuery.contains('thematic_focus', [focusFilter]);
+    baseWhereClauses.push(`COALESCE(f.thematic_focus, '{}'::text[]) @> ARRAY['${sqlString(focusFilter)}']::text[]`);
   }
   if (profiledOnly) {
-    dbQuery = dbQuery.not('enriched_at', 'is', null);
+    baseWhereClauses.push('f.enriched_at IS NOT NULL');
   }
   if (geoFilter) {
-    dbQuery = dbQuery.contains('geographic_focus', [geoFilter]);
+    baseWhereClauses.push(`COALESCE(f.geographic_focus, '{}'::text[]) @> ARRAY['${sqlString(geoFilter)}']::text[]`);
   }
-  if (givingMin) {
-    dbQuery = dbQuery.gte('total_giving_annual', givingMin);
+  if (givingMin != null) {
+    baseWhereClauses.push(`COALESCE(f.total_giving_annual, 0) >= ${givingMin}`);
   }
-  if (givingMax) {
-    dbQuery = dbQuery.lte('total_giving_annual', givingMax);
+  if (givingMax != null) {
+    baseWhereClauses.push(`COALESCE(f.total_giving_annual, 0) <= ${givingMax}`);
   }
 
-  // Sort
-  if (sortBy === 'profiled') {
-    dbQuery = dbQuery.order('enriched_at', { ascending: false, nullsFirst: false });
-  } else if (sortBy === 'name') {
-    dbQuery = dbQuery.order('name', { ascending: true });
-  } else if (sortBy === 'giving_asc') {
-    dbQuery = dbQuery.order('total_giving_annual', { ascending: true, nullsFirst: false });
-  } else if (sortBy === 'newest') {
-    dbQuery = dbQuery.order('created_at', { ascending: false });
+  const reviewPredicate =
+    reviewFilter === 'stable'
+      ? `COALESCE(fr.board_roles, 0) > 0
+         AND COALESCE(fr.verified_grants, 0) > 0
+         AND COALESCE(fr.year_memory_count, 0) > 0
+         AND COALESCE(fr.verified_source_backed_count, 0) > 0`
+      : reviewFilter === 'developing'
+        ? `((COALESCE(fr.board_roles, 0) > 0)::int
+            + (COALESCE(fr.verified_grants, 0) > 0)::int
+            + (COALESCE(fr.year_memory_count, 0) > 0)::int
+            + (COALESCE(fr.verified_source_backed_count, 0) > 0)::int) BETWEEN 2 AND 3`
+        : reviewFilter === 'early'
+          ? `((COALESCE(fr.board_roles, 0) > 0)::int
+              + (COALESCE(fr.verified_grants, 0) > 0)::int
+              + (COALESCE(fr.year_memory_count, 0) > 0)::int
+              + (COALESCE(fr.verified_source_backed_count, 0) > 0)::int) <= 1`
+          : null;
+
+  const missingPredicate =
+    missingFilter === 'governance'
+      ? 'COALESCE(fr.board_roles, 0) <= 0'
+      : missingFilter === 'grants'
+        ? 'COALESCE(fr.verified_grants, 0) <= 0'
+        : missingFilter === 'year_memory'
+          ? 'COALESCE(fr.year_memory_count, 0) <= 0'
+          : missingFilter === 'source_backed'
+            ? 'COALESCE(fr.verified_source_backed_count, 0) <= 0'
+            : null;
+
+  function buildReviewCte(whereClauses: string[]) {
+    return `
+      WITH board_counts AS (
+        SELECT
+          company_abn AS acnc_abn,
+          COUNT(*)::int AS board_roles
+        FROM person_roles
+        WHERE cessation_date IS NULL
+        GROUP BY company_abn
+      ),
+      table_grant_counts AS (
+        SELECT
+          foundation_id,
+          COUNT(*)::int AS table_grants
+        FROM foundation_grantees
+        GROUP BY foundation_id
+      ),
+      relationship_grant_counts AS (
+        SELECT
+          s.abn AS acnc_abn,
+          COUNT(*)::int AS relationship_grants
+        FROM gs_relationships r
+        JOIN gs_entities s ON s.id = r.source_entity_id
+        WHERE r.relationship_type = 'grant'
+          AND r.dataset = 'foundation_grantees'
+        GROUP BY s.abn
+      ),
+      year_memory_counts AS (
+        SELECT
+          foundation_id,
+          COUNT(*)::int AS year_memory_count,
+          COUNT(*) FILTER (
+            WHERE COALESCE(metadata->>'source', '') NOT ILIKE '%inferred%'
+          )::int AS verified_source_backed_count
+        FROM foundation_program_years
+        GROUP BY foundation_id
+      ),
+      foundation_review AS (
+        SELECT
+          f.id,
+          COALESCE(b.board_roles, 0) AS board_roles,
+          GREATEST(COALESCE(t.table_grants, 0), COALESCE(r.relationship_grants, 0)) AS verified_grants,
+          COALESCE(y.year_memory_count, 0) AS year_memory_count,
+          COALESCE(y.verified_source_backed_count, 0) AS verified_source_backed_count
+        FROM foundations f
+        LEFT JOIN board_counts b ON b.acnc_abn = f.acnc_abn
+        LEFT JOIN table_grant_counts t ON t.foundation_id = f.id
+        LEFT JOIN relationship_grant_counts r ON r.acnc_abn = f.acnc_abn
+        LEFT JOIN year_memory_counts y ON y.foundation_id = f.id
+      ),
+      filtered AS (
+        SELECT
+          f.*,
+          fr.board_roles,
+          fr.verified_grants,
+          fr.year_memory_count,
+          fr.verified_source_backed_count,
+          CASE
+            WHEN fr.board_roles > 0
+              AND fr.verified_grants > 0
+              AND fr.year_memory_count > 0
+              AND fr.verified_source_backed_count > 0 THEN 'stable'
+            WHEN ((fr.board_roles > 0)::int + (fr.verified_grants > 0)::int + (fr.year_memory_count > 0)::int + (fr.verified_source_backed_count > 0)::int) >= 2 THEN 'developing'
+            ELSE 'early'
+          END AS review_status
+        FROM foundations f
+        LEFT JOIN foundation_review fr ON fr.id = f.id
+        WHERE ${whereClauses.join(' AND ')}
+      )
+    `;
+  }
+
+  if (useReviewSqlPath) {
+    const filteredWhereClauses = [...baseWhereClauses];
+    if (reviewPredicate) filteredWhereClauses.push(reviewPredicate);
+    if (missingPredicate) filteredWhereClauses.push(missingPredicate);
+
+    const orderClause =
+      sortBy === 'profiled'
+        ? 'enriched_at DESC NULLS LAST'
+        : sortBy === 'name'
+          ? 'name ASC'
+          : sortBy === 'giving_asc'
+            ? 'total_giving_annual ASC NULLS LAST'
+            : sortBy === 'newest'
+              ? 'created_at DESC'
+              : sortBy === 'review'
+                ? `CASE review_status
+                     WHEN 'stable' THEN 0
+                     WHEN 'developing' THEN 1
+                     ELSE 2
+                   END ASC,
+                   total_giving_annual DESC NULLS LAST`
+                : 'total_giving_annual DESC NULLS LAST';
+
+    const reviewCte = buildReviewCte(filteredWhereClauses);
+
+    const [{ data: countRows }, { data: foundationRows }, { data: programCounts }, { data: acncSummary }] = await Promise.all([
+      supabase.rpc('exec_sql', {
+        query: `${reviewCte} SELECT COUNT(*)::int AS count FROM filtered`,
+      }),
+      supabase.rpc('exec_sql', {
+        query: `${reviewCte}
+                SELECT id, name, type, website, description, total_giving_annual, thematic_focus, geographic_focus, profile_confidence, enriched_at, created_at
+                FROM filtered
+                ORDER BY ${orderClause}
+                LIMIT ${pageSize} OFFSET ${offset}`,
+      }),
+      supabase.rpc('get_foundation_program_counts'),
+      supabase.rpc('get_foundation_acnc_summary'),
+    ]);
+
+    foundations = (foundationRows || []) as FoundationRow[];
+    count = Number(((countRows as Array<{ count: number }> | null)?.[0]?.count) || 0);
+
+    // rebind for later shared logic
+    var sharedProgramCounts = programCounts;
+    var sharedAcncSummary = acncSummary;
   } else {
-    dbQuery = dbQuery.order('total_giving_annual', { ascending: false, nullsFirst: false });
+    let dbQuery = supabase
+      .from('foundations')
+      .select('id, name, type, website, description, total_giving_annual, thematic_focus, geographic_focus, profile_confidence, enriched_at, created_at', { count: 'exact' });
+
+    if (query) {
+      dbQuery = dbQuery.or(`name.ilike.%${query}%,description.ilike.%${query}%`);
+    }
+    if (typeFilter) {
+      dbQuery = dbQuery.eq('type', typeFilter);
+    }
+    if (focusFilter) {
+      dbQuery = dbQuery.contains('thematic_focus', [focusFilter]);
+    }
+    if (profiledOnly) {
+      dbQuery = dbQuery.not('enriched_at', 'is', null);
+    }
+    if (geoFilter) {
+      dbQuery = dbQuery.contains('geographic_focus', [geoFilter]);
+    }
+    if (givingMin) {
+      dbQuery = dbQuery.gte('total_giving_annual', givingMin);
+    }
+    if (givingMax) {
+      dbQuery = dbQuery.lte('total_giving_annual', givingMax);
+    }
+
+    if (sortBy === 'profiled') {
+      dbQuery = dbQuery.order('enriched_at', { ascending: false, nullsFirst: false });
+    } else if (sortBy === 'name') {
+      dbQuery = dbQuery.order('name', { ascending: true });
+    } else if (sortBy === 'giving_asc') {
+      dbQuery = dbQuery.order('total_giving_annual', { ascending: true, nullsFirst: false });
+    } else if (sortBy === 'newest') {
+      dbQuery = dbQuery.order('created_at', { ascending: false });
+    } else {
+      dbQuery = dbQuery.order('total_giving_annual', { ascending: false, nullsFirst: false });
+    }
+
+    dbQuery = dbQuery.range(offset, offset + pageSize - 1);
+
+    const [{ data: foundationRows, count: totalCount }, { data: programCounts }, { data: acncSummary }] = await Promise.all([
+      dbQuery,
+      supabase.rpc('get_foundation_program_counts'),
+      supabase.rpc('get_foundation_acnc_summary'),
+    ]);
+
+    foundations = (foundationRows || []) as FoundationRow[];
+    count = totalCount || 0;
+    var sharedProgramCounts = programCounts;
+    var sharedAcncSummary = acncSummary;
   }
 
-  dbQuery = dbQuery.range(offset, offset + pageSize - 1);
+  const reviewBreakdownWhereClauses = [...baseWhereClauses];
+  if (missingPredicate) reviewBreakdownWhereClauses.push(missingPredicate);
 
-  const [{ data: foundations, count }, { data: programCounts }, { data: acncSummary }] = await Promise.all([
-    dbQuery,
-    supabase.rpc('get_foundation_program_counts'),
-    supabase.rpc('get_foundation_acnc_summary'),
+  const missingSummaryWhereClauses = [...baseWhereClauses];
+  if (reviewPredicate) missingSummaryWhereClauses.push(reviewPredicate);
+
+  const releaseReviewWhereClauses = [...baseWhereClauses];
+  if (missingPredicate) releaseReviewWhereClauses.push(missingPredicate);
+
+  const releaseMissingWhereClauses = [...baseWhereClauses];
+  if (reviewPredicate) releaseMissingWhereClauses.push(reviewPredicate);
+
+  const [{ data: reviewBreakdown }, { data: missingSignalSummary }] = await Promise.all([
+    supabase.rpc('exec_sql', {
+      query: `${buildReviewCte(reviewBreakdownWhereClauses)}
+              SELECT review_status, COUNT(*)::int AS count
+              FROM filtered
+              GROUP BY review_status`,
+    }),
+    supabase.rpc('exec_sql', {
+      query: `${buildReviewCte(missingSummaryWhereClauses)}
+              SELECT
+                SUM(CASE WHEN COALESCE(board_roles, 0) <= 0 THEN 1 ELSE 0 END)::int AS missing_governance,
+                SUM(CASE WHEN COALESCE(verified_grants, 0) <= 0 THEN 1 ELSE 0 END)::int AS missing_verified_grants,
+                SUM(CASE WHEN COALESCE(year_memory_count, 0) <= 0 THEN 1 ELSE 0 END)::int AS missing_year_memory,
+                SUM(CASE WHEN COALESCE(verified_source_backed_count, 0) <= 0 THEN 1 ELSE 0 END)::int AS missing_source_backed
+              FROM filtered`,
+    }),
   ]);
+
+  const [{ data: releaseReviewCountRows }, { data: releaseMissingCountRows }, { data: resetLaneCountRows }] = await Promise.all([
+    reviewFilter
+      ? supabase.rpc('exec_sql', {
+          query: `${buildReviewCte(releaseReviewWhereClauses)}
+                  SELECT COUNT(*)::int AS count
+                  FROM filtered`,
+        })
+      : Promise.resolve({ data: null }),
+    missingFilter
+      ? supabase.rpc('exec_sql', {
+          query: `${buildReviewCte(releaseMissingWhereClauses)}
+                  SELECT COUNT(*)::int AS count
+                  FROM filtered`,
+        })
+      : Promise.resolve({ data: null }),
+    reviewFilter || missingFilter
+      ? supabase.rpc('exec_sql', {
+          query: `${buildReviewCte(baseWhereClauses)}
+                  SELECT COUNT(*)::int AS count
+                  FROM filtered`,
+        })
+      : Promise.resolve({ data: null }),
+  ]);
+
   const foundationIds = ((foundations || []) as FoundationRow[]).map((foundation) => foundation.id);
-  const { data: powerProfiles } = foundationIds.length
-    ? await supabase
-        .from('foundation_power_profiles')
-        .select('foundation_id, capital_holder_class, capital_source_class, reportable_in_power_map, openness_score, gatekeeping_score')
-        .in('foundation_id', foundationIds)
-    : { data: [] as FoundationPowerProfileRow[] };
+  const [{ data: powerProfiles }, { data: yearMemorySummary }, { data: reviewSummary }] = foundationIds.length
+    ? await Promise.all([
+        supabase
+          .from('foundation_power_profiles')
+          .select('foundation_id, capital_holder_class, capital_source_class, reportable_in_power_map, openness_score, gatekeeping_score')
+          .in('foundation_id', foundationIds),
+        supabase.rpc('exec_sql', {
+          query: `SELECT
+                    foundation_id::text AS foundation_id,
+                    COUNT(*)::int AS year_memory_count,
+                    COUNT(*) FILTER (
+                      WHERE COALESCE(metadata->>'source', '') NOT ILIKE '%inferred%'
+                    )::int AS verified_source_backed_count
+                  FROM foundation_program_years
+                  WHERE foundation_id IN (${foundationIds.map((id) => `'${id}'`).join(', ')})
+                  GROUP BY foundation_id`,
+        }),
+        supabase.rpc('exec_sql', {
+          query: `SELECT
+                    f.id::text AS foundation_id,
+                    (SELECT COUNT(*)::int
+                     FROM person_roles pr
+                     WHERE (
+                         (f.acnc_abn IS NOT NULL AND f.acnc_abn <> '' AND pr.company_abn = f.acnc_abn)
+                         OR ((f.acnc_abn IS NULL OR f.acnc_abn = '') AND pr.company_name = f.name)
+                       )
+                       AND pr.cessation_date IS NULL) AS board_roles,
+                    (SELECT COUNT(*)::int
+                     FROM foundation_grantees fg
+                     WHERE fg.foundation_id = f.id) AS table_grants,
+                    (SELECT COUNT(*)::int
+                     FROM gs_relationships r
+                     JOIN gs_entities s ON s.id = r.source_entity_id
+                     WHERE s.abn = f.acnc_abn
+                       AND r.relationship_type = 'grant'
+                       AND r.dataset = 'foundation_grantees') AS relationship_grants
+                  FROM foundations f
+                  WHERE f.id IN (${foundationIds.map((id) => `'${id}'`).join(', ')})`,
+        }),
+      ])
+    : [
+        { data: [] as FoundationPowerProfileRow[] },
+        { data: [] as FoundationYearMemorySummaryRow[] },
+        { data: [] as FoundationReviewSummaryRow[] },
+      ];
   const totalPages = Math.ceil((count || 0) / pageSize);
 
   // Build lookup map for program counts
   const progCountMap = new Map<string, { programs: number; open: number }>();
-  if (programCounts) {
-    for (const pc of programCounts as Array<{ foundation_id: string; program_count: number; open_count: number }>) {
+  if (sharedProgramCounts) {
+    for (const pc of sharedProgramCounts as Array<{ foundation_id: string; program_count: number; open_count: number }>) {
       progCountMap.set(pc.foundation_id, { programs: Number(pc.program_count), open: Number(pc.open_count) });
     }
   }
 
   // Build lookup map for ACNC financials
   const acncMap = new Map<string, { total_assets: number; grants_given: number; latest_year: number }>();
-  if (acncSummary) {
-    for (const row of acncSummary as Array<{ foundation_id: string; total_assets: number; grants_given: number; latest_year: number }>) {
+  if (sharedAcncSummary) {
+    for (const row of sharedAcncSummary as Array<{ foundation_id: string; total_assets: number; grants_given: number; latest_year: number }>) {
       acncMap.set(row.foundation_id, { total_assets: Number(row.total_assets), grants_given: Number(row.grants_given), latest_year: row.latest_year });
     }
   }
@@ -176,14 +651,65 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
     }
   }
 
+  const yearMemoryMap = new Map<string, { total: number; verified: number }>();
+  if (yearMemorySummary) {
+    for (const row of yearMemorySummary as FoundationYearMemorySummaryRow[]) {
+      yearMemoryMap.set(row.foundation_id, {
+        total: Number(row.year_memory_count),
+        verified: Number(row.verified_source_backed_count),
+      });
+    }
+  }
+
+  const reviewMap = new Map<string, { boardRoles: number; verifiedGrants: number }>();
+  if (reviewSummary) {
+    for (const row of reviewSummary as FoundationReviewSummaryRow[]) {
+      reviewMap.set(row.foundation_id, {
+        boardRoles: Number(row.board_roles),
+        verifiedGrants: Math.max(Number(row.table_grants), Number(row.relationship_grants)),
+      });
+    }
+  }
+
+  const reviewBreakdownMap = new Map<string, number>();
+  if (reviewBreakdown) {
+    for (const row of reviewBreakdown as ReviewBreakdownRow[]) {
+      reviewBreakdownMap.set(row.review_status, Number(row.count));
+    }
+  }
+
+  const missingSignals = ((missingSignalSummary as MissingSignalSummaryRow[] | null)?.[0] || {
+    missing_governance: 0,
+    missing_verified_grants: 0,
+    missing_year_memory: 0,
+    missing_source_backed: 0,
+  }) as MissingSignalSummaryRow;
+  const releaseReviewCount = Number(((releaseReviewCountRows as CountRow[] | null)?.[0]?.count) || 0);
+  const releaseMissingCount = Number(((releaseMissingCountRows as CountRow[] | null)?.[0]?.count) || 0);
+  const resetLaneCount = Number(((resetLaneCountRows as CountRow[] | null)?.[0]?.count) || 0);
+
   const types = ['private_ancillary_fund', 'public_ancillary_fund', 'trust', 'corporate_foundation', 'grantmaker'];
   const focuses = ['arts', 'indigenous', 'health', 'education', 'community', 'environment', 'research'];
   const sortOptions = [
     { value: 'giving', label: 'Highest Giving' },
     { value: 'giving_asc', label: 'Lowest Giving' },
+    { value: 'review', label: 'Review Status' },
     { value: 'profiled', label: 'Recently Profiled' },
     { value: 'newest', label: 'Newest Added' },
     { value: 'name', label: 'Name A-Z' },
+  ];
+  const reviewOptions = [
+    { value: '', label: 'All review states' },
+    { value: 'stable', label: 'Stable review' },
+    { value: 'developing', label: 'Developing review' },
+    { value: 'early', label: 'Early review' },
+  ];
+  const missingOptions = [
+    { value: '', label: 'All evidence gaps' },
+    { value: 'governance', label: 'Missing governance' },
+    { value: 'grants', label: 'Missing verified grants' },
+    { value: 'year_memory', label: 'Missing year memory' },
+    { value: 'source_backed', label: 'Missing source-backed memory' },
   ];
 
   // Build filter query string for pagination
@@ -196,7 +722,241 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
   if (geoFilter) filterParams.set('geo', geoFilter);
   if (givingMin) filterParams.set('giving_min', String(givingMin));
   if (givingMax) filterParams.set('giving_max', String(givingMax));
+  if (reviewFilter) filterParams.set('review', reviewFilter);
+  if (missingFilter) filterParams.set('missing', missingFilter);
   const filterQS = filterParams.toString();
+  const reviewChipBaseParams = new URLSearchParams(filterParams.toString());
+  reviewChipBaseParams.delete('review');
+  const missingChipBaseParams = new URLSearchParams(filterParams.toString());
+  missingChipBaseParams.delete('missing');
+  const reviewSliceResetParams = new URLSearchParams(filterParams.toString());
+  reviewSliceResetParams.delete('review');
+  reviewSliceResetParams.delete('missing');
+  const reviewQuickLinks = [
+    { value: '', label: 'Reset review filter' },
+    { value: 'stable', label: `Stable review (${(reviewBreakdownMap.get('stable') || 0).toLocaleString()})` },
+    { value: 'developing', label: `Developing review (${(reviewBreakdownMap.get('developing') || 0).toLocaleString()})` },
+    { value: 'early', label: `Early review (${(reviewBreakdownMap.get('early') || 0).toLocaleString()})` },
+  ];
+  const missingQuickLinks = [
+    { value: '', label: 'Current gaps', count: null },
+    { value: 'governance', label: 'Governance', count: missingSignals.missing_governance || 0 },
+    { value: 'grants', label: 'Grants', count: missingSignals.missing_verified_grants || 0 },
+    { value: 'year_memory', label: 'Year memory', count: missingSignals.missing_year_memory || 0 },
+    { value: 'source_backed', label: 'Source-backed', count: missingSignals.missing_source_backed || 0 },
+  ];
+  const activeReviewOption = reviewOptions.find((option) => option.value === reviewFilter);
+  const activeMissingOption = missingOptions.find((option) => option.value === missingFilter);
+  const nearbyReviewOptions = reviewOptions
+    .filter((option) => option.value && option.value !== reviewFilter)
+    .map((option) => ({
+      ...option,
+      kind: 'review' as const,
+      count: reviewBreakdownMap.get(option.value) || 0,
+      href: buildReviewHref(reviewChipBaseParams, option.value),
+    }))
+    .filter((option) => option.count > 0)
+    .sort((a, b) => b.count - a.count);
+  const nearbyMissingOptions = missingOptions
+    .filter((option) => option.value && option.value !== missingFilter)
+    .map((option) => {
+      const count =
+        option.value === 'governance'
+          ? missingSignals.missing_governance || 0
+          : option.value === 'grants'
+            ? missingSignals.missing_verified_grants || 0
+            : option.value === 'year_memory'
+              ? missingSignals.missing_year_memory || 0
+              : missingSignals.missing_source_backed || 0;
+      return {
+        ...option,
+        kind: 'missing' as const,
+        count,
+        href: buildMissingHref(missingChipBaseParams, option.value),
+      };
+    })
+    .filter((option) => option.count > 0)
+    .sort((a, b) => b.count - a.count);
+  const closestRecoveryOption =
+    (reviewFilter && missingFilter
+      ? nearbyMissingOptions[0] || nearbyReviewOptions[0]
+      : reviewFilter
+        ? nearbyReviewOptions[0]
+        : missingFilter
+          ? nearbyMissingOptions[0]
+          : undefined);
+  const bestRecoveryOption = closestRecoveryOption || [...nearbyReviewOptions, ...nearbyMissingOptions]
+    .sort((a, b) => b.count - a.count)[0];
+  const bestRecoveryLabel = bestRecoveryOption
+    ? bestRecoveryOption.kind === 'missing'
+      ? bestRecoveryOption.label.replace('Missing ', '').toLowerCase()
+      : bestRecoveryOption.label.toLowerCase()
+    : null;
+  const bestRecoveryReason = bestRecoveryOption
+    ? reviewFilter && missingFilter
+      ? bestRecoveryOption.kind === 'missing'
+        ? 'Closest live recovery that keeps the current review state.'
+        : 'Wider recovery path because no nearby evidence-gap slice is still live.'
+      : reviewFilter
+        ? 'Closest live recovery within the current review-state lane.'
+        : missingFilter
+          ? 'Closest live recovery within the current evidence-gap lane.'
+          : 'Best live recovery from the current directory state.'
+    : null;
+  const sliceCount = Number(count || 0);
+  const isThinSlice = Boolean((reviewFilter || missingFilter) && sliceCount > 0 && sliceCount <= 5);
+  const sliceMode =
+    (reviewFilter || missingFilter) && sliceCount > 0
+      ? sliceCount <= 5
+        ? {
+            label: 'Narrow lead list',
+            description: 'Good for direct prospecting, not for broad landscape claims.',
+            actionLabel: 'Use for: direct outreach and shortlist review',
+            actionHref: '/funding-workspace',
+            actionCta: 'Open funding workspace',
+            secondaryHref: bestRecoveryOption && bestRecoveryOption.count > sliceCount ? bestRecoveryOption.href : null,
+            secondaryCta: bestRecoveryOption && bestRecoveryOption.count > sliceCount ? `Broaden to ${bestRecoveryLabel}` : null,
+            nextStep: bestRecoveryOption && bestRecoveryOption.count > sliceCount
+              ? `Next step: broaden to ${bestRecoveryLabel} if you need a wider market read.`
+              : 'Next step: stay narrow and work the shortlist directly.',
+            className: 'border-bauhaus-yellow bg-warning-light text-bauhaus-black',
+          }
+        : sliceCount <= 50
+          ? {
+              label: 'Focused subset',
+              description: 'Useful for reading a lane closely, but still too small for broad system claims.',
+              actionLabel: 'Use for: close comparison inside one lane',
+              actionHref: '/foundations/compare',
+              actionCta: 'Open compare surface',
+              secondaryHref: '/funding-workspace',
+              secondaryCta: 'Open funding workspace',
+              nextStep: 'Next step: compare the strongest candidates inside this lane before broadening further.',
+              className: 'border-bauhaus-blue/25 bg-link-light text-bauhaus-blue',
+            }
+          : {
+              label: 'Landscape-ready',
+              description: 'Large enough to scan for patterns inside the current reviewability lane.',
+              actionLabel: 'Use for: pattern scanning and gap analysis',
+              actionHref: '/reports/philanthropy-power',
+              actionCta: 'Open philanthropy power map',
+              secondaryHref: '/foundations/compare',
+              secondaryCta: 'Tighten with compare',
+              nextStep: 'Next step: scan the pattern, then tighten the slice when you are ready to shortlist.',
+              className: 'border-money/25 bg-money-light text-money',
+            }
+      : null;
+  const currentLaneSummary =
+    (reviewFilter || missingFilter) && sliceCount > 0
+      ? reviewFilter && missingFilter
+        ? [
+            `Fixed review state: ${activeReviewOption?.label || reviewFilter}.`,
+            `Fixed evidence gap: ${activeMissingOption?.label.replace('Missing ', '') || missingFilter}.`,
+            query ? `Fixed search query: "${query}".` : null,
+            geoFilter ? `Fixed geography: ${geoFilter}.` : null,
+            typeFilter ? `Fixed type: ${typeLabel(typeFilter)}.` : null,
+            focusFilter ? `Fixed focus: ${focusFilter}.` : null,
+            givingMin != null && givingMax != null
+              ? `Fixed annual giving band: ${formatGiving(givingMin)} to ${formatGiving(givingMax)}.`
+              : givingMin != null
+                ? `Fixed annual giving floor: ${formatGiving(givingMin)} and above.`
+                : givingMax != null
+                  ? `Fixed annual giving ceiling: ${formatGiving(givingMax)} and below.`
+                  : null,
+            profiledOnly ? 'Profiled-only view is active.' : null,
+            'Use pivots to move one axis at a time without losing the current lane.',
+          ].filter(Boolean) as string[]
+        : reviewFilter
+          ? [
+              `Fixed review state: ${activeReviewOption?.label || reviewFilter}.`,
+              query ? `Fixed search query: "${query}".` : null,
+              geoFilter ? `Fixed geography: ${geoFilter}.` : null,
+              typeFilter ? `Fixed type: ${typeLabel(typeFilter)}.` : null,
+              focusFilter ? `Fixed focus: ${focusFilter}.` : null,
+              givingMin != null && givingMax != null
+                ? `Fixed annual giving band: ${formatGiving(givingMin)} to ${formatGiving(givingMax)}.`
+                : givingMin != null
+                  ? `Fixed annual giving floor: ${formatGiving(givingMin)} and above.`
+                  : givingMax != null
+                    ? `Fixed annual giving ceiling: ${formatGiving(givingMax)} and below.`
+                    : null,
+              profiledOnly ? 'Profiled-only view is active.' : null,
+              'Evidence gap is still open.',
+              'Use evidence pivots or gap filters to tighten this lane.',
+            ].filter(Boolean) as string[]
+          : [
+              `Fixed evidence gap: ${activeMissingOption?.label.replace('Missing ', '') || missingFilter}.`,
+              query ? `Fixed search query: "${query}".` : null,
+              geoFilter ? `Fixed geography: ${geoFilter}.` : null,
+              typeFilter ? `Fixed type: ${typeLabel(typeFilter)}.` : null,
+              focusFilter ? `Fixed focus: ${focusFilter}.` : null,
+              givingMin != null && givingMax != null
+                ? `Fixed annual giving band: ${formatGiving(givingMin)} to ${formatGiving(givingMax)}.`
+                : givingMin != null
+                  ? `Fixed annual giving floor: ${formatGiving(givingMin)} and above.`
+                  : givingMax != null
+                    ? `Fixed annual giving ceiling: ${formatGiving(givingMax)} and below.`
+                    : null,
+              profiledOnly ? 'Profiled-only view is active.' : null,
+              'Review state is still open.',
+              'Use review pivots or review filters to tighten this lane.',
+            ].filter(Boolean) as string[]
+      : [];
+  const laneControlLinks = [
+    reviewFilter
+      ? {
+          href: buildReviewHref(reviewChipBaseParams, ''),
+          label: `Release review state${releaseReviewCount > 0 ? ` (${releaseReviewCount.toLocaleString()})` : ''}`,
+        }
+      : null,
+    missingFilter
+      ? {
+          href: buildMissingHref(missingChipBaseParams, ''),
+          label: `Release evidence gap${releaseMissingCount > 0 ? ` (${releaseMissingCount.toLocaleString()})` : ''}`,
+        }
+      : null,
+    reviewFilter || missingFilter
+      ? {
+          href: buildMissingHref(reviewSliceResetParams, ''),
+          label: `Reset lane${resetLaneCount > 0 ? ` (${resetLaneCount.toLocaleString()})` : ''}`,
+        }
+      : null,
+  ].filter(Boolean) as Array<{ href: string; label: string }>;
+  const laneType =
+    (reviewFilter || missingFilter) && sliceCount > 0
+      ? reviewFilter && missingFilter
+        ? {
+            label: 'Two-axis lane',
+            description: 'Both review state and evidence gap are fixed.',
+            className: 'border-bauhaus-red/25 bg-bauhaus-red/5 text-bauhaus-red',
+          }
+        : {
+            label: 'Single-axis lane',
+            description: reviewFilter
+              ? 'Review state is fixed; evidence gap can still move.'
+              : 'Evidence gap is fixed; review state can still move.',
+            className: 'border-bauhaus-black/15 bg-bauhaus-canvas text-bauhaus-black',
+          }
+      : null;
+  const emptySliceReasons =
+    reviewFilter && missingFilter
+      ? [
+          nearbyMissingOptions.length > 0 && activeReviewOption?.value
+            ? `The ${activeReviewOption.label.toLowerCase()} lane is still live, but not with ${activeMissingOption?.label.replace('Missing ', '').toLowerCase()}.`
+            : null,
+          nearbyReviewOptions.length > 0 && activeMissingOption?.value
+            ? `The ${activeMissingOption.label.replace('Missing ', '').toLowerCase()} gap still exists, but only in other review states.`
+            : null,
+        ].filter(Boolean) as string[]
+      : [];
+  const adjacentReviewOptions = nearbyReviewOptions.slice(0, 2).map((option) => ({
+    ...option,
+    displayLabel: option.label,
+  }));
+  const adjacentMissingOptions = nearbyMissingOptions.slice(0, 2).map((option) => ({
+    ...option,
+    displayLabel: option.label.replace('Missing ', ''),
+  }));
+  const foundationsList = (foundations as FoundationRow[] || []);
 
   return (
     <ListPreviewProvider>
@@ -219,13 +979,66 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
           {' '}&middot;{' '}
           <a href="/charities" className="text-bauhaus-blue hover:underline font-bold">See all 64,000+ charities &rarr;</a>
         </p>
-        <div className="mt-4 flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-widest">
-          <a href="/reports/philanthropy-power" className="px-3 py-2 border-2 border-bauhaus-black text-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors">
-            Open philanthropy power map
+      <div className="mt-4 flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-widest">
+        <a href="/reports/philanthropy-power" className="px-3 py-2 border-2 border-bauhaus-black text-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors">
+          Open philanthropy power map
+        </a>
+          <a href="/foundations/backlog" className="px-3 py-2 border-2 border-bauhaus-black/20 bg-white text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors">
+            Open backlog
+          </a>
+          <a href="/foundations/review-set" className="px-3 py-2 border-2 border-bauhaus-black/20 bg-bauhaus-canvas text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors">
+            Open review set
+          </a>
+          <a href="/foundations/compare" className="px-3 py-2 border-2 border-bauhaus-red text-bauhaus-red bg-bauhaus-red/5 hover:bg-bauhaus-red hover:text-white transition-colors">
+            Compare foundations
           </a>
           <a href="/funding-workspace" className="px-3 py-2 border-2 border-bauhaus-blue text-bauhaus-blue bg-link-light hover:bg-bauhaus-blue hover:text-white transition-colors">
             Open funding workspace
           </a>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-widest">
+          {reviewQuickLinks.map((option) => {
+            const isActive = (option.value || '') === reviewFilter;
+            return (
+              <a
+                key={option.value || 'all'}
+                href={buildReviewHref(reviewChipBaseParams, option.value)}
+                className={`px-3 py-2 border-2 transition-colors ${
+                  isActive
+                    ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                    : option.value === 'stable'
+                      ? 'border-money text-money bg-money-light hover:bg-money hover:text-white'
+                      : option.value === 'developing'
+                        ? 'border-bauhaus-yellow text-bauhaus-black bg-warning-light hover:bg-bauhaus-yellow'
+                        : option.value === 'early'
+                          ? 'border-bauhaus-black/20 text-bauhaus-muted bg-bauhaus-canvas hover:border-bauhaus-black hover:text-bauhaus-black'
+                          : 'border-bauhaus-black text-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+                }`}
+              >
+                {option.label}
+              </a>
+            );
+          })}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+          {missingQuickLinks.map((option) => {
+            const isActive = (option.value || '') === missingFilter;
+            return (
+              <a
+                key={option.value || 'all'}
+                href={buildMissingHref(missingChipBaseParams, option.value)}
+                className={`border-2 px-3 py-2 transition-colors ${
+                  isActive
+                    ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                    : option.value
+                      ? 'border-bauhaus-black/15 bg-bauhaus-canvas text-bauhaus-black hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+                      : 'border-bauhaus-black/15 bg-bauhaus-canvas text-bauhaus-muted hover:border-bauhaus-black hover:text-bauhaus-black'
+                }`}
+              >
+                {option.count == null ? option.label : `${option.label} ${option.count.toLocaleString()}`}
+              </a>
+            );
+          })}
         </div>
       </div>
 
@@ -254,6 +1067,16 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
             <option key={s.value} value={s.value}>{s.label}</option>
           ))}
         </select>
+        <select name="review" defaultValue={reviewFilter} className="px-4 py-2.5 border-4 border-l-0 border-bauhaus-black text-sm font-bold bg-white focus:outline-none">
+          {reviewOptions.map(option => (
+            <option key={option.value || 'all'} value={option.value}>{option.label}</option>
+          ))}
+        </select>
+        <select name="missing" defaultValue={missingFilter} className="px-4 py-2.5 border-4 border-l-0 border-bauhaus-black text-sm font-bold bg-white focus:outline-none">
+          {missingOptions.map(option => (
+            <option key={option.value || 'all'} value={option.value}>{option.label}</option>
+          ))}
+        </select>
         <label className="flex items-center gap-2 text-xs font-black text-bauhaus-black cursor-pointer px-4 py-2.5 border-4 border-l-0 border-bauhaus-black bg-white uppercase tracking-wider">
           <input type="checkbox" name="profiled" value="1" defaultChecked={profiledOnly} className="accent-bauhaus-red" />
           Profiled
@@ -271,6 +1094,8 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
           {focusFilter && <input type="hidden" name="focus" value={focusFilter} />}
           {profiledOnly && <input type="hidden" name="profiled" value="1" />}
           {sortBy !== 'giving' && <input type="hidden" name="sort" value={sortBy} />}
+          {reviewFilter && <input type="hidden" name="review" value={reviewFilter} />}
+          {missingFilter && <input type="hidden" name="missing" value={missingFilter} />}
           <div className="flex items-center px-3 py-2 border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black">
             <span className="text-[11px] font-black text-bauhaus-muted uppercase tracking-wider mr-2 whitespace-nowrap">Annual Giving</span>
             <input
@@ -304,11 +1129,296 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
         </form>
       </FilterBar>
 
+      {(reviewFilter || missingFilter) && (
+        <div className="mb-4 border-4 border-bauhaus-black bg-bauhaus-canvas px-4 py-3">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">Current review slice</p>
+              <p className="mt-1 text-sm font-bold text-bauhaus-black">
+                {sliceCount.toLocaleString()} foundations in this reviewability subset.
+              </p>
+              <p className="mt-1 text-[11px] font-medium text-bauhaus-muted">
+                Bands: 1-5 narrow lead list, 6-50 focused subset, 51+ landscape-ready.
+              </p>
+              {laneType && (
+                <div className={`mt-2 inline-flex flex-col border-2 px-3 py-2 ${laneType.className}`}>
+                  <p className="text-[10px] font-black uppercase tracking-[0.22em]">{laneType.label}</p>
+                  <p className="mt-1 text-xs font-medium">{laneType.description}</p>
+                </div>
+              )}
+              {sliceMode && (
+                <div className={`mt-2 border-2 px-3 py-2 ${sliceMode.className}`}>
+                  <p className="text-[10px] font-black uppercase tracking-[0.22em]">{sliceMode.label}</p>
+                  <p className="mt-1 text-xs font-medium">{sliceMode.description}</p>
+                  <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-[11px] font-black uppercase tracking-[0.18em]">
+                      {sliceMode.actionLabel}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      <a
+                        href={sliceMode.actionHref}
+                        className="inline-flex border-2 border-current px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.18em] transition-colors hover:bg-bauhaus-black hover:text-white hover:border-bauhaus-black"
+                      >
+                        {sliceMode.actionCta}
+                      </a>
+                      {sliceMode.secondaryHref && sliceMode.secondaryCta && (
+                        <a
+                          href={sliceMode.secondaryHref}
+                          className="inline-flex border-2 border-current/40 px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.18em] opacity-80 transition-colors hover:bg-bauhaus-black hover:text-white hover:border-bauhaus-black hover:opacity-100"
+                        >
+                          {sliceMode.secondaryCta}
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                  <p className="mt-2 text-xs font-medium">
+                    {sliceMode.nextStep}
+                  </p>
+                </div>
+              )}
+              {currentLaneSummary.length > 0 && (
+                <div className="mt-2 border-2 border-bauhaus-black/10 bg-white/70 px-3 py-2">
+                  <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-muted">Current lane</p>
+                  <div className="mt-1 space-y-1 text-xs font-medium text-bauhaus-black">
+                    {currentLaneSummary.map((line) => (
+                      <p key={line}>{line}</p>
+                    ))}
+                  </div>
+                  {laneControlLinks.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                      {laneControlLinks.map((link) => (
+                        <a
+                          key={link.label}
+                          href={link.href}
+                          className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas px-3 py-1.5 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                        >
+                          {link.label}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              {isThinSlice && (
+                <div className="mt-2 border-l-4 border-bauhaus-yellow bg-warning-light px-3 py-2">
+                  <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-muted">Thin slice</p>
+                  <p className="mt-1 text-xs font-medium text-bauhaus-black">
+                    Only {sliceCount.toLocaleString()} foundation{sliceCount === 1 ? '' : 's'} match this reviewability subset. Treat this as a narrow lead list, not a landscape read.
+                  </p>
+                  {bestRecoveryOption && bestRecoveryOption.count > sliceCount && bestRecoveryLabel && (
+                    <p className="mt-1 text-xs font-medium text-bauhaus-muted">
+                      Broaden to {bestRecoveryLabel} to reopen {bestRecoveryOption.count.toLocaleString()} foundations.
+                    </p>
+                  )}
+                </div>
+              )}
+              {(adjacentReviewOptions.length > 0 || adjacentMissingOptions.length > 0) && (
+                <div className="mt-2">
+                  <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-muted">Adjacent live slices</p>
+                  {adjacentReviewOptions.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Review state pivots</p>
+                      <p className="mt-1 text-[11px] font-medium text-bauhaus-muted">
+                        Keep the current evidence gap fixed and move across review states.
+                      </p>
+                      <div className="mt-1 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                        {adjacentReviewOptions.map((option) => (
+                          <a
+                            key={`${option.kind}-${option.value}`}
+                            href={option.href}
+                            className="border-2 border-money/25 bg-money-light px-3 py-1.5 text-money transition-colors hover:border-money hover:bg-money hover:text-white"
+                          >
+                            {option.displayLabel} ({option.count.toLocaleString()})
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {adjacentMissingOptions.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Evidence gap pivots</p>
+                      <p className="mt-1 text-[11px] font-medium text-bauhaus-muted">
+                        Keep the current review state fixed and move across adjacent evidence gaps.
+                      </p>
+                      <div className="mt-1 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                        {adjacentMissingOptions.map((option) => (
+                          <a
+                            key={`${option.kind}-${option.value}`}
+                            href={option.href}
+                            className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-3 py-1.5 text-bauhaus-red transition-colors hover:border-bauhaus-red hover:bg-bauhaus-red hover:text-white"
+                          >
+                            {option.displayLabel} ({option.count.toLocaleString()})
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              {activeReviewOption && activeReviewOption.value && (
+                <span className="border-2 border-money/25 bg-money-light px-2.5 py-1 text-money">
+                  {activeReviewOption.label}
+                </span>
+              )}
+              {activeMissingOption && activeMissingOption.value && (
+                <span className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-2.5 py-1 text-bauhaus-red">
+                  {activeMissingOption.label}
+                </span>
+              )}
+              <a
+                href={buildMissingHref(reviewSliceResetParams, '')}
+                className="border-2 border-bauhaus-black px-2.5 py-1 text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+              >
+                Reset slice
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="space-y-3">
-        {(foundations as FoundationRow[] || []).map((f) => {
+        {foundationsList.length === 0 && (
+          <div className="border-4 border-bauhaus-black bg-white p-5">
+            <p className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-red">No foundations in this slice</p>
+            <h2 className="mt-2 text-xl font-black text-bauhaus-black">This filter combination is too tight.</h2>
+            <p className="mt-2 max-w-3xl text-sm font-medium text-bauhaus-muted">
+              {reviewFilter || missingFilter
+                ? 'The current reviewability filters do not leave any matching foundations. Loosen one of the active slice controls or reset the slice entirely.'
+                : 'The current search and filter combination does not leave any matching foundations. Clear one or more filters and try again.'}
+            </p>
+            {emptySliceReasons.length > 0 && (
+              <div className="mt-4 border-l-4 border-bauhaus-red bg-bauhaus-red/5 px-4 py-3">
+                <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-red">Why this is empty</p>
+                <div className="mt-2 space-y-1 text-sm font-medium text-bauhaus-black">
+                  {emptySliceReasons.map((reason) => (
+                    <p key={reason}>{reason}</p>
+                  ))}
+                </div>
+              </div>
+            )}
+            {bestRecoveryOption && (
+              <div className="mt-4 border-4 border-bauhaus-yellow bg-warning-light p-4">
+                <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-muted">Recommended recovery</p>
+                <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-bold text-bauhaus-black">
+                      Jump to {bestRecoveryLabel} and reopen {bestRecoveryOption.count.toLocaleString()} foundations.
+                    </p>
+                    {bestRecoveryReason && (
+                      <p className="mt-1 text-xs font-medium text-bauhaus-muted">
+                        {bestRecoveryReason}
+                      </p>
+                    )}
+                  </div>
+                  <a
+                    href={bestRecoveryOption.href}
+                    className="inline-flex border-2 border-bauhaus-black bg-bauhaus-yellow px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+                  >
+                    Open best recovery
+                  </a>
+                </div>
+              </div>
+            )}
+            <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              <a
+                href={buildMissingHref(reviewSliceResetParams, '')}
+                className="border-2 border-bauhaus-black px-3 py-2 text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+              >
+                Reset slice
+              </a>
+              {reviewFilter && (
+                <a
+                  href={buildReviewHref(reviewChipBaseParams, '')}
+                  className="border-2 border-money/25 bg-money-light px-3 py-2 text-money transition-colors hover:border-money hover:bg-money hover:text-white"
+                >
+                  Clear review state
+                </a>
+              )}
+              {missingFilter && (
+                <a
+                  href={buildMissingHref(missingChipBaseParams, '')}
+                  className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red transition-colors hover:border-bauhaus-red hover:bg-bauhaus-red hover:text-white"
+                >
+                  Clear evidence gap
+                </a>
+              )}
+              <a
+                href="/foundations"
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Open full directory
+              </a>
+            </div>
+            {nearbyReviewOptions.length > 0 && (
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-muted">Nearest live review states</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                  {nearbyReviewOptions.map((option) => (
+                    <a
+                      key={option.value}
+                      href={option.href}
+                      className="border-2 border-bauhaus-yellow bg-warning-light px-3 py-2 text-bauhaus-black transition-colors hover:bg-bauhaus-yellow"
+                    >
+                      {option.label} ({option.count.toLocaleString()})
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
+            {nearbyMissingOptions.length > 0 && (
+              <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                <p className="text-[10px] font-black uppercase tracking-[0.22em] text-bauhaus-muted">Nearest live evidence gaps</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                  {nearbyMissingOptions.map((option) => (
+                    <a
+                      key={option.value}
+                      href={option.href}
+                      className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red transition-colors hover:border-bauhaus-red hover:bg-bauhaus-red hover:text-white"
+                    >
+                      {option.label.replace('Missing ', '')} ({option.count.toLocaleString()})
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {foundationsList.map((f) => {
           const pc = progCountMap.get(f.id);
           const acnc = acncMap.get(f.id);
           const power = powerMap.get(f.id);
+          const yearMemory = yearMemoryMap.get(f.id);
+          const review = reviewMap.get(f.id);
+          const compareTargets = buildCompareTargets(f.id);
+          const reviewStatus = review
+            ? reviewStatusLabel({
+                boardRoles: review.boardRoles,
+                verifiedGrants: review.verifiedGrants,
+                yearMemory: yearMemory?.total || 0,
+                verifiedSourceBacked: yearMemory?.verified || 0,
+              })
+            : null;
+          const signalSummary = review
+            ? reviewSignals({
+                boardRoles: review.boardRoles,
+                verifiedGrants: review.verifiedGrants,
+                yearMemory: yearMemory?.total || 0,
+                verifiedSourceBacked: yearMemory?.verified || 0,
+              })
+            : [];
+          const missingSignals = review
+            ? missingReviewSignals({
+                boardRoles: review.boardRoles,
+                verifiedGrants: review.verifiedGrants,
+                yearMemory: yearMemory?.total || 0,
+                verifiedSourceBacked: yearMemory?.verified || 0,
+              })
+            : [];
+          const nextMove = missingSignals.length > 0 ? nextMoveForFoundation(f.id, missingSignals) : null;
+          const publicReviewHref = getPublicReviewHref(f.id);
           return (
           <FoundationPreviewTrigger key={f.id} foundation={{
               id: f.id,
@@ -345,6 +1455,21 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
                     {f.website && (
                       <span className="text-[11px] px-1.5 py-0.5 font-black uppercase tracking-wider border-2 border-bauhaus-blue/20 bg-link-light text-bauhaus-blue">Web</span>
                     )}
+                    {yearMemory && yearMemory.total > 0 && (
+                      <span className="text-[11px] px-1.5 py-0.5 font-black uppercase tracking-wider border-2 border-bauhaus-black/20 bg-bauhaus-canvas text-bauhaus-black">
+                        {yearMemory.total} year-memory
+                      </span>
+                    )}
+                    {yearMemory && yearMemory.verified > 0 && (
+                      <span className="text-[11px] px-1.5 py-0.5 font-black uppercase tracking-wider border-2 border-money bg-money-light text-money">
+                        {yearMemory.verified} source-backed
+                      </span>
+                    )}
+                    {reviewStatus && (
+                      <span className={`text-[11px] px-1.5 py-0.5 font-black uppercase tracking-wider border-2 ${reviewStatus.cls}`}>
+                        {reviewStatus.label}
+                      </span>
+                    )}
                     {power && (
                       <>
                         <span className={`text-[11px] px-1.5 py-0.5 font-black uppercase tracking-wider border-2 ${
@@ -369,6 +1494,38 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
                   {f.description && (
                     <div className="text-sm text-bauhaus-muted mt-1 line-clamp-2">
                       {f.description}
+                    </div>
+                  )}
+                  {signalSummary.length > 0 && (
+                    <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.2em]">
+                      <span className="text-bauhaus-muted">Review signals</span>
+                      {signalSummary.map((signal) => (
+                        <span
+                          key={signal.key}
+                          className={`border-2 px-2 py-1 ${
+                            signal.active
+                              ? 'border-money bg-money-light text-money'
+                              : 'border-bauhaus-black/15 bg-bauhaus-canvas text-bauhaus-muted'
+                          }`}
+                        >
+                          {signal.label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {missingSignals.length > 0 && (
+                    <div className="mt-1 text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                      Missing: {missingSignals.join(', ')}
+                    </div>
+                  )}
+                  {nextMove && (
+                    <div className="mt-2">
+                      <a
+                        href={nextMove.href}
+                        className="inline-flex border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red transition-colors hover:border-bauhaus-red hover:bg-bauhaus-red hover:text-white"
+                      >
+                        {nextMove.label}
+                      </a>
                     </div>
                   )}
                 </div>
@@ -399,6 +1556,25 @@ export default async function FoundationsPage({ searchParams }: { searchParams: 
                   ))}
                 </div>
               )}
+              <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.2em]">
+                {publicReviewHref && (
+                  <a
+                    href={publicReviewHref}
+                    className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-2 py-1 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                  >
+                    Open review route
+                  </a>
+                )}
+                {compareTargets.map((target) => (
+                  <a
+                    key={target.id}
+                    href={`/foundations/compare?left=${f.id}&right=${target.id}`}
+                    className="border-2 border-bauhaus-blue/25 bg-link-light px-2 py-1 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                  >
+                    {target.label}
+                  </a>
+                ))}
+              </div>
               {power && (
                 <div className="mt-3 grid gap-2 sm:grid-cols-3 text-[11px] font-bold">
                   <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas px-2 py-2">

--- a/apps/web/src/app/foundations/prf/page.tsx
+++ b/apps/web/src/app/foundations/prf/page.tsx
@@ -3,6 +3,11 @@ import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 
+const PRF_FOUNDATION_ID = '4ee5baca-c898-4318-ae2b-d79b95379cc7';
+const SNOW_FOUNDATION_ID = 'd242967e-0e68-4367-9785-06cf0ec7485e';
+const MINDEROO_FOUNDATION_ID = '8f8704be-d6e8-40f3-b561-ac6630ce5b36';
+const IAN_POTTER_FOUNDATION_ID = 'b9e090e5-1672-48ff-815a-2a6314ebe033';
+
 const money = (n: number | null) =>
   n == null ? '—' : n >= 1_000_000_000
     ? `$${(n / 1_000_000_000).toFixed(1)}B`
@@ -91,6 +96,51 @@ interface FoundationRecord {
   wealth_source: string;
 }
 
+interface ProgramYearRow {
+  id: string;
+  report_year: number | null;
+  fiscal_year: string | null;
+  summary: string | null;
+  reported_amount: number | null;
+  source_report_url: string | null;
+  partners: Array<{ name?: string; role?: string }> | null;
+  places: Array<{ name?: string; type?: string }> | null;
+  metadata: Record<string, unknown> | null;
+  foundation_programs:
+    | {
+        name: string;
+        program_type: string | null;
+      }
+    | Array<{
+        name: string;
+        program_type: string | null;
+      }>
+    | null;
+}
+
+interface FoundationCompareRow {
+  id: string;
+  name: string;
+  total_giving_annual: number | null;
+  year_memory_count: number;
+  open_program_count: number;
+}
+
+function getProgramYearFoundationProgram(row: ProgramYearRow) {
+  if (Array.isArray(row.foundation_programs)) return row.foundation_programs[0] ?? null;
+  return row.foundation_programs ?? null;
+}
+
+function labelise(value: string | null | undefined) {
+  if (!value) return 'Program';
+  return value.replace(/_/g, ' ');
+}
+
+function sourceLabel(value: string | null | undefined) {
+  if (!value) return 'unknown';
+  return value.replace(/_/g, ' ');
+}
+
 async function getData() {
   const db = getServiceSupabase();
 
@@ -103,6 +153,8 @@ async function getData() {
     { data: foundation },
     { data: grantees },
     { data: interlocks },
+    { data: programYears },
+    { data: comparisonRows },
   ] = await Promise.all([
     db.rpc('exec_sql', {
       query: `SELECT jf.recipient_name, jf.recipient_abn, jf.gs_entity_id,
@@ -186,6 +238,31 @@ async function getData() {
                 AND r.relationship_type = 'shared_director'
               ORDER BY (r.properties->>'shared_count')::int DESC NULLS LAST, e.canonical_name`,
     }),
+    db
+      .from('foundation_program_years')
+      .select('id, report_year, fiscal_year, summary, reported_amount, source_report_url, partners, places, metadata, foundation_programs(name, program_type)')
+      .eq('foundation_id', PRF_FOUNDATION_ID)
+      .order('report_year', { ascending: false, nullsFirst: false }),
+    db.rpc('exec_sql', {
+      query: `SELECT
+                f.id,
+                f.name,
+                f.total_giving_annual,
+                (
+                  SELECT COUNT(*)::int
+                  FROM foundation_program_years y
+                  WHERE y.foundation_id = f.id
+                ) AS year_memory_count,
+                (
+                  SELECT COUNT(*)::int
+                  FROM foundation_programs p
+                  WHERE p.foundation_id = f.id
+                    AND p.status = 'open'
+                ) AS open_program_count
+              FROM foundations f
+              WHERE f.id IN ('${PRF_FOUNDATION_ID}', '${SNOW_FOUNDATION_ID}')
+              ORDER BY f.total_giving_annual DESC NULLS LAST`,
+    }),
   ]);
 
   return {
@@ -197,11 +274,13 @@ async function getData() {
     foundation: (foundation || [])[0] as FoundationRecord | undefined,
     grantees: (grantees || []) as Grantee[],
     interlocks: (interlocks || []) as BoardInterlock[],
+    programYears: (programYears || []) as ProgramYearRow[],
+    comparisonRows: (comparisonRows || []) as FoundationCompareRow[],
   };
 }
 
 export default async function PRFIntelligencePage() {
-  const { partners, alma, outcomes, people, portfolio, foundation, grantees, interlocks } =
+  const { partners, alma, outcomes, people, portfolio, foundation, grantees, interlocks, programYears, comparisonRows } =
     await getData();
 
   const jrPartners = partners.filter(
@@ -260,6 +339,24 @@ export default async function PRFIntelligencePage() {
 
   // Community-controlled grantees
   const ccGrantees = grantees.filter((g) => g.is_community_controlled);
+  const snowCompare = comparisonRows.find((row) => row.id === SNOW_FOUNDATION_ID);
+  const prfCompare = comparisonRows.find((row) => row.id === PRF_FOUNDATION_ID);
+  const inferredProgramYears = programYears.filter((row) => {
+    const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+    return source?.includes('inferred');
+  });
+  const reportBackedProgramYears = programYears.filter((row) => {
+    const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+    return !!source && !source.includes('inferred');
+  });
+  const stableSignals = [
+    boardMembers.length > 0,
+    grantees.length > 0,
+    programYears.length > 0,
+    reportBackedProgramYears.length > 0,
+  ].filter(Boolean).length;
+  const totalStableSignals = 4;
+  const isStableReview = stableSignals === totalStableSignals;
 
   return (
     <div className="min-h-screen bg-white text-bauhaus-black">
@@ -280,6 +377,32 @@ export default async function PRFIntelligencePage() {
               Portfolio Intelligence Dashboard — {foundation?.geographic_focus || 'National'} •{' '}
               ABN 32 623 132 472
             </p>
+            <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+              <Link
+                href={`/foundations/compare?left=${PRF_FOUNDATION_ID}&right=${SNOW_FOUNDATION_ID}`}
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Compare PRF with Snow
+              </Link>
+              <Link
+                href={`/foundations/compare?left=${PRF_FOUNDATION_ID}&right=${MINDEROO_FOUNDATION_ID}`}
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Compare PRF with Minderoo
+              </Link>
+              <Link
+                href={`/foundations/compare?left=${PRF_FOUNDATION_ID}&right=${IAN_POTTER_FOUNDATION_ID}`}
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Compare PRF with Ian Potter
+              </Link>
+              <Link
+                href="/foundations/compare"
+                className="border-2 border-bauhaus-black/20 bg-gray-50 px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+              >
+                Open compare surface
+              </Link>
+            </div>
           </div>
           <div className="text-right space-y-1">
             <div className="text-4xl font-black text-bauhaus-red">
@@ -296,6 +419,73 @@ export default async function PRFIntelligencePage() {
       </header>
 
       <div className="mx-auto max-w-7xl px-8 py-8 space-y-12">
+
+        <section className="border-4 border-bauhaus-black bg-white p-6">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Stable review status</div>
+          <div className="mt-4 grid grid-cols-1 gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+            <div className="border-2 border-bauhaus-black bg-gray-50 p-4">
+              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Current completion</div>
+              <div className="mt-2 text-3xl font-black text-bauhaus-black">
+                {stableSignals}/{totalStableSignals}
+              </div>
+              <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                {isStableReview
+                  ? 'PRF now meets the stable review threshold. Governance, verified grants, recurring year memory, and verified source-backed program rows are all visible on this route.'
+                  : 'PRF is one signal away from stable review. The verified grant layer is now visible; the remaining gap is converting recurring program memory from inferred rows into verified source-backed rows.'}
+              </p>
+              <div className="mt-3 h-3 w-full overflow-hidden border-2 border-bauhaus-black bg-white">
+                <div
+                  className="h-full bg-bauhaus-red transition-all"
+                  style={{ width: `${(stableSignals / totalStableSignals) * 100}%` }}
+                />
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                <Link
+                  href="/foundations/compare?left=4ee5baca-c898-4318-ae2b-d79b95379cc7&right=d242967e-0e68-4367-9785-06cf0ec7485e"
+                  className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                >
+                  Back to compare
+                </Link>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="border-2 border-bauhaus-black bg-white p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Already in place</div>
+                <div className="mt-2 text-lg font-black text-bauhaus-black">Verified grant layer is live</div>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                  PRF now surfaces {grantees.length} verified grant rows on this route. The grant visibility layer is no longer a blocker.
+                </p>
+                <Link
+                  href="#how-prf-funds"
+                  className="mt-3 inline-flex items-center border-2 border-bauhaus-red bg-bauhaus-red px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-white transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black"
+                >
+                  Open verified grants
+                </Link>
+              </div>
+
+              <div className="border-2 border-bauhaus-black bg-white p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                  {isStableReview ? 'Already in place' : 'Remaining task'}
+                </div>
+                <div className="mt-2 text-lg font-black text-bauhaus-black">
+                  {isStableReview ? 'Verified source-backed memory is live' : 'Convert inferred rows to verified source-backed memory'}
+                </div>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                  {isStableReview
+                    ? `PRF currently has ${inferredProgramYears.length} inferred program-year rows and ${reportBackedProgramYears.length} verified source-backed rows. The recurring program layer is now anchored to official PRF source pages.`
+                    : `PRF currently has ${inferredProgramYears.length} inferred program-year rows and ${reportBackedProgramYears.length} verified source-backed rows. Stable review needs those recurring strands tied to official PRF source pages so this layer stops leaning on current-surface inference.`}
+                </p>
+                <Link
+                  href="#program-year-memory"
+                  className="mt-3 inline-flex items-center border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                >
+                  {isStableReview ? 'Open verified year memory' : 'Open year memory'}
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
 
         {/* Foundation Overview */}
         <section>
@@ -385,8 +575,154 @@ export default async function PRFIntelligencePage() {
           )}
         </section>
 
-        {/* How PRF Funds */}
+        <section id="program-year-memory">
+          <h2 className="text-xl font-black uppercase tracking-widest border-b-2 border-bauhaus-black pb-2 mb-6">
+            Recurring Program Year Memory
+          </h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {programYears.map((row) => {
+                  const program = getProgramYearFoundationProgram(row);
+                  const partnerLabel = (row.partners || []).map((partner) => partner.name).filter(Boolean).join(', ');
+                  const placeLabel = (row.places || []).map((place) => place.name).filter(Boolean).join(', ');
+                  const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+
+                  return (
+                    <div key={row.id} className="border-2 border-bauhaus-black p-4 bg-gray-50">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[10px] uppercase tracking-[0.18em] text-bauhaus-muted font-black">
+                            {row.fiscal_year || row.report_year || 'Program year'}
+                          </div>
+                          <h3 className="mt-1 text-base font-black text-bauhaus-black">
+                            {program?.name || 'Unnamed program'}
+                          </h3>
+                        </div>
+                        <span className="text-[10px] uppercase tracking-[0.18em] border-2 border-bauhaus-black/30 bg-white px-2 py-1 font-black text-bauhaus-black">
+                          {labelise(program?.program_type || 'program')}
+                        </span>
+                      </div>
+                      {row.summary ? (
+                        <p className="mt-3 text-sm leading-relaxed text-bauhaus-muted">{row.summary}</p>
+                      ) : null}
+                      <div className="mt-3 space-y-1 text-xs font-bold text-bauhaus-muted">
+                        {partnerLabel ? <p>Partners: {partnerLabel}</p> : null}
+                        {placeLabel ? <p>Places: {placeLabel}</p> : null}
+                        {source ? <p>Source: {sourceLabel(source)}</p> : null}
+                        {row.source_report_url ? (
+                          <p>
+                            Evidence:{' '}
+                            <a
+                              href={row.source_report_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-bauhaus-red underline decoration-bauhaus-red underline-offset-4"
+                            >
+                              open source
+                            </a>
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="border-2 border-bauhaus-black p-4 space-y-4 bg-white">
+              <h3 className="font-black text-sm uppercase tracking-wider">What changed here</h3>
+              <p className="text-sm text-bauhaus-muted leading-relaxed">
+                PRF now has a verified source-backed year-memory layer in CivicGraph for the current 2025-26
+                program surface, and that same layer has already created reviewed program snapshots in Empathy Ledger.
+              </p>
+              <div className="space-y-3 text-sm">
+                <div className="flex justify-between gap-4">
+                  <span className="text-bauhaus-muted">Program year rows</span>
+                  <span className="font-mono font-bold">{programYears.length}</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-bauhaus-muted">Source mode</span>
+                  <span className="font-mono font-bold">Official PRF pages</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-bauhaus-muted">EL snapshots</span>
+                  <span className="font-mono font-bold">7 reviewed</span>
+                </div>
+              </div>
+              <div className="border-l-4 border-bauhaus-red pl-3 text-sm font-bold text-bauhaus-black">
+                This is not annual-review-extracted yet, but it is now anchored to official PRF source pages rather
+                than inferred-only program rows. That is enough for stable review while a fuller report extraction
+                layer is built later.
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section>
+          <h2 className="text-xl font-black uppercase tracking-widest border-b-2 border-bauhaus-black pb-2 mb-6">
+            Snow vs PRF
+          </h2>
+          <div className="mb-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+            <Link
+              href={`/foundations/compare?left=${PRF_FOUNDATION_ID}&right=${SNOW_FOUNDATION_ID}`}
+              className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+            >
+              Open side-by-side compare
+            </Link>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {[
+              {
+                label: 'Paul Ramsay',
+                href: '/foundations/prf',
+                compare: prfCompare,
+                note: 'First non-Snow replication case with verified source-backed 2025-26 year memory flowing into EL snapshots.',
+              },
+              {
+                label: 'Snow Foundation',
+                href: '/snow-foundation',
+                compare: snowCompare,
+                note: 'Best verified case so far, with 2023-24 year memory linked across CivicGraph and Empathy Ledger.',
+              },
+            ].map((item) => (
+              <div key={item.label} className="border-2 border-bauhaus-black p-4 bg-white">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-bauhaus-muted font-black">
+                      Comparison route
+                    </div>
+                    <h3 className="mt-1 text-lg font-black text-bauhaus-black">{item.label}</h3>
+                  </div>
+                  <Link
+                    href={item.href}
+                    className="border-2 border-bauhaus-black px-3 py-2 text-[10px] uppercase tracking-[0.18em] font-black hover:bg-bauhaus-black hover:text-white transition-colors"
+                  >
+                    Open
+                  </Link>
+                </div>
+                <div className="mt-4 grid grid-cols-3 gap-3 text-sm">
+                  <div>
+                    <div className="text-bauhaus-muted">Annual giving</div>
+                    <div className="font-mono font-bold">{money(item.compare?.total_giving_annual ?? null)}</div>
+                  </div>
+                  <div>
+                    <div className="text-bauhaus-muted">Open programs</div>
+                    <div className="font-mono font-bold">{item.compare?.open_program_count ?? 0}</div>
+                  </div>
+                  <div>
+                    <div className="text-bauhaus-muted">Year memory</div>
+                    <div className="font-mono font-bold">{item.compare?.year_memory_count ?? 0}</div>
+                  </div>
+                </div>
+                <p className="mt-4 text-sm text-bauhaus-muted leading-relaxed">{item.note}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* How PRF Funds */}
+        <section id="how-prf-funds">
           <h2 className="text-xl font-black uppercase tracking-widest border-b-2 border-bauhaus-black pb-2 mb-6">
             How PRF Funds
           </h2>

--- a/apps/web/src/app/foundations/public-review-route.tsx
+++ b/apps/web/src/app/foundations/public-review-route.tsx
@@ -1,0 +1,420 @@
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+
+const FOUNDATION_LABELS: Record<string, string> = {
+  'd242967e-0e68-4367-9785-06cf0ec7485e': 'Snow',
+  '4ee5baca-c898-4318-ae2b-d79b95379cc7': 'PRF',
+  '8f8704be-d6e8-40f3-b561-ac6630ce5b36': 'Minderoo',
+  'b9e090e5-1672-48ff-815a-2a6314ebe033': 'Ian Potter',
+};
+
+interface PublicReviewRouteProps {
+  foundationId: string;
+  heroTitle: string;
+  heroDescription: string;
+  compareTargets: Array<{ id: string; label: string }>;
+  backHref?: string;
+}
+
+interface FoundationRow {
+  id: string;
+  name: string;
+  acnc_abn: string;
+  description: string | null;
+  website: string | null;
+  total_giving_annual: number | null;
+  profile_confidence: string;
+  geographic_focus: string[] | null;
+  thematic_focus: string[] | null;
+}
+
+interface ProgramYearRow {
+  id: string;
+  report_year: number | null;
+  fiscal_year: string | null;
+  summary: string | null;
+  reported_amount: number | null;
+  source_report_url: string | null;
+  metadata: Record<string, unknown> | null;
+  partners: Array<{ name?: string; role?: string }> | null;
+  places: Array<{ name?: string; type?: string }> | null;
+  foundation_programs:
+    | {
+        name: string;
+        program_type: string | null;
+      }
+    | Array<{
+        name: string;
+        program_type: string | null;
+      }>
+    | null;
+}
+
+interface BoardRoleRow {
+  person_name: string;
+  role_type: string | null;
+  person_entity_id: string | null;
+}
+
+function formatMoney(value: number | null | undefined): string {
+  if (value == null) return '—';
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}K`;
+  return `$${Math.round(value).toLocaleString('en-AU')}`;
+}
+
+function labelise(value: string | null | undefined): string {
+  if (!value) return 'Program';
+  return value.replace(/_/g, ' ');
+}
+
+function sourceLabel(value: string | null | undefined) {
+  if (!value) return 'Unknown source';
+  return value.replace(/_/g, ' ');
+}
+
+function getProgramYearFoundationProgram(row: ProgramYearRow) {
+  if (Array.isArray(row.foundation_programs)) return row.foundation_programs[0] ?? null;
+  return row.foundation_programs ?? null;
+}
+
+function reviewStatus({
+  boardRoleCount,
+  verifiedGrantCount,
+  yearMemoryCount,
+  verifiedSourceBackedCount,
+}: {
+  boardRoleCount: number;
+  verifiedGrantCount: number;
+  yearMemoryCount: number;
+  verifiedSourceBackedCount: number;
+}) {
+  const completed = [
+    boardRoleCount > 0,
+    verifiedGrantCount > 0,
+    yearMemoryCount > 0,
+    verifiedSourceBackedCount > 0,
+  ].filter(Boolean).length;
+
+  if (completed === 4) {
+    return {
+      label: 'Stable review',
+      detail: 'Governance, grant layer, recurring year memory, and verified source-backed memory are all live.',
+    };
+  }
+
+  if (completed >= 2) {
+    return {
+      label: 'Developing review',
+      detail: 'This route is reviewable, but at least one major layer is still thin or absent.',
+    };
+  }
+
+  return {
+    label: 'Early review',
+    detail: 'This route is still too thin for stable review and should be treated as a scouting surface only.',
+  };
+}
+
+function StatCard({ label, value, subtext }: { label: string; value: string; subtext: string }) {
+  return (
+    <div className="border-4 border-bauhaus-black bg-white p-5">
+      <div className="text-xs font-black uppercase tracking-[0.25em] text-bauhaus-muted">{label}</div>
+      <div className="mt-2 text-3xl font-black text-bauhaus-black">{value}</div>
+      <div className="mt-2 text-sm font-medium text-bauhaus-muted">{subtext}</div>
+    </div>
+  );
+}
+
+export async function PublicFoundationReviewRoute({
+  foundationId,
+  heroTitle,
+  heroDescription,
+  compareTargets,
+  backHref = '/foundations',
+}: PublicReviewRouteProps) {
+  const supabase = getServiceSupabase();
+
+  const { data: foundation } = await supabase
+    .from('foundations')
+    .select('id, name, acnc_abn, description, website, total_giving_annual, profile_confidence, geographic_focus, thematic_focus')
+    .eq('id', foundationId)
+    .single<FoundationRow>();
+
+  if (!foundation) {
+    return (
+      <div className="border-4 border-bauhaus-red bg-danger-light p-6">
+        <div className="text-sm font-black uppercase tracking-[0.3em] text-bauhaus-red">Foundation route unavailable</div>
+        <p className="mt-3 text-sm font-medium text-bauhaus-red">
+          The selected foundation did not resolve from the current CivicGraph database.
+        </p>
+      </div>
+    );
+  }
+
+  const [
+    { data: programYears },
+    { data: boardRoles },
+    openProgramsResult,
+    allProgramsResult,
+    foundationGranteeTableResult,
+    { data: verifiedGrantRows },
+  ] = await Promise.all([
+    supabase
+      .from('foundation_program_years')
+      .select('id, report_year, fiscal_year, summary, reported_amount, source_report_url, metadata, partners, places, foundation_programs(name, program_type)')
+      .eq('foundation_id', foundationId)
+      .order('report_year', { ascending: false, nullsFirst: false })
+      .order('fiscal_year', { ascending: false, nullsFirst: false }),
+    (() => {
+      const query = supabase
+        .from('person_roles')
+        .select('person_name, role_type, person_entity_id')
+        .is('cessation_date', null)
+        .order('role_type', { ascending: true })
+        .order('person_name', { ascending: true });
+      return foundation.acnc_abn
+        ? query.eq('company_abn', foundation.acnc_abn)
+        : query.eq('company_name', foundation.name);
+    })(),
+    supabase
+      .from('foundation_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundationId)
+      .eq('status', 'open'),
+    supabase
+      .from('foundation_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundationId)
+      .in('status', ['open', 'closed', 'ongoing']),
+    supabase
+      .from('foundation_grantees')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundationId),
+    supabase.rpc('exec_sql', {
+      query: `SELECT COUNT(*)::int AS count
+              FROM gs_relationships r
+              JOIN gs_entities s ON s.id = r.source_entity_id
+              WHERE s.abn = '${foundation.acnc_abn}'
+                AND r.relationship_type = 'grant'
+                AND r.dataset = 'foundation_grantees'`,
+    }),
+  ]);
+
+  const yearMemoryRows = (programYears || []) as ProgramYearRow[];
+  const roleRows = (boardRoles || []) as BoardRoleRow[];
+  const relationshipGrantCount = Number(((verifiedGrantRows as Array<{ count: number }> | null)?.[0]?.count) || 0);
+  const verifiedGrantCount = Math.max(foundationGranteeTableResult.count || 0, relationshipGrantCount);
+  const verifiedSourceBackedCount = yearMemoryRows.filter((row) => {
+    const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+    return !!source && !source.includes('inferred');
+  }).length;
+  const status = reviewStatus({
+    boardRoleCount: roleRows.length,
+    verifiedGrantCount,
+    yearMemoryCount: yearMemoryRows.length,
+    verifiedSourceBackedCount,
+  });
+
+  const themeLine = foundation.thematic_focus?.length ? foundation.thematic_focus.join(' • ') : 'No theme tags yet';
+  const geographyLine = foundation.geographic_focus?.length ? foundation.geographic_focus.join(' • ') : 'No geography tags yet';
+  const topRoles = roleRows.slice(0, 8);
+  const latestPrograms = yearMemoryRows.slice(0, 8);
+
+  return (
+    <div className="pb-16">
+      <section className="border-b-4 border-bauhaus-black pb-10">
+        <Link
+          href={backHref}
+          className="text-xs font-black uppercase tracking-[0.35em] text-bauhaus-muted transition-colors hover:text-bauhaus-black"
+        >
+          ← Back
+        </Link>
+        <div className="mt-4 text-xs font-black uppercase tracking-[0.35em] text-bauhaus-red">Public review route</div>
+        <h1 className="mt-4 text-4xl font-black leading-[0.9] text-bauhaus-black sm:text-6xl">
+          {heroTitle}
+        </h1>
+        <p className="mt-5 max-w-3xl text-lg font-medium leading-relaxed text-bauhaus-muted">
+          {heroDescription}
+        </p>
+        <div className="mt-6 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.25em]">
+          <span className="border-2 border-bauhaus-black px-3 py-2 text-bauhaus-black">{status.label}</span>
+          <span className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-bauhaus-blue">
+            {foundation.name}
+          </span>
+          <span className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red">
+            ABN {foundation.acnc_abn}
+          </span>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+          {compareTargets.map((target) => (
+            <Link
+              key={target.id}
+              href={`/foundations/compare?left=${foundationId}&right=${target.id}`}
+              className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+            >
+              {target.label}
+            </Link>
+          ))}
+          <Link
+            href={`/foundations/${foundationId}`}
+            className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open foundation detail
+          </Link>
+        </div>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-0 md:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          label="Annual giving"
+          value={formatMoney(foundation.total_giving_annual)}
+          subtext={themeLine}
+        />
+        <StatCard
+          label="Governance roles"
+          value={String(roleRows.length)}
+          subtext={geographyLine}
+        />
+        <StatCard
+          label="Year memory"
+          value={String(yearMemoryRows.length)}
+          subtext={`${verifiedSourceBackedCount} source-backed rows`}
+        />
+        <StatCard
+          label="Open programs"
+          value={String(openProgramsResult.count || 0)}
+          subtext={`${allProgramsResult.count || 0} total tracked programs`}
+        />
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+        <div className="border-4 border-bauhaus-black bg-white p-6">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Review status</div>
+          <div className="mt-3 text-3xl font-black text-bauhaus-black">{status.label}</div>
+          <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">{status.detail}</p>
+          <div className="mt-5 space-y-3 text-sm font-medium text-bauhaus-muted">
+            <div><span className="font-black text-bauhaus-black">Grant layer:</span> {verifiedGrantCount} verified grant rows.</div>
+            <div><span className="font-black text-bauhaus-black">Year-memory layer:</span> {verifiedSourceBackedCount}/{yearMemoryRows.length} rows are source-backed.</div>
+            <div><span className="font-black text-bauhaus-black">Website:</span> {foundation.website || 'No website on profile yet.'}</div>
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-white p-6">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-blue">What this route proves</div>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div className="border-2 border-bauhaus-black p-4">
+              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">People layer</div>
+              <div className="mt-2 text-lg font-black text-bauhaus-black">{roleRows.length} visible governance roles</div>
+              <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                This foundation is legible at the governance layer and can be compared on board visibility, not just funding totals.
+              </p>
+            </div>
+            <div className="border-2 border-bauhaus-black p-4">
+              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Program memory</div>
+              <div className="mt-2 text-lg font-black text-bauhaus-black">{verifiedSourceBackedCount} verified source-backed rows</div>
+              <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                Current recurring strands are now tied to visible sources, so the route reads as evidence-backed rather than inferred.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-6 xl:grid-cols-[0.85fr_1.15fr]">
+        <div className="border-4 border-bauhaus-black bg-white">
+          <div className="border-b-4 border-bauhaus-black bg-bauhaus-yellow px-6 py-4">
+            <div className="text-xs font-black uppercase tracking-[0.28em] text-bauhaus-black">Governance layer</div>
+          </div>
+          <div className="space-y-3 p-6">
+            {topRoles.length === 0 ? (
+              <div className="text-sm font-medium text-bauhaus-muted">No visible board or leadership roles are linked yet.</div>
+            ) : (
+              topRoles.map((role) => (
+                <div key={`${role.person_name}-${role.role_type || 'role'}`} className="border-2 border-bauhaus-black/15 px-4 py-3">
+                  <div className="text-sm font-black text-bauhaus-black">{role.person_name}</div>
+                  <div className="mt-1 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                    {labelise(role.role_type)}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-white">
+          <div className="border-b-4 border-bauhaus-black bg-bauhaus-blue px-6 py-4">
+            <div className="text-xs font-black uppercase tracking-[0.28em] text-white">Latest program year memory</div>
+          </div>
+          <div className="space-y-4 p-6">
+            {latestPrograms.length === 0 ? (
+              <div className="text-sm font-medium text-bauhaus-muted">No recurring program year-memory has been added yet.</div>
+            ) : (
+              latestPrograms.map((row) => {
+                const program = getProgramYearFoundationProgram(row);
+                const source = typeof row.metadata?.source === 'string' ? row.metadata.source : null;
+                return (
+                  <div key={row.id} className="border-2 border-bauhaus-black/15 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="text-lg font-black text-bauhaus-black">{program?.name || 'Unnamed program'}</div>
+                        <div className="mt-1 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                          {row.fiscal_year || row.report_year || 'Unknown year'} · {labelise(program?.program_type)}
+                        </div>
+                      </div>
+                      <div className="text-sm font-black text-bauhaus-red">{formatMoney(row.reported_amount)}</div>
+                    </div>
+                    <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                      {row.summary || 'No narrative summary is attached to this year-memory row yet.'}
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                      <span className="border-2 border-bauhaus-black px-2 py-1 text-bauhaus-black">
+                        Source: {sourceLabel(source)}
+                      </span>
+                      {row.source_report_url ? (
+                        <a
+                          href={row.source_report_url}
+                          className="border-2 border-bauhaus-blue/25 bg-link-light px-2 py-1 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                        >
+                          Evidence: open source
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Next moves</div>
+        <div className="mt-4 grid gap-4 md:grid-cols-3">
+          <Link
+            href={`/foundations/compare?left=${foundationId}&right=d242967e-0e68-4367-9785-06cf0ec7485e`}
+            className="border-2 border-bauhaus-black p-4 transition-colors hover:bg-bauhaus-black hover:text-white"
+          >
+            <div className="text-lg font-black">Compare with Snow</div>
+            <p className="mt-2 text-sm font-medium opacity-80">Use Snow as the strong verified benchmark for portfolio-style review.</p>
+          </Link>
+          <Link
+            href={`/foundations/compare?left=${foundationId}&right=4ee5baca-c898-4318-ae2b-d79b95379cc7`}
+            className="border-2 border-bauhaus-black p-4 transition-colors hover:bg-bauhaus-black hover:text-white"
+          >
+            <div className="text-lg font-black">Compare with PRF</div>
+            <p className="mt-2 text-sm font-medium opacity-80">Contrast source-backed year-memory with a stronger verified grant layer.</p>
+          </Link>
+          <Link
+            href="/foundations/compare"
+            className="border-2 border-bauhaus-black p-4 transition-colors hover:bg-bauhaus-black hover:text-white"
+          >
+            <div className="text-lg font-black">Open compare surface</div>
+            <p className="mt-2 text-sm font-medium opacity-80">Pivot across the four-foundation review set without leaving the public route.</p>
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/foundations/review-set/page.tsx
+++ b/apps/web/src/app/foundations/review-set/page.tsx
@@ -1,0 +1,449 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Foundation Review Set | CivicGraph',
+  description: 'Public hub for the six-foundation review set: Snow, PRF, Minderoo, Ian Potter, ECSTRA, and Rio Tinto.',
+};
+
+const FOUNDATIONS = [
+  {
+    id: 'd242967e-0e68-4367-9785-06cf0ec7485e',
+    label: 'Snow',
+    route: '/snow-foundation',
+    compareTargets: [
+      { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare with PRF' },
+      { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare with Minderoo' },
+      { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare with Ian Potter' },
+      { id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f', label: 'Compare with ECSTRA' },
+      { id: '85f0de43-d004-4122-83a6-287eeecc4da9', label: 'Compare with Rio Tinto' },
+    ],
+  },
+  {
+    id: '4ee5baca-c898-4318-ae2b-d79b95379cc7',
+    label: 'PRF',
+    route: '/foundations/prf',
+    compareTargets: [
+      { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare with Snow' },
+      { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare with Minderoo' },
+      { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare with Ian Potter' },
+      { id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f', label: 'Compare with ECSTRA' },
+      { id: '85f0de43-d004-4122-83a6-287eeecc4da9', label: 'Compare with Rio Tinto' },
+    ],
+  },
+  {
+    id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36',
+    label: 'Minderoo',
+    route: '/foundations/minderoo',
+    compareTargets: [
+      { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare with Snow' },
+      { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare with PRF' },
+      { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare with Ian Potter' },
+      { id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f', label: 'Compare with ECSTRA' },
+      { id: '85f0de43-d004-4122-83a6-287eeecc4da9', label: 'Compare with Rio Tinto' },
+    ],
+  },
+  {
+    id: 'b9e090e5-1672-48ff-815a-2a6314ebe033',
+    label: 'Ian Potter',
+    route: '/foundations/ian-potter',
+    compareTargets: [
+      { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare with Snow' },
+      { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare with PRF' },
+      { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare with Minderoo' },
+      { id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f', label: 'Compare with ECSTRA' },
+      { id: '85f0de43-d004-4122-83a6-287eeecc4da9', label: 'Compare with Rio Tinto' },
+    ],
+  },
+  {
+    id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f',
+    label: 'ECSTRA',
+    route: '/foundations/ecstra',
+    compareTargets: [
+      { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare with Snow' },
+      { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare with PRF' },
+      { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare with Minderoo' },
+      { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare with Ian Potter' },
+      { id: '85f0de43-d004-4122-83a6-287eeecc4da9', label: 'Compare with Rio Tinto' },
+    ],
+  },
+  {
+    id: '85f0de43-d004-4122-83a6-287eeecc4da9',
+    label: 'Rio Tinto',
+    route: '/foundations/rio-tinto',
+    compareTargets: [
+      { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare with Snow' },
+      { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare with PRF' },
+      { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare with Minderoo' },
+      { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare with Ian Potter' },
+      { id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f', label: 'Compare with ECSTRA' },
+    ],
+  },
+] as const;
+
+interface FoundationSummaryRow {
+  id: string;
+  name: string;
+  total_giving_annual: number | null;
+  board_roles: number;
+  verified_grants: number;
+  year_memory_count: number;
+  verified_source_backed_count: number;
+}
+
+interface PairSummary {
+  left: (typeof FOUNDATIONS)[number];
+  right: (typeof FOUNDATIONS)[number];
+  status: string;
+  detail: string;
+  score: number;
+}
+
+function formatMoney(value: number | null | undefined): string {
+  if (value == null) return '—';
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}K`;
+  return `$${Math.round(value).toLocaleString('en-AU')}`;
+}
+
+function reviewLabel(row: FoundationSummaryRow) {
+  const completed = [
+    row.board_roles > 0,
+    row.verified_grants > 0,
+    row.year_memory_count > 0,
+    row.verified_source_backed_count > 0,
+  ].filter(Boolean).length;
+
+  if (completed === 4) return 'Stable review';
+  if (completed >= 2) return 'Developing review';
+  return 'Early review';
+}
+
+function reviewSignalCount(row: FoundationSummaryRow) {
+  return [
+    row.board_roles > 0,
+    row.verified_grants > 0,
+    row.year_memory_count > 0,
+    row.verified_source_backed_count > 0,
+  ].filter(Boolean).length;
+}
+
+function buildPairStatus(left: FoundationSummaryRow, right: FoundationSummaryRow) {
+  const leftSignals = reviewSignalCount(left);
+  const rightSignals = reviewSignalCount(right);
+  const bothStable = leftSignals === 4 && rightSignals === 4;
+  const oneStableOneDeveloping =
+    (leftSignals === 4 && rightSignals >= 2) ||
+    (rightSignals === 4 && leftSignals >= 2);
+
+  if (bothStable) {
+    return {
+      status: 'Ready now',
+      detail: 'Both sides already meet the stable-review threshold.',
+      score: 3,
+    };
+  }
+
+  if (oneStableOneDeveloping) {
+    return {
+      status: 'Close pair',
+      detail: 'One side is stable and the other is reviewable, but still missing part of the evidence stack.',
+      score: 2,
+    };
+  }
+
+  return {
+    status: 'Developing pair',
+    detail: 'This pairing is useful for review, but both sides still need more evidence depth before it becomes a stable benchmark pair.',
+    score: 1,
+  };
+}
+
+export default async function FoundationReviewSetPage() {
+  const supabase = getServiceSupabase();
+  const ids = FOUNDATIONS.map((foundation) => `'${foundation.id}'`).join(',');
+
+  const { data } = await supabase.rpc('exec_sql', {
+    query: `WITH rel AS (
+              SELECT s.abn, COUNT(*)::int AS relationship_grants
+              FROM gs_relationships r
+              JOIN gs_entities s ON s.id = r.source_entity_id
+              WHERE r.relationship_type = 'grant'
+                AND r.dataset = 'foundation_grantees'
+              GROUP BY s.abn
+            ),
+            yrs AS (
+              SELECT
+                foundation_id,
+                COUNT(*)::int AS year_memory_count,
+                COUNT(*) FILTER (
+                  WHERE COALESCE(metadata->>'source', '') NOT ILIKE '%inferred%'
+                )::int AS verified_source_backed_count
+              FROM foundation_program_years
+              GROUP BY foundation_id
+            )
+            SELECT
+              f.id,
+              f.name,
+              f.total_giving_annual,
+              (
+                SELECT COUNT(*)::int
+                FROM person_roles pr
+                WHERE (
+                    (f.acnc_abn IS NOT NULL AND f.acnc_abn <> '' AND pr.company_abn = f.acnc_abn)
+                    OR ((f.acnc_abn IS NULL OR f.acnc_abn = '') AND pr.company_name = f.name)
+                  )
+                  AND pr.cessation_date IS NULL
+              ) AS board_roles,
+              GREATEST(
+                (
+                  SELECT COUNT(*)::int
+                  FROM foundation_grantees fg
+                  WHERE fg.foundation_id = f.id
+                ),
+                COALESCE(rel.relationship_grants, 0)
+              ) AS verified_grants,
+              COALESCE(yrs.year_memory_count, 0) AS year_memory_count,
+              COALESCE(yrs.verified_source_backed_count, 0) AS verified_source_backed_count
+            FROM foundations f
+            LEFT JOIN rel ON rel.abn = f.acnc_abn
+            LEFT JOIN yrs ON yrs.foundation_id = f.id
+            WHERE f.id IN (${ids})
+            ORDER BY f.total_giving_annual DESC NULLS LAST`,
+  });
+
+  const rows = (data || []) as FoundationSummaryRow[];
+  const summaryMap = new Map(rows.map((row) => [row.id, row]));
+  const pairRows: PairSummary[] = FOUNDATIONS.flatMap((left, index) =>
+    FOUNDATIONS.slice(index + 1).flatMap((right) => {
+      const leftRow = summaryMap.get(left.id);
+      const rightRow = summaryMap.get(right.id);
+      if (!leftRow || !rightRow) return [];
+
+      return [{
+        left,
+        right,
+        ...buildPairStatus(leftRow, rightRow),
+      }];
+    })
+  );
+  const recommendedPair = [...pairRows].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const aTotal = (summaryMap.get(a.left.id)?.total_giving_annual || 0) + (summaryMap.get(a.right.id)?.total_giving_annual || 0);
+    const bTotal = (summaryMap.get(b.left.id)?.total_giving_annual || 0) + (summaryMap.get(b.right.id)?.total_giving_annual || 0);
+    return bTotal - aTotal;
+  })[0] || null;
+  const nextClosePair =
+    [...pairRows]
+      .filter((pair) => pair.status === 'Close pair')
+      .sort((a, b) => {
+        const aTotal = (summaryMap.get(a.left.id)?.total_giving_annual || 0) + (summaryMap.get(a.right.id)?.total_giving_annual || 0);
+        const bTotal = (summaryMap.get(b.left.id)?.total_giving_annual || 0) + (summaryMap.get(b.right.id)?.total_giving_annual || 0);
+        return bTotal - aTotal;
+      })[0] || null;
+  const strongestDevelopingPair =
+    [...pairRows]
+      .filter((pair) => pair.status === 'Developing pair')
+      .sort((a, b) => {
+        const aTotal = (summaryMap.get(a.left.id)?.total_giving_annual || 0) + (summaryMap.get(a.right.id)?.total_giving_annual || 0);
+        const bTotal = (summaryMap.get(b.left.id)?.total_giving_annual || 0) + (summaryMap.get(b.right.id)?.total_giving_annual || 0);
+        return bTotal - aTotal;
+      })[0] || null;
+
+  return (
+    <div className="pb-16">
+      <section className="border-b-4 border-bauhaus-black pb-10">
+        <Link
+          href="/foundations"
+          className="text-xs font-black uppercase tracking-[0.35em] text-bauhaus-muted transition-colors hover:text-bauhaus-black"
+        >
+          ← Back to foundations
+        </Link>
+        <div className="mt-4 text-xs font-black uppercase tracking-[0.35em] text-bauhaus-red">Public review set</div>
+        <h1 className="mt-4 text-4xl font-black leading-[0.9] text-bauhaus-black sm:text-6xl">
+          Six-foundation
+          <br />
+          review set
+        </h1>
+        <p className="mt-5 max-w-4xl text-lg font-medium leading-relaxed text-bauhaus-muted">
+          This hub gathers the current benchmark set for public philanthropic review: Snow, PRF,
+          Minderoo, Ian Potter, ECSTRA, and Rio Tinto. Each card links to its compact review route and the closest side-by-side comparisons.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.25em]">
+          <span className="border-2 border-bauhaus-black px-3 py-2 text-bauhaus-black">6 live foundations</span>
+          <span className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-bauhaus-blue">Public review routes</span>
+          <span className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red">Compare-ready set</span>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+          <Link
+            href="/foundations/compare"
+            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+          >
+            Open compare surface
+          </Link>
+          <Link
+            href="/foundations?review=stable"
+            className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open stable slice
+          </Link>
+        </div>
+      </section>
+
+      <section className="mt-10 grid gap-6 xl:grid-cols-2">
+        {FOUNDATIONS.map((foundation) => {
+          const row = summaryMap.get(foundation.id);
+          if (!row) return null;
+          const label = reviewLabel(row);
+
+          return (
+            <div key={foundation.id} className="border-4 border-bauhaus-black bg-white">
+              <div className="border-b-4 border-bauhaus-black bg-bauhaus-yellow px-6 py-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-black">{foundation.label}</div>
+                <div className="mt-1 text-2xl font-black text-bauhaus-black">{row.name}</div>
+              </div>
+              <div className="space-y-5 p-6">
+                <div className="flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                  <span className="border-2 border-bauhaus-black px-2.5 py-1 text-bauhaus-black">{label}</span>
+                  <span className="border-2 border-bauhaus-red/25 bg-bauhaus-red/5 px-2.5 py-1 text-bauhaus-red">
+                    {formatMoney(row.total_giving_annual)} annual giving
+                  </span>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+                    <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Governance</div>
+                    <div className="mt-2 text-2xl font-black text-bauhaus-black">{row.board_roles}</div>
+                  </div>
+                  <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+                    <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Verified grants</div>
+                    <div className="mt-2 text-2xl font-black text-bauhaus-black">{row.verified_grants}</div>
+                  </div>
+                  <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+                    <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Year memory</div>
+                    <div className="mt-2 text-2xl font-black text-bauhaus-black">{row.year_memory_count}</div>
+                  </div>
+                  <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+                    <div className="text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">Source-backed</div>
+                    <div className="mt-2 text-2xl font-black text-bauhaus-black">{row.verified_source_backed_count}</div>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+                  <Link
+                    href={foundation.route}
+                    className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                  >
+                    Open review route
+                  </Link>
+                  {foundation.compareTargets.map((target) => (
+                    <Link
+                      key={target.id}
+                      href={`/foundations/compare?left=${foundation.id}&right=${target.id}`}
+                      className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                    >
+                      {target.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </section>
+
+      <section className="mt-10 border-4 border-bauhaus-black bg-white p-6">
+        {recommendedPair ? (
+          <div className="mb-6 border-2 border-bauhaus-black bg-bauhaus-yellow p-4">
+            <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Recommended starting pair</div>
+            <div className="mt-2 text-2xl font-black text-bauhaus-black">
+              {recommendedPair.left.label} vs {recommendedPair.right.label}
+            </div>
+            <p className="mt-2 max-w-3xl text-sm font-medium leading-relaxed text-bauhaus-black">
+              {recommendedPair.detail}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.18em]">
+              <span className="border-2 border-bauhaus-black px-2.5 py-1 text-bauhaus-black">
+                {recommendedPair.status}
+              </span>
+              <Link
+                href={`/foundations/compare?left=${recommendedPair.left.id}&right=${recommendedPair.right.id}`}
+                className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+              >
+                Open recommended compare
+              </Link>
+            </div>
+          </div>
+        ) : null}
+        {nextClosePair || strongestDevelopingPair ? (
+          <div className="mb-6 grid gap-4 xl:grid-cols-2">
+            {nextClosePair ? (
+              <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+                <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Next close pair</div>
+                <div className="mt-2 text-xl font-black text-bauhaus-black">
+                  {nextClosePair.left.label} vs {nextClosePair.right.label}
+                </div>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                  {nextClosePair.detail}
+                </p>
+                <Link
+                  href={`/foundations/compare?left=${nextClosePair.left.id}&right=${nextClosePair.right.id}`}
+                  className="mt-3 inline-flex border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                >
+                  Open close pair
+                </Link>
+              </div>
+            ) : null}
+            {strongestDevelopingPair ? (
+              <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+                <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Best developing pair</div>
+                <div className="mt-2 text-xl font-black text-bauhaus-black">
+                  {strongestDevelopingPair.left.label} vs {strongestDevelopingPair.right.label}
+                </div>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                  {strongestDevelopingPair.detail}
+                </p>
+                <Link
+                  href={`/foundations/compare?left=${strongestDevelopingPair.left.id}&right=${strongestDevelopingPair.right.id}`}
+                  className="mt-3 inline-flex border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                >
+                  Open developing pair
+                </Link>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Pair matrix</div>
+        <h2 className="mt-2 text-2xl font-black text-bauhaus-black">Live compare pairs inside the review set</h2>
+        <p className="mt-3 max-w-4xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+          These are the live pairings currently available across Snow, PRF, Minderoo, Ian Potter, ECSTRA, and Rio Tinto. Use this as the fastest way to choose the strongest side-by-side route before dropping into the full compare surface.
+        </p>
+        <div className="mt-6 grid gap-4 xl:grid-cols-2">
+          {pairRows.map((pair) => (
+            <div key={`${pair.left.id}-${pair.right.id}`} className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-lg font-black text-bauhaus-black">
+                    {pair.left.label} vs {pair.right.label}
+                  </div>
+                  <div className="mt-1 text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+                    {pair.status}
+                  </div>
+                </div>
+                <Link
+                  href={`/foundations/compare?left=${pair.left.id}&right=${pair.right.id}`}
+                  className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                >
+                  Open compare
+                </Link>
+              </div>
+              <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">{pair.detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/foundations/rio-tinto/page.tsx
+++ b/apps/web/src/app/foundations/rio-tinto/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import { PublicFoundationReviewRoute } from '../public-review-route';
+
+const RIO_TINTO_FOUNDATION_ID = '85f0de43-d004-4122-83a6-287eeecc4da9';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Rio Tinto Review Route | CivicGraph',
+  description: 'Public review route for Rio Tinto Foundation with governance visibility, verified grants, and source-backed year-memory.',
+};
+
+export default async function RioTintoReviewPage() {
+  return (
+    <PublicFoundationReviewRoute
+      foundationId={RIO_TINTO_FOUNDATION_ID}
+      heroTitle="Rio Tinto Foundation review route"
+      heroDescription="This public route shows Rio Tinto as a corporate-foundation review case with named board visibility, a first verified grant layer, and source-backed current program memory across community, Indigenous, and partnership surfaces."
+      compareTargets={[
+        { id: 'd242967e-0e68-4367-9785-06cf0ec7485e', label: 'Compare Rio Tinto with Snow' },
+        { id: '4ee5baca-c898-4318-ae2b-d79b95379cc7', label: 'Compare Rio Tinto with PRF' },
+        { id: '8f8704be-d6e8-40f3-b561-ac6630ce5b36', label: 'Compare Rio Tinto with Minderoo' },
+        { id: 'b9e090e5-1672-48ff-815a-2a6314ebe033', label: 'Compare Rio Tinto with Ian Potter' },
+        { id: '25b80b63-416e-4aaa-b470-2f8dc6fa835f', label: 'Compare Rio Tinto with ECSTRA' },
+      ]}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- New per-foundation deep-dives: \`/foundations/{ecstra,ian-potter,minderoo,rio-tinto}\`.
- New \`/foundations/compare\` side-by-side view.
- New \`/foundations/backlog\` for pipeline tracking.
- New \`/foundations/review-set\` curated review queue + shared \`public-review-route\` scaffold.
- Enriches foundations index, \`[id]/\` page & giving-chart, and \`prf/\`.

Part of phase 2 dirty-tree carve (bucket: foundations-pages).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] Each new foundation page loads without error
- [ ] \`/foundations/compare\` renders with selected foundations