### PR TITLE
docs: Goods V1 signoff + operating plan + pilot testing briefs

### DIFF
--- a/GRANTSCOPE_SIGNOFF.md
+++ b/GRANTSCOPE_SIGNOFF.md
@@ -1,0 +1,68 @@
+# GrantScope Signoff
+
+## Branches
+- Working branch: `codex/goods-civicgraph-signoff`
+- Clean base branch: `main` now matches `origin/main`
+
+## What "done enough to draft and use" means
+- Grant semantics debt is zero:
+  - `status_null_total = 0`
+  - `application_status_null_total = 0`
+  - `open_past_deadline_total = 0`
+- Grant source identity debt is zero:
+  - `blank_source_id_total = 0`
+  - `canonical_mismatch_total = 0`
+- The analytics pipeline health gate passes.
+- Web typecheck passes.
+- Grant engine contract tests pass.
+
+## Repeatable closeout commands
+
+Fast signoff:
+
+```bash
+cd /Users/benknight/Code/grantscope
+pnpm signoff
+```
+
+Full signoff with data and agent reports:
+
+```bash
+cd /Users/benknight/Code/grantscope
+pnpm signoff:full
+```
+
+Branch-only hygiene check:
+
+```bash
+cd /Users/benknight/Code/grantscope
+pnpm branch:check
+```
+
+## What `pnpm signoff` checks
+- current branch is not `main`
+- local `main` matches `origin/main`
+- worktree dirtiness is reported clearly
+- `apps/web` TypeScript passes
+- `@grantscope/engine` contract tests pass
+- grant semantics health gate passes
+- grant source identity health gate passes
+- the analytics-only pipeline gate runs cleanly
+
+## Manual smoke after signoff
+Run the app, then open:
+
+- [ops health](http://127.0.0.1:3003/ops/health)
+  - Grant Semantics and Grant Source Identity both show zero active debt.
+- [data health report](http://127.0.0.1:3003/reports/data-health)
+  - The report matches the ops health counts.
+- [mission control](http://127.0.0.1:3003/mission-control)
+  - Agent registry loads and recent analytics runs are visible.
+- [ops summary](http://127.0.0.1:3003/ops)
+  - Ops summary loads without API errors.
+
+## Reality check
+- This repo still has a broad dirty worktree outside the grant-system closeout slice.
+- `pnpm signoff` separates branch/base health from worktree noise so you can judge system readiness without pretending the whole repo is pristine.
+- `pnpm signoff:full` includes broader data and agent-health reporting. Historical low-success agents and stale long-running non-grant agents still show there as operational context; they are not the closeout gate for the grant-system slice.
+- If you want a truly clean packaging branch, stage only the closeout-related files and commit from the current working branch instead of trying to clean the whole repo at once.

--- a/OPERATING_PLAN.md
+++ b/OPERATING_PLAN.md
@@ -1,0 +1,420 @@
+# GrantScope Operating Plan
+
+Last updated: 2026-04-20
+
+## Mission
+
+GrantScope exists to make Australian philanthropy legible enough that:
+
+- analysts can trust which foundations are real benchmark peers
+- organisations and charities can work out which foundations are the best fit for their mission
+- teams can move from vague prospecting to evidence-backed engagement strategy
+
+The core shift is:
+
+- from "find grants"
+- to "understand foundations, align a mission, and build the right relationship strategy"
+
+This is not just a foundation directory.
+It is a philanthropy intelligence and engagement system.
+
+## Product Promise
+
+For any organisation, project, or mission, GrantScope should help a user answer:
+
+- which foundations are relevant
+- why they are relevant
+- whether they are truly the best fit
+- how to frame the work in that foundation's language
+- what message, proof, and engagement path will most likely move the relationship forward
+
+## Primary Users
+
+### 1. Foundation analyst / philanthropy researcher
+
+Job:
+
+- decide which foundations are real benchmark peers or relevant prospects
+
+Needs:
+
+- reliable reviewability
+- verified grants
+- year memory
+- source-backed evidence
+- strong compare surfaces
+
+Success:
+
+- can confidently say which foundations are stable, developing, weak, or outside the benchmark lane
+
+### 2. Organisation or charity seeking philanthropic partners
+
+Example:
+
+- A Curious Tractor
+
+Job:
+
+- decide which foundations to pursue for a given project, save them, compare fit, and shape a credible engagement strategy
+
+Needs:
+
+- shortlist foundations by mission fit, not only grant availability
+- save foundations by project
+- compare multiple foundations against one project
+- see historical signals, themes, and likely appetite
+- convert foundation research into outreach strategy and message alignment
+
+Success:
+
+- can answer "Should we pursue this foundation, for this project, now, and if so how?"
+
+### 3. Internal partnerships / development lead
+
+Job:
+
+- turn project context, evidence, and foundation fit into a live prospecting pipeline
+
+Needs:
+
+- saved target lists
+- project-specific fit notes
+- talking points
+- proof assets
+- next action states
+
+Success:
+
+- can move from "interesting foundation" to "outreach-ready strategy" without stitching five systems together
+
+## Core User Outcome
+
+The most important user outcome is:
+
+An organisation can take a real project, map it to the right philanthropic prospects, save those prospects, evaluate fit, and generate a relationship strategy grounded in each foundation's goals, evidence, and history.
+
+That is the real product job.
+
+Not:
+
+- prettier compare pages
+- more directory polish
+- more one-off route work
+
+## Canonical Workflow
+
+### Benchmark workflow
+
+Used by analysts and internal teams.
+
+1. Open a foundation or compare route.
+2. Assess whether the foundation is:
+   - stable review
+   - developing review
+   - early review
+   - outside benchmark lane
+3. Understand what evidence is missing.
+4. Upgrade via backlog or automation if the foundation matters.
+
+### Engagement workflow
+
+Used by organisations and charities.
+
+1. Start with an organisation or project.
+2. Define the project frame:
+   - issue
+   - geography
+   - community
+   - stage
+   - evidence base
+   - voice/story assets
+3. Generate a fit-ranked foundation shortlist.
+4. Save foundations into a project-specific prospect set.
+5. For each foundation, answer:
+   - why this foundation
+   - why this project now
+   - where the fit is strongest
+   - where the mismatch is
+6. Produce engagement strategy:
+   - framing
+   - key proof points
+   - likely philanthropic language
+   - first approach
+   - relationship sequence
+
+## Example: Curious Tractor
+
+Curious Tractor is the clearest operating example because the work is not generic grant-seeking.
+It is project-based, place-based, and narrative-heavy.
+
+Example jobs:
+
+- Which foundations are the best fit for JusticeHub?
+- Which foundations are the best fit for The Three Circles?
+- How should the same organisation frame different projects for different philanthropies?
+- Which foundations care about:
+  - communities
+  - youth justice
+  - early intervention
+  - Indigenous leadership
+  - systems change
+  - place-based infrastructure
+  - storytelling and field leadership
+
+The system should let Curious Tractor:
+
+- save Minderoo, Snow, PRF, Ian Potter, and others against a project
+- compare them not just as foundations, but as project-fit options
+- see the exact philanthropic hooks for each project
+- track message alignment and next outreach move
+
+## Example: Minderoo + JusticeHub / Three Circles
+
+This is the best current proof of the deeper product direction.
+
+The useful outcome was not merely:
+
+- "Minderoo looks relevant"
+
+The useful outcome was:
+
+- align The Three Circles to Minderoo's Communities logic
+- tie the work to Minderoo's own reports and strategic language
+- show why the project sits upstream of major public system costs
+- translate local governance, youth voice, and systems evidence into funder-native framing
+- shape a message and artefact strategy that supports real engagement
+
+This is the pattern to productise:
+
+- project context
+- foundation fit
+- evidence alignment
+- messaging alignment
+- engagement strategy
+
+## Product Modules
+
+### 1. Foundation reviewability layer
+
+Purpose:
+
+- tell the truth about how trustworthy each foundation profile is
+
+Current strength:
+
+- strong and already partly built
+
+Outputs:
+
+- stable / developing / early / outside benchmark lane
+- grants, year memory, provenance, governance
+
+### 2. Foundation benchmark set
+
+Purpose:
+
+- create a trusted set of stable foundation references
+
+Current strength:
+
+- working
+
+Outputs:
+
+- review routes
+- compare surfaces
+- review set hub
+
+### 3. Reviewability backlog and automation
+
+Purpose:
+
+- upgrade more foundations without manual rework
+
+Current strength:
+
+- working
+
+Outputs:
+
+- blocked vs actionable queues
+- batch runner
+- automation cadence
+
+### 4. Organisation-to-foundation fit layer
+
+Purpose:
+
+- move from foundation intelligence to project-specific engagement decisions
+
+This is the next major product layer.
+
+Outputs:
+
+- saved foundation lists per organisation/project
+- project-to-foundation fit scoring
+- "best fit for this project" views
+- fit rationale and mismatch flags
+
+### 5. Engagement strategy layer
+
+Purpose:
+
+- help users work out how to approach the foundation, not just whether to look at it
+
+Outputs:
+
+- project framing by foundation
+- message alignment
+- proof stack
+- outreach sequence
+- likely decision hooks
+
+## Product North Star
+
+GrantScope should become the place where a serious organisation can answer:
+
+"Who should we engage, for which project, and how should we frame the work to fit that foundation's actual priorities?"
+
+## KPIs
+
+### System KPIs
+
+- number of stable review foundations
+- number of benchmark-ready compare pairs
+- number of blocked foundations with explicit blocker reason
+- foundations upgraded per week
+
+### User KPIs
+
+- number of saved foundations per organisation/project
+- number of project-fit shortlists created
+- number of engagement briefs generated
+- time from project definition to outreach-ready shortlist
+
+### Strategic KPI
+
+- number of projects for which GrantScope can produce a credible "best-fit philanthropy strategy" without manual external synthesis
+
+## What Has Actually Been Built
+
+The work so far has created the base machinery for this product:
+
+- the foundation reviewability model
+- the stable benchmark set
+- the compare truth layer
+- the backlog and blocker taxonomy
+- the batch upgrade runner
+- live examples proving project-to-foundation strategy value, especially Minderoo / JusticeHub / Three Circles
+
+This means the platform is no longer blocked on concept.
+It is blocked on turning the foundation engine into a user-facing engagement workflow.
+
+## What To Stop Doing
+
+Stop spending primary energy on:
+
+- more compare-page polish
+- more backlog-page chrome
+- more one-off navigation refinement
+- bespoke foundation route work for weak foundations
+
+These are now secondary.
+
+## Highest-Impact Next Steps
+
+### 1. Build project-based saved foundation sets
+
+For an organisation or user, enable:
+
+- create a project
+- attach mission, place, issue, and proof context
+- save candidate foundations to that project
+
+This is the first real bridge from benchmark intelligence to user value.
+
+### 2. Build foundation-fit notes per saved project
+
+For each saved foundation, support:
+
+- fit summary
+- strongest alignment
+- likely objection or mismatch
+- suggested next move
+
+### 3. Build project-to-foundation compare
+
+Not only:
+
+- foundation vs foundation
+
+But:
+
+- project vs foundation
+- project vs shortlisted foundations
+
+This is the real decision surface for organisations.
+
+### 4. Build engagement strategy output
+
+For each saved foundation:
+
+- key framing
+- language to lean into
+- evidence to lead with
+- relationship strategy
+- outreach brief
+
+### 5. Use Curious Tractor as the canonical operating example
+
+Set up at least three live example projects:
+
+- JusticeHub
+- The Three Circles
+- one additional project with a clearly different philanthropic fit
+
+This will prove:
+
+- one organisation
+- multiple projects
+- different best-fit philanthropies
+- different messages and strategies
+
+## Suggested 2-Week Milestone
+
+Ship the first end-to-end engagement workflow for one organisation.
+
+Recommended milestone:
+
+- "Curious Tractor can create a project, save foundations, compare fit, and generate an outreach-ready strategy for Minderoo and at least two other foundations."
+
+Definition of done:
+
+- saved project set exists
+- foundation shortlist exists
+- fit reasoning exists
+- engagement notes exist
+- the system can explain why one foundation is stronger than another for the same project
+
+## Strategic Discipline
+
+The platform should keep these roles clear:
+
+- foundation reviewability tells you whether the foundation profile is trustworthy
+- benchmark comparison tells you how foundations relate to each other
+- project fit tells you whether a foundation is right for your specific mission
+- engagement strategy tells you what to do next
+
+That sequence is the real product arc.
+
+## Final Product Test
+
+GrantScope is succeeding when a user can say:
+
+- "I know which foundations matter."
+- "I know which one fits this project best."
+- "I know why."
+- "I know how to approach them."
+
+That is the mission-aligned result.

--- a/PILOT_SESSION_BRIEFS.md
+++ b/PILOT_SESSION_BRIEFS.md
@@ -1,0 +1,142 @@
+# Pilot Session Briefs
+
+## Purpose
+These are the first three tightly-supported user tests to run now that the pilot-ready foundation set is strong enough.
+
+Use them with:
+
+- [Funding Workspace](/Users/benknight/Code/grantscope/apps/web/src/app/funding-workspace/page.tsx)
+- [Pilot Testing](/Users/benknight/Code/grantscope/PILOT_TESTING.md)
+- [Funding Pilot Cohort](/Users/benknight/Code/grantscope/output/funding-pilot-cohort.md)
+
+## Session 1: ORIC
+
+### Archetype
+Community-controlled organisation working on First Nations youth development, leadership, and employment pathways in Queensland and the Northern Territory.
+
+### Test Prompt
+“We support First Nations young people through on-Country learning, leadership, employment pathways, and community-led capability building.”
+
+### Workspace URL
+`/funding-workspace?mission=First%20Nations%20youth%20leadership%20employment%20on-country&state=Queensland&org_type=ORIC`
+
+### Funders To Watch For
+- `Minderoo Foundation`
+- `THE TRUSTEE FOR TIM FAIRFAX FAMILY FOUNDATION`
+- `The Goodes O'Loughlin Foundation Limited`
+- `Paul Ramsay Foundation Limited`
+- `CBA Foundation`
+
+### Why These Are Good Checks
+- they cover Indigenous, youth, community, and regional/rural themes
+- they test whether the product can distinguish:
+  - relationship-led philanthropy
+  - open programs
+  - broader community funders
+
+### Success Looks Like
+- the user finds at least `3` plausible matches quickly
+- at least `2` feel genuinely mission-aligned
+- the user can say which are:
+  - build relationship
+  - apply now
+
+### Failure To Watch
+- Indigenous/community-controlled intent is not obvious in the results
+- generic large foundations crowd out stronger cultural-fit funders
+- the user cannot tell why one Indigenous-aligned funder is stronger than another
+
+## Session 2: Charity
+
+### Archetype
+Health or family-support charity focused on serious illness, children, or medical research, operating nationally or in Queensland/Western Australia.
+
+### Test Prompt
+“We support children and families affected by serious illness through care, family support, and research-backed health outcomes.”
+
+### Workspace URL
+`/funding-workspace?mission=children%20families%20serious%20illness%20health%20research&state=Queensland&org_type=Charity`
+
+### Funders To Watch For
+- `Children's Hospital Foundation Queensland`
+- `Perth Childrens Hospital Foundation Limited`
+- `Snowdome Foundation Limited`
+- `Paul Ramsay Foundation Limited`
+- `Minderoo Foundation`
+
+### Why These Are Good Checks
+- they test whether the product can surface both:
+  - specialist health/research funders
+  - broader strategic philanthropy
+- they check whether state-specific and national health signals are handled properly
+
+### Success Looks Like
+- the user can identify which matches are clearly health-specific
+- the user can explain why a strategic foundation like `Paul Ramsay` might still matter
+- the user knows the next move for at least `3` matches
+
+### Failure To Watch
+- all health-related foundations look interchangeable
+- the user cannot distinguish research funders from general care/community funders
+- the next move is unclear for relationship-led funders
+
+## Session 3: Social Enterprise
+
+### Archetype
+Social enterprise working on financial wellbeing, digital inclusion, employment, and practical capability building for young people and underserved communities.
+
+### Test Prompt
+“We build financial capability, digital inclusion, and employment pathways for young people and underserved communities.”
+
+### Workspace URL
+`/funding-workspace?mission=financial%20wellbeing%20digital%20inclusion%20employment%20youth&state=Victoria&org_type=Social%20enterprise`
+
+### Funders To Watch For
+- `ECSTRA FOUNDATION LIMITED`
+- `Good Things Foundation Limited`
+- `CBA Foundation`
+- `Woolworths Group Foundation`
+- `The Trustee for Westpac Scholars Trust`
+
+### Why These Are Good Checks
+- they test a more mixed lane:
+  - financial wellbeing
+  - digital inclusion
+  - employment
+  - social enterprise / leadership
+- they should reveal whether the workspace can handle blended missions rather than a single clean theme
+
+### Success Looks Like
+- the user sees both direct-fit and adjacent-fit funders
+- the user understands why `ECSTRA` and `Good Things` are likely stronger than more generic corporate funders
+- the user can shortlist `3 to 5` realistic next moves
+
+### Failure To Watch
+- broad corporate foundations dominate over higher-fit specialist funders
+- the user cannot tell whether a result is genuinely enterprise-relevant
+- the reasons shown are too vague to support confident shortlisting
+
+## Facilitation Notes
+
+### What To Record In Every Session
+- organisation name
+- mission statement used
+- state and org type used
+- top `5` matches the participant chose
+- which they would save
+- what confused them
+- what extra detail they wanted before contacting or applying
+
+### What To Compare Across Sessions
+- time to first believable match
+- number of matches the user would seriously pursue
+- whether “apply now” versus “relationship-led” is understood
+- whether the reasons shown feel trustworthy
+
+## Immediate Next Step
+Run these three sessions before doing more backlog cleanup.
+
+The current data layer is already strong enough for this:
+- verified pilot-ready foundations in DB: `152`
+
+That means the next big learning should come from users, not more long-tail reviewability burn-down.

--- a/PILOT_TESTING.md
+++ b/PILOT_TESTING.md
@@ -1,0 +1,97 @@
+# Funding Pilot Testing
+
+## Goal
+Prove that GrantScope can help a real organisation quickly:
+
+- find good-fit funders
+- understand why they fit
+- decide whether the move is apply now, open program, or relationship-led
+- know the next concrete step
+
+## Why Now
+The data layer is no longer the main blocker.
+
+Verified current state:
+
+- the reviewability backlog has produced a large pilot-ready set
+- the current database now has more than `40` strong pilot-ready foundations
+- that means user learning should now outrank more long-tail backlog burn-down
+
+## Who To Test With
+Run `3 to 5` tightly supported sessions:
+
+- `1` ORIC
+- `1 to 2` charities
+- `1` social enterprise
+- optionally `A Curious Tractor` as the first internal proving case
+
+## Product Surface
+Use the existing funding workspace:
+
+- [Funding Workspace](/Users/benknight/Code/grantscope/apps/web/src/app/funding-workspace/page.tsx)
+
+Suggested starting URL pattern:
+
+`/funding-workspace?mission=<mission>&state=<state>&org_type=<org_type>`
+
+## Core Test Script
+Use a `20 to 30` minute session.
+
+### Part 1: Setup
+Ask the participant for:
+
+- mission in one sentence
+- primary geography
+- org type
+
+Then enter those into the funding workspace.
+
+### Part 2: Task
+Ask them to do three things:
+
+1. Find `3` funding matches they would seriously consider.
+2. Explain why each one looks relevant.
+3. Say what they would do next for each:
+   - apply now
+   - investigate more
+   - build relationship
+
+### Part 3: Debrief
+Ask:
+
+- Did the matches feel relevant?
+- Did the difference between grant, open program, and relationship-led feel clear?
+- Did you know what to do next?
+- What felt confusing or missing?
+
+## Success Criteria
+The product is working if the user can:
+
+- identify `3 to 5` plausible matches in under `10` minutes
+- explain why at least `2 to 3` feel like a genuine fit
+- state a believable next step without facilitator help
+
+## Failure Signals
+Fix the product before broad rollout if users:
+
+- do not trust why a match was shown
+- cannot tell whether something is open now or relationship-led
+- cannot decide what to do next
+- feel buried by too much data or too many options
+
+## What To Capture
+For each session, record:
+
+- organisation name
+- mission
+- top `5` matches chosen
+- which ones they saved
+- where they got stuck
+- what extra information they wanted
+
+## Immediate Next Step
+Use the pilot cohort export to choose the first `20 to 25` strongest foundations for testing and briefing:
+
+- run `node --env-file=.env scripts/export-funding-pilot-cohort.mjs --limit=25 --out=output/funding-pilot-cohort.md`
+
+That file becomes the working shortlist for the first real-user sessions.


### PR DESCRIPTION
## Summary

Four top-level operating docs carved from the post-Goods V1 WIP snapshot:

- **GRANTSCOPE_SIGNOFF.md** — Goods V1 CEO signoff checklist + status
- **OPERATING_PLAN.md** — Current operating plan
- **PILOT_SESSION_BRIEFS.md** — Pilot session briefs
- **PILOT_TESTING.md** — Pilot testing methodology + handoff

Docs-only, no code changes. Part of phase 2 dirty-tree carve (bucket: root-doc).