### PR TITLE
feat: tracker + profile + ops + nav + entity + for-pages refresh

### DIFF
--- a/apps/web/src/app/charities/page.tsx
+++ b/apps/web/src/app/charities/page.tsx
@@ -58,6 +58,9 @@ const SORT_OPTIONS = [
   { value: 'name', label: 'Name A-Z' },
   { value: 'revenue', label: 'Highest Revenue' },
   { value: 'grants', label: 'Highest Grants' },
+  { value: 'assets', label: 'Highest Assets' },
+  { value: 'fte', label: 'Most Staff' },
+  { value: 'volunteers', label: 'Most Volunteers' },
   { value: 'newest', label: 'Newest Registered' },
 ];
 
@@ -76,6 +79,8 @@ interface CharityRow {
   total_revenue: number | null;
   total_grants_given: number | null;
   total_assets: number | null;
+  staff_fte: number | null;
+  staff_volunteers: number | null;
   latest_financial_year: number | null;
   has_enrichment: boolean;
 }
@@ -138,7 +143,7 @@ export default async function CharitiesPage({ searchParams }: { searchParams: Pr
   // Build query
   let dbQuery = supabase
     .from('v_charity_explorer')
-    .select('abn, name, charity_size, state, pbi, hpc, purposes, beneficiaries, operating_states, is_foundation, website, total_revenue, total_grants_given, total_assets, latest_financial_year, has_enrichment', { count: 'exact' });
+    .select('abn, name, charity_size, state, pbi, hpc, purposes, beneficiaries, operating_states, is_foundation, website, total_revenue, total_grants_given, total_assets, staff_fte, staff_volunteers, latest_financial_year, has_enrichment', { count: 'exact' });
 
   if (query) {
     dbQuery = dbQuery.ilike('name', `%${query}%`);
@@ -182,6 +187,12 @@ export default async function CharitiesPage({ searchParams }: { searchParams: Pr
     dbQuery = dbQuery.order('total_revenue', { ascending: false, nullsFirst: false });
   } else if (sortBy === 'grants') {
     dbQuery = dbQuery.order('total_grants_given', { ascending: false, nullsFirst: false });
+  } else if (sortBy === 'assets') {
+    dbQuery = dbQuery.order('total_assets', { ascending: false, nullsFirst: false });
+  } else if (sortBy === 'fte') {
+    dbQuery = dbQuery.order('staff_fte', { ascending: false, nullsFirst: false });
+  } else if (sortBy === 'volunteers') {
+    dbQuery = dbQuery.order('staff_volunteers', { ascending: false, nullsFirst: false });
   } else if (sortBy === 'newest') {
     dbQuery = dbQuery.order('registration_date', { ascending: false, nullsFirst: false });
   } else {
@@ -219,6 +230,17 @@ export default async function CharitiesPage({ searchParams }: { searchParams: Pr
           {(count || 0).toLocaleString()} charities from the ACNC register — every registered charity in Australia. Search by mission, geography, cause area, size, and financial health.
         </p>
       </div>
+
+      {/* Rankings banner */}
+      <a href="/rankings" className="block mb-4 group">
+        <div className="bg-bauhaus-black border-4 border-bauhaus-black p-4 flex items-center justify-between transition-all group-hover:-translate-y-0.5 bauhaus-shadow-sm">
+          <div>
+            <div className="text-xs font-black text-bauhaus-red uppercase tracking-widest mb-1">New</div>
+            <div className="text-sm font-black text-white">Charity Rankings &mdash; 42,000+ charities scored across 6 dimensions</div>
+          </div>
+          <span className="text-white font-black text-lg ml-4 flex-shrink-0">&rarr;</span>
+        </div>
+      </a>
 
       {/* Insights banner */}
       <a href="/charities/insights" className="block mb-6 group">
@@ -393,6 +415,16 @@ export default async function CharitiesPage({ searchParams }: { searchParams: Pr
                 {c.total_assets != null && c.total_assets > 0 && (
                   <div className="text-[11px] text-bauhaus-muted font-bold tabular-nums">
                     {formatCurrency(c.total_assets)} assets
+                  </div>
+                )}
+                {c.staff_fte != null && c.staff_fte > 0 && (
+                  <div className="text-[11px] text-bauhaus-muted font-bold tabular-nums">
+                    {c.staff_fte.toLocaleString()} FTE
+                  </div>
+                )}
+                {c.staff_volunteers != null && c.staff_volunteers > 0 && (
+                  <div className="text-[11px] text-bauhaus-muted font-bold tabular-nums">
+                    {c.staff_volunteers.toLocaleString()} vol
                   </div>
                 )}
                 {c.latest_financial_year && (

--- a/apps/web/src/app/clarity/page.tsx
+++ b/apps/web/src/app/clarity/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import { BriefingLoopBar } from '@/app/components/briefing-loop-bar';
+import { buildClarityPageState } from '@/app/components/briefing-page-params';
 import { getServiceSupabase } from '@/lib/supabase';
 import SchemaGraph from './schema-graph';
 
@@ -32,6 +34,27 @@ interface Finding {
   claim: string;
   evidence: string;
 }
+
+interface DataCatalogLatest {
+  table_name: string;
+  domain: string;
+  owner_team: string;
+  source_of_truth: boolean;
+  pii_level: string;
+  sla_hours: number;
+  row_count: number | null;
+  freshness_hours: number | null;
+  provenance_coverage_pct: number | null;
+  confidence_coverage_pct: number | null;
+  snapshot_at: string | null;
+}
+
+type SearchParams = {
+  subject?: string;
+  state?: string;
+  lanes?: string;
+  output?: string;
+};
 
 /* ─── Helpers ─────────────────────────────────────── */
 
@@ -135,6 +158,7 @@ async function getData() {
     untaggedResult,
     crossSystemResult,
     desertResult,
+    catalogResult,
   ] = await Promise.all([
     // Fast estimated row counts from pg_stat (no table scan!)
     safe(db.rpc('exec_sql', {
@@ -145,10 +169,21 @@ async function getData() {
     })),
     // ALL tables with estimated row counts
     safe(db.rpc('exec_sql', {
-      query: `SELECT relname as table_name, reltuples::bigint as est_rows
-              FROM pg_class
-              WHERE relkind = 'r' AND relnamespace = 'public'::regnamespace AND reltuples > 0
-              ORDER BY reltuples DESC`,
+      query: `SELECT
+                c.relname as table_name,
+                GREATEST(
+                  COALESCE(s.n_live_tup, 0)::bigint,
+                  COALESCE(c.reltuples, 0)::bigint
+                ) as est_rows
+              FROM pg_class c
+              LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid
+              WHERE c.relkind = 'r'
+                AND c.relnamespace = 'public'::regnamespace
+                AND GREATEST(
+                  COALESCE(s.n_live_tup, 0)::bigint,
+                  COALESCE(c.reltuples, 0)::bigint
+                ) > 0
+              ORDER BY est_rows DESC`,
     })),
     safe(db.rpc('exec_sql', {
       query: `SELECT jurisdiction as state, COUNT(DISTINCT metric_name) as metric_types, COUNT(*) as total
@@ -166,6 +201,10 @@ async function getData() {
     safe(db.rpc('exec_sql', {
       query: `SELECT COUNT(*) as deserts FROM mv_funding_deserts WHERE desert_score >= 70`,
     })),
+    safe(db.from('v_data_catalog_latest')
+      .select('table_name, domain, owner_team, source_of_truth, pii_level, sla_hours, row_count, freshness_hours, provenance_coverage_pct, confidence_coverage_pct, snapshot_at')
+      .order('domain', { ascending: true })
+      .order('table_name', { ascending: true })),
   ]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -193,6 +232,7 @@ async function getData() {
     untagged: parse(untaggedResult) as { state: string; untagged: number }[],
     crossSystem: parse(crossSystemResult) as { system_count: number; entities: number }[],
     deserts: parseFirst(desertResult),
+    dataCatalog: parse(catalogResult) as DataCatalogLatest[],
   };
 }
 
@@ -252,8 +292,8 @@ function generateFindings(data: Awaited<ReturnType<typeof getData>>): Finding[] 
   if (missingStates.length > 0) {
     findings.push({
       severity: 'gap',
-      claim: `${missingStates.join(', ')} lack org-level funding data`,
-      evidence: 'Only QLD has granular per-recipient grant data. Other states have aggregate ROGS budget lines only.',
+      claim: `${missingStates.join(', ')} still have thin org-level funding coverage`,
+      evidence: 'QLD is the only dense per-recipient funding lane. Other states now have some org-level records, but the coverage is still much thinner and often needs to be read alongside aggregate ROGS and AIHW layers.',
     });
   }
 
@@ -299,6 +339,7 @@ interface TableEntry {
 const DOMAIN_RULES: { domain: string; color: string; patterns: RegExp[] }[] = [
   { domain: 'Entity Graph', color: 'bg-bauhaus-black', patterns: [
     /^gs_entit/, /^gs_relationship/, /^entity_/, /^canonical_entit/, /^donor_entity/,
+    /^name_alias/, /^cross_system_stat/,
   ]},
   { domain: 'Registries', color: 'bg-green-500', patterns: [
     /^abr_/, /^asic_/, /^acnc_/, /^oric_/, /^asx_/, /^nz_charit/,
@@ -308,7 +349,8 @@ const DOMAIN_RULES: { domain: string; color: string; patterns: RegExp[] }[] = [
   ]},
   { domain: 'Funding & Grants', color: 'bg-yellow-500', patterns: [
     /^justice_fund/, /^grant_/, /^foundation/, /^research_grant/, /^funding_/,
-    /^saved_grant/, /^saved_found/, /^money_flow/,
+    /^saved_grant/, /^saved_found/, /^money_flow/, /^opportunities_unified/,
+    /^source_frontier/, /^government_program/,
   ]},
   { domain: 'Influence & Accountability', color: 'bg-bauhaus-red', patterns: [
     /^political_/, /^ato_/, /^civic_/, /^oversight_/, /^lobbying/,
@@ -320,7 +362,8 @@ const DOMAIN_RULES: { domain: string; color: string; patterns: RegExp[] }[] = [
   ]},
   { domain: 'Evidence & Outcomes', color: 'bg-pink-500', patterns: [
     /^alma_/, /^outcomes_/, /^aihw_/, /^crime_stat/, /^rogs_/,
-    /^justicehub/, /^justice_matrix/, /^international_prog/,
+    /^justicehub/, /^justice_matrix/, /^international_prog/, /^governed_proof_/,
+    /^tracker_evidence_/,
   ]},
   { domain: 'Social & Disability', color: 'bg-teal-500', patterns: [
     /^ndis_/, /^dss_/, /^social_enter/, /^acara_/, /^community_/,
@@ -334,13 +377,15 @@ const DOMAIN_RULES: { domain: string; color: string; patterns: RegExp[] }[] = [
     /^site_health/, /^health_alert/, /^discover/, /^page_view/,
     /^app_/, /^user_/, /^users$/, /^ce_/, /^integration_/,
     /^processing_/, /^migration_/, /^subscription/, /^pending_sub/,
+    /^alert_event/, /^data_catalog/, /^analysis_job/,
   ]},
   { domain: 'Content & Knowledge', color: 'bg-indigo-400', patterns: [
     /^knowledge_/, /^project_/, /^notion_/, /^blog_/, /^article/,
     /^media_/, /^cms_/, /^wiki_/, /^story/, /^content_/, /^transcript/,
     /^sprint_/, /^idea_/, /^exa_/, /^intelligence_/, /^signal_/,
     /^review_/, /^pulse_/, /^campaign_/, /^el_/, /^portrait/, /^photo/,
-    /^quote/, /^ralph_/, /^agentic_/, /^daily_reflect/,
+    /^quote/, /^ralph_/, /^agentic_/, /^daily_reflect/, /^research_item/,
+    /^ai_discover/,
   ]},
   { domain: 'Finance & Ops', color: 'bg-amber-500', patterns: [
     /^xero_/, /^receipt_/, /^bookkeeping/, /^dext_/, /^email_/,
@@ -357,7 +402,8 @@ const DOMAIN_RULES: { domain: string; color: string; patterns: RegExp[] }[] = [
     /^org_profile/, /^org_member/, /^org_grant/, /^org_program/,
     /^org_milestone/, /^org_leader/, /^org_referral/, /^org_session/,
     /^org_pipeline/, /^org_compliance/, /^org_action/, /^org_participant/,
-    /^public_spend/, /^platform_/, /^profile/, /^tab_/,
+    /^public_spend/, /^platform_/, /^profile/, /^tab_/, /^relationship_health/,
+    /^relationship_pipeline/, /^touchpoint/, /^bank_statement_line/,
   ]},
 ];
 
@@ -424,14 +470,50 @@ function fmtRows(n: number): string {
   return String(n);
 }
 
+function catalogStatus(row: DataCatalogLatest): 'fresh' | 'warning' | 'stale' | 'unknown' | 'no_snapshot' {
+  if (!row.snapshot_at) return 'no_snapshot';
+  if (row.freshness_hours === null || Number.isNaN(Number(row.freshness_hours))) return 'unknown';
+  if (row.freshness_hours <= Number(row.sla_hours ?? 0)) return 'fresh';
+  if (row.freshness_hours <= Number(row.sla_hours ?? 0) * 1.5) return 'warning';
+  return 'stale';
+}
+
+function catalogStatusStyles(status: ReturnType<typeof catalogStatus>): string {
+  if (status === 'fresh') return 'bg-green-100 text-green-700';
+  if (status === 'warning') return 'bg-yellow-100 text-yellow-700';
+  if (status === 'stale') return 'bg-bauhaus-red text-white';
+  if (status === 'unknown') return 'bg-gray-200 text-bauhaus-black';
+  return 'bg-gray-100 text-bauhaus-muted';
+}
+
 /* ─── Page ────────────────────────────────────────── */
 
-export default async function ClarityPage() {
+export default async function ClarityPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const params = await searchParams;
+  const {
+    briefingComposeHref,
+    hasBriefingContext,
+    loop,
+  } = buildClarityPageState(params);
   const data = await getData();
   const findings = generateFindings(data);
+  const catalogRows = data.dataCatalog.map((row) => ({
+    ...row,
+    status: catalogStatus(row),
+  }));
+  const catalogSummary = {
+    total: catalogRows.length,
+    fresh: catalogRows.filter((row) => row.status === 'fresh').length,
+    warning: catalogRows.filter((row) => row.status === 'warning').length,
+    stale: catalogRows.filter((row) => row.status === 'stale').length,
+    unknown: catalogRows.filter((row) => row.status === 'unknown').length,
+    noSnapshot: catalogRows.filter((row) => row.status === 'no_snapshot').length,
+  };
 
   // Build full inventory from live data
   const domains = buildDomains(data.allTables);
+  const inventoryTableCount = Object.values(domains).reduce((s, t) => s + t.length, 0);
+  const inventoryEstimatedRows = Object.values(domains).reduce((s, ts) => s + ts.reduce((a, t) => a + t.records, 0), 0);
 
   // Build topic × state matrix
   const topics = [...new Set(data.topicMatrix.map(t => t.topic))].sort();
@@ -507,6 +589,17 @@ export default async function ClarityPage() {
           How CivicGraph connects public data to make government spending, influence, and outcomes visible.
           Every claim we make is traceable to data. Here is what we have, where it connects, and where gaps remain.
         </p>
+        {hasBriefingContext && loop && (
+          <BriefingLoopBar
+            refineHref={briefingComposeHref}
+            output={loop.output}
+            subject={loop.subject}
+            state={loop.state}
+            lanes={loop.lanes}
+            className="mt-6 max-w-4xl"
+            message={loop.message}
+          />
+        )}
       </div>
 
       {/* ─── Section 1: Full Platform Inventory ─────── */}
@@ -514,8 +607,8 @@ export default async function ClarityPage() {
         <h2 className="text-xl font-black text-bauhaus-black mb-2 uppercase tracking-widest">The Full Platform</h2>
         <p className="text-sm text-bauhaus-muted mb-6 max-w-2xl">
           {fmt(Number(data.entities.total ?? 0))} entities connected by {fmt(Number(data.relationships.total ?? 0))} relationships
-          across {Object.values(domains).reduce((s, t) => s + t.length, 0)} tables and {fmt(Object.values(domains).reduce((s, ts) => s + ts.reduce((a, t) => a + t.records, 0), 0))} total records.
-          Live counts from the database — not hardcoded.
+          across {inventoryTableCount} included tables and ~{fmt(inventoryEstimatedRows)} estimated rows.
+          Inventory totals are live database estimates for speed; linkage and coverage sections below use direct live queries.
         </p>
 
         {/* Summary cards */}
@@ -542,7 +635,7 @@ export default async function ClarityPage() {
               <span className={`inline-block w-3 h-3 rounded-full ${domainColor(domain)}`} />
               {domain}
               <span className="text-bauhaus-muted font-mono text-xs font-normal ml-1">
-                {tables.length} tables &middot; {fmtRows(tables.reduce((s, t) => s + t.records, 0))} rows
+                {tables.length} tables &middot; ~{fmtRows(tables.reduce((s, t) => s + t.records, 0))} rows
               </span>
               <span className="text-bauhaus-muted text-xs ml-auto group-open:rotate-90 transition-transform">&#9654;</span>
             </summary>
@@ -551,7 +644,7 @@ export default async function ClarityPage() {
                 <thead>
                   <tr className="bg-bauhaus-black text-white">
                     <th className="text-left p-2 font-black uppercase tracking-widest">Table</th>
-                    <th className="text-right p-2 font-black uppercase tracking-widest">Records</th>
+                    <th className="text-right p-2 font-black uppercase tracking-widest">Est. Records</th>
                     <th className="text-right p-2 font-black uppercase tracking-widest">Size</th>
                   </tr>
                 </thead>
@@ -568,6 +661,75 @@ export default async function ClarityPage() {
             </div>
           </details>
         ))}
+      </section>
+
+      {/* ─── Section 1B: Data Catalog Snapshot ───────── */}
+      <section className="mb-14">
+        <h2 className="text-xl font-black text-bauhaus-black mb-2 uppercase tracking-widest">Data Catalog Snapshot</h2>
+        <p className="text-sm text-bauhaus-muted mb-6 max-w-2xl">
+          Daily snapshots track table freshness against SLA, plus provenance/confidence coverage where fields exist.
+          This is the trust operations view for what is fresh, stale, and weak.
+        </p>
+
+        {catalogRows.length === 0 ? (
+          <div className="border-4 border-bauhaus-black p-5 bg-white text-sm text-bauhaus-muted">
+            No snapshots found yet. Apply migration <span className="font-mono">20260409000001_data_catalog_and_snapshots.sql</span> and run
+            <span className="font-mono"> snapshot_data_catalog()</span>.
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-0 mb-6">
+              {[
+                { label: 'Tracked', value: catalogSummary.total, tone: 'text-bauhaus-black' },
+                { label: 'Fresh', value: catalogSummary.fresh, tone: 'text-green-700' },
+                { label: 'Warning', value: catalogSummary.warning, tone: 'text-yellow-700' },
+                { label: 'Stale', value: catalogSummary.stale, tone: 'text-bauhaus-red' },
+                { label: 'Unknown', value: catalogSummary.unknown, tone: 'text-bauhaus-black' },
+                { label: 'No Snapshot', value: catalogSummary.noSnapshot, tone: 'text-bauhaus-muted' },
+              ].map((item, idx) => (
+                <div key={item.label} className={`border-4 border-bauhaus-black p-3 bg-white ${idx > 0 ? 'border-l-0' : ''} ${idx >= 2 ? 'max-sm:border-t-0' : ''} ${idx >= 3 ? 'sm:border-t-0 lg:border-t-4' : ''} ${idx >= 6 ? 'lg:border-t-0' : ''}`}>
+                  <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest">{item.label}</div>
+                  <div className={`text-2xl font-black ${item.tone}`}>{fmt(item.value)}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="border-4 border-bauhaus-black bg-white overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left p-2 font-black uppercase tracking-widest">Table</th>
+                    <th className="text-left p-2 font-black uppercase tracking-widest">Domain</th>
+                    <th className="text-right p-2 font-black uppercase tracking-widest">Rows</th>
+                    <th className="text-right p-2 font-black uppercase tracking-widest">Freshness (h)</th>
+                    <th className="text-right p-2 font-black uppercase tracking-widest">SLA (h)</th>
+                    <th className="text-right p-2 font-black uppercase tracking-widest">Prov (%)</th>
+                    <th className="text-right p-2 font-black uppercase tracking-widest">Conf (%)</th>
+                    <th className="text-center p-2 font-black uppercase tracking-widest">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {catalogRows.map((row, idx) => (
+                    <tr key={row.table_name} className={idx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                      <td className="p-2 font-mono font-bold text-bauhaus-black">{row.table_name}</td>
+                      <td className="p-2 text-bauhaus-muted font-semibold">{row.domain}</td>
+                      <td className="p-2 text-right font-mono">{fmt(Number(row.row_count ?? 0))}</td>
+                      <td className="p-2 text-right font-mono">{row.freshness_hours === null ? '—' : Number(row.freshness_hours).toFixed(1)}</td>
+                      <td className="p-2 text-right font-mono">{fmt(Number(row.sla_hours ?? 0))}</td>
+                      <td className="p-2 text-right font-mono">{row.provenance_coverage_pct === null ? '—' : Number(row.provenance_coverage_pct).toFixed(1)}</td>
+                      <td className="p-2 text-right font-mono">{row.confidence_coverage_pct === null ? '—' : Number(row.confidence_coverage_pct).toFixed(1)}</td>
+                      <td className="p-2 text-center">
+                        <span className={`inline-block px-2 py-0.5 text-[10px] font-black uppercase tracking-widest ${catalogStatusStyles(row.status)}`}>
+                          {row.status.replace('_', ' ')}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
       </section>
 
       {/* ─── Section 2: Interactive Schema Graph ──────── */}
@@ -758,7 +920,7 @@ export default async function ClarityPage() {
               <h3 className="font-black text-white mb-2">Entity Resolution</h3>
               <p className="text-white/70 leading-relaxed">
                 The Australian Business Number (ABN) is the universal join key.
-                We resolve 559K+ entities from 8 government data systems using ABN matching
+                We resolve {fmt(Number(data.entities.total ?? 0))}+ entities across multiple public data systems using ABN matching
                 and normalised name fuzzy-matching against ASIC + ACNC registers.
               </p>
             </div>

--- a/apps/web/src/app/components/nav.tsx
+++ b/apps/web/src/app/components/nav.tsx
@@ -4,104 +4,56 @@ import { useState, useRef, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { AccountDropdown } from './account-dropdown';
 import { GlobalSearch } from './global-search';
+import { isAdminEmail } from '@/lib/admin';
 import type { Tier, Module } from '@/lib/subscription';
-import { hasModule, TIER_LABELS, MODULE_LABELS, minimumTier } from '@/lib/subscription';
-
-const ADMIN_EMAILS = ['benjamin@act.place', 'hello@civicgraph.au'];
+import { hasModule, TIER_LABELS, minimumTier } from '@/lib/subscription';
 
 /* ─── Public (logged-out) nav ─────────────────────────────── */
 
 const publicLinks = [
-  { href: '/ask', label: 'Ask' },
-  { href: '/entity', label: 'Intelligence' },
-  { href: '/tender-intelligence', label: 'Procurement' },
-  { href: '/places', label: 'Places' },
-  { href: '/grants', label: 'Grants' },
+  { href: '/start', label: 'Start' },
+  { href: '/grants', label: 'Funding' },
+  { href: '/power', label: 'Power' },
   { href: '/reports', label: 'Reports' },
-  { href: '/developers', label: 'API' },
+  { href: '/pricing', label: 'Pricing' },
 ];
 
 const megaMenuSections = [
   {
-    title: 'Intelligence',
+    title: 'Funding Workflow',
     links: [
-      { href: '/entity', label: 'Entity Search', desc: 'Search 560K entities across all datasets' },
-      { href: '/entity/top', label: 'Power Index', desc: 'Top entities ranked by cross-system influence' },
-      { href: '/person', label: 'Who Runs Australia?', desc: 'Board seats, influence & interlocks' },
-      { href: '/sector', label: 'Sector Intelligence', desc: 'Drill into any sector — entities, funding, power' },
-      { href: '/entity/compare', label: 'Compare Entities', desc: 'Side-by-side entity comparison' },
-      { href: '/map', label: 'Funding Desert Map', desc: 'Where disadvantage meets underinvestment' },
-      { href: '/graph', label: 'Network Graph', desc: 'Interactive entity relationship graph' },
+      { href: '/grants', label: 'Grant Search', desc: 'Search live opportunities across government and philanthropic sources' },
+      { href: '/foundations', label: 'Foundation Search', desc: 'Search funders, programs, and giving profiles' },
+      { href: '/profile/matches', label: 'Matched Grants', desc: 'See the strongest opportunities for your organisation' },
+      { href: '/tracker', label: 'Grant Tracker', desc: 'Shortlist, stage, and manage your active pipeline' },
+      { href: '/alerts', label: 'Alerts', desc: 'Get notified when opportunities or deadlines change' },
     ],
   },
   {
-    title: 'Decision Tools',
+    title: 'Market And Power',
     links: [
-      { href: '/ask', label: 'Ask CivicGraph', desc: 'Natural language queries across all datasets' },
-      { href: '/evidence', label: 'Evidence Synthesis', desc: 'ALMA evidence analysis and synthesis' },
-      { href: '/scenarios', label: 'Scenario Modelling', desc: 'What-if allocation analysis' },
+      { href: '/tender-intelligence', label: 'Tender Intelligence', desc: 'Check suppliers, pathways, and procurement options' },
+      { href: '/power', label: 'Power Map', desc: 'See the money, entities, and relationships shaping a field' },
+      { href: '/reports/big-philanthropy', label: 'Big Philanthropy', desc: 'Track foundation power, giving, and concentration' },
+      { href: '/clarity', label: 'Data Clarity', desc: 'Understand what the graph covers and how the systems connect' },
     ],
   },
   {
-    title: 'Procurement Intelligence',
+    title: 'Reporting And Story',
     links: [
-      { href: '/tender-intelligence', label: 'Tender Intelligence', desc: 'Supplier discovery & compliance scoring' },
-      { href: '/tender-intelligence#enrich', label: 'List Enrichment', desc: 'Upload & enrich supplier lists' },
-      { href: '/tender-intelligence#pack', label: 'Intelligence Pack', desc: 'Full procurement analysis report' },
-      { href: '/for/government', label: 'For Government', desc: 'Procurement officers & commissioners' },
+      { href: '/reports', label: 'Investigations', desc: 'Read the stronger public argument emerging from the live graph' },
+      { href: '/reports/civicgraph-thesis', label: 'CivicGraph Thesis', desc: 'See the broader product and category case' },
+      { href: '/start', label: 'Innovation Guide', desc: 'Start with the guided flow and move toward a real organisation or plan' },
+      { href: '/ask', label: 'Ask CivicGraph', desc: 'Query the broader intelligence graph in natural language' },
     ],
   },
   {
-    title: 'Domain Intelligence',
+    title: 'Platform',
     links: [
-      { href: '/reports/youth-justice', label: 'Youth Justice', desc: 'Detention, recidivism, CtG targets, ALMA evidence' },
-      { href: '/reports/child-protection', label: 'Child Protection', desc: 'Notifications, OOHC, substantiation, ROGS 16A' },
-      { href: '/reports/disability', label: 'Disability & NDIS', desc: 'Participation, expenditure, thin markets, ROGS 15A' },
-      { href: '/reports/education', label: 'Education', desc: 'Attendance, retention, ICSEA, ROGS 4A' },
-      { href: '/reports/nsw', label: 'State Dashboards', desc: 'Cross-domain intelligence by jurisdiction' },
-      { href: '/reports/youth-justice/national', label: 'National Comparisons', desc: 'State-by-state outcome comparison' },
-    ],
-  },
-  {
-    title: 'Explore Data',
-    links: [
-      { href: '/grants', label: 'Grants', desc: 'Search live grant opportunities' },
-      { href: '/foundations', label: 'Foundations', desc: 'Search giving foundations and programs' },
-      { href: '/charities', label: 'Charities', desc: 'Search Australian charities' },
-      { href: '/entities', label: 'Entity Graph', desc: 'National entity graph across contracts, grants, and donations' },
-      { href: '/social-enterprises', label: 'Social Enterprises', desc: 'B Corps, indigenous & disability enterprises' },
-      { href: '/dashboard', label: 'Dashboard', desc: 'Overview & key metrics' },
-    ],
-  },
-  {
-    title: 'Investigations',
-    links: [
-      { href: '/reports/power-concentration', label: 'Power Index', desc: '82K entities scored across 7 datasets' },
-      { href: '/reports/political-money', label: 'Political Money', desc: 'Who funds politics & what they get back' },
-      { href: '/reports/donor-contractors', label: 'Donor-Contractors', desc: 'Entities that both donate and hold government contracts' },
-      { href: '/reports/cross-reference', label: '$74B Question', desc: 'Who gets government contracts?' },
-      { href: '/reports/big-philanthropy', label: '$222 Billion', desc: 'Where charity money goes' },
-      { href: '/reports/community-parity', label: 'Community Parity', desc: 'Who benefits, who misses out' },
-      { href: '/reports/who-runs-australia', label: 'Who Runs Australia?', desc: 'Boards, donations, lobbying & contracts' },
-      { href: '/reports/funding-deserts', label: 'Funding Deserts', desc: 'Where disadvantage meets underinvestment' },
-      { href: '/reports/data-health', label: 'Data Health', desc: 'Coverage & completeness across 7 systems' },
-      { href: '/reports/tax-transparency', label: 'Tax Transparency', desc: 'Government contracts vs tax paid' },
-      { href: '/reports/exec-remuneration', label: 'Exec Remuneration', desc: 'Executive pay vs service delivery' },
-      { href: '/reports/board-interlocks', label: 'Board Interlocks', desc: 'Who controls Australia\'s charities?' },
-      { href: '/reports/charity-contracts', label: 'Charity Contracts', desc: 'Charity exec pay vs government contracts' },
-      { href: '/reports/influence-network', label: 'Influence Network', desc: 'Lobby, donate, win contracts — the cycle' },
-      { href: '/reports/power-network', label: 'Power Network', desc: 'Who runs Australia\'s civic sector?' },
-      { href: '/reports/desert-overhead', label: 'Desert Overhead', desc: 'Exec pay in disadvantaged areas' },
-      { href: '/reports/community-efficiency', label: 'ACCO Efficiency', desc: 'Community-controlled orgs deliver more with less' },
-    ],
-  },
-  {
-    title: 'For',
-    links: [
-      { href: '/for/government', label: 'Government', desc: 'Procurement & commissioning intelligence' },
-      { href: '/for/community', label: 'Community Orgs', desc: 'Find grants, track applications' },
-      { href: '/for/funders', label: 'Funders', desc: 'Portfolio intelligence & discovery' },
-      { href: '/for/researchers', label: 'Researchers', desc: 'Open data & living reports' },
+      { href: '/pricing', label: 'Pricing', desc: 'Compare Community, Professional, Organisation, and Funder plans' },
+      { href: '/for/community', label: 'For Community Teams', desc: 'How the product helps nonprofits and grant consultants' },
+      { href: '/developers', label: 'API', desc: 'Programmatic access and developer entry points' },
+      { href: '/places', label: 'Place Packs', desc: 'Place-based funding and allocation intelligence' },
     ],
   },
 ];
@@ -117,10 +69,20 @@ type NavModule = {
 };
 
 const workspaceModules: NavModule[] = [
-  { id: 'home', label: 'Dashboard', href: '/home' },
+  {
+    id: 'home',
+    label: 'Today',
+    href: '/home',
+    children: [
+      { label: 'Home', href: '/home' },
+      { label: 'My Org', href: '/org' },
+      { label: 'Briefing Hub', href: '/briefing' },
+      { label: 'Data Clarity', href: '/clarity' },
+    ],
+  },
   {
     id: 'grants',
-    label: 'Grants',
+    label: 'Funding',
     href: '/grants',
     module: 'grants',
     children: [
@@ -129,12 +91,13 @@ const workspaceModules: NavModule[] = [
       { label: 'Tracker', href: '/tracker' },
       { label: 'Foundations', href: '/foundations' },
       { label: 'Foundation Tracker', href: '/foundations/tracker' },
+      { label: 'Grant Frontier', href: '/reports/grant-frontier' },
       { label: 'Alerts', href: '/alerts' },
     ],
   },
   {
     id: 'procurement',
-    label: 'Procurement',
+    label: 'Markets',
     href: '/tender-intelligence',
     module: 'procurement',
     children: [
@@ -143,27 +106,15 @@ const workspaceModules: NavModule[] = [
     ],
   },
   {
-    id: 'allocation',
-    label: 'Allocation',
-    href: '/reports',
-    module: 'allocation',
-    children: [
-      { label: 'Reports', href: '/reports' },
-      { label: 'Youth Justice', href: '/reports/youth-justice' },
-      { label: 'Child Protection', href: '/reports/child-protection' },
-      { label: 'Disability', href: '/reports/disability' },
-      { label: 'Education', href: '/reports/education' },
-      { label: 'Places', href: '/places' },
-      { label: 'Power Map', href: '/power' },
-    ],
-  },
-  {
     id: 'research',
-    label: 'Research',
+    label: 'Intelligence',
     href: '/reports',
     module: 'research',
     children: [
       { label: 'Reports', href: '/reports' },
+      { label: 'Power Map', href: '/power' },
+      { label: 'Big Philanthropy', href: '/reports/big-philanthropy' },
+      { label: 'Reallocation Atlas', href: '/reports/reallocation-atlas' },
       { label: 'Ask', href: '/ask' },
       { label: 'Evidence', href: '/evidence' },
       { label: 'Scenarios', href: '/scenarios' },
@@ -174,18 +125,8 @@ const workspaceModules: NavModule[] = [
       { label: 'Funding Map', href: '/map' },
       { label: 'Network Graph', href: '/graph' },
       { label: 'Charities', href: '/charities' },
-      { label: 'Social Enterprises', href: '/social-enterprises' },
-    ],
-  },
-  {
-    id: 'relationships',
-    label: 'Relationships',
-    href: '/org',
-    module: 'relationships',
-    children: [
-      { label: 'My Org', href: '/org' },
-      { label: 'Contacts', href: '/org/__SLUG__/contacts' },
-      { label: 'Knowledge Wiki', href: '/knowledge' },
+      { label: 'Place Packs', href: '/places' },
+      { label: 'Thesis', href: '/reports/civicgraph-thesis' },
     ],
   },
 ];
@@ -194,6 +135,7 @@ const workspaceModules: NavModule[] = [
 
 const adminLinks = [
   { href: '/ops', label: 'Ops' },
+  { href: '/portfolio-control', label: 'Portfolio Control' },
   { href: '/mission-control', label: 'Mission Control' },
   { href: '/goods-workspace', label: 'Goods Workspace' },
 ];
@@ -217,7 +159,7 @@ export function NavBar({ initialUserEmail, subscriptionTier = 'community', isImp
   const pathname = usePathname();
 
   const isLoggedIn = !!userEmail;
-  const isAdmin = isLoggedIn && ADMIN_EMAILS.includes(userEmail);
+  const isAdmin = isLoggedIn && isAdminEmail(userEmail);
   const tier = subscriptionTier;
 
   // Resolve org-slug-dependent links (hide links that need a slug when none is available)
@@ -437,13 +379,6 @@ export function NavBar({ initialUserEmail, subscriptionTier = 'community', isImp
               <span className="hidden lg:inline">Search</span>
               <kbd className="hidden lg:inline-block px-1.5 py-0.5 text-[9px] font-black text-bauhaus-muted border border-bauhaus-black/20 ml-1">&#8984;K</kbd>
             </button>
-            <div className="w-px h-6 bg-bauhaus-black/20 mx-1" />
-            <a
-              href="/mission-control"
-              className="px-3 py-2 text-xs font-black uppercase tracking-widest text-bauhaus-red hover:bg-bauhaus-red hover:text-white transition-colors"
-            >
-              Mission Control
-            </a>
             <button
               ref={btnRef}
               onClick={() => { setMegaOpen(!megaOpen); }}
@@ -464,6 +399,12 @@ export function NavBar({ initialUserEmail, subscriptionTier = 'community', isImp
               className="px-3 py-2 text-xs font-black uppercase tracking-widest text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white transition-colors"
             >
               Login
+            </a>
+            <a
+              href="/register"
+              className="px-3 py-2 text-xs font-black uppercase tracking-widest text-white bg-bauhaus-red hover:bg-bauhaus-black transition-colors"
+            >
+              Start Free
             </a>
           </div>
 
@@ -532,6 +473,13 @@ export function NavBar({ initialUserEmail, subscriptionTier = 'community', isImp
               </div>
             ))}
             <div className="mt-4 pt-4 border-t-2 border-bauhaus-black/20">
+              <a
+                href="/register"
+                className="block px-3 py-3 text-sm font-black uppercase tracking-widest text-white bg-bauhaus-red hover:bg-bauhaus-black transition-colors mb-2"
+                onClick={() => setMobileOpen(false)}
+              >
+                Start Free
+              </a>
               <a
                 href="/login"
                 className="block px-3 py-3 text-sm font-black uppercase tracking-widest text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white transition-colors"

--- a/apps/web/src/app/components/workspace-page-header.tsx
+++ b/apps/web/src/app/components/workspace-page-header.tsx
@@ -23,8 +23,8 @@ export function WorkspacePageHeader({
 }: WorkspacePageHeaderProps) {
   return (
     <header className={compact ? 'mb-4' : 'mb-6'}>
-      <div className="flex items-start justify-between gap-4">
-        <div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
           {eyebrow && (
             <p className="text-[11px] font-semibold uppercase tracking-wide mb-1" style={{ color: 'var(--ws-text-tertiary)' }}>
               {eyebrow}
@@ -43,7 +43,7 @@ export function WorkspacePageHeader({
           )}
         </div>
         {actions && (
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
             {actions}
           </div>
         )}

--- a/apps/web/src/app/entity/[gsId]/page.tsx
+++ b/apps/web/src/app/entity/[gsId]/page.tsx
@@ -56,6 +56,12 @@ interface PowerRow {
   procurement_dollars: number; justice_dollars: number; donation_dollars: number;
   total_dollar_flow: number; distinct_govt_buyers: number; distinct_parties_funded: number;
 }
+interface RankingRow {
+  score_composite: number; rank_composite: number; total_ranked: number;
+  score_revenue: number; score_growth: number; score_leverage: number;
+  score_efficiency: number; score_network: number; score_health: number;
+  cagr: number; revenue: number; network_connections: number;
+}
 interface AtoRow { total_income: number; taxable_income: number; tax_payable: number; effective_tax_rate: number; report_year: string; industry: string }
 interface BoardRow { person_name: string; role_type: string; appointment_date: string | null; cessation_date: string | null; source: string }
 interface RevolvingDoorRow {
@@ -92,7 +98,7 @@ export default async function EntityPage({ params }: { params: Promise<{ gsId: s
 
   const supabase = getServiceSupabase();
 
-  const [funding, contracts, donations, relationships, alma, acnc, power, ato, board, revolvingDoor, impactReports, mmrStats, anaoCompliance, outcomeMetrics, policyEvents] = await Promise.all([
+  const [funding, contracts, donations, relationships, alma, acnc, power, ato, board, revolvingDoor, impactReports, mmrStats, anaoCompliance, outcomeMetrics, policyEvents, charityRanking] = await Promise.all([
     entity.abn ? safe(supabase.rpc('exec_sql', {
       query: `SELECT program_name, SUM(amount_dollars)::bigint as total, COUNT(*)::int as records,
                 MIN(financial_year) as from_fy, MAX(financial_year) as to_fy
@@ -203,6 +209,14 @@ export default async function EntityPage({ params }: { params: Promise<{ gsId: s
          WHERE jurisdiction = '${esc(entity.state)}' AND domain = 'youth-justice' AND severity IN ('critical', 'significant')
          ORDER BY event_date DESC LIMIT 5`,
     })) as Promise<PolicyEventRow[] | null> : null,
+    // Charity ranking
+    entity.abn ? safe(supabase.rpc('exec_sql', {
+      query: `SELECT score_composite, rank_composite, total_ranked,
+                score_revenue::numeric(10,1), score_growth::numeric(10,1), score_leverage::numeric(10,1),
+                score_efficiency::numeric(10,1), score_network::numeric(10,1), score_health::numeric(10,1),
+                cagr::numeric(10,1), revenue::bigint, network_connections
+         FROM mv_charity_rankings WHERE abn = '${entity.abn}' LIMIT 1`,
+    })) as Promise<RankingRow[] | null> : null,
   ]);
 
   const totalFunding = funding?.reduce((s, r) => s + Number(r.total), 0) ?? 0;
@@ -221,6 +235,10 @@ export default async function EntityPage({ params }: { params: Promise<{ gsId: s
   const outcomesData = (outcomeMetrics as OutcomeMetricRow[] | null) ?? [];
   const policyData = (policyEvents as PolicyEventRow[] | null) ?? [];
   const hasJurisdictionContext = outcomesData.length > 0 || policyData.length > 0;
+  const rankingData = (charityRanking as RankingRow[] | null)?.[0] ?? null;
+  const sectorPercentile = rankingData
+    ? ((Number(rankingData.total_ranked) - Number(rankingData.rank_composite) + 1) / Number(rankingData.total_ranked) * 100).toFixed(1)
+    : null;
   const trendSignals = outcomesData.length > 0
     ? pickTopTrends(computeTrendSignals(outcomesData, entity.state ?? ''), 2)
     : [];
@@ -286,6 +304,11 @@ export default async function EntityPage({ params }: { params: Promise<{ gsId: s
                 Community Controlled
               </span>
             )}
+            {rankingData && sectorPercentile && (
+              <Link href="/rankings" className="text-[10px] px-2 py-0.5 bg-bauhaus-blue/20 border border-bauhaus-blue/30 rounded-sm font-bold uppercase tracking-wider text-bauhaus-blue hover:bg-bauhaus-blue/30 transition-colors">
+                Top {sectorPercentile}% — Ranked #{Number(rankingData.rank_composite).toLocaleString()} of {Number(rankingData.total_ranked).toLocaleString()}
+              </Link>
+            )}
           </div>
           {(entity.lga_name || entity.state) && (
             <div className="mt-2 flex items-center gap-3 text-sm text-gray-400">
@@ -331,6 +354,29 @@ export default async function EntityPage({ params }: { params: Promise<{ gsId: s
               <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Power Score</p>
               <p className="text-3xl font-black mt-1">{Number(powerData.power_score).toFixed(1)}</p>
               <p className="text-xs text-gray-400 mt-1">{powerData.system_count} systems</p>
+            </div>
+          )}
+          {rankingData && (
+            <div className="bg-white border-2 border-bauhaus-blue shadow-sm p-4">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Charity Score</p>
+              <p className="text-3xl font-black mt-1 text-bauhaus-blue">{Number(rankingData.score_composite).toFixed(1)}</p>
+              <div className="mt-2 space-y-1">
+                {[
+                  { label: 'Rev', score: Number(rankingData.score_revenue), color: 'bg-green-500' },
+                  { label: 'Growth', score: Number(rankingData.score_growth), color: 'bg-blue-500' },
+                  { label: 'Lever', score: Number(rankingData.score_leverage), color: 'bg-purple-500' },
+                  { label: 'Effic', score: Number(rankingData.score_efficiency), color: 'bg-amber-500' },
+                  { label: 'Net', score: Number(rankingData.score_network), color: 'bg-red-500' },
+                  { label: 'Hlth', score: Number(rankingData.score_health), color: 'bg-teal-500' },
+                ].map(d => (
+                  <div key={d.label} className="flex items-center gap-1.5">
+                    <span className="text-[9px] w-10 text-gray-400 font-bold">{d.label}</span>
+                    <div className="flex-1 h-1.5 bg-gray-100">
+                      <div className={`h-full ${d.color}`} style={{ width: `${Math.min(100, d.score)}%` }} />
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
           {totalDollarFlow > 0 && (

--- a/apps/web/src/app/for/corporate/page.tsx
+++ b/apps/web/src/app/for/corporate/page.tsx
@@ -403,7 +403,7 @@ export default async function ForCorporatePage() {
           </div>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              href="/auth/signup"
+              href="/register"
               className="inline-block py-3 px-8 font-black text-sm uppercase tracking-widest border-4 border-bauhaus-black bg-bauhaus-black text-white transition-all hover:bg-bauhaus-yellow hover:text-bauhaus-black"
             >
               Start Free

--- a/apps/web/src/app/for/philanthropy/page.tsx
+++ b/apps/web/src/app/for/philanthropy/page.tsx
@@ -626,7 +626,7 @@ export default async function ForPhilanthropyPage() {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              href="/auth/signup"
+              href="/register"
               className="inline-block py-4 px-10 font-black text-sm uppercase tracking-widest border-4 border-white bg-white text-bauhaus-red bauhaus-shadow-sm transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
             >
               Get Started Free

--- a/apps/web/src/app/ops/health/health-client.tsx
+++ b/apps/web/src/app/ops/health/health-client.tsx
@@ -15,6 +15,30 @@ interface HealthData {
     community: { orgs: number };
     socialEnterprises: { total: number; enriched: number };
   };
+  grantSemantics: {
+    statusNull: number;
+    applicationStatusNull: number;
+    openPastDeadline: number;
+    ghlUnknown: number;
+    topIssueSources: Array<{
+      source: string;
+      statusNull: number;
+      applicationStatusNull: number;
+      openPastDeadline: number;
+      totalIssues: number;
+    }>;
+  };
+  sourceIdentity: {
+    blankSourceId: number;
+    canonicalMismatch: number;
+    duplicateShadows: number;
+    topIssueSources: Array<{
+      source: string;
+      blankSourceId: number;
+      canonicalMismatch: number;
+      totalIssues: number;
+    }>;
+  };
   entityGraph: {
     totalEntities: number;
     totalRelationships: number;
@@ -159,15 +183,15 @@ function freshnessStatus(iso: string | null): { label: string; color: string } {
 }
 
 function computeHealthScore(data: HealthData): number {
-  const { stats, entityGraph, dataFreshness } = data;
+  const { stats, grantSemantics, sourceIdentity, entityGraph, dataFreshness } = data;
 
-  // Data completeness (40%)
+  // Data completeness (30%)
   const grantsEmbedPct = pctNum(stats.grants.embedded, stats.grants.total);
   const foundationsProfiledPct = pctNum(stats.foundations.profiled, stats.foundations.total);
   const entityPopulated = entityGraph.totalEntities > 0 ? 100 : 0;
   const completeness = (grantsEmbedPct + foundationsProfiledPct + entityPopulated) / 3;
 
-  // Data freshness (40%)
+  // Data freshness (30%)
   const freshnessScores = dataFreshness
     .filter(d => d.lastUpdated !== null)
     .map(d => {
@@ -181,11 +205,39 @@ function computeHealthScore(data: HealthData): number {
     ? freshnessScores.reduce((a, b) => a + b, 0) / freshnessScores.length
     : 0;
 
-  // Enrichment quality (20%)
+  // Enrichment quality (15%)
   const grantsEnrichedPct = pctNum(stats.grants.enriched, stats.grants.total);
   const quality = grantsEnrichedPct;
 
-  return Math.round(completeness * 0.4 + avgFreshness * 0.4 + quality * 0.2);
+  // Grant semantics integrity (15%)
+  const semanticsIssueCount =
+    grantSemantics.statusNull
+    + grantSemantics.applicationStatusNull
+    + grantSemantics.openPastDeadline;
+  let semantics = 100;
+  if (grantSemantics.statusNull > 0) semantics -= 35;
+  if (grantSemantics.applicationStatusNull > 0) semantics -= 30;
+  if (grantSemantics.openPastDeadline > 0) semantics -= 35;
+  const ratioPenalty = Math.min(25, (semanticsIssueCount / Math.max(stats.grants.total, 1)) * 2500);
+  semantics = Math.max(0, semantics - ratioPenalty);
+
+  // Grant source identity integrity (10%)
+  const sourceIdentityIssueCount =
+    sourceIdentity.blankSourceId
+    + sourceIdentity.canonicalMismatch;
+  let sourceIdentityIntegrity = 100;
+  if (sourceIdentity.blankSourceId > 0) sourceIdentityIntegrity -= 60;
+  if (sourceIdentity.canonicalMismatch > 0) sourceIdentityIntegrity -= 40;
+  const sourceIdentityRatioPenalty = Math.min(20, (sourceIdentityIssueCount / Math.max(stats.grants.total, 1)) * 2000);
+  sourceIdentityIntegrity = Math.max(0, sourceIdentityIntegrity - sourceIdentityRatioPenalty);
+
+  return Math.round(
+    completeness * 0.30
+    + avgFreshness * 0.30
+    + quality * 0.15
+    + semantics * 0.15
+    + sourceIdentityIntegrity * 0.10
+  );
 }
 
 const PIPELINE_STAGES = [
@@ -237,9 +289,9 @@ const BLOCKERS = [
   },
   {
     severity: 'medium' as const,
-    title: 'No freshness tracking',
-    desc: 'No mechanism to detect stale/expired grants. Grants that disappear from sources are never marked as closed.',
-    fix: null,
+    title: 'Foundation program sync still needs throughput work',
+    desc: 'Grant semantics are now guarded, but foundation profiling and program refresh remain the slowest path in the pipeline. Higher batch size and parallelism still matter.',
+    fix: 'npx tsx scripts/build-foundation-profiles.mjs --limit=100 --concurrency=5',
   },
 ];
 
@@ -307,7 +359,7 @@ export function HealthClient() {
     );
   }
 
-  const { stats, entityGraph, totalRecords, dataFreshness, sourceBreakdown, confidenceBreakdown, recentRuns, discoveryRuns } = data;
+  const { stats, grantSemantics, sourceIdentity, entityGraph, totalRecords, dataFreshness, sourceBreakdown, confidenceBreakdown, recentRuns, discoveryRuns } = data;
   const confMap = Object.fromEntries(confidenceBreakdown.map(c => [c.confidence, c.total]));
   const healthScore = computeHealthScore(data);
 
@@ -361,9 +413,9 @@ export function HealthClient() {
           </div>
           <div className="flex-1">
             <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-3">Composite Health Score</h2>
-            <div className="grid grid-cols-3 gap-4 text-xs">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4 text-xs">
               <div>
-                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Data Completeness (40%)</div>
+                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Data Completeness (30%)</div>
                 <div className="font-mono">
                   Grants embedded: {pct(stats.grants.embedded, stats.grants.total)}% |
                   Foundations profiled: {pct(stats.foundations.profiled, stats.foundations.total)}% |
@@ -371,15 +423,31 @@ export function HealthClient() {
                 </div>
               </div>
               <div>
-                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Data Freshness (40%)</div>
+                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Data Freshness (30%)</div>
                 <div className="font-mono">
                   {dataFreshness.filter(d => d.lastUpdated !== null && ageInDays(d.lastUpdated) < 7).length}/{dataFreshness.filter(d => d.lastUpdated !== null).length} sources updated this week
                 </div>
               </div>
               <div>
-                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Enrichment Quality (20%)</div>
+                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Enrichment Quality (15%)</div>
                 <div className="font-mono">
                   Grants enriched: {pct(stats.grants.enriched, stats.grants.total)}%
+                </div>
+              </div>
+              <div>
+                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Semantics Integrity (15%)</div>
+                <div className="font-mono">
+                  null status: {grantSemantics.statusNull} |
+                  null app: {grantSemantics.applicationStatusNull} |
+                  stale-open: {grantSemantics.openPastDeadline}
+                </div>
+              </div>
+              <div>
+                <div className="font-black uppercase tracking-wider text-bauhaus-muted mb-1">Source Identity (10%)</div>
+                <div className="font-mono">
+                  blank ids: {sourceIdentity.blankSourceId} |
+                  mismatch: {sourceIdentity.canonicalMismatch} |
+                  dupes: {sourceIdentity.duplicateShadows}
                 </div>
               </div>
             </div>
@@ -424,6 +492,115 @@ export function HealthClient() {
           </div>
           <StatCard label="Community Orgs" value={stats.community.orgs} href="/ops/health/community-orgs" />
           <StatCard label="Social Enterprises" value={stats.socialEnterprises?.total ?? 0} total={undefined} href="/ops/health/social-enterprises" />
+        </div>
+      </section>
+
+      {/* ===== GRANT SEMANTICS ===== */}
+      <section className="mb-10">
+        <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+          Grant Semantics
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <StatCard label="Null Status" value={grantSemantics.statusNull} />
+          <StatCard label="Null Application Status" value={grantSemantics.applicationStatusNull} />
+          <StatCard label="Open Past Deadline" value={grantSemantics.openPastDeadline} />
+          <StatCard label="GHL Unknown" value={grantSemantics.ghlUnknown} />
+        </div>
+        <div className="border-4 border-bauhaus-black mt-4 p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-1">Current Guardrail State</div>
+              <div className="text-sm text-bauhaus-black">
+                {grantSemantics.statusNull === 0 && grantSemantics.applicationStatusNull === 0 && grantSemantics.openPastDeadline === 0
+                  ? 'Semantics debt is currently at zero. Pipeline health checks will fail if these counts regress.'
+                  : 'Semantics debt has reappeared. The health check agent should now be treated as a failing pipeline gate.'}
+              </div>
+            </div>
+            <div className={`px-3 py-2 text-xs font-black uppercase tracking-widest border-2 ${
+              grantSemantics.statusNull === 0 && grantSemantics.applicationStatusNull === 0 && grantSemantics.openPastDeadline === 0
+                ? 'border-green-500 text-green-700 bg-green-50'
+                : 'border-red-500 text-red-700 bg-red-50'
+            }`}>
+              {grantSemantics.statusNull === 0 && grantSemantics.applicationStatusNull === 0 && grantSemantics.openPastDeadline === 0
+                ? 'Healthy'
+                : 'Regression'}
+            </div>
+          </div>
+
+          {grantSemantics.topIssueSources.length > 0 ? (
+            <div className="mt-4">
+              <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Top Regressing Sources</div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                {grantSemantics.topIssueSources.map((source) => (
+                  <div key={source.source} className="border-2 border-bauhaus-black/20 p-3">
+                    <div className="text-xs font-black uppercase tracking-wider text-bauhaus-muted">{source.source}</div>
+                    <div className="text-lg font-black">{source.totalIssues.toLocaleString()}</div>
+                    <div className="text-xs font-mono text-bauhaus-muted mt-1">
+                      status={source.statusNull.toLocaleString()} | app={source.applicationStatusNull.toLocaleString()} | stale-open={source.openPastDeadline.toLocaleString()}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="mt-4 text-xs text-green-700 font-mono">
+              No issue sources are currently outstanding.
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* ===== SOURCE IDENTITY ===== */}
+      <section className="mb-10">
+        <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+          Grant Source Identity
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <StatCard label="Blank Source ID" value={sourceIdentity.blankSourceId} />
+          <StatCard label="Canonical Mismatch" value={sourceIdentity.canonicalMismatch} />
+          <StatCard label="Tracked Duplicates" value={sourceIdentity.duplicateShadows} />
+        </div>
+        <div className="border-4 border-bauhaus-black mt-4 p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-1">Current Guardrail State</div>
+              <div className="text-sm text-bauhaus-black">
+                {sourceIdentity.blankSourceId === 0 && sourceIdentity.canonicalMismatch === 0
+                  ? 'Grant-engine source keys are canonical. Duplicate legacy shadows remain explicitly tracked, not silently blank or mis-keyed.'
+                  : 'Grant-engine source identity drift has reappeared. Blank source ids or canonical mismatches now need cleanup before this starts affecting source-level reporting.'}
+              </div>
+            </div>
+            <div className={`px-3 py-2 text-xs font-black uppercase tracking-widest border-2 ${
+              sourceIdentity.blankSourceId === 0 && sourceIdentity.canonicalMismatch === 0
+                ? 'border-green-500 text-green-700 bg-green-50'
+                : 'border-red-500 text-red-700 bg-red-50'
+            }`}>
+              {sourceIdentity.blankSourceId === 0 && sourceIdentity.canonicalMismatch === 0
+                ? 'Healthy'
+                : 'Regression'}
+            </div>
+          </div>
+
+          {sourceIdentity.topIssueSources.length > 0 ? (
+            <div className="mt-4">
+              <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Top Regressing Sources</div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                {sourceIdentity.topIssueSources.map((source) => (
+                  <div key={source.source} className="border-2 border-bauhaus-black/20 p-3">
+                    <div className="text-xs font-black uppercase tracking-wider text-bauhaus-muted">{source.source}</div>
+                    <div className="text-lg font-black">{source.totalIssues.toLocaleString()}</div>
+                    <div className="text-xs font-mono text-bauhaus-muted mt-1">
+                      blank={source.blankSourceId.toLocaleString()} | mismatch={source.canonicalMismatch.toLocaleString()}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="mt-4 text-xs text-green-700 font-mono">
+              No source-identity issue sources are currently outstanding.
+            </div>
+          )}
         </div>
       </section>
 

--- a/apps/web/src/app/ops/layout.tsx
+++ b/apps/web/src/app/ops/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+import { requireAdminPage } from '@/lib/admin-auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function OpsLayout({ children }: { children: ReactNode }) {
+  await requireAdminPage('/ops');
+  return children;
+}

--- a/apps/web/src/app/ops/ops-client.tsx
+++ b/apps/web/src/app/ops/ops-client.tsx
@@ -9,9 +9,169 @@ interface OpsData {
     foundations: { total: number; profiled: number; withWebsite: number; programs: number };
     community: { orgs: number; acncRecords: number };
     socialEnterprises: { total: number; enriched: number };
+    billing: { paidProfiles: number; activeTrials: number; expiringTrials: number; atRisk: number; scheduledChurn: number; trialStarts30d: number; remindersSent30d: number; reminderClicks30d: number; portalOpens30d: number };
   };
+  dataReview: {
+    windowDays: number;
+    reviewCount: number;
+    recentReviewDate: string | null;
+    grantRows: number;
+    foundationRows: number;
+    grantPrecision: number;
+    foundationPrecision: number;
+    openNowTrust: number;
+    topIssues: Array<{ issue: string; count: number }>;
+    noisySources: Array<{ source: string; count: number }>;
+  };
+  dataReviewBenchmarks: Array<{
+    key: string;
+    label: string;
+    current: number;
+    target: number;
+    unit: '%' | 'rows';
+    passing: boolean;
+    gap: number;
+  }>;
+  dataReviewDecision: {
+    status: 'insufficient_data' | 'pass' | 'mixed' | 'failing';
+    recommendation: string;
+    benchmarkPassCount: number;
+    benchmarkTotal: number;
+    reviewIsStale: boolean;
+  };
+  productFunnel: {
+    windowDays: number;
+    profileReadyUsers: number;
+    firstShortlistUsers: number;
+    pipelineStartedUsers: number;
+    firstAlertUsers: number;
+    alertClickUsers: number;
+    checkoutStartedUsers: number;
+    trialStartedUsers: number;
+    billingReminderUsers: number;
+    billingReminderClickUsers: number;
+    billingPortalUsers: number;
+    activatedUsers: number;
+  };
+  pilotSummary: {
+    total: number;
+    consultants: number;
+    nonprofits: number;
+    active: number;
+    completed: number;
+    paid: number;
+    strongYes: number;
+    conditionalYes: number;
+    linkedAccounts: number;
+    profileReady: number;
+    shortlistStarted: number;
+    pipelineStarted: number;
+    alertCreated: number;
+    weeklyActive: number;
+    veryDisappointed: number;
+    paymentSignals: Record<string, number>;
+    stageCounts: Record<string, number>;
+  };
+  pilotBenchmarks: Array<{
+    key: string;
+    label: string;
+    current: number;
+    target: number;
+    passing: boolean;
+    gap: number;
+  }>;
+  pilotDecision: {
+    status: 'insufficient_data' | 'pass' | 'mixed' | 'failing';
+    recommendation: string;
+    benchmarkPassCount: number;
+    benchmarkTotal: number;
+    strongerCohort: 'consultant' | 'nonprofit' | null;
+  };
+  pilotCohorts: Array<{
+    cohort: 'consultant' | 'nonprofit' | 'other';
+    total: number;
+    linkedAccounts: number;
+    weeklyActive: number;
+    profileReady: number;
+    shortlistStarted: number;
+    pipelineStarted: number;
+    alertCreated: number;
+    strongYes: number;
+    conditionalYes: number;
+    paid: number;
+    paidOrCommitted: number;
+    veryDisappointed: number;
+    weeklyActiveRate: number;
+    profileReadyRate: number;
+    shortlistRate: number;
+    pipelineRate: number;
+    alertRate: number;
+    paymentIntentRate: number;
+    paidOrCommittedRate: number;
+    paidRate: number;
+    seanEllisRate: number;
+  }>;
+  pilotAttention: Array<{
+    pilotId: string;
+    participant_name: string;
+    organization_name: string | null;
+    cohort: 'consultant' | 'nonprofit' | 'other';
+    stage: PilotParticipant['stage'];
+    payment_intent: PilotParticipant['payment_intent'];
+    severity: 'high' | 'medium' | 'low';
+    reason: string;
+    detail: string;
+    daysSinceTouch: number;
+    updated_at: string;
+  }>;
+  pilots: PilotParticipant[];
+  upgradeSources: Record<string, { viewed: number; clicked: number; started: number; activated: number }>;
+  upcomingBillingProfiles: BillingProfile[];
   recentRuns: AgentRun[];
   lastUpdated: string;
+}
+
+interface PilotParticipant {
+  id: string;
+  participant_name: string;
+  email: string;
+  organization_name: string | null;
+  role_title: string | null;
+  cohort: 'consultant' | 'nonprofit' | 'other';
+  stage: 'lead' | 'invited' | 'scheduled' | 'onboarded' | 'active' | 'completed' | 'paid' | 'declined';
+  payment_intent: 'unknown' | 'strong_yes' | 'conditional_yes' | 'not_now' | 'no_budget' | 'no_fit';
+  sean_ellis_response: 'unknown' | 'very_disappointed' | 'somewhat_disappointed' | 'not_disappointed';
+  pilot_source: string | null;
+  funding_task: string | null;
+  notes: string | null;
+  linked_user_id: string | null;
+  linked_org_profile_id: string | null;
+  created_at: string;
+  updated_at: string;
+  last_contact_at: string | null;
+  onboarding_at: string | null;
+  observed_session_at: string | null;
+  closeout_at: string | null;
+  activation: {
+    linkedAccount: boolean;
+    weeklyActive: boolean;
+    profileReady: boolean;
+    shortlistStarted: boolean;
+    pipelineStarted: boolean;
+    alertCreated: boolean;
+    checkoutStarted: boolean;
+    activated: boolean;
+  };
+}
+
+interface BillingProfile {
+  id: string;
+  name: string | null;
+  subscription_plan: string | null;
+  subscription_status: string | null;
+  subscription_trial_end: string | null;
+  subscription_current_period_end: string | null;
+  subscription_cancel_at_period_end: boolean | null;
 }
 
 interface AgentRun {
@@ -29,7 +189,7 @@ interface AgentRun {
 }
 
 const TOOL_INVENTORY = [
-  { stage: 'Grant Discovery', tools: '15 source plugins (Cheerio, GrantConnect API, ARC API, CKAN)', cost: 'Free' },
+  { stage: 'Grant Discovery', tools: '31 source plugins (Cheerio, GrantConnect API, ARC API, CKAN)', cost: 'Free' },
   { stage: 'Grant Enrichment', tools: 'Cheerio + Groq/Gemini/DeepSeek/Minimax (auto-rotate)', cost: 'Free' },
   { stage: 'Grant Embedding', tools: 'OpenAI text-embedding-3-small', cost: '~$0.02/500' },
   { stage: 'Foundation Profiling', tools: 'Firecrawl + 9 LLM providers (Gemini-grounded first)', cost: '~$0.05/ea' },
@@ -42,11 +202,16 @@ const QUICK_ACTIONS = [
   { label: 'Enrich Grants (Free)', cmd: 'node --env-file=.env scripts/enrich-grants-free.mjs --limit=100', desc: 'Scrape + extract with free LLMs' },
   { label: 'Profile Foundations', cmd: 'node --env-file=.env scripts/build-foundation-profiles.mjs --limit=20', desc: 'AI-profile un-enriched foundations' },
   { label: 'Backfill Embeddings', cmd: 'node --env-file=.env scripts/backfill-embeddings.mjs --limit=500', desc: 'Generate missing vectors' },
-  { label: 'Run Discovery', cmd: 'node --env-file=.env scripts/grantscope-discovery.mjs', desc: 'Full multi-source grant discovery' },
+  { label: 'Run Discovery', cmd: 'npx tsx scripts/grantscope-discovery.mjs', desc: 'Full multi-source grant discovery' },
   { label: 'Sync ACNC', cmd: 'node --env-file=.env scripts/sync-acnc-register.mjs', desc: 'Download + update ACNC register' },
   { label: 'Import ORIC', cmd: 'node --env-file=.env scripts/import-oric-register.mjs', desc: 'Indigenous corp register (data.gov.au)' },
   { label: 'Enrich SEs', cmd: 'node --env-file=.env scripts/enrich-social-enterprises.mjs --limit=100', desc: 'AI-profile social enterprises' },
 ];
+
+const PILOT_STAGE_OPTIONS: PilotParticipant['stage'][] = ['lead', 'invited', 'scheduled', 'onboarded', 'active', 'completed', 'paid', 'declined'];
+const PILOT_PAYMENT_OPTIONS: PilotParticipant['payment_intent'][] = ['unknown', 'strong_yes', 'conditional_yes', 'not_now', 'no_budget', 'no_fit'];
+const PILOT_COHORT_OPTIONS: PilotParticipant['cohort'][] = ['consultant', 'nonprofit', 'other'];
+const PILOT_SEAN_ELLIS_OPTIONS: PilotParticipant['sean_ellis_response'][] = ['unknown', 'very_disappointed', 'somewhat_disappointed', 'not_disappointed'];
 
 function pct(n: number, total: number): string {
   if (total === 0) return '0';
@@ -68,6 +233,11 @@ function timeAgo(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '\u2014';
+  return new Date(iso).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
 function HealthCard({ label, value, total, sub }: { label: string; value: number; total: number; sub?: string }) {
@@ -111,23 +281,153 @@ export function OpsClient() {
   const [data, setData] = useState<OpsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [copied, setCopied] = useState<string | null>(null);
+  const [pilotError, setPilotError] = useState<string | null>(null);
+  const [pilotSuccess, setPilotSuccess] = useState<string | null>(null);
+  const [savingPilot, setSavingPilot] = useState(false);
+  const [savingPilotId, setSavingPilotId] = useState<string | null>(null);
+  const [reviewFile, setReviewFile] = useState<File | null>(null);
+  const [uploadingReview, setUploadingReview] = useState(false);
+  const [reviewUploadMessage, setReviewUploadMessage] = useState<string | null>(null);
+  const [reviewUploadError, setReviewUploadError] = useState<string | null>(null);
+  const [pilotDrafts, setPilotDrafts] = useState<Record<string, { stage: PilotParticipant['stage']; payment_intent: PilotParticipant['payment_intent']; notes: string; sean_ellis_response: PilotParticipant['sean_ellis_response'] }>>({});
+  const [newPilot, setNewPilot] = useState({
+    participant_name: '',
+    email: '',
+    organization_name: '',
+    cohort: 'consultant' as PilotParticipant['cohort'],
+    stage: 'lead' as PilotParticipant['stage'],
+    payment_intent: 'unknown' as PilotParticipant['payment_intent'],
+    notes: '',
+  });
   const router = useRouter();
 
+  async function loadOps() {
+    setLoading(true);
+    const response = await fetch('/api/ops');
+    if (response.status === 401) {
+      router.push('/login');
+      return;
+    }
+    const payload = await response.json();
+    setData(payload);
+    const nextDrafts = (payload.pilots || []).reduce((acc: Record<string, { stage: PilotParticipant['stage']; payment_intent: PilotParticipant['payment_intent']; notes: string; sean_ellis_response: PilotParticipant['sean_ellis_response'] }>, pilot: PilotParticipant) => {
+      acc[pilot.id] = {
+        stage: pilot.stage,
+        payment_intent: pilot.payment_intent,
+        notes: pilot.notes || '',
+        sean_ellis_response: pilot.sean_ellis_response,
+      };
+      return acc;
+    }, {});
+    setPilotDrafts(nextDrafts);
+    setLoading(false);
+  }
+
   useEffect(() => {
-    fetch('/api/ops')
-      .then((r) => {
-        if (r.status === 401) { router.push('/login'); return null; }
-        return r.json();
-      })
-      .then((d) => { if (d) setData(d); })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+    loadOps().catch(() => setLoading(false));
   }, [router]);
 
   function copyCmd(cmd: string) {
     navigator.clipboard.writeText(cmd);
     setCopied(cmd);
     setTimeout(() => setCopied(null), 2000);
+  }
+
+  function setPilotDraft(id: string, patch: Partial<{ stage: PilotParticipant['stage']; payment_intent: PilotParticipant['payment_intent']; notes: string; sean_ellis_response: PilotParticipant['sean_ellis_response'] }>) {
+    setPilotDrafts((current) => ({
+      ...current,
+      [id]: {
+        stage: current[id]?.stage ?? 'lead',
+        payment_intent: current[id]?.payment_intent ?? 'unknown',
+        notes: current[id]?.notes ?? '',
+        sean_ellis_response: current[id]?.sean_ellis_response ?? 'unknown',
+        ...patch,
+      },
+    }));
+  }
+
+  async function createPilot() {
+    setSavingPilot(true);
+    setPilotError(null);
+    setPilotSuccess(null);
+    try {
+      const response = await fetch('/api/ops/pilots', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newPilot),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || 'Failed to create pilot participant');
+      }
+      setPilotSuccess('Pilot participant added.');
+      setNewPilot({
+        participant_name: '',
+        email: '',
+        organization_name: '',
+        cohort: 'consultant',
+        stage: 'lead',
+        payment_intent: 'unknown',
+        notes: '',
+      });
+      await loadOps();
+    } catch (error) {
+      setPilotError(error instanceof Error ? error.message : 'Failed to create pilot participant');
+    } finally {
+      setSavingPilot(false);
+    }
+  }
+
+  async function savePilot(id: string) {
+    const draft = pilotDrafts[id];
+    if (!draft) return;
+    setSavingPilotId(id);
+    setPilotError(null);
+    setPilotSuccess(null);
+    try {
+      const response = await fetch(`/api/ops/pilots/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(draft),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || 'Failed to update pilot participant');
+      }
+      setPilotSuccess('Pilot participant updated.');
+      await loadOps();
+    } catch (error) {
+      setPilotError(error instanceof Error ? error.message : 'Failed to update pilot participant');
+    } finally {
+      setSavingPilotId(null);
+    }
+  }
+
+  async function uploadReviewCsv() {
+    if (!reviewFile) return;
+    setUploadingReview(true);
+    setReviewUploadMessage(null);
+    setReviewUploadError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', reviewFile);
+      const response = await fetch('/api/ops/validation-reviews/import', {
+        method: 'POST',
+        body: formData,
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || 'Failed to import validation review CSV');
+      }
+      setReviewUploadMessage(`Imported ${payload.imported} review row${payload.imported === 1 ? '' : 's'}.`);
+      setReviewFile(null);
+      await loadOps();
+    } catch (error) {
+      setReviewUploadError(error instanceof Error ? error.message : 'Failed to import validation review CSV');
+    } finally {
+      setUploadingReview(false);
+    }
   }
 
   if (loading) {
@@ -147,6 +447,23 @@ export function OpsClient() {
   }
 
   const { health, recentRuns } = data;
+  const funnel = data.productFunnel;
+  const billing = data.health.billing;
+  const dataReview = data.dataReview;
+  const dataReviewBenchmarks = data.dataReviewBenchmarks;
+  const dataReviewDecision = data.dataReviewDecision;
+  const pilotSummary = data.pilotSummary;
+  const pilotBenchmarks = data.pilotBenchmarks;
+  const pilotDecision = data.pilotDecision;
+  const pilotCohorts = data.pilotCohorts;
+  const pilotAttention = data.pilotAttention;
+  const upgradeSources = Object.entries(data.upgradeSources || {})
+    .sort((a, b) => b[1].viewed - a[1].viewed || b[1].started - a[1].started)
+    .slice(0, 6);
+  const shortlistRate = funnel.profileReadyUsers > 0 ? (funnel.firstShortlistUsers / funnel.profileReadyUsers) * 100 : 0;
+  const pipelineRate = funnel.firstShortlistUsers > 0 ? (funnel.pipelineStartedUsers / funnel.firstShortlistUsers) * 100 : 0;
+  const checkoutRate = funnel.alertClickUsers > 0 ? (funnel.checkoutStartedUsers / funnel.alertClickUsers) * 100 : 0;
+  const activationRate = funnel.checkoutStartedUsers > 0 ? (funnel.activatedUsers / funnel.checkoutStartedUsers) * 100 : 0;
 
   return (
     <div>
@@ -195,6 +512,682 @@ export function OpsClient() {
             </div>
           </div>
         </div>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+          Activation Funnel ({funnel.windowDays} Days)
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Profile Ready</div>
+            <div className="text-3xl font-black text-bauhaus-black">{funnel.profileReadyUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">Users with a usable org profile</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">First Shortlist</div>
+            <div className="text-3xl font-black text-bauhaus-blue">{funnel.firstShortlistUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pct(funnel.firstShortlistUsers, funnel.profileReadyUsers)} of profile-ready users</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Pipeline Started</div>
+            <div className="text-3xl font-black text-bauhaus-black">{funnel.pipelineStartedUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pct(funnel.pipelineStartedUsers, funnel.firstShortlistUsers)} of shortlisted users</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">First Alert Created</div>
+            <div className="text-3xl font-black text-bauhaus-red">{funnel.firstAlertUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">Alert-product adoption</div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Alert Click Users</div>
+            <div className="text-3xl font-black text-bauhaus-black">{funnel.alertClickUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">Clicked from alert or digest</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Checkout Started</div>
+            <div className="text-3xl font-black text-bauhaus-blue">{funnel.checkoutStartedUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{checkoutRate.toFixed(1)}% of click users</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Activated</div>
+            <div className="text-3xl font-black text-green-700">{funnel.activatedUsers}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{activationRate.toFixed(1)}% of checkout starts</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Stage Rates</div>
+            <div className="text-sm font-black text-bauhaus-black leading-6">
+              <div>Shortlist: {shortlistRate.toFixed(1)}%</div>
+              <div>Pipeline: {pipelineRate.toFixed(1)}%</div>
+              <div>Checkout: {checkoutRate.toFixed(1)}%</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+          Billing Health
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-4">
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Paid Profiles</div>
+            <div className="text-3xl font-black text-bauhaus-black">{billing.paidProfiles}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">
+              {billing.trialStarts30d} trial start{billing.trialStarts30d !== 1 ? 's' : ''} in the last 30 days
+            </div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Active Trials</div>
+            <div className="text-3xl font-black text-bauhaus-blue">{billing.activeTrials}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">
+              {billing.remindersSent30d} reminder{billing.remindersSent30d !== 1 ? 's' : ''} sent · {billing.reminderClicks30d} click{billing.reminderClicks30d !== 1 ? 's' : ''} · {billing.portalOpens30d} portal open{billing.portalOpens30d !== 1 ? 's' : ''} in 30 days
+            </div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Trials Ending Soon</div>
+            <div className="text-3xl font-black text-bauhaus-red">{billing.expiringTrials}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">Within the next 7 days</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Payment Risk</div>
+            <div className="text-3xl font-black text-bauhaus-red">{billing.atRisk}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">Past due or unpaid</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Scheduled Churn</div>
+            <div className="text-3xl font-black text-bauhaus-black">{billing.scheduledChurn}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">Cancel at period end</div>
+          </div>
+        </div>
+
+        {data.upcomingBillingProfiles.length > 0 && (
+          <div className="border-4 border-bauhaus-black overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white">
+                  <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Workspace</th>
+                  <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Plan</th>
+                  <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Status</th>
+                  <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Trial End</th>
+                  <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Period End</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.upcomingBillingProfiles.map((profile) => (
+                  <tr key={profile.id} className="border-t-2 border-bauhaus-black/10">
+                    <td className="px-4 py-3 font-bold">{profile.name || 'Untitled workspace'}</td>
+                    <td className="px-4 py-3 uppercase">{profile.subscription_plan || 'community'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 text-xs font-black uppercase tracking-wider ${
+                        profile.subscription_status === 'trialing'
+                          ? 'bg-bauhaus-blue text-white'
+                          : profile.subscription_cancel_at_period_end || ['past_due', 'unpaid'].includes(profile.subscription_status || '')
+                            ? 'bg-bauhaus-red text-white'
+                            : 'bg-gray-300 text-bauhaus-black'
+                      }`}>
+                        {profile.subscription_cancel_at_period_end
+                          ? 'cancelling'
+                          : profile.subscription_status || 'unknown'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 font-mono">{formatDate(profile.subscription_trial_end)}</td>
+                    <td className="px-4 py-3 font-mono">{formatDate(profile.subscription_current_period_end)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+          Data Truth Loop
+        </h2>
+
+        <div className="border-4 border-bauhaus-black p-5 mb-4">
+          <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-3">
+            Import Weekly Review CSV
+          </div>
+          <div className="flex flex-col lg:flex-row lg:items-center gap-3">
+            <input
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(event) => setReviewFile(event.target.files?.[0] || null)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm bg-white"
+            />
+            <button
+              onClick={uploadReviewCsv}
+              disabled={!reviewFile || uploadingReview}
+              className="border-4 border-bauhaus-black bg-bauhaus-blue text-white px-4 py-2 text-xs font-black uppercase tracking-widest disabled:opacity-50"
+            >
+              {uploadingReview ? 'Importing...' : 'Import Review CSV'}
+            </button>
+            <a
+              href="/api/ops/validation-reviews/template"
+              className="border-2 border-bauhaus-black px-4 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Download Template
+            </a>
+          </div>
+          {reviewFile && (
+            <div className="text-xs text-bauhaus-muted mt-3">
+              Ready to import: {reviewFile.name}
+            </div>
+          )}
+          {reviewUploadMessage && (
+            <div className="text-xs font-black uppercase tracking-widest text-green-700 mt-3">
+              {reviewUploadMessage}
+            </div>
+          )}
+          {reviewUploadError && (
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-red mt-3">
+              {reviewUploadError}
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Reviews Imported</div>
+            <div className="text-3xl font-black text-bauhaus-black">{dataReview.reviewCount}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">
+              {dataReview.recentReviewDate ? `Latest review ${formatDate(dataReview.recentReviewDate)}` : 'No review data yet'}
+            </div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Grant Precision</div>
+            <div className={`text-3xl font-black ${dataReview.grantPrecision >= 70 ? 'text-green-700' : 'text-bauhaus-red'}`}>
+              {dataReview.grantPrecision.toFixed(1)}%
+            </div>
+            <div className="text-xs text-bauhaus-muted mt-2">{dataReview.grantRows} grant reviews · target 70%</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Foundation Precision</div>
+            <div className={`text-3xl font-black ${dataReview.foundationPrecision >= 75 ? 'text-green-700' : 'text-bauhaus-red'}`}>
+              {dataReview.foundationPrecision.toFixed(1)}%
+            </div>
+            <div className="text-xs text-bauhaus-muted mt-2">{dataReview.foundationRows} foundation reviews · target 75%</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Open Now Trust</div>
+            <div className={`text-3xl font-black ${dataReview.openNowTrust >= 85 ? 'text-green-700' : 'text-bauhaus-red'}`}>
+              {dataReview.openNowTrust.toFixed(1)}%
+            </div>
+            <div className="text-xs text-bauhaus-muted mt-2">Target 85%</div>
+          </div>
+        </div>
+
+        <div className={`border-4 p-5 mb-4 ${
+          dataReviewDecision.status === 'pass'
+            ? 'border-green-700 bg-green-50'
+            : dataReviewDecision.status === 'mixed'
+              ? 'border-yellow-500 bg-yellow-50'
+              : dataReviewDecision.status === 'failing'
+                ? 'border-bauhaus-red bg-red-50'
+                : 'border-bauhaus-black bg-white'
+        }`}>
+          <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">
+            Data Quality Read
+          </div>
+          <div className="text-lg font-black text-bauhaus-black mb-2">
+            {dataReviewDecision.benchmarkPassCount}/{dataReviewDecision.benchmarkTotal} trust benchmarks passing
+          </div>
+          <div className="text-sm text-bauhaus-black">
+            {dataReviewDecision.recommendation}
+          </div>
+        </div>
+
+        {dataReview.reviewCount === 0 ? (
+          <div className="border-4 border-dashed border-bauhaus-black/20 p-8 text-center">
+            <div className="text-sm text-bauhaus-muted mb-3">
+              No data-review rows imported yet. Fill the scorecard CSV and import it to turn trust review into live ops metrics.
+            </div>
+            <div className="font-mono text-xs text-bauhaus-black break-all">
+              node --env-file=.env scripts/import-validation-reviews.mjs thoughts/plans/grantscope-data-review-scorecard-template.csv --apply
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="border-4 border-bauhaus-black overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Benchmark</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Current</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Target</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Gap</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dataReviewBenchmarks.map((metric) => (
+                    <tr key={metric.key} className="border-t-2 border-bauhaus-black/10">
+                      <td className="px-4 py-3 font-bold">{metric.label}</td>
+                      <td className="px-4 py-3 text-right font-mono">
+                        {metric.unit === '%' ? `${metric.current.toFixed(1)}%` : metric.current.toFixed(0)}
+                      </td>
+                      <td className="px-4 py-3 text-right font-mono">
+                        {metric.unit === '%' ? `${metric.target.toFixed(1)}%` : metric.target.toFixed(0)}
+                      </td>
+                      <td className={`px-4 py-3 text-right font-mono ${metric.gap >= 0 ? 'text-green-700' : 'text-bauhaus-red'}`}>
+                        {metric.gap >= 0 ? '+' : ''}{metric.gap.toFixed(1)} {metric.unit === '%' ? 'pts' : 'rows'}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <span className={`px-2 py-0.5 text-xs font-black uppercase tracking-wider ${
+                          metric.passing ? 'bg-green-700 text-white' : 'bg-bauhaus-red text-white'
+                        }`}>
+                          {metric.passing ? 'passing' : 'below'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div className="border-4 border-bauhaus-black overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-bauhaus-black text-white">
+                      <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Top Issue</th>
+                      <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Count</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dataReview.topIssues.map((issue) => (
+                      <tr key={issue.issue} className="border-t-2 border-bauhaus-black/10">
+                        <td className="px-4 py-3 font-bold">{issue.issue}</td>
+                        <td className="px-4 py-3 text-right font-mono">{issue.count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="border-4 border-bauhaus-black overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-bauhaus-black text-white">
+                      <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Noisy Source</th>
+                      <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Wrong / Noisy</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dataReview.noisySources.map((source) => (
+                      <tr key={source.source} className="border-t-2 border-bauhaus-black/10">
+                        <td className="px-4 py-3 font-bold">{source.source}</td>
+                        <td className="px-4 py-3 text-right font-mono">{source.count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {upgradeSources.length > 0 && (
+        <section className="mb-10">
+          <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+            Upgrade Sources
+          </h2>
+          <div className="border-4 border-bauhaus-black overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white">
+                  <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Source</th>
+                  <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Views</th>
+                  <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Clicks</th>
+                  <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Checkout Starts</th>
+                  <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Activations</th>
+                  <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Click Rate</th>
+                  <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Activation Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {upgradeSources.map(([source, counts]) => (
+                  <tr key={source} className="border-t-2 border-bauhaus-black/10">
+                    <td className="px-4 py-3 font-bold">{source}</td>
+                    <td className="px-4 py-3 text-right font-mono">{counts.viewed}</td>
+                    <td className="px-4 py-3 text-right font-mono">{counts.clicked}</td>
+                    <td className="px-4 py-3 text-right font-mono">{counts.started}</td>
+                    <td className="px-4 py-3 text-right font-mono">{counts.activated}</td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {counts.viewed > 0 ? `${((counts.clicked / counts.viewed) * 100).toFixed(1)}%` : '0%'}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {counts.started > 0 ? `${((counts.activated / counts.started) * 100).toFixed(1)}%` : '0%'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <section className="mb-10">
+        <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-muted mb-4 border-b-2 border-bauhaus-black pb-2">
+          Pilot Validation
+        </h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-4">
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Pilot Participants</div>
+            <div className="text-3xl font-black text-bauhaus-black">{pilotSummary.total}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pilotSummary.consultants} consultants · {pilotSummary.nonprofits} nonprofits</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Active Pilots</div>
+            <div className="text-3xl font-black text-bauhaus-blue">{pilotSummary.active}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pilotSummary.completed} completed · {pilotSummary.paid} paid</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Payment Signal</div>
+            <div className="text-3xl font-black text-green-700">{pilotSummary.strongYes}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pilotSummary.conditionalYes} conditional yes</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Linked Accounts</div>
+            <div className="text-3xl font-black text-bauhaus-black">{pilotSummary.linkedAccounts}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pilotSummary.profileReady} profile-ready · {pilotSummary.shortlistStarted} shortlisted</div>
+          </div>
+          <div className="border-4 border-bauhaus-black p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">Pilot Activation</div>
+            <div className="text-3xl font-black text-bauhaus-red">{pilotSummary.pipelineStarted}</div>
+            <div className="text-xs text-bauhaus-muted mt-2">{pilotSummary.alertCreated} created alerts · {pilotSummary.weeklyActive} active this week</div>
+          </div>
+        </div>
+
+        <div className={`border-4 p-5 mb-4 ${
+          pilotDecision.status === 'pass'
+            ? 'border-green-700 bg-green-50'
+            : pilotDecision.status === 'mixed'
+              ? 'border-yellow-500 bg-yellow-50'
+              : pilotDecision.status === 'failing'
+                ? 'border-bauhaus-red bg-red-50'
+                : 'border-bauhaus-black bg-white'
+        }`}>
+          <div className="text-xs font-black uppercase tracking-widest text-bauhaus-muted mb-2">
+            Pilot Read
+          </div>
+          <div className="text-lg font-black text-bauhaus-black mb-2">
+            {pilotDecision.benchmarkPassCount}/{pilotDecision.benchmarkTotal} pilot benchmarks passing
+          </div>
+          <div className="text-sm text-bauhaus-black">
+            {pilotDecision.recommendation}
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black p-5 mb-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-3 mb-3">
+            <input
+              value={newPilot.participant_name}
+              onChange={(event) => setNewPilot((current) => ({ ...current, participant_name: event.target.value }))}
+              placeholder="Participant name"
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm"
+            />
+            <input
+              value={newPilot.email}
+              onChange={(event) => setNewPilot((current) => ({ ...current, email: event.target.value }))}
+              placeholder="Email"
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm"
+            />
+            <input
+              value={newPilot.organization_name}
+              onChange={(event) => setNewPilot((current) => ({ ...current, organization_name: event.target.value }))}
+              placeholder="Organisation"
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm"
+            />
+            <select
+              value={newPilot.cohort}
+              onChange={(event) => setNewPilot((current) => ({ ...current, cohort: event.target.value as PilotParticipant['cohort'] }))}
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm bg-white"
+            >
+              {PILOT_COHORT_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+            <select
+              value={newPilot.stage}
+              onChange={(event) => setNewPilot((current) => ({ ...current, stage: event.target.value as PilotParticipant['stage'] }))}
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm bg-white"
+            >
+              {PILOT_STAGE_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+            <select
+              value={newPilot.payment_intent}
+              onChange={(event) => setNewPilot((current) => ({ ...current, payment_intent: event.target.value as PilotParticipant['payment_intent'] }))}
+              className="border-2 border-bauhaus-black px-3 py-2 text-sm bg-white"
+            >
+              {PILOT_PAYMENT_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+          <textarea
+            value={newPilot.notes}
+            onChange={(event) => setNewPilot((current) => ({ ...current, notes: event.target.value }))}
+            placeholder="Notes"
+            className="w-full border-2 border-bauhaus-black px-3 py-2 text-sm min-h-24 mb-3"
+          />
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              onClick={createPilot}
+              disabled={savingPilot}
+              className="border-4 border-bauhaus-black bg-bauhaus-red text-white px-4 py-2 text-xs font-black uppercase tracking-widest disabled:opacity-50"
+            >
+              {savingPilot ? 'Saving...' : 'Add Pilot Participant'}
+            </button>
+            {pilotSuccess && <div className="text-xs font-black uppercase tracking-widest text-green-700">{pilotSuccess}</div>}
+            {pilotError && <div className="text-xs font-black uppercase tracking-widest text-bauhaus-red">{pilotError}</div>}
+          </div>
+        </div>
+
+        {data.pilots.length === 0 ? (
+          <div className="border-4 border-dashed border-bauhaus-black/20 p-8 text-center">
+            <div className="text-sm text-bauhaus-muted">No pilot participants yet. Add the first consultant or nonprofit test user above.</div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="border-4 border-bauhaus-black overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Benchmark</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Current</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Target</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Gap</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pilotBenchmarks.map((metric) => (
+                    <tr key={metric.key} className="border-t-2 border-bauhaus-black/10">
+                      <td className="px-4 py-3 font-bold">{metric.label}</td>
+                      <td className="px-4 py-3 text-right font-mono">{metric.current.toFixed(1)}%</td>
+                      <td className="px-4 py-3 text-right font-mono">{metric.target.toFixed(1)}%</td>
+                      <td className={`px-4 py-3 text-right font-mono ${metric.gap >= 0 ? 'text-green-700' : 'text-bauhaus-red'}`}>
+                        {metric.gap >= 0 ? '+' : ''}{metric.gap.toFixed(1)} pts
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <span className={`px-2 py-0.5 text-xs font-black uppercase tracking-wider ${
+                          metric.passing ? 'bg-green-700 text-white' : 'bg-bauhaus-red text-white'
+                        }`}>
+                          {metric.passing ? 'passing' : 'below'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="border-4 border-bauhaus-black overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Cohort</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Participants</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Weekly Active</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Shortlisted</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Pipeline</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Alerts</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Paid / Commit</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Sean Ellis</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pilotCohorts.map((cohort) => (
+                    <tr key={cohort.cohort} className="border-t-2 border-bauhaus-black/10">
+                      <td className="px-4 py-3 font-bold uppercase">{cohort.cohort}</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.total}</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.weeklyActiveRate.toFixed(1)}%</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.shortlistRate.toFixed(1)}%</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.pipelineRate.toFixed(1)}%</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.alertRate.toFixed(1)}%</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.paidOrCommittedRate.toFixed(1)}%</td>
+                      <td className="px-4 py-3 text-right font-mono">{cohort.seanEllisRate.toFixed(1)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {pilotAttention.length > 0 && (
+              <div className="border-4 border-bauhaus-black overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-bauhaus-black text-white">
+                      <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Needs Attention</th>
+                      <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Reason</th>
+                      <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Detail</th>
+                      <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Days</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pilotAttention.map((item) => (
+                      <tr key={item.pilotId} className="border-t-2 border-bauhaus-black/10">
+                        <td className="px-4 py-3">
+                          <div className="font-bold">{item.participant_name}</div>
+                          <div className="text-xs text-bauhaus-muted">{item.organization_name || item.cohort}</div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`px-2 py-0.5 text-xs font-black uppercase tracking-wider ${
+                            item.severity === 'high'
+                              ? 'bg-bauhaus-red text-white'
+                              : item.severity === 'medium'
+                                ? 'bg-yellow-400 text-bauhaus-black'
+                                : 'bg-gray-300 text-bauhaus-black'
+                          }`}>
+                            {item.reason}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-bauhaus-muted">{item.detail}</td>
+                        <td className="px-4 py-3 text-right font-mono">{item.daysSinceTouch}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            <div className="border-4 border-bauhaus-black overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Participant</th>
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Cohort</th>
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Stage</th>
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Payment Intent</th>
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Sean Ellis</th>
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Activation</th>
+                    <th className="text-left px-4 py-2 font-black uppercase tracking-wider text-xs">Notes</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Updated</th>
+                    <th className="text-right px-4 py-2 font-black uppercase tracking-wider text-xs">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.pilots.map((pilot) => (
+                    <tr key={pilot.id} className="border-t-2 border-bauhaus-black/10 align-top">
+                      <td className="px-4 py-3">
+                        <div className="font-bold">{pilot.participant_name}</div>
+                        <div className="text-xs text-bauhaus-muted">{pilot.organization_name || pilot.email}</div>
+                        {pilot.linked_user_id && <div className="text-[11px] font-mono text-green-700 mt-1">linked account</div>}
+                      </td>
+                      <td className="px-4 py-3 uppercase text-xs font-black tracking-wider">{pilot.cohort}</td>
+                      <td className="px-4 py-3">
+                        <select
+                          value={pilotDrafts[pilot.id]?.stage ?? pilot.stage}
+                          onChange={(event) => setPilotDraft(pilot.id, { stage: event.target.value as PilotParticipant['stage'] })}
+                          className="border-2 border-bauhaus-black px-2 py-1 text-xs bg-white"
+                        >
+                          {PILOT_STAGE_OPTIONS.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-4 py-3">
+                        <select
+                          value={pilotDrafts[pilot.id]?.payment_intent ?? pilot.payment_intent}
+                          onChange={(event) => setPilotDraft(pilot.id, { payment_intent: event.target.value as PilotParticipant['payment_intent'] })}
+                          className="border-2 border-bauhaus-black px-2 py-1 text-xs bg-white"
+                        >
+                          {PILOT_PAYMENT_OPTIONS.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-4 py-3">
+                        <select
+                          value={pilotDrafts[pilot.id]?.sean_ellis_response ?? pilot.sean_ellis_response}
+                          onChange={(event) => setPilotDraft(pilot.id, { sean_ellis_response: event.target.value as PilotParticipant['sean_ellis_response'] })}
+                          className="border-2 border-bauhaus-black px-2 py-1 text-xs bg-white"
+                        >
+                          {PILOT_SEAN_ELLIS_OPTIONS.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-bauhaus-muted">
+                        <div>{pilot.activation.weeklyActive ? 'active this week' : 'no recent activity'}</div>
+                        <div>{pilot.activation.profileReady ? 'profile' : 'no profile'}</div>
+                        <div>{pilot.activation.shortlistStarted ? 'shortlisted' : 'no shortlist'}</div>
+                        <div>{pilot.activation.pipelineStarted ? 'pipeline' : 'no pipeline'}</div>
+                        <div>{pilot.activation.alertCreated ? 'alerts' : 'no alerts'}</div>
+                      </td>
+                      <td className="px-4 py-3 min-w-52">
+                        <textarea
+                          value={pilotDrafts[pilot.id]?.notes ?? pilot.notes ?? ''}
+                          onChange={(event) => setPilotDraft(pilot.id, { notes: event.target.value })}
+                          className="w-full border-2 border-bauhaus-black px-2 py-1 text-xs min-h-20"
+                        />
+                      </td>
+                      <td className="px-4 py-3 text-right text-xs text-bauhaus-muted">{timeAgo(pilot.updated_at)}</td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          onClick={() => savePilot(pilot.id)}
+                          disabled={savingPilotId === pilot.id}
+                          className="border-2 border-bauhaus-black px-3 py-1 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white disabled:opacity-50"
+                        >
+                          {savingPilotId === pilot.id ? 'Saving...' : 'Save'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </section>
 
       {/* Tool Inventory */}

--- a/apps/web/src/app/profile/matches/matches-client.tsx
+++ b/apps/web/src/app/profile/matches/matches-client.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { ThumbsVote } from '@/app/components/thumbs-vote';
 
 interface MatchedGrant {
@@ -15,6 +16,7 @@ interface MatchedGrant {
   url: string | null;
   grant_type: string;
   fit_score: number;
+  match_reasons: string[];
 }
 
 interface GrantDetail {
@@ -52,16 +54,20 @@ interface LearningInsights {
 
 function GrantSidebar({
   grantId,
+  grantName,
   fitScore,
   onClose,
   onTrack,
   isTracked,
+  trackerHref,
 }: {
   grantId: string;
+  grantName: string;
   fitScore: number;
   onClose: () => void;
-  onTrack: (id: string) => void;
+  onTrack: (id: string, name?: string) => void;
   isTracked: boolean;
+  trackerHref: string;
 }) {
   const [detail, setDetail] = useState<GrantDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -252,17 +258,21 @@ function GrantSidebar({
 
             {/* Actions */}
             <div className="flex gap-3 pt-2">
-              <button
-                onClick={() => onTrack(detail.id)}
-                disabled={isTracked}
-                className={`flex-1 text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black transition-colors ${
-                  isTracked
-                    ? 'bg-bauhaus-black text-white'
-                    : 'hover:bg-bauhaus-black hover:text-white'
-                }`}
-              >
-                {isTracked ? 'Tracked' : 'Add to Tracker'}
-              </button>
+              {isTracked ? (
+                <Link
+                  href={trackerHref}
+                  className="flex-1 text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black text-center bg-bauhaus-black text-white"
+                >
+                  Open Tracker
+                </Link>
+              ) : (
+                <button
+                  onClick={() => onTrack(detail.id, grantName || detail.name)}
+                  className="flex-1 text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+                >
+                  Add to Tracker
+                </button>
+              )}
               <Link
                 href={`/grants/${detail.id}`}
                 className="flex-1 text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black text-center bg-bauhaus-blue text-white hover:bg-bauhaus-black transition-colors"
@@ -367,6 +377,7 @@ function LearningBanner({ voteCount, learning }: { voteCount: number; learning: 
 }
 
 export function MatchesClient() {
+  const searchParams = useSearchParams();
   const [matches, setMatches] = useState<MatchedGrant[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -378,9 +389,28 @@ export function MatchesClient() {
   const [activeProject, setActiveProject] = useState<string | null>(null);
   const [availableProjects, setAvailableProjects] = useState<{ code: string; name: string }[]>([]);
   const [learning, setLearning] = useState<LearningInsights | null>(null);
+  const [profileDomains, setProfileDomains] = useState<string[]>([]);
+  const [profileGeo, setProfileGeo] = useState<string[]>([]);
+  const [lastTrackedGrantName, setLastTrackedGrantName] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/tracker?view=personal')
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => {
+        if (!Array.isArray(data)) return;
+        const trackedIds = data
+          .map((item: { grant_id?: string | null; grant?: { id?: string | null } | null }) => item.grant_id || item.grant?.id)
+          .filter((value: string | null | undefined): value is string => Boolean(value));
+        setSavedGrants(prev => new Set([...prev, ...trackedIds]));
+      })
+      .catch(() => {
+        // ignore
+      });
+  }, []);
 
   useEffect(() => {
     setLoading(true);
+    setError('');
     const params = new URLSearchParams({
       threshold: String(minScore / 100),
       limit: '100',
@@ -397,6 +427,8 @@ export function MatchesClient() {
         setVoteCount(data.feedback_count || 0);
         if (data.available_projects) setAvailableProjects(data.available_projects);
         setLearning(data.learning || null);
+        setProfileDomains(data.profile_domains || []);
+        setProfileGeo(data.profile_geo || []);
       })
       .catch(async (r) => {
         if (r instanceof Response) {
@@ -409,21 +441,25 @@ export function MatchesClient() {
       .finally(() => setLoading(false));
   }, [minScore, activeProject]);
 
-  const saveToTracker = useCallback(async (grantId: string) => {
+  const saveToTracker = useCallback(async (grantId: string, grantName?: string) => {
     setSavingGrant(grantId);
     try {
-      await fetch(`/api/tracker/${grantId}`, {
+      const response = await fetch(`/api/tracker/${grantId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ stage: 'discovered', stars: 0, color: 'none' }),
       });
+      if (!response.ok) {
+        throw new Error('Failed to save grant');
+      }
       setSavedGrants(prev => new Set(prev).add(grantId));
+      setLastTrackedGrantName(grantName || matches.find(grant => grant.id === grantId)?.name || 'Grant');
     } catch {
       // ignore
     } finally {
       setSavingGrant(null);
     }
-  }, []);
+  }, [matches]);
 
   function fitColor(score: number) {
     if (score >= 80) return 'bg-bauhaus-blue';
@@ -434,6 +470,9 @@ export function MatchesClient() {
   const activeProjectName = activeProject
     ? availableProjects.find(p => p.code === activeProject)?.name
     : null;
+  const onboardingMode = searchParams.get('onboarding') === '1';
+  const trackerHref = onboardingMode ? '/tracker?onboarding=1' : '/tracker';
+  const profileSummary = [...profileDomains.slice(0, 3), ...profileGeo.slice(0, 2)].filter(Boolean);
 
   if (loading) {
     return (
@@ -449,7 +488,7 @@ export function MatchesClient() {
     return (
       <div className="space-y-4">
         <h1 className="text-3xl font-black uppercase tracking-tight text-bauhaus-black">
-          Matched Grants
+          {onboardingMode ? 'Step 2: Review Matches' : 'Matched Grants'}
         </h1>
         <div className="border-4 border-bauhaus-red bg-danger-light p-6">
           <p className="text-sm font-bold text-bauhaus-red">{error}</p>
@@ -467,10 +506,15 @@ export function MatchesClient() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-4">
         <div>
+          {onboardingMode && (
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
+              Step 2 of 3
+            </div>
+          )}
           <h1 className="text-3xl font-black uppercase tracking-tight text-bauhaus-black">
-            Matched Grants
+            {onboardingMode ? 'Review Your Best-Fit Grants' : 'Matched Grants'}
           </h1>
           <p className="text-sm text-bauhaus-muted mt-1">
             {matches.length} grants matched
@@ -478,18 +522,83 @@ export function MatchesClient() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Link
-            href="/profile/answers"
-            className="text-xs font-black uppercase tracking-widest text-bauhaus-black hover:text-bauhaus-blue border-3 border-bauhaus-black px-4 py-2"
-          >
-            Answer Bank
-          </Link>
+          {onboardingMode ? (
+            <Link
+              href={trackerHref}
+              className="text-xs font-black uppercase tracking-widest text-bauhaus-black hover:text-bauhaus-blue border-3 border-bauhaus-black px-4 py-2"
+            >
+              Continue To Tracker
+            </Link>
+          ) : (
+            <Link
+              href="/profile/answers"
+              className="text-xs font-black uppercase tracking-widest text-bauhaus-black hover:text-bauhaus-blue border-3 border-bauhaus-black px-4 py-2"
+            >
+              Answer Bank
+            </Link>
+          )}
           <Link
             href="/profile"
             className="text-xs font-black uppercase tracking-widest text-bauhaus-blue hover:text-bauhaus-black border-3 border-bauhaus-black px-4 py-2"
           >
             Edit Profile
           </Link>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.7fr),minmax(280px,0.9fr)]">
+        <div className="border-4 border-bauhaus-black bg-white p-5">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-blue">
+            {onboardingMode ? 'Profile Saved' : 'How To Use This'}
+          </div>
+          <h2 className="mt-2 text-xl font-black uppercase tracking-tight text-bauhaus-black">
+            {onboardingMode ? 'Now shortlist the strongest grants' : 'Shortlist first, then move the strongest grants into Tracker'}
+          </h2>
+          <p className="mt-2 text-sm text-bauhaus-black/75">
+            {onboardingMode
+              ? 'Your profile is now rich enough to generate matches. Open a grant, check the reason chips, and track at least one strong option to complete this step.'
+              : 'These results combine profile similarity, sector overlap, geography overlap, and your previous feedback. Open a grant, check the reason chips, and track the ones worth active work.'}
+          </p>
+          {profileSummary.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {profileSummary.map(value => (
+                <span
+                  key={value}
+                  className="text-[10px] font-black uppercase tracking-widest text-bauhaus-black border border-bauhaus-black/20 px-2 py-1"
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-bauhaus-blue p-5 text-white">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-white/80">
+            {onboardingMode ? 'Step 2 Goal' : 'Next Action'}
+          </div>
+          <h2 className="mt-2 text-lg font-black uppercase tracking-tight">
+            {onboardingMode ? 'Track your first grant' : 'Build your first shortlist'}
+          </h2>
+          <p className="mt-2 text-sm text-white/85">
+            {onboardingMode
+              ? 'Once at least one good fit is in Tracker, you can start moving it from discovery into real pipeline work.'
+              : 'Add likely opportunities to Tracker so you can move from discovery into review, drafting, and submission.'}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link
+              href={trackerHref}
+              className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-white hover:bg-white hover:text-bauhaus-blue transition-colors"
+            >
+              Open Tracker
+            </Link>
+            <Link
+              href="/profile"
+              className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-white/60 text-white/90 hover:border-white hover:text-white transition-colors"
+            >
+              Refine Profile
+            </Link>
+          </div>
         </div>
       </div>
 
@@ -530,6 +639,39 @@ export function MatchesClient() {
         <LearningBanner voteCount={voteCount} learning={learning} />
       )}
 
+      {onboardingMode && !lastTrackedGrantName && (
+        <div className="border-4 border-bauhaus-yellow bg-bauhaus-yellow/15 p-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-black">Next Move</div>
+          <p className="mt-2 text-sm text-bauhaus-black/80">
+            Track one grant from this list to complete step 2, then continue into your pipeline tracker.
+          </p>
+        </div>
+      )}
+
+      {lastTrackedGrantName && (
+        <div className="border-4 border-bauhaus-blue bg-bauhaus-blue/5 p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-blue">
+              {onboardingMode ? 'Step 2 Complete' : 'Shortlisted'}
+            </div>
+            <p className="mt-1 text-sm font-bold text-bauhaus-black">
+              {lastTrackedGrantName} is now in your tracker.
+            </p>
+            {onboardingMode && (
+              <p className="mt-1 text-xs text-bauhaus-black/70">
+                Continue to tracker and move it beyond Discovered when it becomes a real pipeline priority.
+              </p>
+            )}
+          </div>
+          <Link
+            href={trackerHref}
+            className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-blue text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white transition-colors"
+          >
+            {onboardingMode ? 'Continue To Tracker' : 'Review In Tracker'}
+          </Link>
+        </div>
+      )}
+
       {/* Filters */}
       <div className="flex items-center gap-4 border-4 border-bauhaus-black bg-white p-4">
         <label className="text-xs font-black uppercase tracking-widest text-bauhaus-black whitespace-nowrap">
@@ -552,13 +694,64 @@ export function MatchesClient() {
 
       {/* Results */}
       {matches.length === 0 ? (
-        <div className="border-4 border-bauhaus-black/20 p-8 text-center">
-          <p className="text-sm text-bauhaus-muted">
-            No grants found above {minScore}% fit{activeProjectName ? ` for ${activeProjectName}` : ''}. Try lowering the threshold or updating your profile.
+        <div className="border-4 border-bauhaus-black bg-white p-8">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
+            No Matches Yet
+          </div>
+          <h2 className="mt-2 text-2xl font-black uppercase tracking-tight text-bauhaus-black">
+            Nothing cleared {minScore}% fit{activeProjectName ? ` for ${activeProjectName}` : ''}
+          </h2>
+          <p className="mt-2 text-sm text-bauhaus-black/75 max-w-2xl">
+            Try lowering the threshold, clearing the active project, or broadening your profile domains and geography so the matcher has
+            more signal to work with.
           </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            {minScore > 50 && (
+              <button
+                onClick={() => {
+                  setMinScore(Math.max(50, minScore - 10));
+                  setLoading(true);
+                }}
+                className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors"
+              >
+                Lower To {Math.max(50, minScore - 10)}%
+              </button>
+            )}
+            {activeProject && (
+              <button
+                onClick={() => setActiveProject(null)}
+                className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-blue text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white transition-colors"
+              >
+                Show All Projects
+              </button>
+            )}
+            <Link
+              href="/profile"
+              className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black text-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors"
+            >
+              Update Profile
+            </Link>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">
+          <div className="flex flex-col gap-3 border-4 border-bauhaus-black bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
+                {onboardingMode ? 'Step 2 Output' : 'Best-Fit Results'}
+              </div>
+              <p className="mt-1 text-sm text-bauhaus-black/75">
+                Review why each grant matched, then add the strongest options to your tracker for active follow-up.
+              </p>
+            </div>
+            <Link
+              href={trackerHref}
+              className="text-xs font-black uppercase tracking-widest px-4 py-3 border-3 border-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors"
+            >
+              Open Tracker
+            </Link>
+          </div>
+
           {matches.map(grant => (
             <div
               key={grant.id}
@@ -592,17 +785,22 @@ export function MatchesClient() {
                         projectCode={activeProject || undefined}
                         onVote={() => setVoteCount(c => c + 1)}
                       />
-                      <button
-                        onClick={() => saveToTracker(grant.id)}
-                        disabled={savingGrant === grant.id || savedGrants.has(grant.id)}
-                        className={`text-xs font-black uppercase tracking-widest px-3 py-2 border-3 border-bauhaus-black transition-colors ${
-                          savedGrants.has(grant.id)
-                            ? 'bg-bauhaus-black text-white'
-                            : 'hover:bg-bauhaus-black hover:text-white disabled:opacity-50'
-                        }`}
-                      >
-                        {savedGrants.has(grant.id) ? 'Tracked' : savingGrant === grant.id ? '...' : 'Track'}
-                      </button>
+                      {savedGrants.has(grant.id) ? (
+                        <Link
+                          href={trackerHref}
+                          className="text-xs font-black uppercase tracking-widest px-3 py-2 border-3 border-bauhaus-black bg-bauhaus-black text-white"
+                        >
+                          In Tracker
+                        </Link>
+                      ) : (
+                        <button
+                          onClick={() => saveToTracker(grant.id, grant.name)}
+                          disabled={savingGrant === grant.id}
+                          className="text-xs font-black uppercase tracking-widest px-3 py-2 border-3 border-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white disabled:opacity-50"
+                        >
+                          {savingGrant === grant.id ? '...' : 'Track'}
+                        </button>
+                      )}
                     </div>
                   </div>
 
@@ -610,7 +808,25 @@ export function MatchesClient() {
                     <p className="text-xs text-bauhaus-black/70 mt-2 line-clamp-2">{grant.description}</p>
                   )}
 
-                  <div className="flex items-center gap-4 mt-3">
+                  {grant.match_reasons?.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
+                        Why This Matched
+                      </div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {grant.match_reasons.map(reason => (
+                          <span
+                            key={reason}
+                            className="text-[10px] font-black uppercase tracking-widest text-bauhaus-black border border-bauhaus-black/20 px-2 py-1"
+                          >
+                            {reason}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="mt-3 flex flex-wrap items-center gap-4">
                     {grant.amount_max && (
                       <span className="text-xs font-bold text-bauhaus-black">
                         Up to ${grant.amount_max.toLocaleString()}
@@ -643,10 +859,12 @@ export function MatchesClient() {
       {selectedGrant && (
         <GrantSidebar
           grantId={selectedGrant.id}
+          grantName={selectedGrant.name}
           fitScore={selectedGrant.fit_score}
           onClose={() => setSelectedGrant(null)}
           onTrack={saveToTracker}
           isTracked={savedGrants.has(selectedGrant.id)}
+          trackerHref={trackerHref}
         />
       )}
 

--- a/apps/web/src/app/profile/profile-client.tsx
+++ b/apps/web/src/app/profile/profile-client.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { startCheckoutForTier } from '@/lib/start-checkout';
+import { resolveSubscriptionTier, TIER_LABELS } from '@/lib/subscription';
 
 interface TeamMember {
   id: string;
@@ -143,6 +146,12 @@ interface OrgProfile {
   notify_threshold: number;
   org_status: string;
   auspice_org_name: string;
+  stripe_customer_id?: string | null;
+  subscription_plan?: string | null;
+  subscription_status?: string | null;
+  subscription_trial_end?: string | null;
+  subscription_current_period_end?: string | null;
+  subscription_cancel_at_period_end?: boolean;
 }
 
 const EMPTY_PROFILE: OrgProfile = {
@@ -161,6 +170,12 @@ const EMPTY_PROFILE: OrgProfile = {
   notify_threshold: 0.75,
   org_status: 'exploring',
   auspice_org_name: '',
+  stripe_customer_id: null,
+  subscription_plan: 'community',
+  subscription_status: null,
+  subscription_trial_end: null,
+  subscription_current_period_end: null,
+  subscription_cancel_at_period_end: false,
 };
 
 interface MatchedGrant {
@@ -181,10 +196,121 @@ function getIsImpersonating(): boolean {
   return document.cookie.split(';').some(c => c.trim().startsWith('cg_impersonate_org='));
 }
 
+function getSafeRedirect(value: string | null): string | null {
+  if (!value) return null;
+  if (!value.startsWith('/') || value.startsWith('//')) return null;
+  return value;
+}
+
+function getBillingSource(value: string | null): string {
+  if (!value) return 'profile_billing_panel';
+  const normalized = value.trim().slice(0, 80);
+  return normalized.length > 0 ? normalized : 'profile_billing_panel';
+}
+
+function formatBillingDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString('en-AU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function getBillingStatusDetails(profile: OrgProfile) {
+  const tier = resolveSubscriptionTier(profile.subscription_plan);
+  const planLabel = TIER_LABELS[tier];
+  const status = (profile.subscription_status || '').toLowerCase();
+  const trialEnd = formatBillingDate(profile.subscription_trial_end);
+  const periodEnd = formatBillingDate(profile.subscription_current_period_end);
+
+  if (profile.subscription_cancel_at_period_end && periodEnd) {
+    return {
+      planLabel,
+      statusLabel: 'Ending',
+      toneClass: 'bg-bauhaus-red text-white',
+      summary: `${planLabel} stays active until ${periodEnd}.`,
+      detail: 'Billing is set to cancel at the end of the current period.',
+      nextLabel: 'Ends',
+      nextValue: periodEnd,
+    };
+  }
+
+  switch (status) {
+    case 'trialing':
+      return {
+        planLabel,
+        statusLabel: 'Trialing',
+        toneClass: 'bg-bauhaus-yellow text-bauhaus-black',
+        summary: `${planLabel} trial is live.`,
+        detail: trialEnd
+          ? `Your free trial ends on ${trialEnd}.`
+          : 'Your free trial is active now.',
+        nextLabel: 'Trial ends',
+        nextValue: trialEnd,
+      };
+    case 'active':
+      return {
+        planLabel,
+        statusLabel: 'Active',
+        toneClass: 'bg-bauhaus-blue text-white',
+        summary: `${planLabel} is active.`,
+        detail: periodEnd
+          ? `Your next renewal is ${periodEnd}.`
+          : 'Billing is active for this workspace.',
+        nextLabel: 'Renews',
+        nextValue: periodEnd,
+      };
+    case 'past_due':
+    case 'unpaid':
+      return {
+        planLabel,
+        statusLabel: 'Needs attention',
+        toneClass: 'bg-bauhaus-red text-white',
+        summary: `Payment needs attention for ${planLabel}.`,
+        detail: periodEnd
+          ? `The current billing period ends on ${periodEnd}.`
+          : 'Update billing details to keep access uninterrupted.',
+        nextLabel: 'Period ends',
+        nextValue: periodEnd,
+      };
+    case 'canceled':
+    case 'cancelled':
+      return {
+        planLabel,
+        statusLabel: 'Ended',
+        toneClass: 'bg-bauhaus-black text-white',
+        summary: `${planLabel} has ended.`,
+        detail: periodEnd
+          ? `Your last billing period ended on ${periodEnd}.`
+          : 'This workspace is currently on the Community plan.',
+        nextLabel: 'Ended',
+        nextValue: periodEnd,
+      };
+    default:
+      return {
+        planLabel,
+        statusLabel: tier === 'community' ? 'Community' : 'Syncing',
+        toneClass: tier === 'community' ? 'bg-bauhaus-black text-white' : 'bg-bauhaus-yellow text-bauhaus-black',
+        summary: tier === 'community' ? 'Community plan is active.' : `${planLabel} checkout completed.`,
+        detail: tier === 'community'
+          ? 'Upgrade when you want alerts, weekly digests, and shared pipeline workflow.'
+          : 'Billing is syncing. Refresh in a moment if the status has not appeared yet.',
+        nextLabel: trialEnd ? 'Trial ends' : periodEnd ? 'Renews' : null,
+        nextValue: trialEnd || periodEnd,
+      };
+  }
+}
+
 export function ProfileClient() {
   const [profile, setProfile] = useState<OrgProfile>(EMPTY_PROFILE);
   const [loading, setLoading] = useState(true);
   const isImpersonating = getIsImpersonating();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [showAdvancedSetup, setShowAdvancedSetup] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
@@ -200,6 +326,9 @@ export function ProfileClient() {
   const [inviting, setInviting] = useState(false);
   const [inviteMessage, setInviteMessage] = useState('');
   const [removingMember, setRemovingMember] = useState<string | null>(null);
+  const [openingBillingPortal, setOpeningBillingPortal] = useState(false);
+  const [startingProfessionalTrial, setStartingProfessionalTrial] = useState(false);
+  const [billingError, setBillingError] = useState('');
 
   useEffect(() => {
     fetch('/api/profile')
@@ -344,7 +473,24 @@ export function ProfileClient() {
       setProfile(prev => ({ ...prev, id: data.id }));
       setSaved(true);
 
-      // Auto-load matches after save
+      const wasFirstRun = !profile.id;
+      const explicitRedirect =
+        getSafeRedirect(searchParams.get('next')) ||
+        getSafeRedirect(searchParams.get('redirect'));
+      const billingSuccess = searchParams.get('billing') === 'success';
+      const shouldAdvanceToMatches = !billingSuccess && wasFirstRun;
+
+      if (explicitRedirect && !billingSuccess) {
+        router.push(explicitRedirect);
+        return;
+      }
+
+      if (shouldAdvanceToMatches) {
+        router.push('/profile/matches?onboarding=1');
+        return;
+      }
+
+      // Auto-load matches after save for in-place profile edits
       loadMatches();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save');
@@ -393,6 +539,39 @@ export function ProfileClient() {
     }
   }
 
+  async function handleOpenBillingPortal() {
+    setBillingError('');
+    setOpeningBillingPortal(true);
+    try {
+      const response = await fetch('/api/billing/portal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: billingInteractionSource }),
+      });
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok || !data?.url) {
+        throw new Error(data?.error || 'Could not open billing portal.');
+      }
+
+      window.location.href = data.url;
+    } catch (err) {
+      setBillingError(err instanceof Error ? err.message : 'Could not open billing portal.');
+    } finally {
+      setOpeningBillingPortal(false);
+    }
+  }
+
+  async function handleStartProfessionalTrial() {
+    setBillingError('');
+    setStartingProfessionalTrial(true);
+    const result = await startCheckoutForTier('professional', billingInteractionSource);
+    if (!result.ok) {
+      setBillingError(result.error);
+    }
+    setStartingProfessionalTrial(false);
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[40vh]">
@@ -403,17 +582,152 @@ export function ProfileClient() {
     );
   }
 
+  const isFirstRunProfile = !profile.id;
+  const isCompressedOnboarding = isFirstRunProfile && !showAdvancedSetup;
+  const billingSuccess = searchParams.get('billing') === 'success';
+  const billingInteractionSource = getBillingSource(searchParams.get('billing_source'));
+  const billingTier = resolveSubscriptionTier(profile.subscription_plan);
+  const billingDetails = billingSuccess && !profile.subscription_status
+    ? {
+        planLabel: 'Professional',
+        statusLabel: 'Syncing',
+        toneClass: 'bg-bauhaus-yellow text-bauhaus-black',
+        summary: 'Checkout completed.',
+        detail: 'Stripe is still confirming the subscription state. Refresh in a moment if this does not update automatically.',
+        nextLabel: null,
+        nextValue: null,
+      }
+    : getBillingStatusDetails(profile);
+  const showBillingSection = billingSuccess || Boolean(profile.stripe_customer_id) || billingTier !== 'community' || Boolean(profile.subscription_status);
+
   return (
     <div className="space-y-8">
       {/* Header */}
       <div>
         <h1 className="text-3xl font-black uppercase tracking-tight text-bauhaus-black">
-          Organisation Profile
+          {isCompressedOnboarding ? 'Quick Profile Setup' : 'Organisation Profile'}
         </h1>
         <p className="text-sm text-bauhaus-muted mt-1">
-          Describe your organisation to find grants matched to your mission
+          {isCompressedOnboarding
+            ? 'Start with the minimum details needed to unlock matched grants. You can add the rest after your first results.'
+            : 'Describe your organisation so CivicGraph can match grants, funders, and alerts to your work.'}
         </p>
       </div>
+
+      {showBillingSection && (
+        <section className="border-4 border-bauhaus-black bg-white">
+          <div className="bg-bauhaus-red px-5 py-3 flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-sm font-black text-white uppercase tracking-widest">Billing</h2>
+            <span className={`px-3 py-1 text-[10px] font-black uppercase tracking-widest border-2 border-bauhaus-black ${billingDetails.toneClass}`}>
+              {billingDetails.statusLabel}
+            </span>
+          </div>
+          <div className="p-5 space-y-4">
+            {billingSuccess && (
+              <div className="border-2 border-green-700 bg-green-50 px-4 py-3 text-sm font-bold text-green-800">
+                Checkout completed. Your billing status is now syncing with CivicGraph.
+              </div>
+            )}
+
+            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+              <div className="space-y-2">
+                <p className="text-sm font-black uppercase tracking-wide text-bauhaus-black">
+                  {billingDetails.summary}
+                </p>
+                <p className="text-sm text-bauhaus-muted">
+                  {billingDetails.detail}
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3 md:min-w-[260px]">
+                <div className="border-2 border-bauhaus-black px-3 py-3">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Plan</div>
+                  <div className="mt-1 text-sm font-black text-bauhaus-black">{billingDetails.planLabel}</div>
+                </div>
+                <div className="border-2 border-bauhaus-black px-3 py-3">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                    {billingDetails.nextLabel || 'Status'}
+                  </div>
+                  <div className="mt-1 text-sm font-black text-bauhaus-black">
+                    {billingDetails.nextValue || billingDetails.statusLabel}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {profile.subscription_cancel_at_period_end && profile.subscription_current_period_end && (
+              <p className="text-xs font-bold uppercase tracking-widest text-bauhaus-red">
+                Access changes at period end on {formatBillingDate(profile.subscription_current_period_end)}.
+              </p>
+            )}
+
+            {billingError && (
+              <div className="border-2 border-bauhaus-red bg-danger-light px-4 py-3 text-sm font-bold text-bauhaus-red">
+                {billingError}
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-3">
+              {profile.stripe_customer_id ? (
+                <button
+                  type="button"
+                  onClick={handleOpenBillingPortal}
+                  disabled={openingBillingPortal}
+                  className="px-4 py-3 text-xs font-black uppercase tracking-widest bg-bauhaus-black text-white border-4 border-bauhaus-black hover:bg-bauhaus-blue disabled:opacity-50"
+                >
+                  {openingBillingPortal ? 'Opening...' : 'Manage Billing'}
+                </button>
+              ) : !billingSuccess ? (
+                <button
+                  type="button"
+                  onClick={handleStartProfessionalTrial}
+                  disabled={startingProfessionalTrial}
+                  className="px-4 py-3 text-xs font-black uppercase tracking-widest bg-bauhaus-blue text-white border-4 border-bauhaus-black hover:bg-bauhaus-black disabled:opacity-50"
+                >
+                  {startingProfessionalTrial ? 'Starting...' : 'Start Professional Trial'}
+                </button>
+              ) : null}
+              <Link
+                href={`/pricing${billingInteractionSource !== 'profile_billing_panel' ? `?billing_source=${encodeURIComponent(billingInteractionSource)}` : ''}`}
+                className="px-4 py-3 text-xs font-black uppercase tracking-widest bg-white text-bauhaus-black border-4 border-bauhaus-black hover:bg-bauhaus-yellow transition-colors"
+              >
+                Compare Plans
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {(saved || (profile.name && profile.domains.length > 0 && profile.geographic_focus.length > 0)) && (
+        <section className="border-4 border-bauhaus-black bg-bauhaus-canvas">
+          <div className="bg-bauhaus-blue px-5 py-3">
+            <h2 className="text-sm font-black text-white uppercase tracking-widest">Next Step</h2>
+          </div>
+          <div className="p-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-sm font-black text-bauhaus-black uppercase tracking-wide">
+                Review matched grants, then save the strongest opportunities into your tracker.
+              </p>
+              <p className="text-sm text-bauhaus-muted mt-2">
+                Your profile is detailed enough to drive better matching and alerting.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/profile/matches"
+                className="px-4 py-3 text-xs font-black uppercase tracking-widest bg-bauhaus-blue text-white border-4 border-bauhaus-black hover:bg-bauhaus-black transition-colors"
+              >
+                Review Matches
+              </Link>
+              <Link
+                href="/tracker?onboarding=1"
+                className="px-4 py-3 text-xs font-black uppercase tracking-widest bg-white text-bauhaus-black border-4 border-bauhaus-black hover:bg-bauhaus-yellow transition-colors"
+              >
+                Open Tracker
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Claimed Charities — only for incorporated orgs, hidden during impersonation */}
       {claims.length > 0 && profile.org_status === 'incorporated' && !isImpersonating && (
@@ -472,438 +786,567 @@ export function ProfileClient() {
           </div>
         )}
 
-        {/* Journey Status */}
-        <section className="border-4 border-bauhaus-black bg-white">
-          <div className="bg-bauhaus-black px-5 py-3">
-            <h2 className="text-sm font-black text-white uppercase tracking-widest">Your Journey</h2>
-          </div>
-          <div className="p-5 space-y-4">
-            <div className="flex flex-wrap items-center gap-2">
-              {ORG_STATUSES.map((status, i) => {
-                const isActive = profile.org_status === status.value;
-                const isPast = ORG_STATUSES.findIndex(s => s.value === profile.org_status) > i;
-                return (
-                  <div key={status.value} className="flex items-center gap-2">
-                    {i > 0 && (
-                      <div className={`hidden sm:block w-6 h-0.5 ${isPast || isActive ? 'bg-bauhaus-black' : 'bg-bauhaus-black/20'}`} />
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => setProfile(p => ({ ...p, org_status: status.value }))}
-                      className={`px-3 py-2 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
-                        isActive
-                          ? 'bg-bauhaus-blue text-white border-bauhaus-black'
-                          : isPast
-                          ? 'bg-bauhaus-blue/20 text-bauhaus-black border-bauhaus-black/40'
-                          : 'bg-white text-bauhaus-black/50 border-bauhaus-black/20 hover:border-bauhaus-black/40'
-                      }`}
-                    >
-                      {status.label}
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-            <p className="text-sm text-bauhaus-muted">
-              {ORG_STATUSES.find(s => s.value === profile.org_status)?.description}
-            </p>
-          </div>
-        </section>
-
-        {/* Identity */}
-        <section className="border-4 border-bauhaus-black bg-white">
-          <div className="bg-bauhaus-black px-5 py-3">
-            <h2 className="text-sm font-black text-white uppercase tracking-widest">Identity</h2>
-          </div>
-          <div className="p-5 space-y-4">
-            <div>
-              <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                Organisation Name *
-              </label>
-              <input
-                type="text"
-                value={profile.name}
-                onChange={e => setProfile(p => ({ ...p, name: e.target.value }))}
-                required
-                className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                placeholder="A Curious Tractor"
-              />
-            </div>
-
-            <div>
-              <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                Mission Statement
-              </label>
-              <input
-                type="text"
-                value={profile.mission}
-                onChange={e => setProfile(p => ({ ...p, mission: e.target.value }))}
-                className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                placeholder="Communities own their narratives, land, and economic futures"
-              />
-            </div>
-
-            <div>
-              <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                Description
-              </label>
-              <textarea
-                value={profile.description}
-                onChange={e => setProfile(p => ({ ...p, description: e.target.value }))}
-                rows={4}
-                className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue resize-y"
-                placeholder="What does your organisation do? What communities do you serve?"
-              />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {profile.org_status === 'incorporated' && (
-                <div>
-                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                    ABN
-                  </label>
-                  <input
-                    type="text"
-                    value={profile.abn}
-                    onChange={e => setProfile(p => ({ ...p, abn: e.target.value }))}
-                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                    placeholder="21 591 780 066"
-                  />
-                </div>
-              )}
-              {profile.org_status === 'auspiced' && (
-                <div>
-                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                    Auspicing Organisation
-                  </label>
-                  <input
-                    type="text"
-                    value={profile.auspice_org_name}
-                    onChange={e => setProfile(p => ({ ...p, auspice_org_name: e.target.value }))}
-                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                    placeholder="Name of the organisation auspicing you"
-                  />
-                  <p className="text-xs text-bauhaus-muted mt-1">
-                    You can operate under a registered org&apos;s structure while you grow
-                  </p>
-                </div>
-              )}
-              <div>
-                <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                  Website
-                </label>
-                <input
-                  type="url"
-                  value={profile.website}
-                  onChange={e => setProfile(p => ({ ...p, website: e.target.value }))}
-                  className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                  placeholder="https://act.place"
-                />
+        {isCompressedOnboarding ? (
+          <>
+            <section className="border-4 border-bauhaus-black bg-bauhaus-canvas">
+              <div className="bg-bauhaus-red px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Quick Setup</h2>
               </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Focus Areas */}
-        <section className="border-4 border-bauhaus-black bg-white">
-          <div className="bg-bauhaus-blue px-5 py-3">
-            <h2 className="text-sm font-black text-white uppercase tracking-widest">Focus Areas</h2>
-          </div>
-          <div className="p-5 space-y-4">
-            <div>
-              <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-3">
-                Domains
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {DOMAIN_OPTIONS.map(domain => (
-                  <button
-                    key={domain}
-                    type="button"
-                    onClick={() => setProfile(p => ({ ...p, domains: toggleArray(p.domains, domain) }))}
-                    className={`px-3 py-1.5 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
-                      profile.domains.includes(domain)
-                        ? 'bg-bauhaus-blue text-white border-bauhaus-black'
-                        : 'bg-white text-bauhaus-black border-bauhaus-black/30 hover:border-bauhaus-black'
-                    }`}
-                  >
-                    {domain}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-3">
-                Geographic Focus
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {GEO_OPTIONS.map(geo => (
-                  <button
-                    key={geo}
-                    type="button"
-                    onClick={() => setProfile(p => ({ ...p, geographic_focus: toggleArray(p.geographic_focus, geo) }))}
-                    className={`px-3 py-1.5 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
-                      profile.geographic_focus.includes(geo)
-                        ? 'bg-bauhaus-yellow text-bauhaus-black border-bauhaus-black'
-                        : 'bg-white text-bauhaus-black border-bauhaus-black/30 hover:border-bauhaus-black'
-                    }`}
-                  >
-                    {geo}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Organisation Details */}
-        <section className="border-4 border-bauhaus-black bg-white">
-          <div className="bg-bauhaus-red px-5 py-3">
-            <h2 className="text-sm font-black text-white uppercase tracking-widest">Details</h2>
-          </div>
-          <div className="p-5 space-y-4">
-            <div>
-              <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                Organisation Type
-              </label>
-              <select
-                value={profile.org_type}
-                onChange={e => setProfile(p => ({ ...p, org_type: e.target.value }))}
-                className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue bg-white"
-              >
-                {ORG_TYPES.map(t => (
-                  <option key={t.value} value={t.value}>{t.label}</option>
-                ))}
-              </select>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                  Annual Revenue ($)
-                </label>
-                <input
-                  type="number"
-                  value={profile.annual_revenue}
-                  onChange={e => setProfile(p => ({ ...p, annual_revenue: e.target.value }))}
-                  className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                  placeholder="250000"
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                  Team Size
-                </label>
-                <input
-                  type="number"
-                  value={profile.team_size}
-                  onChange={e => setProfile(p => ({ ...p, team_size: e.target.value }))}
-                  className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                  placeholder="12"
-                />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* What Should I Be? — only for exploring/pre_formation */}
-        {(profile.org_status === 'exploring' || profile.org_status === 'pre_formation') && (
-          <section className="border-4 border-bauhaus-black bg-white">
-            <div className="bg-bauhaus-blue px-5 py-3">
-              <h2 className="text-sm font-black text-white uppercase tracking-widest">What Should I Be?</h2>
-            </div>
-            <div className="p-5 space-y-4">
-              <p className="text-sm text-bauhaus-muted">
-                Based on your mission and focus areas, here are some structures to consider.
-                Fill in more details above for better recommendations.
-              </p>
-              {getFormationRecommendations(profile).map(rec => (
-                <div key={rec.type} className="border-2 border-bauhaus-black/20 p-4 space-y-2">
-                  <h3 className="text-sm font-black uppercase tracking-wide text-bauhaus-black">
-                    {rec.type}
-                  </h3>
-                  <p className="text-sm text-bauhaus-black/70">{rec.description}</p>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
-                    <div className="bg-green-50 border border-green-200 px-3 py-2">
-                      <span className="font-black text-green-800 uppercase tracking-wider">Benefit:</span>{' '}
-                      <span className="text-green-700">{rec.benefit}</span>
-                    </div>
-                    <div className="bg-amber-50 border border-amber-200 px-3 py-2">
-                      <span className="font-black text-amber-800 uppercase tracking-wider">Requires:</span>{' '}
-                      <span className="text-amber-700">{rec.requirement}</span>
-                    </div>
-                  </div>
-                  <a
-                    href={rec.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block text-xs font-black text-bauhaus-blue uppercase tracking-widest hover:text-bauhaus-black"
-                  >
-                    Learn more &rarr;
-                  </a>
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* Projects */}
-        <section className="border-4 border-bauhaus-black bg-white">
-          <div className="bg-bauhaus-black px-5 py-3 flex items-center justify-between">
-            <h2 className="text-sm font-black text-white uppercase tracking-widest">Projects</h2>
-            <button
-              type="button"
-              onClick={addProject}
-              className="text-xs font-black text-bauhaus-yellow uppercase tracking-widest hover:text-white"
-            >
-              + Add
-            </button>
-          </div>
-          <div className="p-5 space-y-4">
-            {profile.projects.length === 0 && (
-              <p className="text-sm text-bauhaus-muted">
-                Add your projects to improve grant matching accuracy
-              </p>
-            )}
-            {profile.projects.map((project, i) => (
-              <div key={i} className="border-2 border-bauhaus-black/20 p-4 space-y-3">
-                <div className="flex items-start gap-3">
-                  <div className="flex-1">
-                    <input
-                      type="text"
-                      value={project.name}
-                      onChange={e => updateProject(i, 'name', e.target.value)}
-                      placeholder="Project name"
-                      className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
-                    />
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => removeProject(i)}
-                    className="text-xs font-black text-bauhaus-red uppercase tracking-widest hover:text-bauhaus-black mt-2"
-                  >
-                    Remove
-                  </button>
-                </div>
-                <textarea
-                  value={project.description}
-                  onChange={e => updateProject(i, 'description', e.target.value)}
-                  placeholder="What does this project do?"
-                  rows={2}
-                  className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue resize-y"
-                />
-              </div>
-            ))}
-          </div>
-        </section>
-
-        {/* Team Management */}
-        {profile.id && (
-          <section className="border-4 border-bauhaus-black bg-white">
-            <div className="bg-green-600 px-5 py-3 flex items-center justify-between">
-              <h2 className="text-sm font-black text-white uppercase tracking-widest">Team</h2>
-              <span className="text-xs font-black text-white/80 uppercase tracking-widest">
-                {teamMembers.length} member{teamMembers.length !== 1 ? 's' : ''}
-              </span>
-            </div>
-            <div className="p-5 space-y-4">
-              {/* Member List */}
-              {teamLoading ? (
-                <div className="text-sm font-black uppercase tracking-widest text-bauhaus-muted animate-pulse">
-                  Loading team...
-                </div>
-              ) : teamMembers.length === 0 ? (
-                <p className="text-sm text-bauhaus-muted">
-                  No team members yet. Invite colleagues to share your grant tracker.
+              <div className="p-5 space-y-3">
+                <p className="text-sm text-bauhaus-black font-bold">
+                  These fields are enough to get your first matched grants.
                 </p>
-              ) : (
-                <div className="divide-y-2 divide-bauhaus-black/10">
-                  {teamMembers.map(member => {
-                    const isPending = !member.user_id;
+                <p className="text-sm text-bauhaus-muted">
+                  You can add ABN, projects, revenue, team members, and organisational structure after you see your first results.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setShowAdvancedSetup(true)}
+                  className="text-xs font-black text-bauhaus-blue uppercase tracking-widest hover:text-bauhaus-black"
+                >
+                  Show Full Setup
+                </button>
+              </div>
+            </section>
+
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-black px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Identity</h2>
+              </div>
+              <div className="p-5 space-y-4">
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                    Organisation Name *
+                  </label>
+                  <input
+                    type="text"
+                    value={profile.name}
+                    onChange={e => setProfile(p => ({ ...p, name: e.target.value }))}
+                    required
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                    placeholder="A Curious Tractor"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                    Mission Statement
+                  </label>
+                  <input
+                    type="text"
+                    value={profile.mission}
+                    onChange={e => setProfile(p => ({ ...p, mission: e.target.value }))}
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                    placeholder="Communities own their narratives, land, and economic futures"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                    Description
+                  </label>
+                  <textarea
+                    value={profile.description}
+                    onChange={e => setProfile(p => ({ ...p, description: e.target.value }))}
+                    rows={3}
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue resize-y"
+                    placeholder="What does your organisation do? What communities do you serve?"
+                  />
+                </div>
+              </div>
+            </section>
+
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-blue px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Focus Areas</h2>
+              </div>
+              <div className="p-5 space-y-4">
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-3">
+                    Domains
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {DOMAIN_OPTIONS.map(domain => (
+                      <button
+                        key={domain}
+                        type="button"
+                        onClick={() => setProfile(p => ({ ...p, domains: toggleArray(p.domains, domain) }))}
+                        className={`px-3 py-1.5 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
+                          profile.domains.includes(domain)
+                            ? 'bg-bauhaus-blue text-white border-bauhaus-black'
+                            : 'bg-white text-bauhaus-black border-bauhaus-black/30 hover:border-bauhaus-black'
+                        }`}
+                      >
+                        {domain}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-3">
+                    Geographic Focus
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {GEO_OPTIONS.map(geo => (
+                      <button
+                        key={geo}
+                        type="button"
+                        onClick={() => setProfile(p => ({ ...p, geographic_focus: toggleArray(p.geographic_focus, geo) }))}
+                        className={`px-3 py-1.5 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
+                          profile.geographic_focus.includes(geo)
+                            ? 'bg-bauhaus-yellow text-bauhaus-black border-bauhaus-black'
+                            : 'bg-white text-bauhaus-black border-bauhaus-black/30 hover:border-bauhaus-black'
+                        }`}
+                      >
+                        {geo}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </section>
+          </>
+        ) : (
+          <>
+            {/* Journey Status */}
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-black px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Your Journey</h2>
+              </div>
+              <div className="p-5 space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  {ORG_STATUSES.map((status, i) => {
+                    const isActive = profile.org_status === status.value;
+                    const isPast = ORG_STATUSES.findIndex(s => s.value === profile.org_status) > i;
                     return (
-                      <div key={member.id} className="py-3 flex items-center justify-between gap-4">
-                        <div className="min-w-0">
-                          <span className={`text-sm font-black truncate block ${isPending ? 'text-bauhaus-muted' : 'text-bauhaus-black'}`}>
-                            {member.email || member.invited_email || (member.user_id ? member.user_id.slice(0, 8) + '...' : 'Unknown')}
-                          </span>
-                          <div className="flex items-center gap-2 mt-0.5">
-                            {isPending ? (
-                              <span className="inline-block px-2 py-0.5 text-[10px] font-black uppercase tracking-widest border-2 border-bauhaus-black bg-gray-200 text-bauhaus-muted">
-                                Pending
-                              </span>
-                            ) : (
-                              <span className={`inline-block px-2 py-0.5 text-[10px] font-black uppercase tracking-widest border-2 border-bauhaus-black ${
-                                member.role === 'admin' ? 'bg-bauhaus-red text-white' :
-                                member.role === 'editor' ? 'bg-bauhaus-blue text-white' :
-                                'bg-bauhaus-yellow text-bauhaus-black'
-                              }`}>
-                                {member.role}
-                              </span>
-                            )}
-                            {member.accepted_at && (
-                              <span className="text-[10px] text-bauhaus-muted">
-                                Joined {new Date(member.accepted_at).toLocaleDateString('en-AU')}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                        {currentUserRole === 'admin' && (
-                          <button
-                            type="button"
-                            onClick={() => handleRemoveMember(member.id)}
-                            disabled={removingMember === member.id}
-                            className="text-xs font-black text-bauhaus-red uppercase tracking-widest hover:text-bauhaus-black disabled:opacity-50"
-                          >
-                            {removingMember === member.id ? '...' : isPending ? 'Cancel' : 'Remove'}
-                          </button>
+                      <div key={status.value} className="flex items-center gap-2">
+                        {i > 0 && (
+                          <div className={`hidden sm:block w-6 h-0.5 ${isPast || isActive ? 'bg-bauhaus-black' : 'bg-bauhaus-black/20'}`} />
                         )}
+                        <button
+                          type="button"
+                          onClick={() => setProfile(p => ({ ...p, org_status: status.value }))}
+                          className={`px-3 py-2 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
+                            isActive
+                              ? 'bg-bauhaus-blue text-white border-bauhaus-black'
+                              : isPast
+                              ? 'bg-bauhaus-blue/20 text-bauhaus-black border-bauhaus-black/40'
+                              : 'bg-white text-bauhaus-black/50 border-bauhaus-black/20 hover:border-bauhaus-black/40'
+                          }`}
+                        >
+                          {status.label}
+                        </button>
                       </div>
                     );
                   })}
                 </div>
-              )}
+                <p className="text-sm text-bauhaus-muted">
+                  {ORG_STATUSES.find(s => s.value === profile.org_status)?.description}
+                </p>
+              </div>
+            </section>
 
-              {/* Invite Form (admin only) */}
-              {currentUserRole === 'admin' && (
-                <div className="border-t-2 border-bauhaus-black/10 pt-4">
+            {/* Identity */}
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-black px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Identity</h2>
+              </div>
+              <div className="p-5 space-y-4">
+                <div>
                   <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
-                    Invite Team Member
+                    Organisation Name *
                   </label>
-                  <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={profile.name}
+                    onChange={e => setProfile(p => ({ ...p, name: e.target.value }))}
+                    required
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                    placeholder="A Curious Tractor"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                    Mission Statement
+                  </label>
+                  <input
+                    type="text"
+                    value={profile.mission}
+                    onChange={e => setProfile(p => ({ ...p, mission: e.target.value }))}
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                    placeholder="Communities own their narratives, land, and economic futures"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                    Description
+                  </label>
+                  <textarea
+                    value={profile.description}
+                    onChange={e => setProfile(p => ({ ...p, description: e.target.value }))}
+                    rows={4}
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue resize-y"
+                    placeholder="What does your organisation do? What communities do you serve?"
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {profile.org_status === 'incorporated' && (
+                    <div>
+                      <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                        ABN
+                      </label>
+                      <input
+                        type="text"
+                        value={profile.abn}
+                        onChange={e => setProfile(p => ({ ...p, abn: e.target.value }))}
+                        className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                        placeholder="21 591 780 066"
+                      />
+                    </div>
+                  )}
+                  {profile.org_status === 'auspiced' && (
+                    <div>
+                      <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                        Auspicing Organisation
+                      </label>
+                      <input
+                        type="text"
+                        value={profile.auspice_org_name}
+                        onChange={e => setProfile(p => ({ ...p, auspice_org_name: e.target.value }))}
+                        className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                        placeholder="Name of the organisation auspicing you"
+                      />
+                      <p className="text-xs text-bauhaus-muted mt-1">
+                        You can operate under a registered org&apos;s structure while you grow
+                      </p>
+                    </div>
+                  )}
+                  <div>
+                    <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                      Website
+                    </label>
                     <input
-                      type="email"
-                      value={inviteEmail}
-                      onChange={e => setInviteEmail(e.target.value)}
-                      placeholder="colleague@org.au"
-                      className="flex-1 border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                      type="url"
+                      value={profile.website}
+                      onChange={e => setProfile(p => ({ ...p, website: e.target.value }))}
+                      className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                      placeholder="https://act.place"
                     />
-                    <select
-                      value={inviteRole}
-                      onChange={e => setInviteRole(e.target.value)}
-                      className="border-4 border-bauhaus-black px-2 py-2 text-xs font-black uppercase tracking-widest bg-white focus:outline-none focus:border-bauhaus-blue"
-                    >
-                      <option value="viewer">Viewer</option>
-                      <option value="editor">Editor</option>
-                      <option value="admin">Admin</option>
-                    </select>
-                    <button
-                      type="button"
-                      onClick={handleInvite}
-                      disabled={inviting || !inviteEmail.trim()}
-                      className="px-4 py-2 text-xs font-black uppercase tracking-widest bg-bauhaus-black text-white hover:bg-bauhaus-blue disabled:opacity-50 border-4 border-bauhaus-black"
-                    >
-                      {inviting ? '...' : 'Invite'}
-                    </button>
                   </div>
-                  {inviteMessage && (
-                    <p className={`text-xs font-bold mt-2 ${inviteMessage.includes('Failed') || inviteMessage.includes('error') ? 'text-bauhaus-red' : 'text-green-700'}`}>
-                      {inviteMessage}
+                </div>
+              </div>
+            </section>
+
+            {/* Focus Areas */}
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-blue px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Focus Areas</h2>
+              </div>
+              <div className="p-5 space-y-4">
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-3">
+                    Domains
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {DOMAIN_OPTIONS.map(domain => (
+                      <button
+                        key={domain}
+                        type="button"
+                        onClick={() => setProfile(p => ({ ...p, domains: toggleArray(p.domains, domain) }))}
+                        className={`px-3 py-1.5 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
+                          profile.domains.includes(domain)
+                            ? 'bg-bauhaus-blue text-white border-bauhaus-black'
+                            : 'bg-white text-bauhaus-black border-bauhaus-black/30 hover:border-bauhaus-black'
+                        }`}
+                      >
+                        {domain}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-3">
+                    Geographic Focus
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {GEO_OPTIONS.map(geo => (
+                      <button
+                        key={geo}
+                        type="button"
+                        onClick={() => setProfile(p => ({ ...p, geographic_focus: toggleArray(p.geographic_focus, geo) }))}
+                        className={`px-3 py-1.5 text-xs font-black uppercase tracking-wider border-3 transition-colors ${
+                          profile.geographic_focus.includes(geo)
+                            ? 'bg-bauhaus-yellow text-bauhaus-black border-bauhaus-black'
+                            : 'bg-white text-bauhaus-black border-bauhaus-black/30 hover:border-bauhaus-black'
+                        }`}
+                      >
+                        {geo}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
+
+        {!isCompressedOnboarding && (
+          <>
+            {/* Organisation Details */}
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-red px-5 py-3">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Details</h2>
+              </div>
+              <div className="p-5 space-y-4">
+                <div>
+                  <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                    Organisation Type
+                  </label>
+                  <select
+                    value={profile.org_type}
+                    onChange={e => setProfile(p => ({ ...p, org_type: e.target.value }))}
+                    className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue bg-white"
+                  >
+                    {ORG_TYPES.map(t => (
+                      <option key={t.value} value={t.value}>{t.label}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                      Annual Revenue ($)
+                    </label>
+                    <input
+                      type="number"
+                      value={profile.annual_revenue}
+                      onChange={e => setProfile(p => ({ ...p, annual_revenue: e.target.value }))}
+                      className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                      placeholder="250000"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                      Team Size
+                    </label>
+                    <input
+                      type="number"
+                      value={profile.team_size}
+                      onChange={e => setProfile(p => ({ ...p, team_size: e.target.value }))}
+                      className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                      placeholder="12"
+                    />
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* What Should I Be? — only for exploring/pre_formation */}
+            {(profile.org_status === 'exploring' || profile.org_status === 'pre_formation') && (
+              <section className="border-4 border-bauhaus-black bg-white">
+                <div className="bg-bauhaus-blue px-5 py-3">
+                  <h2 className="text-sm font-black text-white uppercase tracking-widest">What Should I Be?</h2>
+                </div>
+                <div className="p-5 space-y-4">
+                  <p className="text-sm text-bauhaus-muted">
+                    Based on your mission and focus areas, here are some structures to consider.
+                    Fill in more details above for better recommendations.
+                  </p>
+                  {getFormationRecommendations(profile).map(rec => (
+                    <div key={rec.type} className="border-2 border-bauhaus-black/20 p-4 space-y-2">
+                      <h3 className="text-sm font-black uppercase tracking-wide text-bauhaus-black">
+                        {rec.type}
+                      </h3>
+                      <p className="text-sm text-bauhaus-black/70">{rec.description}</p>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+                        <div className="bg-green-50 border border-green-200 px-3 py-2">
+                          <span className="font-black text-green-800 uppercase tracking-wider">Benefit:</span>{' '}
+                          <span className="text-green-700">{rec.benefit}</span>
+                        </div>
+                        <div className="bg-amber-50 border border-amber-200 px-3 py-2">
+                          <span className="font-black text-amber-800 uppercase tracking-wider">Requires:</span>{' '}
+                          <span className="text-amber-700">{rec.requirement}</span>
+                        </div>
+                      </div>
+                      <a
+                        href={rec.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block text-xs font-black text-bauhaus-blue uppercase tracking-widest hover:text-bauhaus-black"
+                      >
+                        Learn more &rarr;
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Projects */}
+            <section className="border-4 border-bauhaus-black bg-white">
+              <div className="bg-bauhaus-black px-5 py-3 flex items-center justify-between">
+                <h2 className="text-sm font-black text-white uppercase tracking-widest">Projects</h2>
+                <button
+                  type="button"
+                  onClick={addProject}
+                  className="text-xs font-black text-bauhaus-yellow uppercase tracking-widest hover:text-white"
+                >
+                  + Add
+                </button>
+              </div>
+              <div className="p-5 space-y-4">
+                {profile.projects.length === 0 && (
+                  <p className="text-sm text-bauhaus-muted">
+                    Add your projects to improve grant matching accuracy
+                  </p>
+                )}
+                {profile.projects.map((project, i) => (
+                  <div key={i} className="border-2 border-bauhaus-black/20 p-4 space-y-3">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1">
+                        <input
+                          type="text"
+                          value={project.name}
+                          onChange={e => updateProject(i, 'name', e.target.value)}
+                          placeholder="Project name"
+                          className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => removeProject(i)}
+                        className="text-xs font-black text-bauhaus-red uppercase tracking-widest hover:text-bauhaus-black mt-2"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                    <textarea
+                      value={project.description}
+                      onChange={e => updateProject(i, 'description', e.target.value)}
+                      placeholder="What does this project do?"
+                      rows={2}
+                      className="w-full border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue resize-y"
+                    />
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Team Management */}
+            {profile.id && (
+              <section className="border-4 border-bauhaus-black bg-white">
+                <div className="bg-green-600 px-5 py-3 flex items-center justify-between">
+                  <h2 className="text-sm font-black text-white uppercase tracking-widest">Team</h2>
+                  <span className="text-xs font-black text-white/80 uppercase tracking-widest">
+                    {teamMembers.length} member{teamMembers.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                <div className="p-5 space-y-4">
+                  {/* Member List */}
+                  {teamLoading ? (
+                    <div className="text-sm font-black uppercase tracking-widest text-bauhaus-muted animate-pulse">
+                      Loading team...
+                    </div>
+                  ) : teamMembers.length === 0 ? (
+                    <p className="text-sm text-bauhaus-muted">
+                      No team members yet. Invite colleagues to share your grant tracker.
                     </p>
+                  ) : (
+                    <div className="divide-y-2 divide-bauhaus-black/10">
+                      {teamMembers.map(member => {
+                        const isPending = !member.user_id;
+                        return (
+                          <div key={member.id} className="py-3 flex items-center justify-between gap-4">
+                            <div className="min-w-0">
+                              <span className={`text-sm font-black truncate block ${isPending ? 'text-bauhaus-muted' : 'text-bauhaus-black'}`}>
+                                {member.email || member.invited_email || (member.user_id ? member.user_id.slice(0, 8) + '...' : 'Unknown')}
+                              </span>
+                              <div className="flex items-center gap-2 mt-0.5">
+                                {isPending ? (
+                                  <span className="inline-block px-2 py-0.5 text-[10px] font-black uppercase tracking-widest border-2 border-bauhaus-black bg-gray-200 text-bauhaus-muted">
+                                    Pending
+                                  </span>
+                                ) : (
+                                  <span className={`inline-block px-2 py-0.5 text-[10px] font-black uppercase tracking-widest border-2 border-bauhaus-black ${
+                                    member.role === 'admin' ? 'bg-bauhaus-red text-white' :
+                                    member.role === 'editor' ? 'bg-bauhaus-blue text-white' :
+                                    'bg-bauhaus-yellow text-bauhaus-black'
+                                  }`}>
+                                    {member.role}
+                                  </span>
+                                )}
+                                {member.accepted_at && (
+                                  <span className="text-[10px] text-bauhaus-muted">
+                                    Joined {new Date(member.accepted_at).toLocaleDateString('en-AU')}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                            {currentUserRole === 'admin' && (
+                              <button
+                                type="button"
+                                onClick={() => handleRemoveMember(member.id)}
+                                disabled={removingMember === member.id}
+                                className="text-xs font-black text-bauhaus-red uppercase tracking-widest hover:text-bauhaus-black disabled:opacity-50"
+                              >
+                                {removingMember === member.id ? '...' : isPending ? 'Cancel' : 'Remove'}
+                              </button>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {/* Invite Form (admin only) */}
+                  {currentUserRole === 'admin' && (
+                    <div className="border-t-2 border-bauhaus-black/10 pt-4">
+                      <label className="block text-xs font-black text-bauhaus-black uppercase tracking-widest mb-2">
+                        Invite Team Member
+                      </label>
+                      <div className="flex gap-2">
+                        <input
+                          type="email"
+                          value={inviteEmail}
+                          onChange={e => setInviteEmail(e.target.value)}
+                          placeholder="colleague@org.au"
+                          className="flex-1 border-4 border-bauhaus-black px-3 py-2 text-sm font-medium focus:outline-none focus:border-bauhaus-blue"
+                        />
+                        <select
+                          value={inviteRole}
+                          onChange={e => setInviteRole(e.target.value)}
+                          className="border-4 border-bauhaus-black px-2 py-2 text-xs font-black uppercase tracking-widest bg-white focus:outline-none focus:border-bauhaus-blue"
+                        >
+                          <option value="viewer">Viewer</option>
+                          <option value="editor">Editor</option>
+                          <option value="admin">Admin</option>
+                        </select>
+                        <button
+                          type="button"
+                          onClick={handleInvite}
+                          disabled={inviting || !inviteEmail.trim()}
+                          className="px-4 py-2 text-xs font-black uppercase tracking-widest bg-bauhaus-black text-white hover:bg-bauhaus-blue disabled:opacity-50 border-4 border-bauhaus-black"
+                        >
+                          {inviting ? '...' : 'Invite'}
+                        </button>
+                      </div>
+                      {inviteMessage && (
+                        <p className={`text-xs font-bold mt-2 ${inviteMessage.includes('Failed') || inviteMessage.includes('error') ? 'text-bauhaus-red' : 'text-green-700'}`}>
+                          {inviteMessage}
+                        </p>
+                      )}
+                    </div>
                   )}
                 </div>
-              )}
-            </div>
-          </section>
+              </section>
+            )}
+          </>
         )}
 
         {/* Save */}
@@ -913,8 +1356,17 @@ export function ProfileClient() {
             disabled={saving}
             className="bg-bauhaus-red text-white font-black uppercase tracking-widest px-8 py-3 text-sm border-4 border-bauhaus-black hover:bg-bauhaus-black disabled:opacity-50 bauhaus-shadow-sm"
           >
-            {saving ? 'Saving & Matching...' : 'Save & Find Matches'}
+            {saving ? 'Saving & Matching...' : isCompressedOnboarding ? 'Save & See Matches' : 'Save & Find Matches'}
           </button>
+          {isCompressedOnboarding && (
+            <button
+              type="button"
+              onClick={() => setShowAdvancedSetup(true)}
+              className="text-xs font-black text-bauhaus-blue uppercase tracking-widest hover:text-bauhaus-black"
+            >
+              Show Full Setup
+            </button>
+          )}
           {saved && (
             <span className="text-sm font-black text-green-700 uppercase tracking-widest">
               Saved

--- a/apps/web/src/app/tracker/kanban-board.tsx
+++ b/apps/web/src/app/tracker/kanban-board.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState, useCallback } from 'react';
 import { DragDropContext, Droppable, type DropResult } from '@hello-pangea/dnd';
 import type { SavedGrantRow } from './page';
@@ -45,8 +46,13 @@ function applyFilters(grants: SavedGrantRow[], filters: Filters): SavedGrantRow[
   });
 }
 
-export function KanbanBoard({ initialGrants }: { initialGrants: SavedGrantRow[] }) {
-  const [grants, setGrants] = useState(initialGrants);
+export function KanbanBoard({
+  grants,
+  onGrantsChange,
+}: {
+  grants: SavedGrantRow[];
+  onGrantsChange: (grants: SavedGrantRow[]) => void;
+}) {
   const [filters, setFilters] = useState<Filters>({ minStars: 0, color: null, search: '', sortByDeadline: false });
 
   const filtered = applyFilters(grants, filters);
@@ -65,12 +71,13 @@ export function KanbanBoard({ initialGrants }: { initialGrants: SavedGrantRow[] 
 
   const handleRemove = useCallback(
     (grantId: string) => {
-      setGrants((prev) => prev.filter((g) => g.grant_id !== grantId));
+      const previousGrants = grants;
+      onGrantsChange(previousGrants.filter((g) => g.grant_id !== grantId));
       fetch(`/api/tracker/${grantId}`, { method: 'DELETE' }).catch(() => {
-        setGrants(initialGrants);
+        onGrantsChange(previousGrants);
       });
     },
-    [initialGrants]
+    [grants, onGrantsChange]
   );
 
   const handleDragEnd = useCallback(
@@ -78,15 +85,15 @@ export function KanbanBoard({ initialGrants }: { initialGrants: SavedGrantRow[] 
       if (!result.destination) return;
       const newStage = result.destination.droppableId;
       const grantId = result.draggableId;
+      const previousGrants = grants;
+      const nextGrants = previousGrants.map((g) =>
+        g.grant_id === grantId
+          ? { ...g, stage: newStage, updated_at: new Date().toISOString() }
+          : g
+      );
 
       // Optimistic update
-      setGrants((prev) =>
-        prev.map((g) =>
-          g.grant_id === grantId
-            ? { ...g, stage: newStage, updated_at: new Date().toISOString() }
-            : g
-        )
-      );
+      onGrantsChange(nextGrants);
 
       // Persist
       fetch(`/api/tracker/${grantId}`, {
@@ -95,10 +102,10 @@ export function KanbanBoard({ initialGrants }: { initialGrants: SavedGrantRow[] 
         body: JSON.stringify({ stage: newStage }),
       }).catch(() => {
         // Revert on error
-        setGrants(initialGrants);
+        onGrantsChange(previousGrants);
       });
     },
-    [initialGrants]
+    [grants, onGrantsChange]
   );
 
   return (
@@ -106,14 +113,30 @@ export function KanbanBoard({ initialGrants }: { initialGrants: SavedGrantRow[] 
       <TrackerFilters filters={filters} onChange={setFilters} />
 
       {grants.length === 0 ? (
-        <div className="border-2 border-dashed border-bauhaus-black/20 p-8 text-center">
-          <div className="text-lg font-black text-bauhaus-black uppercase tracking-tight mb-2">
-            No saved grants yet
+        <div className="border-4 border-dashed border-bauhaus-black/20 bg-white p-8 text-center">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
+            Step 3 Needs A Shortlist
           </div>
-          <p className="text-sm text-bauhaus-muted font-medium">
-            Browse <a href="/grants" className="text-bauhaus-blue font-bold hover:underline">grants</a> and
-            use the star rating to save them here.
+          <div className="mt-2 text-lg font-black text-bauhaus-black uppercase tracking-tight">
+            No tracked grants yet
+          </div>
+          <p className="mt-2 text-sm text-bauhaus-muted font-medium max-w-xl mx-auto">
+            Start with your matched grants if you want the fastest path, or browse the full grants index if you are still exploring.
           </p>
+          <div className="mt-5 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/profile/matches"
+              className="px-4 py-3 border-3 border-bauhaus-black text-xs font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-black hover:text-white transition-colors"
+            >
+              Open Matched Grants
+            </Link>
+            <Link
+              href="/grants"
+              className="px-4 py-3 border-3 border-bauhaus-blue text-xs font-black uppercase tracking-widest text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white transition-colors"
+            >
+              Browse All Grants
+            </Link>
+          </div>
         </div>
       ) : (
         <DragDropContext onDragEnd={handleDragEnd}>

--- a/apps/web/src/app/tracker/tracker-client.tsx
+++ b/apps/web/src/app/tracker/tracker-client.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import type { SavedGrantRow } from './page';
 import { KanbanBoard } from './kanban-board';
 import { GrantActionsProvider } from '@/app/components/grant-card-actions';
@@ -13,6 +14,7 @@ export function TrackerClient() {
   const [viewMode, setViewMode] = useState<'personal' | 'org'>('personal');
   const [didInit, setDidInit] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // Detect impersonation on client mount and auto-switch to org view
   useEffect(() => {
@@ -41,6 +43,22 @@ export function TrackerClient() {
       .finally(() => setLoading(false));
   }, [router, viewMode, didInit]);
 
+  const onboardingMode = searchParams.get('onboarding') === '1' && viewMode === 'personal';
+  const completedMode = searchParams.get('completed') === '1' && viewMode === 'personal';
+  const hasProgressedGrant = grants.some((grant) => grant.stage !== 'discovered');
+  const showGuidedOnboarding = onboardingMode && !hasProgressedGrant;
+  const discoveredCount = grants.filter((grant) => grant.stage === 'discovered').length;
+  const researchingCount = grants.filter((grant) => grant.stage === 'researching').length;
+  const activeCount = grants.filter((grant) =>
+    ['pursuing', 'submitted', 'negotiating', 'approved'].includes(grant.stage)
+  ).length;
+
+  useEffect(() => {
+    if (onboardingMode && hasProgressedGrant) {
+      router.replace('/tracker?completed=1');
+    }
+  }, [onboardingMode, hasProgressedGrant, router]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[40vh]">
@@ -56,21 +74,98 @@ export function TrackerClient() {
       <div className="mb-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
+            {showGuidedOnboarding && (
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
+                Step 3 of 3
+              </div>
+            )}
+            {completedMode && (
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-green-700">
+                Setup Complete
+              </div>
+            )}
             <h1 className="text-2xl font-black text-bauhaus-black uppercase tracking-tight">
-              Grant Tracker
+              {showGuidedOnboarding ? 'Build Your Grant Pipeline' : completedMode ? 'Your Tracker Is Live' : 'Grant Tracker'}
             </h1>
             <p className="mt-1 text-sm font-medium text-bauhaus-muted">
-              Detailed grant-stage movement still lives here. For the joined money, funder, partner, and need view, use the funding workspace.
+              {showGuidedOnboarding
+                ? 'Your shortlisted grants are here. Move the strongest options out of Discovered and use the board as your working queue.'
+                : completedMode
+                ? 'You have moved at least one grant into active pipeline work. From here, use the tracker as your working system and the home dashboard as your daily summary.'
+                : 'Detailed grant-stage movement still lives here. For the joined money, funder, partner, and need view, use the funding workspace.'}
             </p>
           </div>
-          <a
-            href="/funding-workspace"
-            className="inline-flex px-4 py-3 border-2 border-bauhaus-black text-bauhaus-black text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
-          >
-            Open Funding Workspace
-          </a>
+          {showGuidedOnboarding || completedMode ? (
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/profile/matches"
+                className="inline-flex px-4 py-3 border-2 border-bauhaus-black text-bauhaus-black text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+              >
+                {completedMode ? 'Review More Matches' : 'Add More Matches'}
+              </Link>
+              <Link
+                href="/home"
+                className="inline-flex px-4 py-3 border-2 border-bauhaus-blue text-bauhaus-blue text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-blue hover:text-white transition-colors"
+              >
+                Go To Home
+              </Link>
+            </div>
+          ) : (
+            <a
+              href="/funding-workspace"
+              className="inline-flex px-4 py-3 border-2 border-bauhaus-black text-bauhaus-black text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+            >
+              Open Funding Workspace
+            </a>
+          )}
         </div>
       </div>
+
+      {showGuidedOnboarding && (
+        <div className="mb-6 grid gap-3 md:grid-cols-3">
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">Discovered</div>
+            <div className="mt-2 text-3xl font-black text-bauhaus-black">{discoveredCount}</div>
+            <p className="mt-2 text-xs text-bauhaus-black/75">
+              Fresh shortlist items. Keep maybes here and open the strongest first.
+            </p>
+          </div>
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-blue">Researching</div>
+            <div className="mt-2 text-3xl font-black text-bauhaus-black">{researchingCount}</div>
+            <p className="mt-2 text-xs text-bauhaus-black/75">
+              Move grants here once they look real enough to investigate properly.
+            </p>
+          </div>
+          <div className="border-4 border-bauhaus-black bg-bauhaus-blue p-4 text-white">
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-white/80">Active Work</div>
+            <div className="mt-2 text-3xl font-black">{activeCount}</div>
+            <p className="mt-2 text-xs text-white/85">
+              Pursuing, submitted, negotiating, or approved. This is the active pipeline you are actually working.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {showGuidedOnboarding && grants.length > 0 && (
+        <div className="mb-6 border-4 border-bauhaus-blue bg-bauhaus-blue/5 p-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-blue">What To Do Next</div>
+          <p className="mt-2 text-sm text-bauhaus-black/80">
+            Start by dragging one or two strong-fit grants into <span className="font-black">Researching</span>. Leave weaker options in
+            <span className="font-black"> Discovered</span> so the board stays honest and manageable.
+          </p>
+        </div>
+      )}
+
+      {completedMode && (
+        <div className="mb-6 border-4 border-green-700 bg-green-50 p-4">
+          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-green-700">Pipeline Started</div>
+          <p className="mt-2 text-sm text-bauhaus-black/80">
+            Step 3 is complete. Keep moving strong grants through the tracker, and use the home dashboard for your overall pipeline summary.
+          </p>
+        </div>
+      )}
+
       <div className="flex gap-0 mb-6 border-4 border-bauhaus-black w-fit">
         <button
           onClick={() => setViewMode('personal')}
@@ -95,7 +190,7 @@ export function TrackerClient() {
       </div>
       <GrantActionsProvider>
         <GrantListWithPreview>
-          <KanbanBoard initialGrants={grants} />
+          <KanbanBoard grants={grants} onGrantsChange={setGrants} />
         </GrantListWithPreview>
       </GrantActionsProvider>
     </div>


### PR DESCRIPTION
## Summary
Workspace shell refresh + per-page enrichments across:
- Components: \`nav.tsx\`, \`workspace-page-header.tsx\`
- New \`/ops/layout.tsx\` + enriched \`health-client\` + \`ops-client\`
- \`/charities\`, \`/clarity\`, \`/for/{corporate,philanthropy}\` marketing updates
- \`/entity/[gsId]\` enrichments
- \`/profile\` + \`/profile/matches\` (uses \`start-checkout\` upgrade CTA)
- \`/tracker\` kanban-board + tracker-client refresh

**Stacked on \`feat/alerts-infrastructure\` (PR #10)** because \`profile-client\` imports \`start-checkout\`.

Part of phase 2 dirty-tree carve (bucket: tracker-profile).

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] Each page loads: /charities, /clarity, /for/corporate, /for/philanthropy, /entity/[gsId], /ops, /profile, /tracker
- [ ] Upgrade CTA from profile/matches kicks off Stripe checkout