### PR TITLE
feat(misc-app): funding-workspace, goods-intelligence, goods-workspace, portfolio-control, rankings, snow-foundation + layout + marketing refresh

### DIFF
--- a/apps/web/src/app/funding-workspace/context-form.tsx
+++ b/apps/web/src/app/funding-workspace/context-form.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+
+type ProjectOption = {
+  id: string;
+  name: string;
+  slug: string | null;
+  description: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+const STATE_OPTIONS = [
+  'National',
+  'Queensland',
+  'New South Wales',
+  'Victoria',
+  'Western Australia',
+  'South Australia',
+  'Tasmania',
+  'Australian Capital Territory',
+  'Northern Territory',
+];
+
+const ORG_TYPE_OPTIONS = [
+  'ORIC',
+  'Charity',
+  'Social enterprise',
+  'Community group',
+];
+
+function buildProjectMission(project: ProjectOption | null) {
+  if (!project) return '';
+  const profileSummary =
+    typeof project.metadata?.profile_summary === 'string' ? project.metadata.profile_summary.trim() : '';
+  const fundingBrief =
+    typeof project.metadata?.funding_brief === 'string' ? project.metadata.funding_brief.trim() : '';
+  return profileSummary || fundingBrief || [project.name, project.description].filter(Boolean).join('. ').trim();
+}
+
+export function FundingWorkspaceContextForm({
+  initialMission,
+  rawMission,
+  initialState,
+  initialOrgType,
+  profileMission,
+  projects,
+  selectedProjectSlug,
+}: {
+  initialMission: string;
+  rawMission: string;
+  initialState: string;
+  initialOrgType: string;
+  profileMission: string;
+  projects: ProjectOption[];
+  selectedProjectSlug: string;
+}) {
+  const projectOptions = projects.filter((project): project is ProjectOption & { slug: string } => Boolean(project.slug));
+  const projectMissionMap = Object.fromEntries(
+    projectOptions.map((project) => [project.slug, buildProjectMission(project)])
+  ) as Record<string, string>;
+
+  const initialAutoMission = selectedProjectSlug
+    ? projectMissionMap[selectedProjectSlug] || profileMission
+    : profileMission;
+
+  const [projectValue, setProjectValue] = useState(selectedProjectSlug);
+  const [missionValue, setMissionValue] = useState(initialMission);
+  const [stateValue, setStateValue] = useState(initialState);
+  const [orgTypeValue, setOrgTypeValue] = useState(initialOrgType);
+  const [lastAutoMission, setLastAutoMission] = useState(initialAutoMission);
+  const [missionDirty, setMissionDirty] = useState(
+    Boolean(rawMission) &&
+      rawMission !== initialAutoMission &&
+      rawMission !== profileMission
+  );
+
+  function handleProjectChange(nextProjectSlug: string) {
+    const nextAutoMission = nextProjectSlug ? projectMissionMap[nextProjectSlug] || profileMission : profileMission;
+    const shouldSyncMission =
+      !missionDirty ||
+      missionValue === lastAutoMission ||
+      missionValue === profileMission;
+
+    setProjectValue(nextProjectSlug);
+    setLastAutoMission(nextAutoMission);
+
+    if (shouldSyncMission) {
+      setMissionValue(nextAutoMission);
+      setMissionDirty(false);
+    }
+  }
+
+  return (
+    <form className="mt-8 grid gap-4 border-2 border-bauhaus-black bg-bauhaus-canvas p-4 md:grid-cols-[minmax(0,2.2fr)_220px_220px_auto] md:items-end">
+      <label className="block">
+        <span className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Mission or project</span>
+        <input
+          type="text"
+          name="mission"
+          value={missionValue}
+          onChange={(event) => {
+            setMissionValue(event.target.value);
+            setMissionDirty(true);
+          }}
+          placeholder="Youth justice on Country, community manufacturing, Indigenous health..."
+          className="mt-2 w-full border-2 border-bauhaus-black bg-white px-4 py-3 text-sm font-medium text-bauhaus-black outline-none placeholder:text-bauhaus-muted"
+        />
+      </label>
+
+      {projectOptions.length > 0 ? (
+        <label className="block md:col-span-3">
+          <span className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Project context</span>
+          <select
+            name="project"
+            value={projectValue}
+            onChange={(event) => handleProjectChange(event.target.value)}
+            className="mt-2 w-full border-2 border-bauhaus-black bg-white px-4 py-3 text-sm font-medium text-bauhaus-black outline-none"
+          >
+            <option value="">Whole organisation</option>
+            {projectOptions.map((project) => (
+              <option key={project.id} value={project.slug}>
+                {project.name}
+              </option>
+            ))}
+          </select>
+          <p className="mt-2 text-[11px] font-medium text-bauhaus-muted">
+            Changing project updates the brief automatically unless you have already edited the mission text yourself.
+          </p>
+        </label>
+      ) : null}
+
+      <label className="block">
+        <span className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">State</span>
+        <select
+          name="state"
+          value={stateValue}
+          onChange={(event) => setStateValue(event.target.value)}
+          className="mt-2 w-full border-2 border-bauhaus-black bg-white px-4 py-3 text-sm font-medium text-bauhaus-black outline-none"
+        >
+          <option value="">Anywhere in Australia</option>
+          {STATE_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Organisation type</span>
+        <select
+          name="org_type"
+          value={orgTypeValue}
+          onChange={(event) => setOrgTypeValue(event.target.value)}
+          className="mt-2 w-full border-2 border-bauhaus-black bg-white px-4 py-3 text-sm font-medium text-bauhaus-black outline-none"
+        >
+          <option value="">Any organisation type</option>
+          {ORG_TYPE_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button
+        type="submit"
+        className="border-2 border-bauhaus-red bg-bauhaus-red px-5 py-3 text-sm font-black uppercase tracking-[0.18em] text-white transition-colors hover:bg-white hover:text-bauhaus-red"
+      >
+        Find matches
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/app/funding-workspace/page.tsx
+++ b/apps/web/src/app/funding-workspace/page.tsx
@@ -1,0 +1,1550 @@
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+import { createSupabaseServer } from '@/lib/supabase-server';
+import { getCurrentOrgProfileContext } from '@/lib/org-profile';
+import { FundingWorkspaceShortlistButton } from './shortlist-button';
+import { FundingWorkspaceContextForm } from './context-form';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Funding Matches — CivicGraph',
+  description: 'Find grants, programs, and foundations that fit your mission, then shortlist the next move.',
+};
+
+type FundingWorkspacePageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+type GrantRow = {
+  id: string;
+  name: string;
+  provider: string | null;
+  description: string | null;
+  amount_min: number | null;
+  amount_max: number | null;
+  closes_at: string | null;
+  categories: string[] | null;
+  focus_areas: string[] | null;
+  target_recipients: string[] | null;
+  geography: string | null;
+  status: string | null;
+  url: string | null;
+  last_verified_at: string | null;
+};
+
+type FoundationRow = {
+  id: string;
+  name: string;
+  type: string | null;
+  website: string | null;
+  description: string | null;
+  total_giving_annual: number | null;
+  thematic_focus: string[] | null;
+  geographic_focus: string[] | null;
+  target_recipients: string[] | null;
+  open_programs: unknown;
+  profile_confidence: string | null;
+  giving_philosophy: string | null;
+  application_tips: string | null;
+};
+
+type GrantMatch = {
+  row: GrantRow;
+  score: number;
+  reasons: string[];
+  motion: string;
+  actionLabel: string;
+  blocked: boolean;
+  requiredGrantHits: number;
+  requiredGrantMinHits: number;
+};
+
+type FoundationMatch = {
+  row: FoundationRow;
+  score: number;
+  reasons: string[];
+  motion: string;
+  actionLabel: string;
+  openProgramCount: number;
+  savedForProject: boolean;
+  tagHits: number;
+};
+
+type OrgProjectRow = {
+  id: string;
+  name: string;
+  slug: string | null;
+  description: string | null;
+  status: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+const STATE_OPTIONS = [
+  'National',
+  'Queensland',
+  'New South Wales',
+  'Victoria',
+  'Western Australia',
+  'South Australia',
+  'Tasmania',
+  'Australian Capital Territory',
+  'Northern Territory',
+];
+
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'in',
+  'into',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'our',
+  'that',
+  'the',
+  'their',
+  'this',
+  'to',
+  'we',
+  'with',
+  'your',
+  'impact',
+  'infrastructure',
+  'organisation',
+  'organisations',
+  'program',
+  'programs',
+  'project',
+  'projects',
+  'sector',
+  'social',
+  'system',
+  'systems',
+]);
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? '';
+  return value ?? '';
+}
+
+function titleCase(value: string) {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function formatCurrencyRange(min: number | null, max: number | null) {
+  if (min && max) return `$${min.toLocaleString()}-$${max.toLocaleString()}`;
+  if (max) return `Up to $${max.toLocaleString()}`;
+  if (min) return `From $${min.toLocaleString()}`;
+  return 'Amount not specified';
+}
+
+function formatCompactCurrency(value: number | null) {
+  if (!value) return 'Amount not listed';
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatDeadline(date: string | null) {
+  if (!date) return 'No closing date listed';
+  return new Date(date).toLocaleDateString('en-AU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function toArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+}
+
+function countOpenPrograms(value: unknown) {
+  if (!Array.isArray(value)) return 0;
+  return value.length;
+}
+
+function shortText(value: string | null | undefined, maxLength = 180) {
+  if (!value) return '';
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function buildMissionTokens(...values: string[]) {
+  const raw = values
+    .flatMap((value) => value.split(/[,\n/]+/g))
+    .flatMap((value) => value.split(/\s+/g))
+    .map((value) => value.trim().toLowerCase())
+    .map((value) => value.replace(/[^a-z0-9&-]/g, ''))
+    .filter((value) => value.length >= 3)
+    .filter((value) => !STOP_WORDS.has(value));
+
+  return Array.from(new Set(raw)).slice(0, 10);
+}
+
+function orgTypeTerms(orgType: string) {
+  const normalized = orgType.toLowerCase();
+  if (normalized === 'oric') {
+    return ['indigenous', 'aboriginal', 'torres', 'community', 'controlled'];
+  }
+  if (normalized === 'charity') {
+    return ['charity', 'community', 'social', 'not-for-profit'];
+  }
+  if (normalized === 'social enterprise') {
+    return ['social', 'enterprise', 'employment', 'community'];
+  }
+  if (normalized === 'community group') {
+    return ['community', 'place', 'local'];
+  }
+  return [];
+}
+
+function projectIntentTerms(project: OrgProjectRow | null) {
+  const metadata = project?.metadata ?? {};
+  const terms: string[] = [];
+
+  if (metadata && typeof metadata === 'object' && 'creative' in metadata && metadata.creative === true) {
+    terms.push('creative', 'arts', 'culture', 'documentary', 'film', 'media', 'narrative', 'storytelling');
+  }
+
+  const pillar = typeof metadata?.pillar === 'string' ? metadata.pillar.toLowerCase() : '';
+  if (pillar === 'justice') {
+    terms.push('justice', 'legal', 'incarceration', 'alternatives', 'community');
+  }
+  if (pillar === 'enterprise') {
+    terms.push('enterprise', 'employment', 'marketplace', 'procurement', 'buyers');
+  }
+  if (pillar === 'technology') {
+    terms.push('technology', 'data', 'measurement', 'accountability', 'infrastructure');
+  }
+
+  const fundingTags = Array.isArray(metadata?.funding_tags)
+    ? metadata.funding_tags.filter((item): item is string => typeof item === 'string')
+    : [];
+  terms.push(...fundingTags);
+
+  return Array.from(new Set(terms));
+}
+
+function projectProfileSummary(project: OrgProjectRow | null) {
+  const metadata = project?.metadata ?? {};
+  const profileSummary =
+    typeof metadata?.profile_summary === 'string' ? metadata.profile_summary.trim() : '';
+  const fundingBrief =
+    typeof metadata?.funding_brief === 'string' ? metadata.funding_brief.trim() : '';
+
+  return profileSummary || fundingBrief || [project?.name, project?.description].filter(Boolean).join('. ').trim();
+}
+
+function legacyProjectMission(project: OrgProjectRow | null) {
+  return [project?.name, project?.description].filter(Boolean).join('. ').trim();
+}
+
+function projectMetadataList(project: OrgProjectRow | null, key: string) {
+  const metadata = project?.metadata ?? {};
+  return Array.isArray(metadata?.[key])
+    ? metadata[key].filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function projectFundingBrief(project: OrgProjectRow | null) {
+  const metadata = project?.metadata ?? {};
+  return typeof metadata?.funding_brief === 'string' ? metadata.funding_brief.trim() : '';
+}
+
+function projectPriorityTerms(project: OrgProjectRow | null) {
+  const proofPoints = projectMetadataList(project, 'proof_points');
+  const fundingTags = projectMetadataList(project, 'funding_tags');
+  const fundingBrief = projectFundingBrief(project);
+
+  return Array.from(
+    new Set([
+      ...buildMissionTokens(fundingBrief, proofPoints.join(' ')),
+      ...fundingTags.map((tag) => tag.toLowerCase()),
+    ])
+  ).slice(0, 12);
+}
+
+function projectFundingTags(project: OrgProjectRow | null) {
+  const metadata = project?.metadata ?? {};
+  return Array.isArray(metadata?.funding_tags)
+    ? metadata.funding_tags.filter((item): item is string => typeof item === 'string').map((item) => item.toLowerCase())
+    : [];
+}
+
+function projectPreferredFoundationTypes(project: OrgProjectRow | null) {
+  const metadata = project?.metadata ?? {};
+  const preferred = new Set<string>();
+
+  if (metadata && typeof metadata === 'object' && 'creative' in metadata && metadata.creative === true) {
+    preferred.add('arts_culture');
+    preferred.add('philanthropic_foundation');
+    preferred.add('corporate_foundation');
+    preferred.add('community_foundation');
+    preferred.add('grantmaker');
+    preferred.add('trust');
+  }
+
+  const pillar = typeof metadata?.pillar === 'string' ? metadata.pillar.toLowerCase() : '';
+  if (pillar === 'justice') {
+    preferred.add('philanthropic_foundation');
+    preferred.add('grantmaker');
+    preferred.add('trust');
+    preferred.add('indigenous_organisation');
+  }
+  if (pillar === 'enterprise') {
+    preferred.add('corporate_foundation');
+    preferred.add('community_foundation');
+    preferred.add('philanthropic_foundation');
+    preferred.add('grantmaker');
+  }
+  if (pillar === 'technology') {
+    preferred.add('philanthropic_foundation');
+    preferred.add('corporate_foundation');
+    preferred.add('grantmaker');
+    preferred.add('trust');
+  }
+
+  const explicitPreferred = Array.isArray(metadata?.preferred_foundation_types)
+    ? metadata.preferred_foundation_types.filter((item): item is string => typeof item === 'string')
+    : [];
+  for (const type of explicitPreferred) preferred.add(type.toLowerCase());
+
+  return preferred;
+}
+
+function projectBlockedFoundationTypes(project: OrgProjectRow | null) {
+  const metadata = project?.metadata ?? {};
+  const blocked = new Set<string>();
+
+  if (metadata && typeof metadata === 'object' && 'creative' in metadata && metadata.creative === true) {
+    blocked.add('university');
+    blocked.add('research_body');
+    blocked.add('primary_health_network');
+    blocked.add('hospital');
+    blocked.add('service_delivery');
+    blocked.add('legal_aid');
+  }
+
+  const explicitBlocked = Array.isArray(metadata?.blocked_foundation_types)
+    ? metadata.blocked_foundation_types.filter((item): item is string => typeof item === 'string')
+    : [];
+  for (const type of explicitBlocked) blocked.add(type.toLowerCase());
+
+  return blocked;
+}
+
+function projectBlockedFoundationNames(project: OrgProjectRow | null) {
+  return new Set(
+    projectMetadataList(project, 'blocked_foundation_names').map((item) => item.toLowerCase())
+  );
+}
+
+function projectBlockedGrantTerms(project: OrgProjectRow | null) {
+  return projectMetadataList(project, 'blocked_grant_terms').map((item) => item.toLowerCase());
+}
+
+function projectBlockedGrantProviderTerms(project: OrgProjectRow | null) {
+  return projectMetadataList(project, 'blocked_grant_provider_terms').map((item) => item.toLowerCase());
+}
+
+function projectBlockedGrantNames(project: OrgProjectRow | null) {
+  return new Set(projectMetadataList(project, 'blocked_grant_names').map((item) => item.toLowerCase()));
+}
+
+function projectRequiredGrantTerms(project: OrgProjectRow | null) {
+  return projectMetadataList(project, 'required_grant_terms').map((item) => item.toLowerCase());
+}
+
+function projectRequiredGrantMinHits(project: OrgProjectRow | null) {
+  const value = project?.metadata && typeof project.metadata === 'object' ? project.metadata.required_grant_min_hits : null;
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function scoreText(text: string, tokens: string[]) {
+  let score = 0;
+  const reasons: string[] = [];
+
+  for (const token of tokens) {
+    if (!text.includes(token)) continue;
+    score += 1;
+    reasons.push(token);
+  }
+
+  return { score, reasons };
+}
+
+function countOverlap(values: Array<string | null | undefined>, tokens: string[]) {
+  const haystack = values
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return tokens.filter((token) => haystack.includes(token)).length;
+}
+
+function foundationTypeWeight(type: string | null | undefined) {
+  switch ((type ?? '').toLowerCase()) {
+    case 'philanthropic_foundation':
+    case 'private_ancillary_fund':
+    case 'public_ancillary_fund':
+    case 'corporate_foundation':
+    case 'community_foundation':
+    case 'grantmaker':
+    case 'trust':
+      return 4;
+    case 'arts_culture':
+    case 'animal_welfare':
+    case 'environmental':
+    case 'health_charity':
+    case 'indigenous_organisation':
+    case 'international_aid':
+      return 2;
+    case 'education_body':
+    case 'hospital':
+    case 'legal_aid':
+    case 'peak_body':
+    case 'primary_health_network':
+    case 'research_body':
+    case 'service_delivery':
+    case 'university':
+      return -3;
+    default:
+      return 0;
+  }
+}
+
+function foundationTypeAdjustment(type: string | null | undefined, preferredTypes: Set<string>, blockedTypes: Set<string>) {
+  const normalized = (type ?? '').toLowerCase();
+  if (!normalized) return 0;
+  if (blockedTypes.has(normalized)) return -8;
+  if (preferredTypes.has(normalized)) return 5;
+  return 0;
+}
+
+function geographyMatches(value: string | string[] | null | undefined, state: string) {
+  if (!value || !state || state === 'National') return false;
+  const haystack = Array.isArray(value) ? value.join(' ').toLowerCase() : value.toLowerCase();
+  const target = state.toLowerCase();
+  const aliases = new Map<string, string[]>([
+    ['queensland', ['qld']],
+    ['new south wales', ['nsw']],
+    ['victoria', ['vic']],
+    ['western australia', ['wa']],
+    ['south australia', ['sa']],
+    ['tasmania', ['tas']],
+    ['australian capital territory', ['act']],
+    ['northern territory', ['nt']],
+  ]);
+
+  if (haystack.includes(target) || haystack.includes('national') || haystack.includes('australia')) return true;
+  return (aliases.get(target) ?? []).some((alias) => haystack.includes(alias));
+}
+
+function buildGrantReasons(row: GrantRow, scoreTerms: string[], state: string, keywordHits: number, categoryHits: number) {
+  const reasons: string[] = [];
+  const focus = [...(row.focus_areas ?? []), ...(row.categories ?? [])];
+  const matchedFocus = focus.filter((item) => scoreTerms.some((term) => item.toLowerCase().includes(term)));
+
+  if (matchedFocus.length > 0) {
+    reasons.push(`Fits ${matchedFocus.slice(0, 2).join(' and ')}`);
+  } else if (keywordHits >= 2) {
+    reasons.push(`${keywordHits} mission keyword matches`);
+  } else if (categoryHits > 0) {
+    reasons.push(`${categoryHits} thematic matches`);
+  }
+
+  if (state && geographyMatches(row.geography, state)) {
+    reasons.push(`Works for ${state}`);
+  }
+
+  if (row.closes_at) {
+    reasons.push(`Open until ${formatDeadline(row.closes_at)}`);
+  } else if (row.last_verified_at) {
+    reasons.push(`Still being tracked as live`);
+  }
+
+  return reasons.slice(0, 3);
+}
+
+function buildGrantReasonsWithPriority(
+  row: GrantRow,
+  scoreTerms: string[],
+  priorityTerms: string[],
+  state: string,
+  keywordHits: number,
+  categoryHits: number,
+  priorityHits: number,
+) {
+  const reasons = buildGrantReasons(row, scoreTerms, state, keywordHits, categoryHits);
+  if (priorityTerms.length > 0 && priorityHits > 0 && !reasons.some((reason) => reason.includes('project-fit'))) {
+    reasons.unshift(`${priorityHits} project-fit signals`);
+  }
+  return reasons.slice(0, 3);
+}
+
+function buildFoundationReasons(
+  row: FoundationRow,
+  scoreTerms: string[],
+  state: string,
+  openProgramCount: number,
+  keywordHits: number,
+  projectBoosted: boolean,
+) {
+  const reasons: string[] = [];
+  const matchedFocus = (row.thematic_focus ?? []).filter((item) =>
+    scoreTerms.some((term) => item.toLowerCase().includes(term))
+  );
+
+  if (projectBoosted) {
+    reasons.push('Already shortlisted for this project');
+  }
+
+  if (matchedFocus.length > 0) {
+    reasons.push(`Funds ${matchedFocus.slice(0, 2).join(' and ')}`);
+  } else if (keywordHits >= 2) {
+    reasons.push(`${keywordHits} mission keyword matches`);
+  }
+
+  if (state && geographyMatches(row.geographic_focus, state)) {
+    reasons.push(`Works in ${state}`);
+  }
+
+  if (openProgramCount > 0) {
+    reasons.push(`${openProgramCount} open program${openProgramCount === 1 ? '' : 's'} found`);
+  } else {
+    reasons.push('Better approached by intro than cold application');
+  }
+
+  return reasons.slice(0, 3);
+}
+
+function buildFoundationReasonsWithPriority(
+  row: FoundationRow,
+  scoreTerms: string[],
+  priorityTerms: string[],
+  state: string,
+  openProgramCount: number,
+  keywordHits: number,
+  projectBoosted: boolean,
+  priorityHits: number,
+) {
+  const reasons = buildFoundationReasons(row, scoreTerms, state, openProgramCount, keywordHits, projectBoosted);
+  if (priorityTerms.length > 0 && priorityHits > 0 && !projectBoosted && !reasons.some((reason) => reason.includes('project-fit'))) {
+    reasons.unshift(`${priorityHits} project-fit signals`);
+  }
+  return reasons.slice(0, 3);
+}
+
+function scoreGrant(
+  row: GrantRow,
+  scoreTerms: string[],
+  priorityTerms: string[],
+  blockedGrantNames: Set<string>,
+  blockedGrantTerms: string[],
+  blockedGrantProviderTerms: string[],
+  requiredGrantTerms: string[],
+  requiredGrantMinHits: number,
+  state: string,
+  orgType: string
+): GrantMatch {
+  const text = [
+    row.name,
+    row.description,
+    ...(row.categories ?? []),
+    ...(row.focus_areas ?? []),
+    ...(row.target_recipients ?? []),
+    row.geography,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  const { score: keywordHits } = scoreText(text, scoreTerms);
+  const categoryHits = countOverlap([...(row.categories ?? []), ...(row.focus_areas ?? []), ...(row.target_recipients ?? [])], scoreTerms);
+  const priorityHits = priorityTerms.length > 0
+    ? countOverlap(
+        [
+          row.description,
+          ...(row.categories ?? []),
+          ...(row.focus_areas ?? []),
+          ...(row.target_recipients ?? []),
+        ],
+        priorityTerms,
+      )
+    : 0;
+  const blockedByName = blockedGrantNames.has(row.name.toLowerCase());
+  const blockedByTerm = blockedGrantTerms.some((term) => text.includes(term));
+  const blockedByProvider = blockedGrantProviderTerms.some((term) =>
+    (row.provider ?? '').toLowerCase().includes(term)
+  );
+  const blocked = blockedByName || blockedByTerm || blockedByProvider;
+  const requiredGrantHits = requiredGrantTerms.length > 0
+    ? countOverlap(
+        [
+          row.name,
+          row.description,
+          ...(row.categories ?? []),
+          ...(row.focus_areas ?? []),
+          ...(row.target_recipients ?? []),
+        ],
+        requiredGrantTerms,
+      )
+    : 0;
+  let score = categoryHits * 5 + keywordHits * 2 + priorityHits * 4;
+
+  if (state && geographyMatches(row.geography, state)) score += 3;
+  if (orgType && (row.target_recipients ?? []).some((entry) => entry.toLowerCase().includes(orgType.toLowerCase()))) {
+    score += 2;
+  }
+  if (row.closes_at) {
+    const days = Math.ceil((new Date(row.closes_at).getTime() - Date.now()) / 86400000);
+    if (days >= 0 && days <= 30) score += 2;
+    else if (days > 30 && days <= 90) score += 1;
+  } else if (row.last_verified_at) {
+    score += 1;
+  }
+  if (blocked) score -= 12;
+  if (requiredGrantTerms.length > 0 && requiredGrantHits < requiredGrantMinHits) score -= 10;
+  else if (requiredGrantHits > 0) score += requiredGrantHits * 3;
+
+  return {
+    row,
+    score,
+    reasons: buildGrantReasonsWithPriority(row, scoreTerms, priorityTerms, state, keywordHits, categoryHits, priorityHits),
+    motion: row.closes_at ? 'Draft the application and confirm eligibility now.' : 'Check the guidance and shortlist it for follow-up.',
+    actionLabel: row.closes_at ? 'Apply now' : 'Watch',
+    blocked,
+    requiredGrantHits,
+    requiredGrantMinHits,
+  };
+}
+
+function scoreFoundation(
+  row: FoundationRow,
+  scoreTerms: string[],
+  priorityTerms: string[],
+  state: string,
+  orgType: string,
+  savedForProject: boolean,
+  preferredTypes: Set<string>,
+  blockedTypes: Set<string>,
+  blockedNames: Set<string>,
+  requiredTags: string[],
+): FoundationMatch {
+  const openProgramCount = countOpenPrograms(row.open_programs);
+  const text = [
+    row.name,
+    row.description,
+    row.giving_philosophy,
+    row.application_tips,
+    ...(row.thematic_focus ?? []),
+    ...(row.geographic_focus ?? []),
+    ...(row.target_recipients ?? []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  const { score: keywordHits } = scoreText(text, scoreTerms);
+  const thematicHits = countOverlap([...(row.thematic_focus ?? []), ...(row.target_recipients ?? [])], scoreTerms);
+  const priorityHits = priorityTerms.length > 0
+    ? countOverlap(
+        [
+          row.description,
+          row.giving_philosophy,
+          row.application_tips,
+          ...(row.thematic_focus ?? []),
+          ...(row.target_recipients ?? []),
+        ],
+        priorityTerms,
+      )
+    : 0;
+  const tagHits = requiredTags.length > 0
+    ? countOverlap(
+        [
+          row.description,
+          row.giving_philosophy,
+          row.application_tips,
+          ...(row.thematic_focus ?? []),
+          ...(row.target_recipients ?? []),
+        ],
+        requiredTags,
+      )
+    : 0;
+  let score = thematicHits * 5 + keywordHits * 2 + priorityHits * 4;
+
+  if (state && geographyMatches(row.geographic_focus, state)) score += 3;
+  if (orgType && (row.target_recipients ?? []).some((entry) => entry.toLowerCase().includes(orgType.toLowerCase()))) {
+    score += 2;
+  }
+  score += foundationTypeWeight(row.type);
+  score += foundationTypeAdjustment(row.type, preferredTypes, blockedTypes);
+  if (openProgramCount > 0) score += 2;
+  if (row.profile_confidence === 'high') score += 1;
+  if (row.total_giving_annual && row.total_giving_annual > 1_000_000) score += 1;
+  if (savedForProject) score += 8;
+  if (blockedNames.has(row.name.toLowerCase()) && !savedForProject) score -= 10;
+  if (requiredTags.length > 0 && tagHits === 0 && !savedForProject) score -= 6;
+
+  return {
+    row,
+    score,
+    reasons: buildFoundationReasonsWithPriority(
+      row,
+      scoreTerms,
+      priorityTerms,
+      state,
+      openProgramCount,
+      keywordHits,
+      savedForProject,
+      priorityHits,
+    ),
+    motion: openProgramCount > 0
+      ? 'Start with the live program page, then shortlist the best-fit program.'
+      : 'Lead with a short intro note and a tight mission-fit case, not a generic ask.',
+    actionLabel: openProgramCount > 0 ? 'Open program' : 'Build relationship',
+    openProgramCount,
+    savedForProject,
+    tagHits,
+  };
+}
+
+function prioritizeSaved(matches: FoundationMatch[]) {
+  return [...matches].sort((a, b) => {
+    if (a.savedForProject !== b.savedForProject) return a.savedForProject ? -1 : 1;
+    return b.score - a.score;
+  });
+}
+
+function shouldShowFoundation(
+  match: FoundationMatch,
+  effectiveMission: string,
+  blockedTypes: Set<string>,
+  blockedNames: Set<string>,
+  requiredTags: string[],
+) {
+  const normalizedType = (match.row.type ?? '').toLowerCase();
+  if (match.savedForProject) return true;
+  if (blockedNames.has(match.row.name.toLowerCase())) return false;
+  if (blockedTypes.has(normalizedType)) return false;
+  if (requiredTags.length > 0 && match.tagHits === 0) return false;
+  if (!effectiveMission) return true;
+  return match.score >= 7;
+}
+
+function chooseKeywords(mission: string, theme: string, lens: string, orgType: string, extraTerms: string[] = []) {
+  const terms = buildMissionTokens(mission, theme, lens, ...orgTypeTerms(orgType), ...extraTerms);
+  return terms.length > 0 ? terms : ['community', 'youth', 'place'];
+}
+
+function searchLabel(state: string, orgType: string) {
+  const parts = [];
+  if (state) parts.push(state);
+  if (orgType) parts.push(orgType);
+  return parts.length > 0 ? parts.join(' · ') : 'Any Australian organisation';
+}
+
+function shouldShowGrant(match: GrantMatch, effectiveMission: string) {
+  if (match.blocked) return false;
+  if (match.requiredGrantMinHits > 0 && match.requiredGrantHits < match.requiredGrantMinHits) return false;
+  if (!effectiveMission) return true;
+  return match.score >= 6;
+}
+
+function normalizeOrgType(value: string | null | undefined) {
+  const normalized = (value ?? '').trim().toLowerCase();
+  if (!normalized) return '';
+  if (normalized === 'oric' || normalized === 'indigenous_corp') return 'ORIC';
+  if (normalized === 'charity' || normalized === 'nfp') return 'Charity';
+  if (normalized === 'social enterprise' || normalized === 'social_enterprise') return 'Social enterprise';
+  if (normalized === 'community group' || normalized === 'collective' || normalized === 'cooperative') {
+    return 'Community group';
+  }
+  return titleCase(normalized);
+}
+
+function inferStateFromGeography(values: string[] | null | undefined) {
+  const focus = toArray(values).map((entry) => entry.toLowerCase());
+  if (focus.length === 0) return '';
+  if (focus.some((entry) => entry.includes('national') || entry.includes('australia'))) {
+    return 'National';
+  }
+
+  return (
+    STATE_OPTIONS.find((option) => {
+      const lower = option.toLowerCase();
+      return focus.some((entry) => entry.includes(lower));
+    }) ?? ''
+  );
+}
+
+function EmptyLane({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="border-2 border-dashed border-bauhaus-black/20 bg-bauhaus-canvas p-5">
+      <div className="text-sm font-black uppercase tracking-[0.18em] text-bauhaus-muted">{title}</div>
+      <p className="mt-3 max-w-2xl text-sm font-medium leading-relaxed text-bauhaus-muted">{body}</p>
+    </div>
+  );
+}
+
+export default async function FundingWorkspacePage({ searchParams }: FundingWorkspacePageProps) {
+  const [resolvedParams, authClient] = await Promise.all([
+    searchParams
+      ? searchParams
+      : Promise.resolve({} as Record<string, string | string[] | undefined>),
+    createSupabaseServer(),
+  ]);
+  const serviceDb = getServiceSupabase();
+  const explicitOrgSlug = firstParam(resolvedParams.org).trim();
+  const projectSlug = firstParam(resolvedParams.project).trim();
+  const {
+    data: { user },
+  } = await authClient.auth.getUser();
+  const orgContext = user ? await getCurrentOrgProfileContext(serviceDb, user.id) : null;
+  const implicitProjectProfile =
+    !orgContext?.profile && !explicitOrgSlug && projectSlug
+      ? (
+          await serviceDb
+            .from('org_projects')
+            .select(`
+              slug,
+              name,
+              description,
+              org_profile:org_profile_id(
+                id,
+                name,
+                slug,
+                abn,
+                subscription_plan,
+                org_type,
+                geographic_focus,
+                mission,
+                description
+              )
+            `)
+            .eq('slug', projectSlug)
+            .maybeSingle()
+        ).data
+      : null;
+  const explicitProfile =
+    !orgContext?.profile && explicitOrgSlug && process.env.NODE_ENV !== 'production'
+      ? (
+          await serviceDb
+            .from('org_profiles')
+            .select('id, name, slug, abn, subscription_plan, org_type, geographic_focus, mission, description')
+            .eq('slug', explicitOrgSlug)
+            .maybeSingle()
+        ).data
+      : null;
+  const implicitProfile = Array.isArray(implicitProjectProfile?.org_profile)
+    ? implicitProjectProfile?.org_profile[0]
+    : implicitProjectProfile?.org_profile;
+  const profile = orgContext?.profile ?? explicitProfile ?? implicitProfile ?? null;
+
+  const mission = firstParam(resolvedParams.mission).trim();
+  const theme = firstParam(resolvedParams.theme).trim();
+  const lens = firstParam(resolvedParams.lens).trim();
+  const state = firstParam(resolvedParams.state).trim();
+  const orgType = firstParam(resolvedParams.org_type).trim();
+
+  const profileMission = (profile?.mission || profile?.description || '').trim();
+  const profileState = inferStateFromGeography(profile?.geographic_focus);
+  const profileOrgType = normalizeOrgType(profile?.org_type);
+
+  const [{ data: grantsData }, { data: foundationsData }, { data: projectsData }] = await Promise.all([
+    serviceDb
+      .from('grant_opportunities')
+      .select('id, name, provider, description, amount_min, amount_max, closes_at, categories, focus_areas, target_recipients, geography, status, url, last_verified_at')
+      .or(`closes_at.gte.${new Date().toISOString().slice(0, 10)},and(closes_at.is.null,last_verified_at.gte.${new Date(Date.now() - 180 * 86400000).toISOString()})`)
+      .not('status', 'in', '(closed,archived)')
+      .order('closes_at', { ascending: true, nullsFirst: false })
+      .limit(200),
+    serviceDb
+      .from('foundations')
+      .select('id, name, type, website, description, total_giving_annual, thematic_focus, geographic_focus, target_recipients, open_programs, profile_confidence, giving_philosophy, application_tips')
+      .not('enriched_at', 'is', null)
+      .order('total_giving_annual', { ascending: false, nullsFirst: false })
+      .limit(220),
+    profile
+      ? serviceDb
+          .from('org_projects')
+          .select('id, name, slug, description, status, metadata')
+          .eq('org_profile_id', profile.id)
+          .order('sort_order', { ascending: true, nullsFirst: false })
+          .order('name', { ascending: true })
+      : Promise.resolve({ data: [] as OrgProjectRow[] }),
+  ]);
+
+  const projects = (projectsData ?? []) as OrgProjectRow[];
+  const selectedProject = projects.find((project) => project.slug === projectSlug) ?? null;
+  const projectMission = projectProfileSummary(selectedProject);
+  const staleLegacyMission =
+    Boolean(mission) && Boolean(selectedProject) && mission === legacyProjectMission(selectedProject);
+  const manualMission = staleLegacyMission ? '' : mission;
+  const fundingBrief =
+    projectFundingBrief(selectedProject);
+  const proofPoints = projectMetadataList(selectedProject, 'proof_points');
+  const sourcePaths = projectMetadataList(selectedProject, 'source_paths');
+  const visibleFundingTags = projectMetadataList(selectedProject, 'funding_tags').slice(0, 8);
+  const priorityTerms = projectPriorityTerms(selectedProject);
+  const currentContextLabel = selectedProject
+    ? `${selectedProject.name} · ${profile?.name ?? 'Project context'}`
+    : profile?.name ?? 'Any Australian organisation';
+
+  const { data: savedProjectFoundations } = selectedProject
+    ? await serviceDb
+        .from('org_project_foundations')
+        .select('foundation_id')
+        .eq('org_project_id', selectedProject.id)
+    : { data: [] as Array<{ foundation_id: string }> };
+  const savedFoundationIds = new Set((savedProjectFoundations ?? []).map((row) => row.foundation_id));
+  const baseFoundationRows = (foundationsData ?? []) as FoundationRow[];
+  const missingSavedFoundationIds = [...savedFoundationIds].filter(
+    (foundationId) => !baseFoundationRows.some((row) => row.id === foundationId)
+  );
+  const { data: savedFoundationRows } = missingSavedFoundationIds.length > 0
+    ? await serviceDb
+        .from('foundations')
+        .select('id, name, type, website, description, total_giving_annual, thematic_focus, geographic_focus, target_recipients, open_programs, profile_confidence, giving_philosophy, application_tips')
+        .in('id', missingSavedFoundationIds)
+    : { data: [] as FoundationRow[] };
+  const mergedFoundationRows = [
+    ...baseFoundationRows,
+    ...((savedFoundationRows ?? []) as FoundationRow[]),
+  ];
+
+  const effectiveMission =
+    manualMission || [theme, lens].filter(Boolean).map(titleCase).join(' ') || projectMission || profileMission;
+  const effectiveState = state || profileState;
+  const effectiveOrgType = orgType || profileOrgType;
+  const requiredFundingTags = projectFundingTags(selectedProject);
+  const preferredFoundationTypes = projectPreferredFoundationTypes(selectedProject);
+  const blockedFoundationTypes = projectBlockedFoundationTypes(selectedProject);
+  const blockedFoundationNames = projectBlockedFoundationNames(selectedProject);
+  const blockedGrantTerms = projectBlockedGrantTerms(selectedProject);
+  const blockedGrantProviderTerms = projectBlockedGrantProviderTerms(selectedProject);
+  const blockedGrantNames = projectBlockedGrantNames(selectedProject);
+  const requiredGrantTerms = projectRequiredGrantTerms(selectedProject);
+  const requiredGrantMinHits = projectRequiredGrantMinHits(selectedProject);
+  const scoreTerms = chooseKeywords(
+    effectiveMission,
+    theme,
+    lens,
+    effectiveOrgType,
+    [...projectIntentTerms(selectedProject), ...priorityTerms]
+  );
+  const appliedProfileDefaults = [
+    !manualMission && projectMission ? 'Project brief' : null,
+    !manualMission && !projectMission && profileMission ? 'Mission' : null,
+    !state && profileState ? 'State' : null,
+    !orgType && profileOrgType ? 'Organisation type' : null,
+  ].filter(Boolean) as string[];
+
+  const grantMatches = ((grantsData ?? []) as GrantRow[])
+    .map((row) =>
+      scoreGrant(
+        row,
+        scoreTerms,
+        priorityTerms,
+        blockedGrantNames,
+        blockedGrantTerms,
+        blockedGrantProviderTerms,
+        requiredGrantTerms,
+        requiredGrantMinHits,
+        effectiveState,
+        effectiveOrgType
+      )
+    )
+    .filter((match) => shouldShowGrant(match, effectiveMission))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6);
+
+  const foundationMatches = mergedFoundationRows
+    .map((row) =>
+      scoreFoundation(
+        row,
+        scoreTerms,
+        priorityTerms,
+        effectiveState,
+        effectiveOrgType,
+        savedFoundationIds.has(row.id),
+        preferredFoundationTypes,
+        blockedFoundationTypes,
+        blockedFoundationNames,
+        requiredFundingTags,
+      )
+    )
+    .sort((a, b) => b.score - a.score);
+  const visibleFoundationMatches = foundationMatches.filter(
+    (match) => shouldShowFoundation(match, effectiveMission, blockedFoundationTypes, blockedFoundationNames, requiredFundingTags)
+  );
+
+  const openProgramMatches = prioritizeSaved(visibleFoundationMatches.filter((match) => match.openProgramCount > 0)).slice(0, 4);
+  const relationshipMatches = prioritizeSaved(visibleFoundationMatches.filter((match) => match.openProgramCount === 0)).slice(0, 4);
+  const projectIsFoundationLed =
+    Boolean(selectedProject) &&
+    grantMatches.length === 0 &&
+    (openProgramMatches.length > 0 || relationshipMatches.length > 0);
+  const recommendedApproach = projectIsFoundationLed
+    ? {
+        label: 'Recommended approach',
+        title: 'Foundation-led right now',
+        body:
+          openProgramMatches.length > 0
+            ? `Start with open foundation programs first, then work relationship-led funders for ${selectedProject?.name ?? 'this project'}.`
+            : `Start with relationship-led foundations for ${selectedProject?.name ?? 'this project'}. There is no credible live grant lane right now.`,
+        tone: 'border-bauhaus-blue bg-link-light text-bauhaus-blue',
+      }
+    : grantMatches.length > 0
+      ? {
+          label: 'Recommended approach',
+          title: 'Grant-led first',
+          body:
+            openProgramMatches.length > 0 || relationshipMatches.length > 0
+              ? 'Use the strongest live grant first, then support it with foundation outreach.'
+              : 'Work the live grant lane first. It currently looks stronger than the foundation lanes.',
+          tone: 'border-bauhaus-black bg-white text-bauhaus-black',
+        }
+      : openProgramMatches.length > 0 || relationshipMatches.length > 0
+        ? {
+            label: 'Recommended approach',
+            title: 'Foundation-led',
+            body: 'The current signal is stronger in the foundation lanes than in grants.',
+            tone: 'border-bauhaus-red bg-bauhaus-red/5 text-bauhaus-red',
+          }
+        : null;
+  const quickStarts = [
+    grantMatches[0]
+      ? {
+          title: grantMatches[0].row.name,
+          lane: 'Open now',
+          href: `/grants/${grantMatches[0].row.id}`,
+          action: grantMatches[0].actionLabel,
+          nextMove: grantMatches[0].motion,
+          tone: 'border-bauhaus-black bg-white text-bauhaus-black',
+        }
+      : null,
+    openProgramMatches[0]
+      ? {
+          title: openProgramMatches[0].row.name,
+          lane: 'Open programs',
+          href: `/foundations/${openProgramMatches[0].row.id}`,
+          action: openProgramMatches[0].actionLabel,
+          nextMove: openProgramMatches[0].motion,
+          tone: 'border-bauhaus-blue bg-link-light text-bauhaus-blue',
+        }
+      : null,
+    relationshipMatches[0]
+      ? {
+          title: relationshipMatches[0].row.name,
+          lane: 'Relationship-led',
+          href: `/foundations/${relationshipMatches[0].row.id}`,
+          action: relationshipMatches[0].actionLabel,
+          nextMove: relationshipMatches[0].motion,
+          tone: 'border-bauhaus-red bg-bauhaus-red/5 text-bauhaus-red',
+        }
+      : null,
+  ].filter(Boolean) as Array<{
+    title: string;
+    lane: string;
+    href: string;
+    action: string;
+    nextMove: string;
+    tone: string;
+  }>;
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="mx-auto max-w-7xl px-6 py-10">
+        <div className="border-4 border-bauhaus-black bg-white">
+          <div className="border-b-4 border-bauhaus-black p-6 md:p-8">
+            <p className="text-xs font-black uppercase tracking-[0.28em] text-bauhaus-red">Funding Matches</p>
+            <h1 className="mt-3 max-w-4xl text-4xl font-black uppercase tracking-tight text-bauhaus-black md:text-5xl">
+              Find Grants, Programs, And Philanthropists That Fit Your Mission
+            </h1>
+            <p className="mt-4 max-w-3xl text-base font-medium leading-relaxed text-bauhaus-muted">
+              This is the minimal funding workspace for smaller organisations: define the mission, get a ranked shortlist,
+              and decide the next move. No giant map. No heavy process.
+            </p>
+
+            {profile ? (
+              <div className="mt-6 border-2 border-bauhaus-black bg-white p-4">
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">
+                      Using organisation profile
+                    </div>
+                    <div className="mt-2 text-lg font-black uppercase tracking-tight text-bauhaus-black">{profile.name}</div>
+                    <p className="mt-2 max-w-2xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                      {selectedProject
+                        ? `Currently matching for ${selectedProject.name} inside ${profile.name}. ${appliedProfileDefaults.length > 0
+                            ? `Loaded ${appliedProfileDefaults.join(', ').toLowerCase()} from the organisation and project context.`
+                            : 'Your current URL or form values are overriding the saved defaults.'}`
+                        : appliedProfileDefaults.length > 0
+                          ? `Loaded ${appliedProfileDefaults.join(', ').toLowerCase()} from this organisation profile. You can still override them below.`
+                          : 'This organisation profile is available, but the current search is using your manual values from the URL or form.'}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    {profile.org_type ? (
+                      <span className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                        {normalizeOrgType(profile.org_type)}
+                      </span>
+                    ) : null}
+                    {profile.geographic_focus?.length ? (
+                      <span className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                        {profile.geographic_focus.slice(0, 2).join(' · ')}
+                      </span>
+                    ) : null}
+                    <Link
+                      href={profile.slug ? `/org/${profile.slug}` : '/org'}
+                      className="border-2 border-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+                    >
+                      Open org
+                    </Link>
+                    {selectedProject && profile.slug && selectedProject.slug ? (
+                      <Link
+                        href={`/org/${profile.slug}/${selectedProject.slug}`}
+                        className="border-2 border-bauhaus-blue px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+                      >
+                        Open project
+                      </Link>
+                    ) : null}
+                    <Link
+                      href="/profile"
+                      className="border-2 border-bauhaus-black/20 px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black hover:border-bauhaus-black"
+                    >
+                      Edit profile
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-6 border-2 border-dashed border-bauhaus-black/20 bg-bauhaus-canvas p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">No organisation profile loaded</div>
+                <p className="mt-2 max-w-2xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                  This page works as a generic matcher, but it gets better once you set up your organisation profile and let the workspace preload your mission, geography, and organisation type.
+                </p>
+                {process.env.NODE_ENV !== 'production' ? (
+                  <p className="mt-2 max-w-2xl text-[11px] font-medium leading-relaxed text-bauhaus-muted">
+                    Local testing: add <span className="font-black text-bauhaus-black">?org=act</span> to preload a known org without signing in.
+                  </p>
+                ) : null}
+                <div className="mt-3">
+                  <Link href="/profile" className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red underline underline-offset-4">
+                    Create or update profile
+                  </Link>
+                </div>
+              </div>
+            )}
+
+            <FundingWorkspaceContextForm
+              initialMission={effectiveMission}
+              rawMission={manualMission}
+              initialState={effectiveState}
+              initialOrgType={effectiveOrgType}
+              profileMission={profileMission}
+              projects={projects}
+              selectedProjectSlug={selectedProject?.slug ?? ''}
+            />
+
+            {selectedProject && (projectMission || fundingBrief || proofPoints.length > 0 || sourcePaths.length > 0) ? (
+              <div className="mt-6 border-2 border-bauhaus-black bg-bauhaus-canvas p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Compiled project brief</div>
+                <p className="mt-2 max-w-3xl text-sm font-medium leading-relaxed text-bauhaus-black">
+                  {projectMission}
+                </p>
+                {fundingBrief && fundingBrief !== projectMission ? (
+                  <p className="mt-3 max-w-3xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                    {fundingBrief}
+                  </p>
+                ) : null}
+                {visibleFundingTags.length > 0 ? (
+                  <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.14em]">
+                    {visibleFundingTags.map((tag) => (
+                      <span key={tag} className="border-2 border-bauhaus-blue bg-link-light px-2.5 py-2 text-bauhaus-blue">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+                {proofPoints.length > 0 ? (
+                  <div className="mt-4">
+                    <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Proof points</div>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.14em]">
+                      {proofPoints.slice(0, 4).map((point) => (
+                        <span key={point} className="border-2 border-bauhaus-black/15 bg-white px-2.5 py-2 text-bauhaus-black">
+                          {point}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+                {sourcePaths.length > 0 ? (
+                  <p className="mt-4 text-[11px] font-medium leading-relaxed text-bauhaus-muted">
+                    Source-backed from ACT wiki: {sourcePaths.length} source{sourcePaths.length === 1 ? '' : 's'} linked to this project profile.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            {recommendedApproach ? (
+              <div className={`mt-6 border-2 p-4 ${recommendedApproach.tone}`}>
+                <div className="text-[10px] font-black uppercase tracking-[0.18em]">
+                  {recommendedApproach.label}
+                </div>
+                <div className="mt-2 text-lg font-black uppercase tracking-tight">
+                  {recommendedApproach.title}
+                </div>
+                <p className="mt-2 max-w-3xl text-sm font-medium leading-relaxed opacity-90">
+                  {recommendedApproach.body}
+                </p>
+              </div>
+            ) : null}
+
+            <div className="mt-5 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.16em]">
+              <span className="border-2 border-bauhaus-black/20 bg-white px-3 py-2 text-bauhaus-black">
+                {searchLabel(effectiveState, effectiveOrgType)}
+              </span>
+              {profile ? (
+                <span className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red">
+                  {profile.name}
+                </span>
+              ) : null}
+              {selectedProject ? (
+                <span className="border-2 border-bauhaus-black bg-white px-3 py-2 text-bauhaus-black">
+                  {selectedProject.name}
+                </span>
+              ) : null}
+              <span className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black">
+                {currentContextLabel}
+              </span>
+              {scoreTerms.map((term) => (
+                <span key={term} className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-bauhaus-blue">
+                  {term}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-8 grid gap-3 md:grid-cols-3">
+              <div className="border-2 border-bauhaus-black bg-white p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Open now</div>
+                <div className="mt-2 text-3xl font-black uppercase tracking-tight text-bauhaus-black">{grantMatches.length}</div>
+                <p className="mt-2 text-sm font-medium text-bauhaus-muted">
+                  {projectIsFoundationLed
+                    ? `${selectedProject?.name ?? 'This project'} looks foundation-led right now, not grant-led.`
+                    : 'Current grants and time-bound opportunities that look usable now.'}
+                </p>
+              </div>
+              <div className="border-2 border-bauhaus-blue bg-link-light p-4 text-bauhaus-blue">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em]">Open programs</div>
+                <div className="mt-2 text-3xl font-black uppercase tracking-tight">{openProgramMatches.length}</div>
+                <p className="mt-2 text-sm font-medium opacity-80">Foundations that appear to have a live program surface, not just a general profile.</p>
+              </div>
+              <div className="border-2 border-bauhaus-red bg-bauhaus-red/5 p-4 text-bauhaus-red">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em]">Relationship-led</div>
+                <div className="mt-2 text-3xl font-black uppercase tracking-tight">{relationshipMatches.length}</div>
+                <p className="mt-2 text-sm font-medium opacity-80">Foundations that look mission-aligned but need a tighter intro path than a cold application.</p>
+              </div>
+            </div>
+
+            {quickStarts.length > 0 ? (
+              <div className="mt-8 border-2 border-bauhaus-black bg-white p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Start here</div>
+                <div className="mt-4 grid gap-3 lg:grid-cols-3">
+                  {quickStarts.map((item) => (
+                    <Link key={item.href} href={item.href} className={`border-2 p-4 transition-colors hover:bg-bauhaus-black hover:text-white ${item.tone}`}>
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="text-[10px] font-black uppercase tracking-[0.16em]">{item.lane}</div>
+                        <div className="border-2 border-current px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em]">
+                          {item.action}
+                        </div>
+                      </div>
+                      <div className="mt-3 text-base font-black uppercase tracking-tight">{item.title}</div>
+                      <p className="mt-3 text-sm font-medium leading-relaxed opacity-80">{item.nextMove}</p>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="grid gap-0 xl:grid-cols-[1.05fr_1fr_1fr]">
+            <section className="border-b-4 border-bauhaus-black p-6 xl:border-b-0 xl:border-r-4">
+              <div className="flex items-end justify-between gap-4">
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Lane one</p>
+                  <h2 className="mt-2 text-2xl font-black uppercase tracking-tight text-bauhaus-black">Open now</h2>
+                </div>
+                <Link href="/grants" className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-black underline underline-offset-4">
+                  Open grants search
+                </Link>
+              </div>
+              <p className="mt-3 max-w-xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                These are the grants worth checking first if you want a live application route rather than a relationship process.
+              </p>
+
+              <div className="mt-6 space-y-4">
+                {grantMatches.length === 0 ? (
+                  <EmptyLane
+                    title={projectIsFoundationLed ? 'No credible grant lane right now' : 'No live grant matches'}
+                    body={
+                      projectIsFoundationLed
+                        ? `${selectedProject?.name ?? 'This project'} currently looks stronger as an open-program or relationship-led foundation play. Skip the grant hunt for now and work the foundation lanes instead.`
+                        : 'Try a broader mission phrase or remove the geography filter. If nothing shows up, the better next move is likely a relationship-led foundation rather than an application.'
+                    }
+                  />
+                ) : (
+                  grantMatches.map((match) => (
+                    <div key={match.row.id} className="border-2 border-bauhaus-black bg-white p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Grant</div>
+                          <Link href={`/grants/${match.row.id}`} className="mt-2 block text-lg font-black uppercase tracking-tight text-bauhaus-black hover:text-bauhaus-red">
+                            {match.row.name}
+                          </Link>
+                          <p className="mt-1 text-sm font-medium text-bauhaus-muted">{match.row.provider ?? 'Provider not listed'}</p>
+                        </div>
+                        <div className="text-right">
+                          <div className="border-2 border-bauhaus-black/15 bg-bauhaus-canvas px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black">
+                            {formatCurrencyRange(match.row.amount_min, match.row.amount_max)}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.14em]">
+                        {match.reasons.map((reason) => (
+                          <span key={reason} className="border-2 border-bauhaus-blue bg-link-light px-2.5 py-2 text-bauhaus-blue">
+                            {reason}
+                          </span>
+                        ))}
+                      </div>
+
+                      <p className="mt-4 text-sm font-medium leading-relaxed text-bauhaus-black">
+                        {shortText(match.row.description, 170) || 'No description listed yet.'}
+                      </p>
+
+                      <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                        <div className="mb-2 inline-flex border-2 border-bauhaus-black px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-bauhaus-black">
+                          {match.actionLabel}
+                        </div>
+                        <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Best next move</div>
+                        <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-black">{match.motion}</p>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <FundingWorkspaceShortlistButton
+                          kind="grant"
+                          itemId={match.row.id}
+                          orgProfileId={profile?.id}
+                          orgSlug={profile?.slug}
+                          projectId={selectedProject?.id}
+                          projectSlug={selectedProject?.slug}
+                          projectName={selectedProject?.name}
+                          itemName={match.row.name}
+                          providerName={match.row.provider}
+                          deadline={match.row.closes_at}
+                          amountDisplay={formatCurrencyRange(match.row.amount_min, match.row.amount_max)}
+                          amountNumeric={match.row.amount_max ?? match.row.amount_min}
+                        />
+                        <Link href={`/grants/${match.row.id}`} className="border-2 border-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black hover:bg-bauhaus-black hover:text-white">
+                          Open grant
+                        </Link>
+                        {match.row.url ? (
+                          <a href={match.row.url} target="_blank" rel="noreferrer" className="border-2 border-bauhaus-black/20 px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black hover:border-bauhaus-black">
+                            Source
+                          </a>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="border-b-4 border-bauhaus-black p-6 xl:border-b-0 xl:border-r-4">
+              <div className="flex items-end justify-between gap-4">
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-blue">Lane two</p>
+                  <h2 className="mt-2 text-2xl font-black uppercase tracking-tight text-bauhaus-black">Open programs</h2>
+                </div>
+                <Link href="/foundations" className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-black underline underline-offset-4">
+                  Open foundations
+                </Link>
+              </div>
+              <p className="mt-3 max-w-xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                These funders look like they have an actual program surface now, which is the closest thing to an apply-now route on the foundation side.
+              </p>
+
+              <div className="mt-6 space-y-4">
+                {openProgramMatches.length === 0 ? (
+                  <EmptyLane
+                    title="No open programs surfaced"
+                    body="That usually means the stronger move is relationship-first rather than a form-led application. Check the right-hand lane instead of forcing an application route."
+                  />
+                ) : (
+                  openProgramMatches.map((match) => (
+                    <div key={match.row.id} className="border-2 border-bauhaus-blue bg-white p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-blue">Foundation program</div>
+                          <Link href={`/foundations/${match.row.id}`} className="mt-2 block text-lg font-black uppercase tracking-tight text-bauhaus-black hover:text-bauhaus-blue">
+                            {match.row.name}
+                          </Link>
+                          <p className="mt-1 text-sm font-medium text-bauhaus-muted">{formatCompactCurrency(match.row.total_giving_annual)} annual giving</p>
+                        </div>
+                        <div className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-blue">
+                          {match.openProgramCount} program{match.openProgramCount === 1 ? '' : 's'}
+                        </div>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.14em]">
+                        {match.reasons.map((reason) => (
+                          <span key={reason} className="border-2 border-bauhaus-blue bg-link-light px-2.5 py-2 text-bauhaus-blue">
+                            {reason}
+                          </span>
+                        ))}
+                      </div>
+
+                      <p className="mt-4 text-sm font-medium leading-relaxed text-bauhaus-black">
+                        {shortText(match.row.description, 170) || 'No description listed yet.'}
+                      </p>
+
+                      <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                        <div className="mb-2 inline-flex border-2 border-bauhaus-blue px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-bauhaus-blue">
+                          {match.actionLabel}
+                        </div>
+                        <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Best next move</div>
+                        <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-black">{match.motion}</p>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <FundingWorkspaceShortlistButton
+                          kind="foundation"
+                          itemId={match.row.id}
+                          orgProfileId={profile?.id}
+                          orgSlug={profile?.slug}
+                          projectId={selectedProject?.id}
+                          projectSlug={selectedProject?.slug}
+                          projectName={selectedProject?.name}
+                        />
+                        <Link href={`/foundations/${match.row.id}`} className="border-2 border-bauhaus-blue px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white">
+                          Open profile
+                        </Link>
+                        {match.row.website ? (
+                          <a href={match.row.website} target="_blank" rel="noreferrer" className="border-2 border-bauhaus-black/20 px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black hover:border-bauhaus-black">
+                            Website
+                          </a>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="p-6">
+              <div className="flex items-end justify-between gap-4">
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Lane three</p>
+                  <h2 className="mt-2 text-2xl font-black uppercase tracking-tight text-bauhaus-black">Relationship-led</h2>
+                </div>
+                <Link href="/foundations/tracker" className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-black underline underline-offset-4">
+                  Open foundation tracker
+                </Link>
+              </div>
+              <p className="mt-3 max-w-xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+                These are the foundations that look mission-aligned but usually need a short intro path, proof, and a clearer first conversation rather than a cold application.
+              </p>
+
+              <div className="mt-6 space-y-4">
+                {relationshipMatches.length === 0 ? (
+                  <EmptyLane
+                    title="No relationship-led foundations surfaced"
+                    body="Try a broader mission phrase or remove the state filter. If this still stays empty, the better move may be to start in grants and grow proof first."
+                  />
+                ) : (
+                  relationshipMatches.map((match) => (
+                    <div key={match.row.id} className="border-2 border-bauhaus-red bg-white p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Foundation</div>
+                          <Link href={`/foundations/${match.row.id}`} className="mt-2 block text-lg font-black uppercase tracking-tight text-bauhaus-black hover:text-bauhaus-red">
+                            {match.row.name}
+                          </Link>
+                          <p className="mt-1 text-sm font-medium text-bauhaus-muted">{formatCompactCurrency(match.row.total_giving_annual)} annual giving</p>
+                        </div>
+                        <div className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-red">
+                          Relationship-led
+                        </div>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.14em]">
+                        {match.reasons.map((reason) => (
+                          <span key={reason} className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-2.5 py-2 text-bauhaus-red">
+                            {reason}
+                          </span>
+                        ))}
+                      </div>
+
+                      <p className="mt-4 text-sm font-medium leading-relaxed text-bauhaus-black">
+                        {shortText(match.row.description, 170) || 'No description listed yet.'}
+                      </p>
+
+                      <div className="mt-4 border-t-2 border-bauhaus-black/10 pt-4">
+                        <div className="mb-2 inline-flex border-2 border-bauhaus-red px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-bauhaus-red">
+                          {match.actionLabel}
+                        </div>
+                        <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">Best next move</div>
+                        <p className="mt-2 text-sm font-medium leading-relaxed text-bauhaus-black">{match.motion}</p>
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <FundingWorkspaceShortlistButton
+                          kind="foundation"
+                          itemId={match.row.id}
+                          orgProfileId={profile?.id}
+                          orgSlug={profile?.slug}
+                          projectId={selectedProject?.id}
+                          projectSlug={selectedProject?.slug}
+                          projectName={selectedProject?.name}
+                        />
+                        <Link href={`/foundations/${match.row.id}`} className="border-2 border-bauhaus-red px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-red hover:bg-bauhaus-red hover:text-white">
+                          Open profile
+                        </Link>
+                        {match.row.website ? (
+                          <a href={match.row.website} target="_blank" rel="noreferrer" className="border-2 border-bauhaus-black/20 px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black hover:border-bauhaus-black">
+                            Website
+                          </a>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/funding-workspace/shortlist-button.tsx
+++ b/apps/web/src/app/funding-workspace/shortlist-button.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { createSupabaseBrowser } from '@/lib/supabase-browser';
+
+type FundingWorkspaceShortlistButtonProps = {
+  kind: 'grant' | 'foundation';
+  itemId: string;
+  orgProfileId?: string | null;
+  orgSlug?: string | null;
+  projectId?: string | null;
+  projectSlug?: string | null;
+  projectName?: string | null;
+  itemName?: string;
+  providerName?: string | null;
+  deadline?: string | null;
+  amountDisplay?: string | null;
+  amountNumeric?: number | null;
+};
+
+export function FundingWorkspaceShortlistButton({
+  kind,
+  itemId,
+  orgProfileId,
+  orgSlug,
+  projectId,
+  projectSlug,
+  projectName,
+  itemName,
+  providerName,
+  deadline,
+  amountDisplay,
+  amountNumeric,
+}: FundingWorkspaceShortlistButtonProps) {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const supabase = createSupabaseBrowser();
+    supabase.auth.getUser().then(({ data }) => {
+      setIsLoggedIn(Boolean(data.user));
+    });
+  }, []);
+
+  const destinationHref =
+    kind === 'grant'
+      ? orgSlug
+        ? projectSlug
+          ? `/org/${orgSlug}/${projectSlug}`
+          : `/org/${orgSlug}`
+        : null
+      : orgSlug && projectSlug
+        ? `/org/${orgSlug}/${projectSlug}`
+        : null;
+
+  const destinationLabel =
+    kind === 'grant'
+      ? projectName
+        ? `Open ${projectName} pipeline`
+        : 'Open organisation dashboard'
+      : projectName
+        ? `Open ${projectName}`
+        : 'Open project';
+
+  async function onSave() {
+    if (!isLoggedIn) {
+      const next = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.href = `/login?next=${next}`;
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      let endpoint = kind === 'grant' ? `/api/tracker/${itemId}` : `/api/foundations/saved/${itemId}`;
+      let method: 'PUT' | 'POST' = 'PUT';
+      let body: Record<string, unknown> = { stage: 'discovered' };
+
+      if (kind === 'grant' && orgProfileId) {
+        endpoint = `/api/org/${orgProfileId}/pipeline`;
+        method = 'POST';
+        body = {
+          project_id: projectId ?? null,
+          name: itemName,
+          amount_display: amountDisplay ?? null,
+          amount_numeric: amountNumeric ?? null,
+          funder: providerName ?? null,
+          deadline: deadline ?? null,
+          status: 'prospect',
+          grant_opportunity_id: itemId,
+          funder_type: 'government',
+        };
+      } else if (kind === 'foundation' && orgProfileId && projectId) {
+        endpoint = `/api/org/${orgProfileId}/projects/${projectId}/foundations`;
+        method = 'POST';
+        body = {
+          foundation_id: itemId,
+          stage: 'saved',
+          engagement_status: 'researching',
+        };
+      }
+
+      const response = await fetch(endpoint, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (response.status === 401) {
+        const next = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.href = `/login?next=${next}`;
+        return;
+      }
+
+      if (response.status === 403) {
+        window.location.href = '/pricing';
+        return;
+      }
+
+      if (!response.ok) return;
+      setSaved(true);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (saved) {
+    const savedLabel =
+      kind === 'grant' && orgProfileId
+        ? projectName
+          ? `Added to ${projectName} pipeline`
+          : 'Added to organisation pipeline'
+        : kind === 'foundation' && orgProfileId && projectId
+          ? projectName
+            ? `Saved to ${projectName}`
+            : 'Saved to project'
+          : 'Saved to shortlist';
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="border-2 border-money bg-money-light px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-money">
+          {savedLabel}
+        </span>
+        {destinationHref ? (
+          <Link
+            href={destinationHref}
+            className="border-2 border-money px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-money transition-colors hover:bg-money hover:text-white"
+          >
+            {destinationLabel}
+          </Link>
+        ) : null}
+      </div>
+    );
+  }
+
+  const buttonLabel =
+    kind === 'grant' && orgProfileId
+      ? 'Add to pipeline'
+      : kind === 'foundation' && orgProfileId && projectId
+        ? 'Save to project'
+        : 'Save shortlist';
+
+  return (
+    <button
+      type="button"
+      onClick={onSave}
+      disabled={isSaving}
+      className="border-2 border-bauhaus-black bg-white px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white disabled:cursor-wait disabled:opacity-60"
+    >
+      {isSaving ? 'Saving...' : buttonLabel}
+    </button>
+  );
+}

--- a/apps/web/src/app/goods-intelligence/page.tsx
+++ b/apps/web/src/app/goods-intelligence/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function GoodsIntelligenceRedirectPage() {
+  redirect('/goods-workspace');
+}

--- a/apps/web/src/app/goods-workspace/goods-community-map.tsx
+++ b/apps/web/src/app/goods-workspace/goods-community-map.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+import { useEffect } from 'react';
+import L from 'leaflet';
+import { CircleMarker, Popup, TileLayer, useMap } from 'react-leaflet';
+import { AustraliaMap } from '@/app/components/australia-map';
+import { MapLegend } from '@/app/components/map-legend';
+import 'leaflet/dist/leaflet.css';
+
+export type GoodsMapLayer = 'need' | 'beds' | 'washers' | 'fridges' | 'buyer-gaps' | 'partners';
+
+export interface GoodsMapPoint {
+  id: string;
+  name: string;
+  state: string | null;
+  lat: number;
+  lng: number;
+  needScore: number;
+  needReason: string;
+  demandBeds: number;
+  demandWashers: number;
+  demandFridges: number;
+  buyerCount: number;
+  partnerCount: number;
+  goodsBuyerGap: boolean;
+  crosswalkBuyerGap: boolean;
+  postcodeGap: boolean;
+  remoteness: string | null;
+  proofLine: string | null;
+}
+
+interface GoodsCommunityMapProps {
+  points: GoodsMapPoint[];
+  selectedPoint: GoodsMapPoint | null;
+  selectedLayer: GoodsMapLayer;
+  onSelect: (id: string) => void;
+  onOpenDossier: () => void;
+  expanded?: boolean;
+  ntOnly?: boolean;
+}
+
+function layerLabel(layer: GoodsMapLayer): string {
+  switch (layer) {
+    case 'beds':
+      return 'Beds demand';
+    case 'washers':
+      return 'Washer demand';
+    case 'fridges':
+      return 'Fridge demand';
+    case 'buyer-gaps':
+      return 'Buyer + enrichment gaps';
+    case 'partners':
+      return 'Partner presence';
+    case 'need':
+    default:
+      return 'Need score';
+  }
+}
+
+function needColor(score: number): string {
+  if (score >= 3000) return '#D02020';
+  if (score >= 1800) return '#EA580C';
+  if (score >= 900) return '#F0C020';
+  if (score > 0) return '#1040C0';
+  return '#9CA3AF';
+}
+
+function demandColor(value: number): string {
+  if (value >= 400) return '#D02020';
+  if (value >= 160) return '#EA580C';
+  if (value >= 40) return '#F0C020';
+  if (value > 0) return '#1040C0';
+  return '#9CA3AF';
+}
+
+function partnerColor(value: number): string {
+  if (value >= 8) return '#059669';
+  if (value >= 4) return '#1040C0';
+  if (value >= 1) return '#F0C020';
+  return '#9CA3AF';
+}
+
+function gapColor(point: GoodsMapPoint): string {
+  if (point.goodsBuyerGap) return '#D02020';
+  if (point.crosswalkBuyerGap) return '#EA580C';
+  if (point.postcodeGap) return '#F0C020';
+  return '#059669';
+}
+
+function layerColor(point: GoodsMapPoint, layer: GoodsMapLayer): string {
+  switch (layer) {
+    case 'beds':
+      return demandColor(point.demandBeds);
+    case 'washers':
+      return demandColor(point.demandWashers);
+    case 'fridges':
+      return demandColor(point.demandFridges);
+    case 'buyer-gaps':
+      return gapColor(point);
+    case 'partners':
+      return partnerColor(point.partnerCount);
+    case 'need':
+    default:
+      return needColor(point.needScore);
+  }
+}
+
+function layerValue(point: GoodsMapPoint, layer: GoodsMapLayer): number {
+  switch (layer) {
+    case 'beds':
+      return point.demandBeds;
+    case 'washers':
+      return point.demandWashers;
+    case 'fridges':
+      return point.demandFridges;
+    case 'buyer-gaps':
+      return point.goodsBuyerGap ? 3 : point.crosswalkBuyerGap ? 2 : point.postcodeGap ? 1 : 0;
+    case 'partners':
+      return point.partnerCount;
+    case 'need':
+    default:
+      return point.needScore;
+  }
+}
+
+function markerRadius(point: GoodsMapPoint, layer: GoodsMapLayer, selected: boolean): number {
+  const value = layerValue(point, layer);
+  let radius = 4;
+  switch (layer) {
+    case 'beds':
+    case 'washers':
+    case 'fridges':
+      radius = Math.max(4, Math.min(14, Math.sqrt(value) * 0.45));
+      break;
+    case 'buyer-gaps':
+      radius = value > 0 ? 8 : 4;
+      break;
+    case 'partners':
+      radius = Math.max(4, Math.min(13, 4 + value * 0.8));
+      break;
+    case 'need':
+    default:
+      radius = Math.max(4, Math.min(15, Math.sqrt(value) * 0.18));
+      break;
+  }
+  return selected ? radius + 3 : radius;
+}
+
+function layerValueText(point: GoodsMapPoint, layer: GoodsMapLayer): string {
+  switch (layer) {
+    case 'beds':
+      return `${point.demandBeds} beds requested`;
+    case 'washers':
+      return `${point.demandWashers} washers requested`;
+    case 'fridges':
+      return `${point.demandFridges} fridges requested`;
+    case 'buyer-gaps':
+      if (point.goodsBuyerGap) return 'No Goods buyer lead yet';
+      if (point.crosswalkBuyerGap) return 'Crosswalk buyer gap';
+      if (point.postcodeGap) return 'Postcode / enrichment gap';
+      return 'Goods buyer lead present';
+    case 'partners':
+      return `${point.partnerCount} community-controlled partners`;
+    case 'need':
+    default:
+      return `Need score ${point.needScore}`;
+  }
+}
+
+function selectedPriorityCallout(point: GoodsMapPoint, layer: GoodsMapLayer): string {
+  if (layer === 'buyer-gaps') {
+    if (point.goodsBuyerGap) return 'No Goods buyer lead is linked yet, so buyer discovery needs to happen before outreach.';
+    if (point.crosswalkBuyerGap) return 'The Goods layer has a lead, but the stricter civic graph crosswalk is still missing for this community.';
+    if (point.postcodeGap) return 'This community still needs postcode or enrichment cleanup before the record is fully reliable.';
+    return 'This community currently has at least one Goods buyer lead and no known enrichment blocker.';
+  }
+  if (layer === 'partners') {
+    return point.partnerCount > 0
+      ? `There are ${point.partnerCount} community-controlled partner signals here that could support production, assembly, or aftercare.`
+      : 'Partner visibility is thin here, so local relationship discovery is still needed.';
+  }
+  if (layer === 'beds' || layer === 'washers' || layer === 'fridges') {
+    return `${layerValueText(point, layer)}. ${point.needReason}`;
+  }
+  return point.needReason;
+}
+
+function legendItemsForLayer(layer: GoodsMapLayer) {
+  switch (layer) {
+    case 'beds':
+    case 'washers':
+    case 'fridges':
+      return [
+        { color: '#D02020', label: 'High demand' },
+        { color: '#EA580C', label: 'Strong demand' },
+        { color: '#F0C020', label: 'Moderate demand' },
+        { color: '#1040C0', label: 'Low demand' },
+      ];
+    case 'buyer-gaps':
+      return [
+        { color: '#D02020', label: 'No Goods buyer lead' },
+        { color: '#EA580C', label: 'Crosswalk gap' },
+        { color: '#F0C020', label: 'Postcode gap' },
+        { color: '#059669', label: 'Buyer lead present' },
+      ];
+    case 'partners':
+      return [
+        { color: '#059669', label: 'Strong partner presence' },
+        { color: '#1040C0', label: 'Some partners' },
+        { color: '#F0C020', label: 'Thin partner signal' },
+        { color: '#9CA3AF', label: 'No known partners' },
+      ];
+    case 'need':
+    default:
+      return [
+        { color: '#D02020', label: 'Critical pressure' },
+        { color: '#EA580C', label: 'High pressure' },
+        { color: '#F0C020', label: 'Moderate pressure' },
+        { color: '#1040C0', label: 'Lower pressure' },
+      ];
+  }
+}
+
+function FitToGoodsPoints({
+  points,
+  selectedPoint,
+  expanded,
+}: {
+  points: GoodsMapPoint[];
+  selectedPoint: GoodsMapPoint | null;
+  expanded: boolean;
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (selectedPoint) {
+      map.flyTo([selectedPoint.lat, selectedPoint.lng], expanded ? 7 : 6, {
+        duration: 0.8,
+      });
+      return;
+    }
+    if (points.length === 0) return;
+    const bounds = L.latLngBounds(points.map((point) => [point.lat, point.lng] as [number, number]));
+    map.fitBounds(bounds, { padding: expanded ? [80, 80] : [40, 40] });
+  }, [expanded, map, points, selectedPoint]);
+
+  return null;
+}
+
+export function GoodsCommunityMap({
+  points,
+  selectedPoint,
+  selectedLayer,
+  onSelect,
+  onOpenDossier,
+  expanded = false,
+  ntOnly = true,
+}: GoodsCommunityMapProps) {
+  if (points.length === 0) {
+    return (
+      <div className="border-4 border-bauhaus-black bg-white p-6">
+        <p className="text-sm text-bauhaus-muted">No mapped communities match the current filters.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <AustraliaMap height={expanded ? 760 : 440}>
+        <TileLayer
+          attribution='&copy; <a href="https://carto.com">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png"
+          pane="tooltipPane"
+        />
+        {points.map((point) => {
+          const selected = selectedPoint?.id === point.id;
+          return (
+            <CircleMarker
+              key={point.id}
+              center={[point.lat, point.lng]}
+              radius={markerRadius(point, selectedLayer, selected)}
+              pathOptions={{
+                color: '#111111',
+                fillColor: layerColor(point, selectedLayer),
+                fillOpacity: point.goodsBuyerGap || point.crosswalkBuyerGap ? 0.9 : 0.72,
+                weight: selected ? 3 : 1,
+              }}
+              eventHandlers={{
+                click: () => onSelect(point.id),
+              }}
+            >
+              <Popup>
+                <div className="text-xs max-w-[220px]">
+                  <div className="font-black text-sm">{point.name}{point.state ? ` (${point.state})` : ''}</div>
+                  <div className="mt-1 text-bauhaus-muted">{point.remoteness || 'Remoteness unknown'}</div>
+                  <div className="mt-2 font-semibold">{layerValueText(point, selectedLayer)}</div>
+                  <div className="mt-1 text-bauhaus-muted">{selectedPriorityCallout(point, selectedLayer)}</div>
+                  <button
+                    type="button"
+                    onClick={onOpenDossier}
+                    className="mt-3 border-2 border-bauhaus-black px-2 py-1 text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+                  >
+                    Open dossier
+                  </button>
+                </div>
+              </Popup>
+            </CircleMarker>
+          );
+        })}
+        <FitToGoodsPoints points={points} selectedPoint={selectedPoint} expanded={expanded} />
+      </AustraliaMap>
+
+      <MapLegend title={layerLabel(selectedLayer)} items={legendItemsForLayer(selectedLayer)} />
+
+      <div className="absolute top-4 left-4 z-[1000] bg-white border-2 border-bauhaus-black px-3 py-2">
+        <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">
+          {ntOnly ? 'NT-first map view' : 'NT + QLD map view'}
+        </p>
+        <p className="mt-1 text-sm font-black">{points.length} visible communities</p>
+      </div>
+
+      <div className="absolute top-4 right-4 z-[1000] max-w-[340px] bg-white border-4 border-bauhaus-black p-4 shadow-[8px_8px_0_0_rgba(0,0,0,0.1)]">
+        <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">On-map priority callout</p>
+        {selectedPoint ? (
+          <>
+            <h3 className="mt-1 text-lg font-black">
+              {selectedPoint.name}
+              {selectedPoint.state ? ` (${selectedPoint.state})` : ''}
+            </h3>
+            <p className="mt-1 text-sm text-bauhaus-muted">{layerValueText(selectedPoint, selectedLayer)}</p>
+            <p className="mt-2 text-sm text-bauhaus-black">{selectedPriorityCallout(selectedPoint, selectedLayer)}</p>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+              <div className="border border-bauhaus-black px-2 py-1">
+                <p className="uppercase tracking-widest text-bauhaus-muted">Beds</p>
+                <p className="font-black">{selectedPoint.demandBeds}</p>
+              </div>
+              <div className="border border-bauhaus-black px-2 py-1">
+                <p className="uppercase tracking-widest text-bauhaus-muted">Washers</p>
+                <p className="font-black">{selectedPoint.demandWashers}</p>
+              </div>
+              <div className="border border-bauhaus-black px-2 py-1">
+                <p className="uppercase tracking-widest text-bauhaus-muted">Fridges</p>
+                <p className="font-black">{selectedPoint.demandFridges}</p>
+              </div>
+              <div className="border border-bauhaus-black px-2 py-1">
+                <p className="uppercase tracking-widest text-bauhaus-muted">Partners</p>
+                <p className="font-black">{selectedPoint.partnerCount}</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onOpenDossier}
+              className="mt-3 w-full border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Open community dossier
+            </button>
+          </>
+        ) : (
+          <p className="mt-2 text-sm text-bauhaus-muted">
+            Select a community marker to see why it is high priority and jump into its dossier.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/goods-workspace/goods-workspace-client.tsx
+++ b/apps/web/src/app/goods-workspace/goods-workspace-client.tsx
@@ -1,0 +1,2697 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import type { GoodsMapLayer } from './goods-community-map';
+
+const GoodsCommunityMap = dynamic(
+  () => import('./goods-community-map').then((module) => ({ default: module.GoodsCommunityMap })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="border-4 border-bauhaus-black bg-white p-6 min-h-[440px] flex items-center justify-center">
+        <div className="text-bauhaus-muted font-black text-sm uppercase tracking-widest animate-pulse">
+          Loading Goods map...
+        </div>
+      </div>
+    ),
+  },
+);
+
+export type SearchMode = 'need-led' | 'buyer-led' | 'capital-led' | 'partner-led';
+
+export interface GoodsCommunityRow {
+  id: string;
+  community_name: string;
+  state: string | null;
+  postcode: string | null;
+  lga_name: string | null;
+  region_label: string | null;
+  service_region: string | null;
+  land_council: string | null;
+  remoteness: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  priority: string | null;
+  signal_type: string | null;
+  signal_source: string | null;
+  demand_beds: number | null;
+  demand_washers: number | null;
+  demand_fridges: number | null;
+  demand_mattresses: number | null;
+  assets_deployed: number | null;
+  assets_active: number | null;
+  assets_overdue: number | null;
+  latest_checkin_date: string | null;
+  known_buyer_name: string | null;
+  buyer_entity_count: number | null;
+  store_count: number | null;
+  health_service_count: number | null;
+  housing_org_count: number | null;
+  council_count: number | null;
+  community_controlled_org_count: number | null;
+  total_local_entities: number | null;
+  total_govt_contract_value: number | null;
+  total_justice_funding: number | null;
+  total_foundation_grants: number | null;
+  ndis_provider_count: number | null;
+  ndis_thin_market: boolean | null;
+  proof_line: string | null;
+  story: string | null;
+  youth_employment_angle: string | null;
+  data_quality_score: number | null;
+  updated_at: string | null;
+}
+
+export interface GoodsProcurementEntityRow {
+  id: string;
+  community_id: string | null;
+  gs_id: string | null;
+  entity_name: string | null;
+  abn: string | null;
+  entity_type: string | null;
+  buyer_role: string | null;
+  procurement_method: string | null;
+  estimated_annual_spend: number | null;
+  current_supplier: string | null;
+  contract_cycle: string | null;
+  relationship_status: string | null;
+  contact_surface: string | null;
+  product_fit: string[] | null;
+  fit_score: number | null;
+  next_action: string | null;
+  govt_contract_count: number | null;
+  govt_contract_value: number | null;
+  is_community_controlled: boolean | null;
+  website: string | null;
+  updated_at: string | null;
+}
+
+export interface GoodsProcurementSignalRow {
+  id: string;
+  signal_type: string | null;
+  priority: string | null;
+  community_id: string | null;
+  title: string | null;
+  description: string | null;
+  estimated_value: number | null;
+  estimated_units: number | null;
+  products_needed: string[] | null;
+  funding_confidence: string | null;
+  status: string | null;
+  action_notes: string | null;
+  source_agent: string | null;
+  updated_at: string | null;
+  created_at: string | null;
+}
+
+export interface GoodsFoundationRow {
+  id: string;
+  name: string | null;
+  type: string | null;
+  website: string | null;
+  description: string | null;
+  total_giving_annual: number | null;
+  avg_grant_size: number | null;
+  thematic_focus: string[] | null;
+  geographic_focus: string[] | null;
+  profile_confidence: string | null;
+  open_programs: unknown;
+}
+
+export interface GoodsGrantRow {
+  id: string;
+  name: string | null;
+  provider: string | null;
+  url: string | null;
+  amount_min: number | null;
+  amount_max: number | null;
+  closes_at: string | null;
+  categories: string[] | null;
+  focus_areas: string[] | null;
+  geography: string | null;
+  status: string | null;
+  grant_type: string | null;
+  program_type: string | null;
+  last_verified_at: string | null;
+}
+
+export interface NtCommunityCoverageRow {
+  community_name: string | null;
+  region_label: string | null;
+  postcode: string | null;
+  goods_focus_priority: string | null;
+  known_buyer_name: string | null;
+  entity_match_count: number | null;
+  buyer_match_count: number | null;
+  store_count: number | null;
+  health_count: number | null;
+  housing_count: number | null;
+  council_count: number | null;
+  community_controlled_match_count: number | null;
+  needs_postcode_enrichment: boolean | null;
+}
+
+export interface GoodsGhlPipelineStageRow {
+  stage_name: string | null;
+  stage_count: number | null;
+  stage_value: number | null;
+}
+
+export interface GoodsGhlOpportunityRow {
+  ghl_id: string | null;
+  name: string | null;
+  stage_name: string | null;
+  status: string | null;
+  monetary_value: number | null;
+  assigned_to: string | null;
+  ghl_contact_id: string | null;
+  updated_at: string | null;
+}
+
+export interface GoodsBuyerGhlOpportunityRow {
+  name: string | null;
+  stage_name: string | null;
+  status: string | null;
+  monetary_value: number | null;
+  assigned_to: string | null;
+  ghl_contact_id: string | null;
+  updated_at: string | null;
+}
+
+export interface GoodsBuyerGhlContactRow {
+  ghl_id: string | null;
+  company_name: string | null;
+  engagement_status: string | null;
+  last_contact_date: string | null;
+  website: string | null;
+  updated_at: string | null;
+}
+
+export interface GoodsCommunityPipelineRow {
+  name: string | null;
+  stage_name: string | null;
+  status: string | null;
+  monetary_value: number | null;
+  assigned_to: string | null;
+  updated_at: string | null;
+}
+
+export interface GoodsGhlSyncRow {
+  id: string;
+  operation: string | null;
+  status: string | null;
+  records_processed: number | null;
+  records_created: number | null;
+  records_updated: number | null;
+  records_failed: number | null;
+  triggered_by: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  metadata: unknown;
+}
+
+interface GoodsWorkspaceClientProps {
+  userEmail: string | null;
+  orgProfile: {
+    id: string;
+    name: string | null;
+    abn: string | null;
+    subscription_plan: string | null;
+  } | null;
+  ghlDefaultOwnerConfigured: boolean;
+  ghlDefaultOwnerLabel: string | null;
+  communities: GoodsCommunityRow[];
+  buyers: GoodsProcurementEntityRow[];
+  signals: GoodsProcurementSignalRow[];
+  foundations: GoodsFoundationRow[];
+  grants: GoodsGrantRow[];
+  ntCoverageRows: NtCommunityCoverageRow[];
+  goodsPipelineStages: GoodsGhlPipelineStageRow[];
+  goodsPipelineOpportunities: GoodsGhlOpportunityRow[];
+  goodsBuyerPipelineOpportunities: GoodsBuyerGhlOpportunityRow[];
+  goodsBuyerContacts: GoodsBuyerGhlContactRow[];
+  goodsCommunityPipelineRows: GoodsCommunityPipelineRow[];
+  goodsPushLog: GoodsGhlSyncRow[];
+}
+
+type CapitalTarget = {
+  key: string;
+  source: 'foundation' | 'grant';
+  name: string;
+  provider: string;
+  score: number;
+  instrumentType: string;
+  openness: 'open' | 'relationship-led' | 'mixed';
+  amountHint: string;
+  regionFit: string;
+  reason: string;
+  link: string | null;
+};
+
+type BuyerOutreachTarget = {
+  key: string;
+  type: 'buyer';
+  name: string;
+  company: string;
+  community: string | null;
+  state: string | null;
+  score: number;
+  reason: string;
+  nextAction: string;
+  recommendedAsk: string;
+  targetSummary: string;
+  contactSurface: string | null;
+  relationshipStatus: string | null;
+  link: string | null;
+  crmPreviewOperation: 'create-opportunity' | 'update-opportunity';
+  crmPreviewSummary: string;
+  tags: string[];
+};
+
+type BuyerRankedEntry = {
+  buyer: GoodsProcurementEntityRow;
+  community: GoodsCommunityRow | undefined;
+  score: { score: number; reason: string };
+};
+
+type CanonicalBuyerCard = {
+  key: string;
+  name: string;
+  abn: string | null;
+  score: number;
+  reasons: string[];
+  nextAction: string;
+  contactSurface: string | null;
+  relationshipStatus: string | null;
+  link: string | null;
+  contractCount: number;
+  contractValue: number;
+  roles: string[];
+  communities: Array<{
+    id: string;
+    name: string;
+    state: string | null;
+  }>;
+  primaryCommunity: GoodsCommunityRow | undefined;
+  communityCount: number;
+  matchedRows: number;
+  representativeEntry: BuyerRankedEntry;
+  isCommunityControlled: boolean;
+};
+
+type BuyerReadinessBucket = 'ready-now' | 'relationship-path' | 'contact-gap';
+
+type BuyerPipelineCard = CanonicalBuyerCard & {
+  readiness: BuyerReadinessBucket;
+  readinessLabel: string;
+  readinessSummary: string;
+  readinessScore: number;
+  buyerOpportunityStage: string | null;
+  buyerOpportunityAssignedTo: string | null;
+  buyerOpportunityUpdatedAt: string | null;
+  buyerOpportunityValue: number;
+  communityPipelineStage: string | null;
+  communityPipelineAssignedTo: string | null;
+  communityPipelineUpdatedAt: string | null;
+  communityPipelineValue: number;
+  engagementStatus: string | null;
+  lastContactDate: string | null;
+  outcomeSummary: string;
+  outcomeBoost: number;
+};
+
+type CapitalOutreachTarget = {
+  key: string;
+  type: 'capital';
+  name: string;
+  company: string;
+  community: string | null;
+  state: string | null;
+  score: number;
+  reason: string;
+  nextAction: string;
+  recommendedAsk: string;
+  targetSummary: string;
+  link: string | null;
+  tags: string[];
+  source: CapitalTarget['source'];
+  instrumentType: string;
+  openness: CapitalTarget['openness'];
+};
+
+type PartnerOutreachTarget = {
+  key: string;
+  type: 'partner';
+  name: string;
+  company: string;
+  community: string | null;
+  state: string | null;
+  score: number;
+  reason: string;
+  nextAction: string;
+  recommendedAsk: string;
+  targetSummary: string;
+  tags: string[];
+};
+
+type OutreachPushTarget =
+  | BuyerOutreachTarget
+  | CapitalOutreachTarget
+  | PartnerOutreachTarget;
+
+const MODE_LABELS: Record<SearchMode, string> = {
+  'need-led': 'Need-led',
+  'buyer-led': 'Buyer-led',
+  'capital-led': 'Capital-led',
+  'partner-led': 'Partner-led',
+};
+
+const BUYER_ANCHOR_NAMES = [
+  'centrecorp',
+  'centrebuild',
+  'outback stores',
+  'alpa',
+  'arnhem land progress',
+  'miwatj',
+];
+
+const GOODS_KEYWORDS = [
+  'bed',
+  'mattress',
+  'washer',
+  'washing',
+  'fridge',
+  'refrigerat',
+  'whitegoods',
+  'household',
+  'housing',
+  'manufacturing',
+  'community',
+  'indigenous',
+  'remote',
+  'social enterprise',
+  'youth',
+  'employment',
+  'circular',
+];
+
+const GOODS_ADMIN_BASE_URL = 'https://www.goodsoncountry.com/admin';
+const GOODS_QBE_PROGRAM_URL = `${GOODS_ADMIN_BASE_URL}/qbe-program`;
+const GOODS_QBE_ACTIONS_URL = `${GOODS_ADMIN_BASE_URL}/qbe-actions`;
+
+function toNumber(value: number | string | null | undefined): number {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function money(value: number): string {
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function dateLabel(value: string | null): string {
+  if (!value) return '—';
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return '—';
+  return dt.toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function dateTimeLabel(value: string | null): string {
+  if (!value) return '—';
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return '—';
+  return dt.toLocaleString('en-AU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function normalise(value: string | null | undefined): string {
+  return (value || '').toLowerCase().trim();
+}
+
+function roleWeight(role: string | null): number {
+  switch (normalise(role)) {
+    case 'store':
+      return 18;
+    case 'housing_provider':
+      return 20;
+    case 'health_service':
+      return 14;
+    case 'council':
+      return 13;
+    case 'land_council':
+      return 16;
+    case 'community_org':
+      return 12;
+    case 'government':
+      return 10;
+    case 'education':
+      return 9;
+    default:
+      return 3;
+  }
+}
+
+function needScore(community: GoodsCommunityRow): { score: number; reason: string } {
+  const demandBeds = toNumber(community.demand_beds);
+  const demandWashers = toNumber(community.demand_washers);
+  const demandFridges = toNumber(community.demand_fridges);
+  const demandMattresses = toNumber(community.demand_mattresses);
+  const demandTotal = demandBeds + demandWashers + demandFridges + demandMattresses;
+  const overdue = toNumber(community.assets_overdue);
+  const deployed = toNumber(community.assets_deployed);
+  const buyers = toNumber(community.buyer_entity_count);
+  const ccPartners = toNumber(community.community_controlled_org_count);
+  const isNt = normalise(community.state) === 'nt';
+  const remoteWeight = normalise(community.remoteness).includes('very remote')
+    ? 16
+    : normalise(community.remoteness).includes('remote')
+      ? 10
+      : 2;
+  const thinMarketWeight = community.ndis_thin_market ? 8 : 0;
+  const missingBuyerWeight = buyers === 0 ? 20 : Math.max(0, 10 - buyers);
+  const lowCoveragePenalty = deployed === 0 ? 18 : Math.max(0, 8 - deployed);
+  const score = Math.round(
+    demandTotal * 1.7 +
+      overdue * 12 +
+      missingBuyerWeight +
+      lowCoveragePenalty +
+      remoteWeight +
+      thinMarketWeight +
+      (isNt ? 10 : 3) +
+      ccPartners * 1.2
+  );
+
+  const parts: string[] = [];
+  if (demandTotal > 0) parts.push(`${demandTotal} requested units`);
+  if (overdue > 0) parts.push(`${overdue} overdue assets`);
+  if (buyers === 0) parts.push('no known buyer coverage');
+  if (isNt) parts.push('NT priority lane');
+  if (thinMarketWeight > 0) parts.push('NDIS thin market pressure');
+  return { score, reason: parts.join(' • ') || 'baseline signal' };
+}
+
+function buyerPlausibilityScore(buyer: GoodsProcurementEntityRow, community: GoodsCommunityRow | undefined): { score: number; reason: string } {
+  const fit = toNumber(buyer.fit_score);
+  const contracts = toNumber(buyer.govt_contract_count);
+  const contractValue = toNumber(buyer.govt_contract_value);
+  const hasContact = buyer.contact_surface ? 8 : 0;
+  const hasNextAction = buyer.next_action ? 6 : 0;
+  const relationship = normalise(buyer.relationship_status);
+  const relationshipWeight = relationship === 'active' ? 12 : relationship === 'warm' ? 8 : relationship === 'cold' ? 2 : 4;
+  const anchorHit = BUYER_ANCHOR_NAMES.some((name) => normalise(buyer.entity_name).includes(name)) ? 25 : 0;
+  const communityWeight = community && normalise(community.state) === 'nt' ? 8 : 3;
+  const products = (buyer.product_fit || []).join(' ').toLowerCase();
+  const productWeight = ['bed', 'mattress', 'washer', 'fridge', 'whitegoods', 'housing'].reduce((acc, token) => {
+    return products.includes(token) ? acc + 3 : acc;
+  }, 0);
+  const score = Math.round(
+    fit +
+      roleWeight(buyer.buyer_role) +
+      Math.min(contracts * 1.5, 15) +
+      Math.min(contractValue / 250_000, 20) +
+      hasContact +
+      hasNextAction +
+      relationshipWeight +
+      anchorHit +
+      communityWeight +
+      productWeight +
+      (buyer.is_community_controlled ? 6 : 0)
+  );
+
+  const reason = [
+    buyer.buyer_role ? `${buyer.buyer_role.replace('_', ' ')} role` : null,
+    contracts > 0 ? `${contracts} contract records` : null,
+    hasContact ? 'contact surface visible' : 'contact surface missing',
+    anchorHit > 0 ? 'known remote buyer anchor' : null,
+  ]
+    .filter(Boolean)
+    .join(' • ');
+
+  return { score, reason: reason || 'scored from baseline fit and relationship status' };
+}
+
+function canonicalBuyerKey(buyer: GoodsProcurementEntityRow): string {
+  const abn = (buyer.abn || '').replace(/\D/g, '');
+  if (abn) return `abn:${abn}`;
+  const name = normalise(buyer.entity_name).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  if (name) return `name:${name}`;
+  return `buyer:${buyer.id}`;
+}
+
+function relationshipPriority(status: string | null | undefined): number {
+  switch (normalise(status)) {
+    case 'active':
+      return 5;
+    case 'warm':
+      return 4;
+    case 'prospect':
+      return 3;
+    case 'reviewing':
+      return 2;
+    case 'cold':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function roleLabel(role: string): string {
+  return role.replace(/_/g, ' ');
+}
+
+function buyerReadinessMeta(buyer: CanonicalBuyerCard): {
+  readiness: BuyerReadinessBucket;
+  readinessLabel: string;
+  readinessSummary: string;
+  readinessScore: number;
+} {
+  const relationship = normalise(buyer.relationshipStatus);
+  const hasDirectContact = Boolean(buyer.contactSurface);
+  const hasWebsite = Boolean(buyer.link);
+  const hasWarmPath = relationship === 'active' || relationship === 'warm' || relationship === 'prospect';
+
+  if (hasDirectContact) {
+    return {
+      readiness: 'ready-now',
+      readinessLabel: 'Ready now',
+      readinessSummary: 'Direct contact path visible. Push into live outreach this week.',
+      readinessScore: 30,
+    };
+  }
+
+  if (hasWarmPath || hasWebsite) {
+    return {
+      readiness: 'relationship-path',
+      readinessLabel: 'Needs path',
+      readinessSummary: hasWarmPath
+        ? 'Relationship signal exists. Use a warm intro or named path before broad outreach.'
+        : 'Website visible, but direct contact still needs to be found.',
+      readinessScore: 18,
+    };
+  }
+
+  return {
+    readiness: 'contact-gap',
+    readinessLabel: 'Contact gap',
+    readinessSummary: 'High-value buyer, but contact discovery is still missing.',
+    readinessScore: 4,
+  };
+}
+
+function parseBuyerOpportunityName(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(/^\[Buyer\]\s*(.+?)(?:\s+—\s+.*)?$/);
+  return match?.[1]?.trim() || null;
+}
+
+function parseCommunityOpportunityName(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(/^(.+?)\s+—\s+Goods Demand\b/i);
+  return match?.[1]?.trim() || null;
+}
+
+function csvEscape(value: unknown): string {
+  const text = String(value ?? '');
+  if (text.includes(',') || text.includes('"') || text.includes('\n')) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function downloadCsv(filename: string, rows: Array<Record<string, unknown>>) {
+  if (rows.length === 0) return;
+  const headers = Object.keys(rows[0]);
+  const lines = [headers.join(',')];
+  for (const row of rows) {
+    lines.push(headers.map((header) => csvEscape(row[header])).join(','));
+  }
+  const csv = lines.join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function downloadText(filename: string, text: string, mime = 'text/plain;charset=utf-8;') {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function toggleValue(current: string[], value: string): string[] {
+  return current.includes(value) ? current.filter((entry) => entry !== value) : [...current, value];
+}
+
+function communityLabel(community: GoodsCommunityRow | null | undefined): string {
+  if (!community) return 'unassigned community';
+  const parts = [community.community_name, community.state].filter(Boolean);
+  return parts.join(', ') || 'unassigned community';
+}
+
+function buyerRecommendedAsk(buyer: GoodsProcurementEntityRow, community: GoodsCommunityRow | undefined): string {
+  const communityText = communityLabel(community || null);
+  const role = normalise(buyer.buyer_role);
+  if (role === 'housing_provider') {
+    return `Open a housing fit conversation for remote-ready beds and mattresses in ${communityText}.`;
+  }
+  if (role === 'store') {
+    return `Test whether ${buyer.entity_name || 'this buyer'} can distribute a 100+ bed order or recurring essentials supply into ${communityText}.`;
+  }
+  if (role === 'health_service') {
+    return `Explore a health + housing pathway for beds, mattresses, and replacement assets in ${communityText}.`;
+  }
+  if (role === 'council' || role === 'land_council') {
+    return `Ask for the procurement entry path and local production appetite for community-made beds in ${communityText}.`;
+  }
+  return `Book a first scoping call on beds, mattresses, or essential asset supply into ${communityText}.`;
+}
+
+function capitalRecommendedAsk(target: CapitalTarget, community: GoodsCommunityRow | null): string {
+  const communityText = communityLabel(community);
+  if (target.instrumentType.toLowerCase().includes('loan') || target.instrumentType.toLowerCase().includes('catalytic')) {
+    return `Pitch plant + working-capital support for community production in ${communityText}, backed by bed demand and buyer pathways.`;
+  }
+  return `Pitch remote community manufacturing, youth jobs, and durable bed delivery in ${communityText}.`;
+}
+
+function partnerRecommendedAsk(partnerRole: string, community: GoodsCommunityRow | null): string {
+  const communityText = communityLabel(community);
+  return `Open a partnership conversation with ${partnerRole.replace('_', ' ')} organisations that could host production, assembly, distribution, or aftercare in ${communityText}.`;
+}
+
+function buyerTargetSummary(buyer: GoodsProcurementEntityRow, community: GoodsCommunityRow | undefined, reason: string): string {
+  return [
+    buyer.entity_name || 'Unnamed buyer',
+    buyer.buyer_role ? `${buyer.buyer_role.replace('_', ' ')} role` : null,
+    community ? `linked to ${communityLabel(community)}` : null,
+    reason,
+  ]
+    .filter(Boolean)
+    .join(' • ');
+}
+
+function canonicalBuyerTargetSummary(buyer: CanonicalBuyerCard, reason: string): string {
+  const communitySummary =
+    buyer.communities.length > 1
+      ? `${buyer.communities.slice(0, 3).map((community) => community.name).join(', ')}${buyer.communities.length > 3 ? ` +${buyer.communities.length - 3} more` : ''}`
+      : buyer.primaryCommunity
+        ? communityLabel(buyer.primaryCommunity)
+        : null;
+  return [
+    buyer.name,
+    buyer.roles.length ? `${buyer.roles.map(roleLabel).join(' / ')} role` : null,
+    communitySummary ? `covers ${communitySummary}` : null,
+    reason,
+  ]
+    .filter(Boolean)
+    .join(' • ');
+}
+
+function capitalTargetSummary(target: CapitalTarget, community: GoodsCommunityRow | null): string {
+  return [
+    `${target.name} via ${target.provider}`,
+    target.instrumentType,
+    community ? `best tied to ${communityLabel(community)}` : 'national / multi-community pathway',
+    target.reason,
+  ]
+    .filter(Boolean)
+    .join(' • ');
+}
+
+function partnerTargetSummary(role: string, count: number, topNames: string[], community: GoodsCommunityRow | null): string {
+  return [
+    `${count} ${role.replace('_', ' ')} organisations`,
+    community ? `around ${communityLabel(community)}` : null,
+    topNames.length ? `examples: ${topNames.join(', ')}` : null,
+  ]
+    .filter(Boolean)
+    .join(' • ');
+}
+
+function capitalTargetsFromFoundations(foundations: GoodsFoundationRow[]): CapitalTarget[] {
+  return foundations.map((foundation) => {
+    const text = [
+      foundation.name,
+      foundation.description,
+      (foundation.thematic_focus || []).join(' '),
+      (foundation.geographic_focus || []).join(' '),
+    ]
+      .join(' ')
+      .toLowerCase();
+    const geographyText = (foundation.geographic_focus || []).join(', ') || 'National / unspecified';
+    const confidence = normalise(foundation.profile_confidence);
+    const hasOpenPrograms =
+      Array.isArray(foundation.open_programs)
+        ? foundation.open_programs.length > 0
+        : !!foundation.open_programs;
+    const score =
+      (text.includes('indigenous') ? 18 : 0) +
+      (text.includes('community') ? 12 : 0) +
+      (text.includes('remote') ? 12 : 0) +
+      (text.includes('social enterprise') ? 11 : 0) +
+      (text.includes('manufacturing') ? 8 : 0) +
+      (text.includes('circular') ? 7 : 0) +
+      (text.includes('youth') ? 7 : 0) +
+      (text.includes('housing') ? 7 : 0) +
+      (text.includes('nt') || text.includes('northern territory') ? 10 : 0) +
+      (text.includes('qld') || text.includes('queensland') ? 5 : 0) +
+      (hasOpenPrograms ? 8 : 0) +
+      (toNumber(foundation.total_giving_annual) > 2_000_000 ? 12 : toNumber(foundation.total_giving_annual) > 500_000 ? 8 : 4) +
+      (confidence === 'high' ? 8 : confidence === 'medium' ? 4 : 1);
+
+    const openness: CapitalTarget['openness'] = hasOpenPrograms ? 'open' : 'relationship-led';
+    const instrumentType =
+      text.includes('loan') || text.includes('debt') || text.includes('catalytic')
+        ? 'Catalytic / blended finance'
+        : 'Grant / philanthropy';
+    const reason = [
+      text.includes('indigenous') ? 'Indigenous fit' : null,
+      text.includes('community') ? 'Community enterprise fit' : null,
+      text.includes('remote') ? 'Remote-region fit' : null,
+      hasOpenPrograms ? 'Open programs visible' : 'Likely relationship-led',
+    ]
+      .filter(Boolean)
+      .join(' • ');
+
+    return {
+      key: `foundation:${foundation.id}`,
+      source: 'foundation',
+      name: foundation.name || 'Unnamed foundation',
+      provider: foundation.type || 'Foundation',
+      score,
+      instrumentType,
+      openness,
+      amountHint: foundation.total_giving_annual ? `${money(toNumber(foundation.total_giving_annual))}/yr giving` : 'Amount undisclosed',
+      regionFit: geographyText,
+      reason: reason || 'Theme and geography fit',
+      link: foundation.website || null,
+    };
+  });
+}
+
+function capitalTargetsFromGrants(grants: GoodsGrantRow[]): CapitalTarget[] {
+  return grants.map((grant) => {
+    const text = [
+      grant.name,
+      grant.provider,
+      grant.geography,
+      (grant.categories || []).join(' '),
+      (grant.focus_areas || []).join(' '),
+      grant.grant_type,
+      grant.program_type,
+    ]
+      .join(' ')
+      .toLowerCase();
+    const maxAmount = Math.max(toNumber(grant.amount_max), toNumber(grant.amount_min));
+    const score =
+      (text.includes('indigenous') ? 18 : 0) +
+      (text.includes('community') ? 10 : 0) +
+      (text.includes('remote') ? 11 : 0) +
+      (text.includes('housing') ? 8 : 0) +
+      (text.includes('manufacturing') ? 9 : 0) +
+      (text.includes('social enterprise') ? 10 : 0) +
+      (text.includes('youth') ? 7 : 0) +
+      (text.includes('employment') ? 6 : 0) +
+      (text.includes('nt') || text.includes('northern territory') ? 10 : 0) +
+      (text.includes('qld') || text.includes('queensland') ? 6 : 0) +
+      (maxAmount >= 500_000 ? 14 : maxAmount >= 100_000 ? 8 : maxAmount > 0 ? 4 : 2);
+    const grantType = normalise(grant.grant_type);
+    const instrumentType = grantType.includes('loan') ? 'Loan / debt' : 'Grant';
+    const openness: CapitalTarget['openness'] =
+      grant.url || grant.status === 'open' || grant.status === null ? 'open' : 'mixed';
+    const reason = [
+      text.includes('indigenous') ? 'Indigenous/community fit' : null,
+      text.includes('remote') ? 'Remote geography fit' : null,
+      maxAmount > 0 ? `Ticket ${money(maxAmount)}` : 'Ticket not disclosed',
+      grant.closes_at ? `Closes ${dateLabel(grant.closes_at)}` : 'Rolling / no deadline',
+    ]
+      .filter(Boolean)
+      .join(' • ');
+    return {
+      key: `grant:${grant.id}`,
+      source: 'grant',
+      name: grant.name || 'Unnamed grant',
+      provider: grant.provider || 'Unknown provider',
+      score,
+      instrumentType,
+      openness,
+      amountHint: maxAmount > 0 ? money(maxAmount) : 'Amount undisclosed',
+      regionFit: grant.geography || 'National / unspecified',
+      reason,
+      link: grant.url || null,
+    };
+  });
+}
+
+export default function GoodsWorkspaceClient({
+  userEmail,
+  orgProfile,
+  ghlDefaultOwnerConfigured,
+  ghlDefaultOwnerLabel,
+  communities,
+  buyers,
+  signals,
+  foundations,
+  grants,
+  ntCoverageRows,
+  goodsPipelineStages,
+  goodsPipelineOpportunities,
+  goodsBuyerPipelineOpportunities,
+  goodsBuyerContacts,
+  goodsCommunityPipelineRows,
+  goodsPushLog,
+}: GoodsWorkspaceClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isRefreshing, startRefreshTransition] = useTransition();
+  const [mode, setMode] = useState<SearchMode>('need-led');
+  const [query, setQuery] = useState('');
+  const [selectedCommunityId, setSelectedCommunityId] = useState<string | null>(null);
+  const [showOnlyNt, setShowOnlyNt] = useState(true);
+  const [pushBusy, setPushBusy] = useState(false);
+  const [pushStatus, setPushStatus] = useState('');
+  const [selectedBuyerKeys, setSelectedBuyerKeys] = useState<string[]>([]);
+  const [selectedCapitalKeys, setSelectedCapitalKeys] = useState<string[]>([]);
+  const [selectedPartnerKeys, setSelectedPartnerKeys] = useState<string[]>([]);
+  const [ownerMode, setOwnerMode] = useState<'unassigned' | 'default-owner'>('unassigned');
+  const [relationshipMode, setRelationshipMode] = useState<'preserve' | 'advance'>('preserve');
+  const [buyerView, setBuyerView] = useState<'all' | BuyerReadinessBucket>('ready-now');
+  const [mapLayer, setMapLayer] = useState<GoodsMapLayer>('need');
+  const [mapExpanded, setMapExpanded] = useState(false);
+
+  const communityById = useMemo(() => {
+    return new Map(communities.map((community) => [community.id, community]));
+  }, [communities]);
+
+  useEffect(() => {
+    const modeParam = searchParams.get('mode');
+    const ntOnlyParam = searchParams.get('ntOnly');
+    const communityParam = searchParams.get('community')?.trim() || searchParams.get('place')?.trim() || '';
+    const lgaParam = searchParams.get('lga')?.trim() || '';
+    const stateParam = searchParams.get('state')?.trim().toUpperCase() || '';
+
+    if (modeParam && Object.prototype.hasOwnProperty.call(MODE_LABELS, modeParam)) {
+      setMode(modeParam as SearchMode);
+    }
+
+    if (ntOnlyParam === 'true') setShowOnlyNt(true);
+    if (ntOnlyParam === 'false') setShowOnlyNt(false);
+
+    if (!communityParam && !lgaParam) return;
+
+    const communityNeedle = normalise(communityParam);
+    const lgaNeedle = normalise(lgaParam);
+    const stateNeedle = normalise(stateParam);
+
+    const matchedCommunity = communities.find((community) => {
+      const matchesState = !stateNeedle || normalise(community.state) === stateNeedle;
+      if (!matchesState) return false;
+
+      const communityName = normalise(community.community_name);
+      const lgaName = normalise(community.lga_name);
+
+      const matchesCommunity =
+        !!communityNeedle &&
+        (communityName === communityNeedle ||
+          communityName.includes(communityNeedle) ||
+          communityNeedle.includes(communityName));
+
+      const matchesLga =
+        !!lgaNeedle &&
+        (lgaName === lgaNeedle || lgaName.includes(lgaNeedle) || lgaNeedle.includes(lgaName));
+
+      return matchesCommunity || matchesLga;
+    });
+
+    if (!matchedCommunity) return;
+
+    setSelectedCommunityId(matchedCommunity.id);
+    setQuery(matchedCommunity.community_name || matchedCommunity.lga_name || '');
+
+    if (stateParam === 'NT') setShowOnlyNt(true);
+    if (stateParam === 'QLD') setShowOnlyNt(false);
+  }, [communities, searchParams]);
+
+  const scopedCommunities = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return communities.filter((community) => {
+      if (showOnlyNt && normalise(community.state) !== 'nt') return false;
+      if (!q) return true;
+      const haystack = [
+        community.community_name,
+        community.postcode,
+        community.lga_name,
+        community.region_label,
+        community.service_region,
+        community.land_council,
+        community.known_buyer_name,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [communities, query, showOnlyNt]);
+
+  const sortedNeedCommunities = useMemo(() => {
+    return [...scopedCommunities]
+      .map((community) => ({ community, ...needScore(community) }))
+      .sort((a, b) => b.score - a.score);
+  }, [scopedCommunities]);
+
+  const selectedCommunity = useMemo(() => {
+    if (selectedCommunityId) {
+      return communityById.get(selectedCommunityId) || null;
+    }
+    return sortedNeedCommunities[0]?.community || null;
+  }, [communityById, selectedCommunityId, sortedNeedCommunities]);
+
+  function openCommunityDossier() {
+    const node = document.getElementById('goods-community-dossier');
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  const sortedBuyers = useMemo<BuyerRankedEntry[]>(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = buyers.filter((buyer) => {
+      const community = buyer.community_id ? communityById.get(buyer.community_id) : undefined;
+      if (showOnlyNt && community && normalise(community.state) !== 'nt') return false;
+      if (!q) return true;
+      const haystack = [
+        buyer.entity_name,
+        buyer.abn,
+        buyer.buyer_role,
+        buyer.contact_surface,
+        buyer.next_action,
+        community?.community_name,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+
+    const buyerRoleFilter = mode === 'partner-led'
+      ? new Set(['community_org', 'land_council', 'council', 'housing_provider', 'health_service'])
+      : null;
+
+    const scoped = buyerRoleFilter
+      ? filtered.filter((buyer) => buyerRoleFilter.has(normalise(buyer.buyer_role)))
+      : filtered;
+
+    return scoped
+      .map((buyer) => {
+        const community = buyer.community_id ? communityById.get(buyer.community_id) : undefined;
+        const score = buyerPlausibilityScore(buyer, community);
+        return { buyer, community, score };
+      })
+      .sort((a, b) => b.score.score - a.score.score);
+  }, [buyers, communityById, mode, query, showOnlyNt]);
+
+  const canonicalBuyers = useMemo<CanonicalBuyerCard[]>(() => {
+    const grouped = new Map<
+      string,
+      {
+        key: string;
+        name: string;
+        abn: string | null;
+        rows: BuyerRankedEntry[];
+        roles: Set<string>;
+        communities: Map<string, { id: string; name: string; state: string | null }>;
+        reasons: string[];
+        nextAction: string | null;
+        contactSurface: string | null;
+        relationshipStatus: string | null;
+        link: string | null;
+        contractCount: number;
+        contractValue: number;
+        representativeEntry: BuyerRankedEntry;
+        isCommunityControlled: boolean;
+      }
+    >();
+
+    for (const entry of sortedBuyers) {
+      const key = canonicalBuyerKey(entry.buyer);
+      const existing = grouped.get(key);
+      const community = entry.community
+        ? {
+            id: entry.community.id,
+            name: entry.community.community_name,
+            state: entry.community.state,
+          }
+        : null;
+
+      if (!existing) {
+        grouped.set(key, {
+          key,
+          name: entry.buyer.entity_name || 'Unnamed buyer',
+          abn: entry.buyer.abn || null,
+          rows: [entry],
+          roles: new Set(entry.buyer.buyer_role ? [entry.buyer.buyer_role] : []),
+          communities: new Map(community ? [[community.id, community]] : []),
+          reasons: entry.score.reason ? [entry.score.reason] : [],
+          nextAction: entry.buyer.next_action || null,
+          contactSurface: entry.buyer.contact_surface || null,
+          relationshipStatus: entry.buyer.relationship_status || null,
+          link: entry.buyer.website || null,
+          contractCount: toNumber(entry.buyer.govt_contract_count),
+          contractValue: toNumber(entry.buyer.govt_contract_value),
+          representativeEntry: entry,
+          isCommunityControlled: Boolean(entry.buyer.is_community_controlled),
+        });
+        continue;
+      }
+
+      existing.rows.push(entry);
+      if (entry.buyer.buyer_role) existing.roles.add(entry.buyer.buyer_role);
+      if (community) existing.communities.set(community.id, community);
+      if (entry.score.reason) existing.reasons.push(entry.score.reason);
+      existing.contractCount = Math.max(existing.contractCount, toNumber(entry.buyer.govt_contract_count));
+      existing.contractValue = Math.max(existing.contractValue, toNumber(entry.buyer.govt_contract_value));
+      existing.isCommunityControlled = existing.isCommunityControlled || Boolean(entry.buyer.is_community_controlled);
+
+      if (!existing.contactSurface && entry.buyer.contact_surface) {
+        existing.contactSurface = entry.buyer.contact_surface;
+      }
+      if (!existing.link && entry.buyer.website) {
+        existing.link = entry.buyer.website;
+      }
+      if (!existing.nextAction && entry.buyer.next_action) {
+        existing.nextAction = entry.buyer.next_action;
+      }
+      if (relationshipPriority(entry.buyer.relationship_status) > relationshipPriority(existing.relationshipStatus)) {
+        existing.relationshipStatus = entry.buyer.relationship_status;
+      }
+
+      const existingIsSelectedCommunity =
+        selectedCommunity && existing.representativeEntry.community?.id === selectedCommunity.id;
+      const nextIsSelectedCommunity = selectedCommunity && entry.community?.id === selectedCommunity.id;
+      if (
+        (!existingIsSelectedCommunity && nextIsSelectedCommunity) ||
+        (existingIsSelectedCommunity === nextIsSelectedCommunity &&
+          entry.score.score > existing.representativeEntry.score.score)
+      ) {
+        existing.representativeEntry = entry;
+      }
+    }
+
+    return Array.from(grouped.values())
+      .map((group) => {
+        const communities = Array.from(group.communities.values()).sort((a, b) => a.name.localeCompare(b.name));
+        const communityCount = communities.length;
+        const coversSelectedCommunity = Boolean(
+          selectedCommunity && communities.some((community) => community.id === selectedCommunity.id),
+        );
+        const primaryCommunity =
+          (coversSelectedCommunity
+            ? group.rows.find((row) => row.community?.id === selectedCommunity?.id)?.community
+            : undefined) || group.representativeEntry.community;
+        const reasons = uniqueStrings(group.reasons).slice(0, 3);
+        const score = Math.round(
+          group.representativeEntry.score.score +
+            Math.min(Math.max(communityCount - 1, 0) * 4, 20) +
+            (coversSelectedCommunity ? 18 : 0) +
+            (group.contactSurface ? 4 : 0) +
+            (group.isCommunityControlled ? 4 : 0),
+        );
+
+        return {
+          key: group.key,
+          name: group.name,
+          abn: group.abn,
+          score,
+          reasons,
+          nextAction:
+            group.nextAction || 'Find the procurement or supply contact and ask for the current buying path.',
+          contactSurface: group.contactSurface,
+          relationshipStatus: group.relationshipStatus,
+          link: group.link,
+          contractCount: group.contractCount,
+          contractValue: group.contractValue,
+          roles: Array.from(group.roles),
+          communities,
+          primaryCommunity,
+          communityCount,
+          matchedRows: group.rows.length,
+          representativeEntry: group.representativeEntry,
+          isCommunityControlled: group.isCommunityControlled,
+        };
+      })
+      .sort((a, b) => b.score - a.score);
+  }, [selectedCommunity, sortedBuyers]);
+
+  const buyerOpportunityLookup = useMemo(() => {
+    const lookup = new Map<string, GoodsBuyerGhlOpportunityRow>();
+    for (const opportunity of goodsBuyerPipelineOpportunities) {
+      const key = normalise(parseBuyerOpportunityName(opportunity.name));
+      if (!key || lookup.has(key)) continue;
+      lookup.set(key, opportunity);
+    }
+    return lookup;
+  }, [goodsBuyerPipelineOpportunities]);
+
+  const buyerContactLookup = useMemo(() => {
+    const lookup = new Map<string, GoodsBuyerGhlContactRow>();
+    for (const contact of goodsBuyerContacts) {
+      const key = normalise(contact.company_name);
+      if (!key || lookup.has(key)) continue;
+      lookup.set(key, contact);
+    }
+    return lookup;
+  }, [goodsBuyerContacts]);
+
+  const communityPipelineLookup = useMemo(() => {
+    const lookup = new Map<string, GoodsCommunityPipelineRow>();
+    for (const opportunity of goodsCommunityPipelineRows) {
+      const key = normalise(parseCommunityOpportunityName(opportunity.name));
+      if (!key || lookup.has(key)) continue;
+      lookup.set(key, opportunity);
+    }
+    return lookup;
+  }, [goodsCommunityPipelineRows]);
+
+  const buyerPipelineCards = useMemo<BuyerPipelineCard[]>(() => {
+    return canonicalBuyers
+      .map((buyer) => {
+        const readiness = buyerReadinessMeta(buyer);
+        const buyerOpportunity = buyerOpportunityLookup.get(normalise(buyer.name));
+        const buyerContact = buyerContactLookup.get(normalise(buyer.name));
+        const communityPipeline = buyer.primaryCommunity
+          ? communityPipelineLookup.get(normalise(buyer.primaryCommunity.community_name))
+          : undefined;
+        const activeBuyerStage = normalise(buyerOpportunity?.stage_name);
+        const buyerOutcomeBoost =
+          buyerOpportunity
+            ? (buyerOpportunity.assigned_to ? 10 : 4) +
+              (activeBuyerStage && activeBuyerStage !== 'new lead' && activeBuyerStage !== 'unknown' ? 12 : 0)
+            : 0;
+        const communityOutcomeBoost =
+          communityPipeline
+            ? (communityPipeline.assigned_to ? 6 : 2) +
+              (normalise(communityPipeline.stage_name) && normalise(communityPipeline.stage_name) !== 'new lead' ? 4 : 0)
+            : 0;
+        const outcomeBoost = buyerOutcomeBoost + communityOutcomeBoost;
+        const outcomeSummary = buyerOpportunity
+          ? `Buyer CRM live: ${buyerOpportunity.stage_name || 'Unknown'}${buyerOpportunity.assigned_to ? ` • ${buyerOpportunity.assigned_to}` : ''}`
+          : communityPipeline
+            ? `Community demand live: ${communityPipeline.stage_name || 'Unknown'}${communityPipeline.assigned_to ? ` • ${communityPipeline.assigned_to}` : ''}`
+            : 'No Goods CRM activity recorded yet';
+        return {
+          ...buyer,
+          ...readiness,
+          readinessScore: readiness.readinessScore + outcomeBoost,
+          buyerOpportunityStage: buyerOpportunity?.stage_name || null,
+          buyerOpportunityAssignedTo: buyerOpportunity?.assigned_to || null,
+          buyerOpportunityUpdatedAt: buyerOpportunity?.updated_at || null,
+          buyerOpportunityValue: toNumber(buyerOpportunity?.monetary_value),
+          communityPipelineStage: communityPipeline?.stage_name || null,
+          communityPipelineAssignedTo: communityPipeline?.assigned_to || null,
+          communityPipelineUpdatedAt: communityPipeline?.updated_at || null,
+          communityPipelineValue: toNumber(communityPipeline?.monetary_value),
+          engagementStatus: buyerContact?.engagement_status || null,
+          lastContactDate: buyerContact?.last_contact_date || null,
+          outcomeSummary,
+          outcomeBoost,
+        };
+      })
+      .sort((a, b) => {
+        if (b.readinessScore !== a.readinessScore) return b.readinessScore - a.readinessScore;
+        return b.score - a.score;
+      });
+  }, [buyerContactLookup, buyerOpportunityLookup, canonicalBuyers, communityPipelineLookup]);
+
+  const capitalTargets = useMemo(() => {
+    const foundationTargets = capitalTargetsFromFoundations(foundations);
+    const grantTargets = capitalTargetsFromGrants(grants);
+    const merged = [...foundationTargets, ...grantTargets];
+    const q = query.trim().toLowerCase();
+    const filtered = merged.filter((target) => {
+      if (!q) return true;
+      const haystack = [target.name, target.provider, target.reason, target.regionFit].join(' ').toLowerCase();
+      return haystack.includes(q);
+    });
+    return filtered.sort((a, b) => b.score - a.score);
+  }, [foundations, grants, query]);
+
+  const selectedCommunitySignals = useMemo(() => {
+    if (!selectedCommunity) return [];
+    return signals
+      .filter((signal) => signal.community_id === selectedCommunity.id)
+      .slice(0, 8);
+  }, [selectedCommunity, signals]);
+
+  const partnerGraphRows = useMemo(() => {
+    const rows = canonicalBuyers.slice(0, 160).reduce<Record<string, { role: string; count: number; topNames: string[] }>>((acc, buyer) => {
+      const roles = buyer.roles.length > 0 ? buyer.roles : ['other'];
+      for (const role of roles) {
+        if (!acc[role]) {
+          acc[role] = { role, count: 0, topNames: [] };
+        }
+        acc[role].count += 1;
+        if (buyer.name && !acc[role].topNames.includes(buyer.name) && acc[role].topNames.length < 4) {
+          acc[role].topNames.push(buyer.name);
+        }
+      }
+      return acc;
+    }, {});
+    return Object.values(rows).sort((a, b) => b.count - a.count);
+  }, [canonicalBuyers]);
+
+  const crosswalkLookup = useMemo(() => {
+    const lookup = new Map<string, NtCommunityCoverageRow>();
+    for (const row of ntCoverageRows) {
+      const key = normalise(row.community_name);
+      if (key) lookup.set(key, row);
+    }
+    return lookup;
+  }, [ntCoverageRows]);
+
+  const mapPoints = useMemo(() => {
+    return sortedNeedCommunities
+      .map((row) => ({
+        id: row.community.id,
+        name: row.community.community_name,
+        state: row.community.state,
+        lat: toNumber(row.community.latitude),
+        lng: toNumber(row.community.longitude),
+        needScore: row.score,
+        needReason: row.reason,
+        demandBeds: toNumber(row.community.demand_beds),
+        demandWashers: toNumber(row.community.demand_washers),
+        demandFridges: toNumber(row.community.demand_fridges),
+        buyerCount: toNumber(row.community.buyer_entity_count),
+        partnerCount: toNumber(row.community.community_controlled_org_count),
+        goodsBuyerGap: normalise(row.community.state) === 'nt' && toNumber(row.community.buyer_entity_count) === 0,
+        crosswalkBuyerGap: toNumber(crosswalkLookup.get(normalise(row.community.community_name))?.buyer_match_count) === 0,
+        postcodeGap: Boolean(crosswalkLookup.get(normalise(row.community.community_name))?.needs_postcode_enrichment),
+        remoteness: row.community.remoteness,
+        proofLine: row.community.proof_line,
+      }))
+      .filter((row) => Number.isFinite(row.lat) && Number.isFinite(row.lng) && row.lat !== 0 && row.lng !== 0);
+  }, [crosswalkLookup, sortedNeedCommunities]);
+
+  const selectedMapPoint = useMemo(() => {
+    if (!selectedCommunity) return mapPoints[0] || null;
+    return mapPoints.find((point) => point.id === selectedCommunity.id) || mapPoints[0] || null;
+  }, [mapPoints, selectedCommunity]);
+
+  const crosswalkZeroBuyerRows = useMemo(() => {
+    return ntCoverageRows.filter((row) => toNumber(row.buyer_match_count) === 0).slice(0, 20);
+  }, [ntCoverageRows]);
+
+  const crosswalkZeroBuyerCount = useMemo(() => {
+    return ntCoverageRows.filter((row) => toNumber(row.buyer_match_count) === 0).length;
+  }, [ntCoverageRows]);
+
+  const goodsZeroBuyerRows = useMemo(() => {
+    return scopedCommunities
+      .filter((community) => normalise(community.state) === 'nt' && toNumber(community.buyer_entity_count) === 0)
+      .slice(0, 20);
+  }, [scopedCommunities]);
+
+  const goodsZeroBuyerCount = goodsZeroBuyerRows.length;
+
+  const postcodeGaps = useMemo(() => {
+    return ntCoverageRows.filter((row) => row.needs_postcode_enrichment).length;
+  }, [ntCoverageRows]);
+
+  const buyerOutreachTargets = useMemo<BuyerOutreachTarget[]>(() => {
+    return buyerPipelineCards.map((entry) => {
+      const roleTags = entry.roles.map((role) => `buyer-role-${normalise(role).replace(/\s+/g, '-')}`);
+      const tags = [
+        'goods-workspace',
+        'buyer-target',
+        showOnlyNt ? 'nt-priority' : 'nt-qld',
+        ...roleTags,
+      ];
+      const reason = uniqueStrings([
+        ...entry.reasons,
+        entry.communityCount > 1 ? `covers ${entry.communityCount} linked communities` : null,
+        entry.primaryCommunity && selectedCommunity && entry.primaryCommunity.id === selectedCommunity.id
+          ? 'selected community match'
+          : null,
+      ]).join(' • ');
+      const crmPreviewOperation = entry.buyerOpportunityStage ? 'update-opportunity' : 'create-opportunity';
+      const crmPreviewSummary = entry.buyerOpportunityStage
+        ? `Will update existing buyer opportunity in ${entry.buyerOpportunityStage}${entry.buyerOpportunityAssignedTo ? ` • owner ${entry.buyerOpportunityAssignedTo}` : ''}.`
+        : entry.communityPipelineStage
+          ? `Will create a new buyer opportunity. Community demand lane already exists in ${entry.communityPipelineStage}.`
+          : 'Will create a new buyer opportunity in the Goods pipeline.';
+
+      return {
+        key: entry.key,
+        type: 'buyer',
+        name: entry.name,
+        company: entry.name,
+        community: entry.primaryCommunity?.community_name || null,
+        state: entry.primaryCommunity?.state || null,
+        score: entry.score,
+        reason: reason || entry.representativeEntry.score.reason,
+        nextAction: entry.nextAction,
+        recommendedAsk: buyerRecommendedAsk(entry.representativeEntry.buyer, entry.primaryCommunity),
+        targetSummary: canonicalBuyerTargetSummary(entry, reason || entry.representativeEntry.score.reason),
+        contactSurface: entry.contactSurface,
+        relationshipStatus: entry.relationshipStatus,
+        link: entry.link,
+        crmPreviewOperation,
+        crmPreviewSummary,
+        tags,
+      };
+    });
+  }, [buyerPipelineCards, selectedCommunity, showOnlyNt]);
+
+  const buyerPipelineCounts = useMemo(() => {
+    return buyerPipelineCards.reduce(
+      (acc, buyer) => {
+        acc.all += 1;
+        acc[buyer.readiness] += 1;
+        return acc;
+      },
+      {
+        all: 0,
+        'ready-now': 0,
+        'relationship-path': 0,
+        'contact-gap': 0,
+      } as Record<'all' | BuyerReadinessBucket, number>,
+    );
+  }, [buyerPipelineCards]);
+
+  const visibleBuyerPipelineCards = useMemo(() => {
+    return buyerView === 'all'
+      ? buyerPipelineCards
+      : buyerPipelineCards.filter((buyer) => buyer.readiness === buyerView);
+  }, [buyerPipelineCards, buyerView]);
+
+  const capitalOutreachTargets = useMemo<CapitalOutreachTarget[]>(() => {
+    return capitalTargets.map((target) => ({
+      key: target.key,
+      type: 'capital',
+      name: target.name,
+      company: target.provider,
+      community: selectedCommunity?.community_name || null,
+      state: selectedCommunity?.state || null,
+      score: target.score,
+      reason: target.reason,
+      nextAction:
+        target.openness === 'open'
+          ? 'Export this target with a tailored ask and move to first outreach.'
+          : 'Treat this as relationship-led: identify introducers, warm links, or board-level pathway first.',
+      recommendedAsk: capitalRecommendedAsk(target, selectedCommunity),
+      targetSummary: capitalTargetSummary(target, selectedCommunity),
+      link: target.link,
+      tags: ['goods-workspace', 'capital-target', target.source, target.openness],
+      source: target.source,
+      instrumentType: target.instrumentType,
+      openness: target.openness,
+    }));
+  }, [capitalTargets, selectedCommunity]);
+
+  const partnerOutreachTargets = useMemo<PartnerOutreachTarget[]>(() => {
+    return partnerGraphRows.map((partner) => ({
+      key: partner.role,
+      type: 'partner',
+      name: partner.topNames[0] || partner.role.replace('_', ' '),
+      company: partner.topNames[0] || partner.role.replace('_', ' '),
+      community: selectedCommunity?.community_name || null,
+      state: selectedCommunity?.state || null,
+      score: partner.count * 10,
+      reason: `Partner cluster ${partner.role.replace('_', ' ')} (${partner.count})`,
+      nextAction: 'Open a production or distribution scoping conversation with the strongest named organisations in this cluster.',
+      recommendedAsk: partnerRecommendedAsk(partner.role, selectedCommunity),
+      targetSummary: partnerTargetSummary(partner.role, partner.count, partner.topNames, selectedCommunity),
+      tags: ['goods-workspace', 'partner-target', partner.role],
+    }));
+  }, [partnerGraphRows, selectedCommunity]);
+
+  const selectedBuyerTargets = useMemo(() => {
+    const explicit = buyerOutreachTargets.filter((target) => selectedBuyerKeys.includes(target.key));
+    if (explicit.length > 0) return explicit;
+
+    const readyNow = buyerOutreachTargets.filter((target) => {
+      const source = buyerPipelineCards.find((buyer) => buyer.key === target.key);
+      return source?.readiness === 'ready-now';
+    });
+    const relationshipPath = buyerOutreachTargets.filter((target) => {
+      const source = buyerPipelineCards.find((buyer) => buyer.key === target.key);
+      return source?.readiness === 'relationship-path';
+    });
+    const contactGaps = buyerOutreachTargets.filter((target) => {
+      const source = buyerPipelineCards.find((buyer) => buyer.key === target.key);
+      return source?.readiness === 'contact-gap';
+    });
+
+    return [...readyNow, ...relationshipPath, ...contactGaps].slice(0, 6);
+  }, [buyerOutreachTargets, buyerPipelineCards, selectedBuyerKeys]);
+
+  const selectedCapitalTargets = useMemo(() => {
+    const explicit = capitalOutreachTargets.filter((target) => selectedCapitalKeys.includes(target.key));
+    return explicit.length > 0 ? explicit : capitalOutreachTargets.slice(0, 5);
+  }, [capitalOutreachTargets, selectedCapitalKeys]);
+
+  const selectedPartnerTargets = useMemo(() => {
+    const explicit = partnerOutreachTargets.filter((target) => selectedPartnerKeys.includes(target.key));
+    return explicit.length > 0 ? explicit : partnerOutreachTargets.slice(0, 3);
+  }, [partnerOutreachTargets, selectedPartnerKeys]);
+
+  const hasExplicitSelection =
+    selectedBuyerKeys.length > 0 || selectedCapitalKeys.length > 0 || selectedPartnerKeys.length > 0;
+
+  const ghlTargets = useMemo<OutreachPushTarget[]>(() => {
+    return [...selectedBuyerTargets, ...selectedCapitalTargets, ...selectedPartnerTargets];
+  }, [selectedBuyerTargets, selectedCapitalTargets, selectedPartnerTargets]);
+
+  const crmPayload = useMemo(() => {
+    return {
+      workspace: 'goods-workspace',
+      selected_community: selectedCommunity
+        ? {
+            name: selectedCommunity.community_name,
+            state: selectedCommunity.state,
+            postcode: selectedCommunity.postcode,
+            need_signal: needScore(selectedCommunity),
+          }
+        : null,
+      selection_mode: hasExplicitSelection ? 'manual' : 'top-ranked-defaults',
+      buyers: selectedBuyerTargets,
+      capital: selectedCapitalTargets,
+      partners: selectedPartnerTargets,
+    };
+  }, [hasExplicitSelection, selectedBuyerTargets, selectedCapitalTargets, selectedCommunity, selectedPartnerTargets]);
+
+  async function runGhlPush(dryRun: boolean) {
+    setPushBusy(true);
+    setPushStatus('');
+    try {
+      const response = await fetch('/api/goods-workspace/ghl-push', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dryRun,
+          maxTargets: 30,
+          ownerMode,
+          relationshipMode,
+          targets: ghlTargets,
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setPushStatus(`Push failed: ${data.error || 'Unknown error'}`);
+        return;
+      }
+      setPushStatus(
+        dryRun
+          ? `Dry run OK: ${data.total} targets prepared for GHL.`
+          : `GHL push complete: ${data.succeeded}/${data.total} succeeded${data.created ? `, ${data.created} created` : ''}${data.updated ? `, ${data.updated} updated` : ''}${data.failed > 0 ? `, ${data.failed} failed` : ''}.`,
+      );
+      if (!dryRun) {
+        startRefreshTransition(() => {
+          router.refresh();
+        });
+      }
+    } catch (error) {
+      setPushStatus(`Push failed: ${error instanceof Error ? error.message : 'Network error'}`);
+    } finally {
+      setPushBusy(false);
+    }
+  }
+
+  const pipelineTotals = useMemo(() => {
+    return goodsPipelineStages.reduce(
+      (acc, row) => {
+        acc.count += toNumber(row.stage_count);
+        acc.value += toNumber(row.stage_value);
+        return acc;
+      },
+      { count: 0, value: 0 },
+    );
+  }, [goodsPipelineStages]);
+
+  const pushLogRows = useMemo(() => {
+    return goodsPushLog.map((row) => {
+      const metadata = row.metadata && typeof row.metadata === 'object' ? (row.metadata as Record<string, unknown>) : {};
+      return {
+        id: row.id,
+        status: row.status || 'unknown',
+        processed: toNumber(row.records_processed),
+        created: toNumber(row.records_created),
+        updated: toNumber(row.records_updated),
+        failed: toNumber(row.records_failed),
+        triggeredBy: row.triggered_by || 'unknown',
+        startedAt: row.started_at,
+        ownerMode: typeof metadata.ownerMode === 'string' ? metadata.ownerMode : 'unknown',
+        relationshipMode: typeof metadata.relationshipMode === 'string' ? metadata.relationshipMode : 'unknown',
+        dryRun: Boolean(metadata.dryRun),
+      };
+    });
+  }, [goodsPushLog]);
+
+  const latestLivePush = useMemo(() => {
+    return pushLogRows.find((row) => !row.dryRun) || null;
+  }, [pushLogRows]);
+
+  const recentMovement = useMemo(() => {
+    const assignedCount = goodsPipelineOpportunities.filter((opportunity) => Boolean(opportunity.assigned_to)).length;
+    const activeCount = goodsPipelineOpportunities.filter((opportunity) => {
+      const stageName = normalise(opportunity.stage_name);
+      return Boolean(stageName) && stageName !== 'new lead' && stageName !== 'unknown';
+    }).length;
+
+    const latestPushTs = latestLivePush?.startedAt ? new Date(latestLivePush.startedAt).getTime() : Number.NaN;
+    const updatedSinceLastPush =
+      Number.isFinite(latestPushTs)
+        ? goodsPipelineOpportunities.filter((opportunity) => {
+            const updatedTs = opportunity.updated_at ? new Date(opportunity.updated_at).getTime() : Number.NaN;
+            return Number.isFinite(updatedTs) && updatedTs > latestPushTs;
+          })
+        : [];
+
+    return {
+      assignedCount,
+      activeCount,
+      updatedSinceLastPush,
+    };
+  }, [goodsPipelineOpportunities, latestLivePush]);
+
+  const exportBuyerRows = useMemo(() => {
+    return buyerOutreachTargets.slice(0, 50).map((entry) => ({
+      buyer_name: entry.name,
+      company: entry.company,
+      community: entry.community || '',
+      state: entry.state || '',
+      readiness:
+        buyerPipelineCards.find((buyer) => buyer.key === entry.key)?.readinessLabel || '',
+      communities_covered:
+        buyerPipelineCards.find((buyer) => buyer.key === entry.key)?.communities.map((community) => community.name).join(' | ') || '',
+      plausibility_score: entry.score,
+      why_plausible: entry.reason,
+      relationship_status: entry.relationshipStatus || '',
+      contact_surface: entry.contactSurface || '',
+      recommended_ask: entry.recommendedAsk,
+      next_action: entry.nextAction,
+      target_summary: entry.targetSummary,
+      website: entry.link || '',
+    }));
+  }, [buyerOutreachTargets, buyerPipelineCards]);
+
+  const exportCapitalRows = useMemo(() => {
+    return capitalOutreachTargets.slice(0, 60).map((target) => ({
+      source: target.source,
+      target_name: target.name,
+      provider: target.company,
+      capital_fit_score: target.score,
+      instrument_type: target.instrumentType,
+      openness: target.openness,
+      community: target.community || '',
+      state: target.state || '',
+      why_fit: target.reason,
+      recommended_ask: target.recommendedAsk,
+      next_action: target.nextAction,
+      target_summary: target.targetSummary,
+      url: target.link || '',
+    }));
+  }, [capitalOutreachTargets]);
+
+  const selectedTargetRows = useMemo(() => {
+    return ghlTargets.map((target) => ({
+      target_type: target.type,
+      target_name: target.name,
+      company_or_provider: target.company,
+      community: target.community || '',
+      state: target.state || '',
+      score: target.score,
+      why_now: target.reason,
+      recommended_ask: target.recommendedAsk,
+      next_action: target.nextAction,
+      relationship_or_openness:
+        target.type === 'buyer'
+          ? target.relationshipStatus || ''
+          : target.type === 'capital'
+            ? target.openness
+            : 'partner cluster',
+      contact_surface_or_link:
+        target.type === 'buyer'
+          ? target.contactSurface || target.link || ''
+          : target.type === 'capital'
+            ? target.link || ''
+            : '',
+      crm_push_preview:
+        target.type === 'buyer'
+          ? target.crmPreviewSummary
+          : target.type === 'capital'
+            ? 'Will create or update a capital target opportunity in Goods pipeline.'
+            : 'Will create or update a partner target opportunity in Goods pipeline.',
+      target_summary: target.targetSummary,
+      tags: target.tags.join(' | '),
+    }));
+  }, [ghlTargets]);
+
+  const selectedBuyerPushSummary = useMemo(() => {
+    return selectedBuyerTargets.reduce(
+      (acc, target) => {
+        if (target.crmPreviewOperation === 'update-opportunity') acc.update += 1;
+        else acc.create += 1;
+        return acc;
+      },
+      { create: 0, update: 0 },
+    );
+  }, [selectedBuyerTargets]);
+
+  const weeklySnapshotMarkdown = useMemo(() => {
+    const leadCommunity = selectedCommunity
+      ? `- Focus community: ${communityLabel(selectedCommunity)}\n- Need signal: ${needScore(selectedCommunity).reason}\n`
+      : '- Focus community: none selected\n';
+    const buyerLines = selectedBuyerTargets
+      .map((target, index) => `${index + 1}. ${target.name} (${target.score})\n   Why: ${target.reason}\n   Ask: ${target.recommendedAsk}\n   Next: ${target.nextAction}`)
+      .join('\n');
+    const capitalLines = selectedCapitalTargets
+      .map((target, index) => `${index + 1}. ${target.name} (${target.score})\n   Why: ${target.reason}\n   Ask: ${target.recommendedAsk}\n   Next: ${target.nextAction}`)
+      .join('\n');
+    const partnerLines = selectedPartnerTargets
+      .map((target, index) => `${index + 1}. ${target.name} (${target.score})\n   Why: ${target.reason}\n   Ask: ${target.recommendedAsk}`)
+      .join('\n');
+    return `# Goods Workspace Weekly Operating Snapshot
+
+Generated from CivicGraph Goods Workspace.
+
+## Focus
+${leadCommunity}
+- Selection mode: ${hasExplicitSelection ? 'manual selection' : 'top-ranked defaults'}
+- Buyer targets in push set: ${selectedBuyerTargets.length}
+- Capital targets in push set: ${selectedCapitalTargets.length}
+- Partner targets in push set: ${selectedPartnerTargets.length}
+
+## Buyer pipeline
+${buyerLines || 'No buyer targets selected.'}
+
+## Capital stack
+${capitalLines || 'No capital targets selected.'}
+
+## Partner graph
+${partnerLines || 'No partner targets selected.'}
+
+## Immediate next actions
+1. Push the selected targets into GHL.
+2. Start outreach on buyers with visible contact surfaces first.
+3. Export capital targets into the Notion outreach table with the recommended ask attached.
+`;
+  }, [hasExplicitSelection, selectedBuyerTargets, selectedCapitalTargets, selectedCommunity, selectedPartnerTargets]);
+
+  const workflowLeadText = mode === 'need-led'
+    ? 'Start from highest-need communities with weakest current coverage, then route to buyers.'
+    : mode === 'buyer-led'
+      ? 'Start from highest-plausibility buyers, then confirm need and production leverage in-community.'
+      : mode === 'capital-led'
+        ? 'Start from strongest funding pathways, then connect to delivery proof and procurement demand.'
+        : 'Start from strongest community partner clusters, then tie to buyers and capital pathways.';
+
+  return (
+    <div className="max-w-[1700px] mx-auto pb-16">
+      <div className="mb-4">
+        <Link href="/tender-intelligence" className="text-xs font-black uppercase tracking-widest text-bauhaus-muted hover:text-bauhaus-black">
+          &larr; Back to Tender Intelligence
+        </Link>
+      </div>
+
+      <section className="border-4 border-bauhaus-black bg-bauhaus-black text-white p-6">
+        <p className="text-xs font-black uppercase tracking-[0.28em] text-bauhaus-yellow mb-3">Goods Workspace</p>
+        <h1 className="text-4xl font-black uppercase tracking-tight mb-3">NT + Remote Buyer & Capital Engine</h1>
+        <p className="text-base text-white/80 max-w-5xl mb-4">
+          Discovery workspace for Goods on Country: map community need, rank plausible procurement buyers for beds and household essentials,
+          and connect to grants, catalytic capital, and philanthropy before pushing approved targets into GHL and the weekly QBE cockpit.
+        </p>
+        <div className="mb-4 grid grid-cols-1 xl:grid-cols-[1fr_auto] gap-4 border-2 border-white/30 bg-white/5 p-4">
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-[0.28em] text-bauhaus-yellow mb-2">Research Workspace</p>
+            <p className="text-sm text-white/85 max-w-4xl">
+              Use this page to discover and rank buyers, capital targets, and partner paths. Run the live weekly raise and outreach process in
+              Goods <span className="font-black">QBE Program</span> and <span className="font-black">QBE Actions</span>, with
+              <span className="font-black"> GHL</span> as the relationship system of record.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-start gap-2 xl:justify-end">
+            <a
+              href={GOODS_QBE_PROGRAM_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="border-2 border-white bg-white px-3 py-2 text-xs font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-yellow"
+            >
+              Open QBE Program
+            </a>
+            <a
+              href={GOODS_QBE_ACTIONS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="border-2 border-white/70 px-3 py-2 text-xs font-black uppercase tracking-widest text-white hover:border-white hover:bg-white hover:text-bauhaus-black"
+            >
+              Open QBE Actions
+            </a>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3 text-sm">
+          <div className="border-2 border-white/40 p-3">
+            <p className="text-[10px] uppercase tracking-widest text-white/70 mb-1">1. Need Signal</p>
+            <p className="font-bold">Map high-pressure communities first.</p>
+          </div>
+          <div className="border-2 border-white/40 p-3">
+            <p className="text-[10px] uppercase tracking-widest text-white/70 mb-1">2. Buyer Pipeline</p>
+            <p className="font-bold">Rank who can plausibly buy/distribute 100+ beds.</p>
+          </div>
+          <div className="border-2 border-white/40 p-3">
+            <p className="text-[10px] uppercase tracking-widest text-white/70 mb-1">3. Capital Stack</p>
+            <p className="font-bold">Match grants, loans, and catalytic capital to stage fit.</p>
+          </div>
+          <div className="border-2 border-white/40 p-3">
+            <p className="text-[10px] uppercase tracking-widest text-white/70 mb-1">4. Outreach Exports</p>
+            <p className="font-bold">Push prepared targets into GHL, then work them from QBE Actions.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-4 border-4 border-bauhaus-black bg-white p-5">
+        <div className="grid grid-cols-1 xl:grid-cols-[1fr_auto] gap-4 items-start">
+          <div>
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue mb-2">Goods Thesis</p>
+            <p className="text-sm text-bauhaus-black leading-relaxed">
+              Build community-owned production and delivery pathways for beds and essentials in remote communities.
+              Use Oonchiumpa and partner communities as proof nodes: local manufacturing, youth jobs, lower freight waste, and stronger asset longevity.
+            </p>
+            <p className="mt-3 text-xs font-medium uppercase tracking-widest text-bauhaus-muted">
+              Discovery here. Execution in GHL + QBE Program.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-2 min-w-[320px]">
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Communities</p>
+              <p className="text-2xl font-black">{scopedCommunities.length}</p>
+            </div>
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Buyer Targets</p>
+              <p className="text-2xl font-black">{canonicalBuyers.length}</p>
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted mt-1">{sortedBuyers.length} linked rows</p>
+            </div>
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Capital Targets</p>
+              <p className="text-2xl font-black">{capitalTargets.length}</p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-4">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search community, postcode, buyer, funder, role, or region"
+            className="border-4 border-bauhaus-black px-4 py-3 text-base font-medium w-full"
+          />
+          <div className="flex flex-wrap gap-2">
+            {(Object.keys(MODE_LABELS) as SearchMode[]).map((nextMode) => (
+              <button
+                key={nextMode}
+                onClick={() => setMode(nextMode)}
+                className={`px-3 py-2 border-2 border-bauhaus-black text-xs font-black uppercase tracking-widest ${
+                  mode === nextMode ? 'bg-bauhaus-black text-white' : 'bg-white text-bauhaus-black'
+                }`}
+              >
+                {MODE_LABELS[nextMode]}
+              </button>
+            ))}
+            <button
+              onClick={() => setShowOnlyNt((current) => !current)}
+              className={`px-3 py-2 border-2 border-bauhaus-black text-xs font-black uppercase tracking-widest ${
+                showOnlyNt ? 'bg-bauhaus-red text-white' : 'bg-white text-bauhaus-black'
+              }`}
+            >
+              {showOnlyNt ? 'NT-only' : 'NT + QLD'}
+            </button>
+          </div>
+        </div>
+        <p className="mt-3 text-sm text-bauhaus-muted">{workflowLeadText}</p>
+      </section>
+
+      <section className="mt-4 grid grid-cols-1 xl:grid-cols-[1.1fr_1fr] gap-4">
+        <div className="border-4 border-bauhaus-black bg-white p-4">
+          <div className="flex items-start justify-between gap-4 mb-3">
+            <div>
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Need Signal</p>
+              <h2 className="text-2xl font-black mt-1">Community Need Map</h2>
+            </div>
+            <div className="text-right text-xs text-bauhaus-muted">
+              <p>{mapPoints.length} mapped communities</p>
+              <p>{goodsZeroBuyerCount} NT communities with no Goods buyer leads</p>
+              <p>{crosswalkZeroBuyerCount} NT crosswalk buyer-match gaps</p>
+              <p>{postcodeGaps} NT postcode/enrichment gaps</p>
+            </div>
+          </div>
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap gap-2">
+              {([
+                ['need', 'Need'],
+                ['beds', 'Beds'],
+                ['washers', 'Washers'],
+                ['fridges', 'Fridges'],
+                ['buyer-gaps', 'Buyer gaps'],
+                ['partners', 'Partners'],
+              ] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setMapLayer(value)}
+                  className={`border-2 px-3 py-2 text-xs font-black uppercase tracking-widest ${
+                    mapLayer === value
+                      ? 'border-bauhaus-black bg-bauhaus-black text-white'
+                      : 'border-bauhaus-black bg-white text-bauhaus-black'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => setMapExpanded(true)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Expand map
+            </button>
+          </div>
+          <GoodsCommunityMap
+            points={mapPoints}
+            selectedPoint={selectedMapPoint}
+            selectedLayer={mapLayer}
+            onSelect={setSelectedCommunityId}
+            onOpenDossier={openCommunityDossier}
+            ntOnly={showOnlyNt}
+          />
+          <div className="mt-3 space-y-2">
+            {sortedNeedCommunities.slice(0, 6).map((entry) => (
+              <button
+                key={entry.community.id}
+                onClick={() => setSelectedCommunityId(entry.community.id)}
+                className={`w-full text-left border-2 px-3 py-2 ${
+                  selectedCommunity?.id === entry.community.id
+                    ? 'border-bauhaus-red bg-bauhaus-red/5'
+                    : 'border-bauhaus-black hover:bg-bauhaus-canvas/40'
+                }`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-black text-bauhaus-black">
+                    {entry.community.community_name} {entry.community.state ? `(${entry.community.state})` : ''}
+                  </p>
+                  <p className="text-sm font-black text-bauhaus-red">{entry.score}</p>
+                </div>
+                <p className="text-xs text-bauhaus-muted mt-1">{entry.reason}</p>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div id="goods-community-dossier" className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Community Need + Proof</p>
+            {selectedCommunity ? (
+              <>
+                <h2 className="text-2xl font-black mt-1">{selectedCommunity.community_name}</h2>
+                <p className="text-sm text-bauhaus-muted">
+                  {(selectedCommunity.state || '—')} • {selectedCommunity.region_label || selectedCommunity.lga_name || 'Region unknown'} • {selectedCommunity.remoteness || 'Remoteness unknown'}
+                </p>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                  <div className="border-2 border-bauhaus-black p-2">
+                    <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Demand</p>
+                    <p className="font-black">
+                      {toNumber(selectedCommunity.demand_beds)} beds • {toNumber(selectedCommunity.demand_washers)} washers
+                    </p>
+                  </div>
+                  <div className="border-2 border-bauhaus-black p-2">
+                    <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Coverage</p>
+                    <p className="font-black">{toNumber(selectedCommunity.buyer_entity_count)} buyer entities</p>
+                  </div>
+                  <div className="border-2 border-bauhaus-black p-2">
+                    <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Assets</p>
+                    <p className="font-black">
+                      {toNumber(selectedCommunity.assets_deployed)} deployed • {toNumber(selectedCommunity.assets_overdue)} overdue
+                    </p>
+                  </div>
+                  <div className="border-2 border-bauhaus-black p-2">
+                    <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Community Partners</p>
+                    <p className="font-black">{toNumber(selectedCommunity.community_controlled_org_count)} controlled orgs</p>
+                  </div>
+                </div>
+                <p className="mt-3 text-sm text-bauhaus-black">
+                  <span className="font-black">Proof:</span> {selectedCommunity.proof_line || selectedCommunity.story || 'No proof line recorded yet.'}
+                </p>
+                <p className="mt-1 text-sm text-bauhaus-muted">
+                  Updated {dateLabel(selectedCommunity.updated_at)} • Source {selectedCommunity.signal_source || 'goods profile'}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-bauhaus-muted mt-2">No community selected.</p>
+            )}
+          </div>
+
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Delivery + Partner Graph</p>
+            <p className="text-sm text-bauhaus-muted mt-1">
+              Role clusters from current procurement entities. Use this to decide where to build local production partnerships versus buyer outreach.
+            </p>
+            <div className="mt-3 space-y-2">
+              {partnerGraphRows.slice(0, 8).map((row) => (
+                <div key={row.role} className="border-2 border-bauhaus-black p-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-black uppercase tracking-wide">{row.role.replace('_', ' ')}</p>
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-black text-bauhaus-blue">{row.count}</p>
+                      <button
+                        onClick={() => setSelectedPartnerKeys((current) => toggleValue(current, row.role))}
+                        className={`border-2 px-2 py-1 text-[10px] font-black uppercase tracking-widest ${
+                          selectedPartnerKeys.includes(row.role)
+                            ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                            : 'border-bauhaus-black bg-white text-bauhaus-black'
+                        }`}
+                      >
+                        {selectedPartnerKeys.includes(row.role) ? 'Selected' : 'Select'}
+                      </button>
+                    </div>
+                  </div>
+                  <p className="text-xs text-bauhaus-muted mt-1">{row.topNames.join(' • ') || 'No named examples yet'}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-4 grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <div className="border-4 border-bauhaus-black bg-white p-4">
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div>
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Buyer Pipeline</p>
+              <h2 className="text-2xl font-black mt-1">Canonical Buyer Targets</h2>
+            </div>
+            <button
+              onClick={() => downloadCsv('goods-buyer-pipeline.csv', exportBuyerRows)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Export CSV
+            </button>
+          </div>
+          <p className="text-sm text-bauhaus-muted mb-3">
+            Deduped to one card per buyer entity, with rolled-up community coverage, contracts, contact path, and the strongest current outreach angle.
+          </p>
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            {([
+              ['ready-now', 'Ready now'],
+              ['relationship-path', 'Needs path'],
+              ['contact-gap', 'Contact gap'],
+              ['all', 'All buyers'],
+            ] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setBuyerView(value)}
+                className={`border-2 px-3 py-2 text-[10px] font-black uppercase tracking-widest ${
+                  buyerView === value
+                    ? 'border-bauhaus-black bg-bauhaus-black text-white'
+                    : 'border-bauhaus-black bg-white text-bauhaus-black'
+                }`}
+              >
+                {label}
+                {' '}
+                (
+                {value === 'all'
+                  ? buyerPipelineCounts.all
+                  : buyerPipelineCounts[value]}
+                )
+              </button>
+            ))}
+          </div>
+          <div className="mb-3 border-2 border-bauhaus-black bg-bauhaus-canvas/30 p-3">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Buyer action queue</p>
+            <p className="mt-1 text-sm text-bauhaus-black">
+              {buyerView === 'ready-now'
+                ? 'Start here for direct outreach. These buyers already have a contact path.'
+                : buyerView === 'relationship-path'
+                  ? 'These buyers are plausible, but you should use a warm intro or named route before treating them as active outreach.'
+                  : buyerView === 'contact-gap'
+                    ? 'These buyers matter, but the next task is contact discovery, not pitching.'
+                    : 'Full buyer universe, sorted with outreach-ready buyers first.'}
+            </p>
+          </div>
+          <div className="space-y-2 max-h-[620px] overflow-y-auto pr-1">
+            {visibleBuyerPipelineCards.slice(0, 30).map((entry) => (
+              <div key={entry.key} className="border-2 border-bauhaus-black p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="font-black text-bauhaus-black">{entry.name}</h3>
+                    <p className="text-xs text-bauhaus-muted mt-1">
+                      {entry.roles.length ? entry.roles.map(roleLabel).join(' • ') : 'unknown role'} • {entry.communityCount} linked communities
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`border px-2 py-1 text-[10px] font-black uppercase tracking-widest ${
+                        entry.readiness === 'ready-now'
+                          ? 'border-green-700 bg-green-700 text-white'
+                          : entry.readiness === 'relationship-path'
+                            ? 'border-bauhaus-blue bg-bauhaus-blue text-white'
+                            : 'border-bauhaus-red bg-bauhaus-red text-white'
+                      }`}
+                    >
+                      {entry.readinessLabel}
+                    </span>
+                    <p className="text-sm font-black text-bauhaus-red">{entry.score}</p>
+                    <button
+                      onClick={() => setSelectedBuyerKeys((current) => toggleValue(current, entry.key))}
+                      className={`border-2 px-2 py-1 text-[10px] font-black uppercase tracking-widest ${
+                        selectedBuyerKeys.includes(entry.key)
+                          ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                          : 'border-bauhaus-black bg-white text-bauhaus-black'
+                      }`}
+                    >
+                      {selectedBuyerKeys.includes(entry.key) ? 'Selected' : 'Select'}
+                    </button>
+                  </div>
+                </div>
+                <p className="text-xs text-bauhaus-black mt-1">
+                  <span className="font-black">Why plausible:</span> {entry.reasons.join(' • ')}
+                </p>
+                <p className="text-xs text-bauhaus-black mt-1">
+                  <span className="font-black">Next action:</span> {entry.nextAction}
+                </p>
+                <p className="text-xs text-bauhaus-muted mt-1">{entry.readinessSummary}</p>
+                <div className="mt-2 border border-bauhaus-black bg-bauhaus-canvas/30 px-3 py-2">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">CRM signal</p>
+                  <p className="mt-1 text-xs text-bauhaus-black">{entry.outcomeSummary}</p>
+                  <p className="mt-1 text-xs text-bauhaus-muted">
+                    {entry.buyerOpportunityStage
+                      ? `Buyer opp updated ${dateLabel(entry.buyerOpportunityUpdatedAt)}`
+                      : entry.communityPipelineStage
+                        ? `Community lane updated ${dateLabel(entry.communityPipelineUpdatedAt)}`
+                        : 'Run a live buyer push to create direct buyer CRM tracking.'}
+                    {entry.lastContactDate ? ` • Last contact ${dateLabel(entry.lastContactDate)}` : ''}
+                    {entry.engagementStatus ? ` • Contact ${entry.engagementStatus}` : ''}
+                  </p>
+                </div>
+                <p className="mt-2 text-xs text-bauhaus-black">
+                  <span className="font-black">Push preview:</span>{' '}
+                  {entry.buyerOpportunityStage ? 'Update existing buyer opp' : 'Create new buyer opp'}
+                  {entry.buyerOpportunityStage ? ` • ${entry.buyerOpportunityStage}` : ''}
+                </p>
+                <p className="text-xs text-bauhaus-muted mt-1">
+                  Contact: {entry.contactSurface || 'missing'} • Relationship: {entry.relationshipStatus || 'unclassified'}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {entry.communities.slice(0, 5).map((community) => (
+                    <span
+                      key={community.id}
+                      className={`border px-2 py-1 text-[10px] font-black uppercase tracking-widest ${
+                        selectedCommunity?.id === community.id
+                          ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                          : 'border-bauhaus-black bg-bauhaus-canvas/40 text-bauhaus-black'
+                      }`}
+                    >
+                      {community.name} {community.state ? `(${community.state})` : ''}
+                    </span>
+                  ))}
+                  {entry.communityCount > 5 ? (
+                    <span className="border border-bauhaus-black bg-bauhaus-canvas/40 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-black">
+                      +{entry.communityCount - 5} more
+                    </span>
+                  ) : null}
+                </div>
+                <div className="mt-2 flex items-center gap-2 text-[11px] text-bauhaus-muted">
+                  <span>{entry.contractCount} contracts</span>
+                  <span>•</span>
+                  <span>{money(entry.contractValue)} contract value</span>
+                  <span>•</span>
+                  <span>{entry.matchedRows} matched rows</span>
+                  {entry.link ? (
+                    <>
+                      <span>•</span>
+                      <a href={entry.link} target="_blank" rel="noreferrer" className="underline font-semibold">
+                        website
+                      </a>
+                    </>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+            {visibleBuyerPipelineCards.length === 0 ? (
+              <div className="border-2 border-bauhaus-black bg-bauhaus-canvas/30 p-4 text-sm text-bauhaus-muted">
+                No buyers match this readiness filter.
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-white p-4">
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div>
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Capital Stack</p>
+              <h2 className="text-2xl font-black mt-1">Grants + Philanthropy + Catalytic Pathways</h2>
+            </div>
+            <button
+              onClick={() => downloadCsv('goods-capital-stack.csv', exportCapitalRows)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Export CSV
+            </button>
+          </div>
+          <div className="space-y-2 max-h-[620px] overflow-y-auto pr-1">
+            {capitalTargets.slice(0, 30).map((target) => (
+              <div key={target.key} className="border-2 border-bauhaus-black p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="font-black text-bauhaus-black">{target.name}</h3>
+                    <p className="text-xs text-bauhaus-muted">{target.provider}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-black text-bauhaus-red">{target.score}</p>
+                    <p className="text-[11px] text-bauhaus-muted uppercase tracking-widest">{target.source}</p>
+                    <button
+                      onClick={() => setSelectedCapitalKeys((current) => toggleValue(current, target.key))}
+                      className={`mt-2 border-2 px-2 py-1 text-[10px] font-black uppercase tracking-widest ${
+                        selectedCapitalKeys.includes(target.key)
+                          ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                          : 'border-bauhaus-black bg-white text-bauhaus-black'
+                      }`}
+                    >
+                      {selectedCapitalKeys.includes(target.key) ? 'Selected' : 'Select'}
+                    </button>
+                  </div>
+                </div>
+                <p className="text-xs text-bauhaus-black mt-2">
+                  <span className="font-black">Why fit:</span> {target.reason}
+                </p>
+                <div className="mt-2 text-xs text-bauhaus-muted flex flex-wrap gap-x-2 gap-y-1">
+                  <span>{target.instrumentType}</span>
+                  <span>•</span>
+                  <span>{target.openness}</span>
+                  <span>•</span>
+                  <span>{target.amountHint}</span>
+                  <span>•</span>
+                  <span>{target.regionFit}</span>
+                </div>
+                {target.link ? (
+                  <a href={target.link} target="_blank" rel="noreferrer" className="inline-block mt-2 text-xs font-black underline">
+                    Open source
+                  </a>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-4 grid grid-cols-1 xl:grid-cols-[1.2fr_1fr] gap-4">
+        <div className="border-4 border-bauhaus-black bg-white p-4">
+          <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Outreach Exports</p>
+          <h2 className="text-2xl font-black mt-1">Notion + CSV + CRM Push Payload</h2>
+          <p className="text-sm text-bauhaus-muted mt-2">
+            Use this payload as the handoff into Goods CRM automation. It is built from your selected targets, or from the current top-ranked defaults if you have not explicitly selected anything yet.
+          </p>
+          <div className="mt-3 grid grid-cols-1 md:grid-cols-4 gap-2 text-sm">
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Selection Mode</p>
+              <p className="font-black">{hasExplicitSelection ? 'Manual' : 'Top-ranked defaults'}</p>
+            </div>
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Buyer Targets</p>
+              <p className="font-black">{selectedBuyerTargets.length}</p>
+            </div>
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Capital Targets</p>
+              <p className="font-black">{selectedCapitalTargets.length}</p>
+            </div>
+            <div className="border-2 border-bauhaus-black p-2">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Partner Targets</p>
+              <p className="font-black">{selectedPartnerTargets.length}</p>
+            </div>
+          </div>
+          <div className="mt-3 border-2 border-bauhaus-black p-3 bg-bauhaus-canvas/30">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue mb-2">Selected target set</p>
+            <div className="mb-3 grid grid-cols-1 md:grid-cols-3 gap-2 text-sm">
+              <div className="border border-bauhaus-black bg-white p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Buyer opps to create</p>
+                <p className="font-black">{selectedBuyerPushSummary.create}</p>
+              </div>
+              <div className="border border-bauhaus-black bg-white p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Buyer opps to update</p>
+                <p className="font-black">{selectedBuyerPushSummary.update}</p>
+              </div>
+              <div className="border border-bauhaus-black bg-white p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Push shape</p>
+                <p className="font-black">{hasExplicitSelection ? 'Manual set' : 'Default set'}</p>
+              </div>
+            </div>
+            <div className="space-y-2 max-h-[240px] overflow-y-auto pr-1">
+              {ghlTargets.map((target) => (
+                <div key={target.key} className="border border-bauhaus-black px-3 py-2 bg-white">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="font-black text-sm">{target.name}</p>
+                    <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">{target.type}</p>
+                  </div>
+                  <p className="text-xs text-bauhaus-muted mt-1">{target.targetSummary}</p>
+                  <p className="text-xs text-bauhaus-black mt-1">
+                    <span className="font-black">Ask:</span> {target.recommendedAsk}
+                  </p>
+                  <p className="text-xs text-bauhaus-black mt-1">
+                    <span className="font-black">Next:</span> {target.nextAction}
+                  </p>
+                  {target.type === 'buyer' ? (
+                    <p className="text-xs text-bauhaus-muted mt-1">
+                      <span className="font-black text-bauhaus-black">CRM preview:</span> {target.crmPreviewSummary}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div className="border-2 border-bauhaus-black p-3">
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue mb-2">Push owner mode</p>
+              <div className="flex flex-wrap gap-2">
+                {([
+                  ['unassigned', 'Leave unassigned'],
+                  ['default-owner', 'Assign default owner'],
+                ] as const).map(([value, label]) => (
+                  <button
+                    key={value}
+                    onClick={() => setOwnerMode(value)}
+                    disabled={value === 'default-owner' && !ghlDefaultOwnerConfigured}
+                    className={`border-2 px-3 py-2 text-xs font-black uppercase tracking-widest ${
+                      ownerMode === value
+                        ? 'border-bauhaus-black bg-bauhaus-black text-white'
+                        : 'border-bauhaus-black bg-white text-bauhaus-black'
+                    } ${value === 'default-owner' && !ghlDefaultOwnerConfigured ? 'cursor-not-allowed opacity-40' : ''}`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              {ghlDefaultOwnerConfigured ? (
+                <p className="mt-2 text-xs text-green-700">
+                  Default owner ready{ghlDefaultOwnerLabel ? `: ${ghlDefaultOwnerLabel}` : ''}. Pushes can land directly with an owner in the Goods pipeline.
+                </p>
+              ) : (
+                <p className="mt-2 text-xs text-bauhaus-red">
+                  Configure <span className="font-black">GHL_GOODS_DEFAULT_ASSIGNED_TO</span> to enable direct owner assignment into the Goods pipeline.
+                </p>
+              )}
+            </div>
+            <div className="border-2 border-bauhaus-black p-3">
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue mb-2">Relationship mode</p>
+              <div className="flex flex-wrap gap-2">
+                {([
+                  ['preserve', 'Preserve current'],
+                  ['advance', 'Advance to active push'],
+                ] as const).map(([value, label]) => (
+                  <button
+                    key={value}
+                    onClick={() => setRelationshipMode(value)}
+                    className={`border-2 px-3 py-2 text-xs font-black uppercase tracking-widest ${
+                      relationshipMode === value
+                        ? 'border-bauhaus-black bg-bauhaus-black text-white'
+                        : 'border-bauhaus-black bg-white text-bauhaus-black'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-2 text-xs text-bauhaus-muted">
+                Preserve uses the current buyer relationship status where available. Advance moves the pushed target into a live outreach lane.
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              onClick={() => {
+                setSelectedBuyerKeys([]);
+                setSelectedCapitalKeys([]);
+                setSelectedPartnerKeys([]);
+              }}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Reset to defaults
+            </button>
+            <button
+              onClick={() => downloadCsv('goods-outreach-notion-ready.csv', selectedTargetRows)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Notion-ready table
+            </button>
+            <button
+              onClick={() => downloadCsv('goods-buyer-targets.csv', exportBuyerRows)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Buyer CSV
+            </button>
+            <button
+              onClick={() => downloadCsv('goods-capital-targets.csv', exportCapitalRows)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Capital CSV
+            </button>
+            <button
+              onClick={() => downloadText('goods-weekly-operating-snapshot.md', weeklySnapshotMarkdown, 'text/markdown;charset=utf-8;')}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Weekly snapshot
+            </button>
+            <button
+              onClick={() => runGhlPush(true)}
+              disabled={pushBusy}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white disabled:opacity-50"
+            >
+              Dry-run GHL push
+            </button>
+            <button
+              onClick={() => runGhlPush(false)}
+              disabled={pushBusy || isRefreshing}
+              className="border-2 border-bauhaus-red bg-bauhaus-red text-white px-3 py-2 text-xs font-black uppercase tracking-widest hover:opacity-90 disabled:opacity-50"
+            >
+              {isRefreshing ? 'Refreshing Goods data…' : 'Push selected targets to GHL'}
+            </button>
+            <a
+              href={GOODS_QBE_ACTIONS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Open QBE Actions
+            </a>
+          </div>
+          {pushStatus ? (
+            <p className={`mt-3 text-sm font-semibold ${pushStatus.includes('failed') ? 'text-bauhaus-red' : 'text-green-700'}`}>
+              {pushStatus}
+            </p>
+          ) : null}
+          <pre className="mt-3 border-2 border-bauhaus-black bg-bauhaus-canvas/40 p-3 text-xs overflow-x-auto whitespace-pre-wrap">
+            {JSON.stringify(crmPayload, null, 2)}
+          </pre>
+        </div>
+
+        <div className="space-y-4">
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Pipeline outcomes</p>
+            <h3 className="text-xl font-black mt-1">Live Goods pipeline state</h3>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+              <div className="border-2 border-bauhaus-black p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Pipeline opportunities</p>
+                <p className="text-2xl font-black">{pipelineTotals.count}</p>
+              </div>
+              <div className="border-2 border-bauhaus-black p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Pipeline value</p>
+                <p className="text-2xl font-black">{money(pipelineTotals.value)}</p>
+              </div>
+              <div className="border-2 border-bauhaus-black p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Assigned now</p>
+                <p className="text-2xl font-black">{recentMovement.assignedCount}</p>
+              </div>
+              <div className="border-2 border-bauhaus-black p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Out of new lead</p>
+                <p className="text-2xl font-black">{recentMovement.activeCount}</p>
+              </div>
+            </div>
+            <div className="mt-3 border-2 border-bauhaus-black p-3 bg-bauhaus-canvas/30">
+              <p className="text-[10px] uppercase tracking-widest text-bauhaus-blue">What moved since last live push</p>
+              {latestLivePush ? (
+                <>
+                  <p className="mt-1 text-sm text-bauhaus-muted">
+                    Last live push: <span className="font-black text-bauhaus-black">{dateTimeLabel(latestLivePush.startedAt)}</span>
+                  </p>
+                  <p className="mt-2 text-sm text-bauhaus-black">
+                    <span className="font-black">{recentMovement.updatedSinceLastPush.length}</span> recent Goods opportunities updated after that push.
+                  </p>
+                  <p className="mt-1 text-xs text-bauhaus-muted">
+                    Latest push created {latestLivePush.created} and updated {latestLivePush.updated} records from {latestLivePush.processed} selected targets.
+                  </p>
+                  <div className="mt-3 space-y-2">
+                    {recentMovement.updatedSinceLastPush.length > 0 ? (
+                      recentMovement.updatedSinceLastPush.slice(0, 5).map((opportunity, index) => (
+                        <div
+                          key={opportunity.ghl_id || `${opportunity.name || 'moved-opportunity'}-${index}`}
+                          className="border border-bauhaus-black bg-white px-3 py-2"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <p className="font-black text-sm">{opportunity.name || 'Unnamed opportunity'}</p>
+                            <p className="text-[10px] uppercase tracking-widest text-bauhaus-red">
+                              {opportunity.stage_name || 'Unknown'}
+                            </p>
+                          </div>
+                          <p className="mt-1 text-xs text-bauhaus-muted">
+                            {money(toNumber(opportunity.monetary_value))} • updated {dateTimeLabel(opportunity.updated_at)}
+                          </p>
+                          <p className="mt-1 text-xs text-bauhaus-black">
+                            Assigned to: {opportunity.assigned_to || 'unassigned'}
+                          </p>
+                        </div>
+                      ))
+                    ) : (
+                      <p className="text-sm text-bauhaus-muted">
+                        No recent Goods opportunities in the latest list have updated after the last recorded live push.
+                      </p>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <p className="mt-2 text-sm text-bauhaus-muted">
+                  No live Goods workspace push has been recorded yet. Run a push and this panel will show what changed afterwards.
+                </p>
+              )}
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-2">
+              {goodsPipelineStages.map((row) => (
+                <div key={row.stage_name || 'Unknown'} className="border-2 border-bauhaus-black p-2 flex items-center justify-between gap-3">
+                  <div>
+                    <p className="font-black text-sm">{row.stage_name || 'Unknown'}</p>
+                    <p className="text-xs text-bauhaus-muted">{money(toNumber(row.stage_value))}</p>
+                  </div>
+                  <p className="text-xl font-black text-bauhaus-red">{toNumber(row.stage_count)}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Recent push activity</p>
+            <div className="mt-3 space-y-2 max-h-[240px] overflow-y-auto pr-1">
+              {pushLogRows.length > 0 ? pushLogRows.map((row) => (
+                <div key={row.id} className="border-2 border-bauhaus-black p-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="font-black text-sm">{row.dryRun ? 'Dry run' : 'CRM push'} • {row.status}</p>
+                    <p className="text-xs text-bauhaus-muted">{dateLabel(row.startedAt)}</p>
+                  </div>
+                  <p className="text-xs text-bauhaus-black mt-1">
+                    {row.processed} targets • {row.created} created • {row.updated} updated • {row.failed} failed
+                  </p>
+                  <p className="text-xs text-bauhaus-muted mt-1">
+                    {row.triggeredBy} • owner: {row.ownerMode} • relationship: {row.relationshipMode}
+                  </p>
+                </div>
+              )) : (
+                <p className="text-sm text-bauhaus-muted">No Goods workspace push log yet.</p>
+              )}
+            </div>
+          </div>
+
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Recent Goods opportunities</p>
+            <div className="mt-3 space-y-2 max-h-[320px] overflow-y-auto pr-1">
+              {goodsPipelineOpportunities.map((opportunity, index) => (
+                <div key={opportunity.ghl_id || `${opportunity.name || 'opportunity'}-${index}`} className="border-2 border-bauhaus-black p-2">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-black text-sm">{opportunity.name || 'Unnamed opportunity'}</p>
+                    <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">{opportunity.stage_name || 'Unknown'}</p>
+                  </div>
+                  <p className="text-xs text-bauhaus-muted mt-1">
+                    {money(toNumber(opportunity.monetary_value))} • {opportunity.status || 'open'} • updated {dateLabel(opportunity.updated_at)}
+                  </p>
+                  <p className="text-xs text-bauhaus-black mt-1">
+                    Assigned to: {opportunity.assigned_to || 'unassigned'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">NT Coverage Gaps</p>
+            <h3 className="text-xl font-black mt-1">Crosswalk + Goods buyer gap check</h3>
+            <p className="text-sm text-bauhaus-muted mt-1">
+              Crosswalk gaps are strict entity-graph keyword matches. Goods buyer leads include crosswalk matches plus verified anchor inference.
+            </p>
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+              <div className="border-2 border-bauhaus-black p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Goods buyer lead gaps</p>
+                <p className="text-2xl font-black text-bauhaus-red">{goodsZeroBuyerCount}</p>
+              </div>
+              <div className="border-2 border-bauhaus-black p-2">
+                <p className="text-[10px] uppercase tracking-widest text-bauhaus-muted">Crosswalk buyer gaps</p>
+                <p className="text-2xl font-black text-bauhaus-red">{crosswalkZeroBuyerCount}</p>
+              </div>
+            </div>
+            <p className="mt-3 text-xs font-black uppercase tracking-widest text-bauhaus-blue">Crosswalk gap communities</p>
+            <div className="mt-3 space-y-2 max-h-[300px] overflow-y-auto pr-1">
+              {crosswalkZeroBuyerRows.map((row, index) => (
+                <div key={`${row.community_name || 'unknown'}-${index}`} className="border-2 border-bauhaus-black p-2">
+                  <p className="font-black text-sm">{row.community_name || 'Unknown community'}</p>
+                  <p className="text-xs text-bauhaus-muted">
+                    {row.region_label || 'Region unknown'} • Postcode {row.postcode || 'missing'} • Priority {row.goods_focus_priority || 'unset'}
+                  </p>
+                </div>
+              ))}
+            </div>
+            {goodsZeroBuyerCount === 0 ? (
+              <p className="mt-3 text-sm text-green-700 font-semibold">All NT Goods communities currently have at least one buyer lead row.</p>
+            ) : (
+              <div className="mt-3 space-y-2">
+                <p className="text-xs font-black uppercase tracking-widest text-bauhaus-red">NT communities still missing Goods buyer leads</p>
+                {goodsZeroBuyerRows.map((community) => (
+                  <div key={community.id} className="border-2 border-bauhaus-red p-2">
+                    <p className="font-black text-sm">{community.community_name}</p>
+                    <p className="text-xs text-bauhaus-muted">
+                      {community.region_label || community.lga_name || 'Region unknown'} • Postcode {community.postcode || 'missing'}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="border-4 border-bauhaus-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">ABN Ownership</p>
+            <p className="text-sm text-bauhaus-black mt-1">
+              Signed in as {userEmail || 'unknown user'}.
+            </p>
+            <p className="text-sm text-bauhaus-black mt-1">
+              Current org: <span className="font-black">{orgProfile?.name || 'Unclaimed org profile'}</span>
+            </p>
+            <p className="text-sm text-bauhaus-black mt-1">
+              Tracked ABN: <span className="font-black">{orgProfile?.abn || 'Missing — add ABN in /profile to claim Goods output under your entity.'}</span>
+            </p>
+            <Link href="/profile" className="inline-block mt-3 border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white">
+              Open profile
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {selectedCommunity && selectedCommunitySignals.length > 0 ? (
+        <section className="mt-4 border-4 border-bauhaus-black bg-white p-4">
+          <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Live Procurement Signals</p>
+          <h2 className="text-2xl font-black mt-1">
+            {selectedCommunity.community_name} signal queue
+          </h2>
+          <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+            {selectedCommunitySignals.map((signal) => (
+              <div key={signal.id} className="border-2 border-bauhaus-black p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-black text-bauhaus-black">{signal.title || 'Untitled signal'}</p>
+                  <p className="text-xs font-black uppercase tracking-widest text-bauhaus-red">{signal.priority || 'unset'}</p>
+                </div>
+                <p className="text-xs text-bauhaus-muted mt-1">{signal.signal_type || 'signal'} • {signal.status || 'new'} • {dateLabel(signal.created_at)}</p>
+                <p className="text-sm text-bauhaus-black mt-2">{signal.description || 'No description yet.'}</p>
+                <p className="text-xs text-bauhaus-muted mt-2">
+                  Units {toNumber(signal.estimated_units)} • Value {money(toNumber(signal.estimated_value))}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {mapExpanded ? (
+        <div className="fixed inset-4 z-[1200] border-4 border-bauhaus-black bg-white p-4 shadow-[12px_12px_0_0_rgba(0,0,0,0.12)]">
+          <div className="mb-3 flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Expanded map</p>
+              <h2 className="text-2xl font-black mt-1">Goods community operating map</h2>
+              <p className="mt-1 text-sm text-bauhaus-muted">
+                Work one community at a time, switch layers, then jump straight into the dossier.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setMapExpanded(false)}
+              className="border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white"
+            >
+              Close map
+            </button>
+          </div>
+          <div className="mb-3 flex flex-wrap gap-2">
+            {([
+              ['need', 'Need'],
+              ['beds', 'Beds'],
+              ['washers', 'Washers'],
+              ['fridges', 'Fridges'],
+              ['buyer-gaps', 'Buyer gaps'],
+              ['partners', 'Partners'],
+            ] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setMapLayer(value)}
+                className={`border-2 px-3 py-2 text-xs font-black uppercase tracking-widest ${
+                  mapLayer === value
+                    ? 'border-bauhaus-black bg-bauhaus-black text-white'
+                    : 'border-bauhaus-black bg-white text-bauhaus-black'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <GoodsCommunityMap
+            points={mapPoints}
+            selectedPoint={selectedMapPoint}
+            selectedLayer={mapLayer}
+            onSelect={setSelectedCommunityId}
+            onOpenDossier={() => {
+              setMapExpanded(false);
+              setTimeout(() => openCommunityDossier(), 120);
+            }}
+            expanded
+            ntOnly={showOnlyNt}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/goods-workspace/page.tsx
+++ b/apps/web/src/app/goods-workspace/page.tsx
@@ -1,0 +1,302 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServer } from '@/lib/supabase-server';
+import { getServiceSupabase } from '@/lib/supabase';
+import GoodsWorkspaceClient, {
+  type GoodsBuyerGhlContactRow,
+  type GoodsBuyerGhlOpportunityRow,
+  type GoodsCommunityRow,
+  type GoodsCommunityPipelineRow,
+  type GoodsGhlOpportunityRow,
+  type GoodsGhlPipelineStageRow,
+  type GoodsGhlSyncRow,
+  type GoodsProcurementEntityRow,
+  type GoodsProcurementSignalRow,
+  type GoodsFoundationRow,
+  type GoodsGrantRow,
+  type NtCommunityCoverageRow,
+} from './goods-workspace-client';
+
+type OrgProfileSummary = {
+  id: string;
+  name: string | null;
+  abn: string | null;
+  subscription_plan: string | null;
+} | null;
+
+async function runSql<T>(query: string): Promise<T[]> {
+  const db = getServiceSupabase();
+  const { data, error } = await db.rpc('exec_sql', { query });
+  if (error) {
+    console.error('goods-workspace SQL failed:', error.message);
+    return [];
+  }
+  return (data as T[]) || [];
+}
+
+export const dynamic = 'force-dynamic';
+
+export default async function GoodsWorkspacePage() {
+  const authDb = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await authDb.auth.getUser();
+
+  if (!user) {
+    redirect('/login?next=%2Fgoods-workspace');
+  }
+
+  const db = getServiceSupabase();
+
+  const { data: orgProfile } = await db
+    .from('org_profiles')
+    .select('id, name, abn, subscription_plan')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  const { data: communitiesData } = await db
+    .from('goods_communities')
+    .select(`
+      id, community_name, state, postcode, lga_name, region_label, service_region, land_council,
+      remoteness, latitude, longitude, priority, signal_type, signal_source,
+      demand_beds, demand_washers, demand_fridges, demand_mattresses,
+      assets_deployed, assets_active, assets_overdue, latest_checkin_date,
+      known_buyer_name, buyer_entity_count, store_count, health_service_count, housing_org_count,
+      council_count, community_controlled_org_count, total_local_entities,
+      total_govt_contract_value, total_justice_funding, total_foundation_grants, ndis_provider_count,
+      ndis_thin_market, proof_line, story, youth_employment_angle, data_quality_score, updated_at
+    `)
+    .in('state', ['NT', 'QLD'])
+    .order('state', { ascending: true })
+    .order('community_name', { ascending: true })
+    .limit(2500);
+
+  const { data: buyersData } = await db
+    .from('goods_procurement_entities')
+    .select(`
+      id, community_id, gs_id, entity_name, abn, entity_type, buyer_role, procurement_method,
+      estimated_annual_spend, current_supplier, contract_cycle, relationship_status, contact_surface,
+      product_fit, fit_score, next_action, govt_contract_count, govt_contract_value,
+      is_community_controlled, website, updated_at
+    `)
+    .order('fit_score', { ascending: false, nullsFirst: false })
+    .limit(6000);
+
+  const { data: signalsData } = await db
+    .from('goods_procurement_signals')
+    .select(`
+      id, signal_type, priority, community_id, title, description, estimated_value, estimated_units,
+      products_needed, funding_confidence, status, action_notes, source_agent, updated_at, created_at
+    `)
+    .order('created_at', { ascending: false })
+    .limit(1200);
+
+  const foundations = await runSql<GoodsFoundationRow>(`
+    SELECT
+      id::text as id,
+      name,
+      type,
+      website,
+      description,
+      total_giving_annual,
+      avg_grant_size,
+      thematic_focus,
+      geographic_focus,
+      profile_confidence,
+      open_programs
+    FROM foundations
+    WHERE
+      LOWER(COALESCE(name, '')) LIKE ANY (ARRAY[
+        '%indigenous%', '%community%', '%remote%', '%social%', '%manufacturing%'
+      ])
+      OR LOWER(COALESCE(description, '')) LIKE ANY (ARRAY[
+        '%indigenous%', '%community%', '%remote%', '%social enterprise%', '%catalytic%', '%loan%',
+        '%manufacturing%', '%circular%', '%youth%', '%housing%'
+      ])
+      OR LOWER(array_to_string(COALESCE(thematic_focus, '{}'::text[]), ',')) LIKE ANY (ARRAY[
+        '%indigenous%', '%community%', '%remote%', '%manufacturing%', '%social enterprise%',
+        '%youth%', '%housing%', '%circular%'
+      ])
+      OR LOWER(array_to_string(COALESCE(geographic_focus, '{}'::text[]), ',')) LIKE ANY (ARRAY[
+        '%nt%', '%northern territory%', '%qld%', '%queensland%', '%remote%', '%regional%'
+      ])
+    ORDER BY total_giving_annual DESC NULLS LAST, updated_at DESC
+    LIMIT 400
+  `);
+
+  const grants = await runSql<GoodsGrantRow>(`
+    SELECT
+      id::text as id,
+      name,
+      provider,
+      url,
+      amount_min,
+      amount_max,
+      closes_at,
+      categories,
+      focus_areas,
+      geography,
+      status,
+      grant_type,
+      program_type,
+      last_verified_at
+    FROM grant_opportunities
+    WHERE
+      (status IS NULL OR LOWER(status) NOT IN ('closed', 'archived'))
+      AND (closes_at IS NULL OR closes_at >= CURRENT_DATE - INTERVAL '14 days')
+      AND (
+        LOWER(COALESCE(name, '')) LIKE ANY (ARRAY[
+          '%indigenous%', '%community%', '%remote%', '%housing%', '%manufacturing%',
+          '%social enterprise%', '%circular%', '%youth%', '%employment%'
+        ])
+        OR LOWER(COALESCE(provider, '')) LIKE ANY (ARRAY[
+          '%foundation%', '%indigenous%', '%community%', '%territory%', '%queensland%'
+        ])
+        OR LOWER(array_to_string(COALESCE(categories, '{}'::text[]), ',')) LIKE ANY (ARRAY[
+          '%indigenous%', '%community%', '%remote%', '%housing%', '%manufacturing%', '%youth%'
+        ])
+        OR LOWER(array_to_string(COALESCE(focus_areas, '{}'::text[]), ',')) LIKE ANY (ARRAY[
+          '%indigenous%', '%community%', '%remote%', '%housing%', '%manufacturing%', '%youth%'
+        ])
+      )
+    ORDER BY COALESCE(closes_at, CURRENT_DATE + INTERVAL '365 days') ASC,
+             COALESCE(amount_max, amount_min, 0) DESC
+    LIMIT 500
+  `);
+
+  const ntCoverageRows = await runSql<NtCommunityCoverageRow>(`
+    SELECT
+      community_name,
+      region_label,
+      postcode,
+      goods_focus_priority,
+      known_buyer_name,
+      entity_match_count,
+      buyer_match_count,
+      store_count,
+      health_count,
+      housing_count,
+      council_count,
+      community_controlled_match_count,
+      needs_postcode_enrichment
+    FROM v_nt_community_procurement_summary
+    ORDER BY
+      CASE WHEN needs_postcode_enrichment THEN 0 ELSE 1 END,
+      buyer_match_count ASC,
+      entity_match_count ASC,
+      community_name ASC
+    LIMIT 250
+  `);
+
+  const goodsPipelineStages = await runSql<GoodsGhlPipelineStageRow>(`
+    SELECT
+      COALESCE(stage_name, 'Unknown') as stage_name,
+      COUNT(*)::int as stage_count,
+      COALESCE(SUM(COALESCE(monetary_value, 0)), 0)::numeric as stage_value
+    FROM ghl_opportunities
+    WHERE pipeline_name = 'Goods'
+    GROUP BY COALESCE(stage_name, 'Unknown')
+    ORDER BY stage_count DESC, stage_value DESC
+  `);
+
+  const goodsPipelineOpportunities = await runSql<GoodsGhlOpportunityRow>(`
+    SELECT
+      ghl_id,
+      name,
+      stage_name,
+      status,
+      monetary_value,
+      assigned_to,
+      ghl_contact_id,
+      COALESCE(ghl_updated_at, updated_at, created_at) as updated_at
+    FROM ghl_opportunities
+    WHERE pipeline_name = 'Goods'
+    ORDER BY COALESCE(ghl_updated_at, updated_at, created_at) DESC
+    LIMIT 24
+  `);
+
+  const goodsBuyerPipelineOpportunities = await runSql<GoodsBuyerGhlOpportunityRow>(`
+    SELECT
+      name,
+      stage_name,
+      status,
+      monetary_value,
+      assigned_to,
+      ghl_contact_id,
+      COALESCE(ghl_updated_at, updated_at, created_at) as updated_at
+    FROM ghl_opportunities
+    WHERE pipeline_name = 'Goods'
+      AND name LIKE '[Buyer] %'
+    ORDER BY COALESCE(ghl_updated_at, updated_at, created_at) DESC
+    LIMIT 400
+  `);
+
+  const goodsBuyerContacts = await runSql<GoodsBuyerGhlContactRow>(`
+    SELECT
+      ghl_id,
+      company_name,
+      engagement_status,
+      last_contact_date,
+      website,
+      COALESCE(ghl_updated_at, updated_at, created_at) as updated_at
+    FROM ghl_contacts
+    WHERE source = 'CivicGraph Goods Workspace'
+      OR 'goods-workspace' = ANY(COALESCE(projects, ARRAY[]::text[]))
+    ORDER BY COALESCE(ghl_updated_at, updated_at, created_at) DESC
+    LIMIT 400
+  `);
+
+  const goodsCommunityPipelineRows = await runSql<GoodsCommunityPipelineRow>(`
+    SELECT
+      name,
+      stage_name,
+      status,
+      monetary_value,
+      assigned_to,
+      COALESCE(ghl_updated_at, updated_at, created_at) as updated_at
+    FROM ghl_opportunities
+    WHERE pipeline_name = 'Goods'
+      AND name NOT LIKE '[%] %'
+    ORDER BY COALESCE(ghl_updated_at, updated_at, created_at) DESC
+    LIMIT 300
+  `);
+
+  const goodsPushLog = await runSql<GoodsGhlSyncRow>(`
+    SELECT
+      id::text as id,
+      operation,
+      status,
+      records_processed,
+      records_created,
+      records_updated,
+      records_failed,
+      triggered_by,
+      started_at,
+      completed_at,
+      metadata
+    FROM ghl_sync_log
+    WHERE operation = 'GoodsWorkspacePush'
+    ORDER BY started_at DESC
+    LIMIT 20
+  `);
+
+  return (
+    <GoodsWorkspaceClient
+      userEmail={user.email ?? null}
+      orgProfile={orgProfile as OrgProfileSummary}
+      ghlDefaultOwnerConfigured={Boolean(process.env.GHL_GOODS_DEFAULT_ASSIGNED_TO)}
+      ghlDefaultOwnerLabel={process.env.GHL_GOODS_DEFAULT_OWNER_LABEL || null}
+      communities={(communitiesData as GoodsCommunityRow[] | null) || []}
+      buyers={(buyersData as GoodsProcurementEntityRow[] | null) || []}
+      signals={(signalsData as GoodsProcurementSignalRow[] | null) || []}
+      foundations={foundations}
+      grants={grants}
+      ntCoverageRows={ntCoverageRows}
+      goodsPipelineStages={goodsPipelineStages}
+      goodsPipelineOpportunities={goodsPipelineOpportunities}
+      goodsBuyerPipelineOpportunities={goodsBuyerPipelineOpportunities}
+      goodsBuyerContacts={goodsBuyerContacts}
+      goodsCommunityPipelineRows={goodsCommunityPipelineRows}
+      goodsPushLog={goodsPushLog}
+    />
+  );
+}

--- a/apps/web/src/app/justice-reinvestment/page.tsx
+++ b/apps/web/src/app/justice-reinvestment/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, Suspense } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 
 interface Intervention {
   id: string;
@@ -75,7 +76,7 @@ const EVIDENCE_LEVELS = [
 
 const STATES = ['All', 'NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
 
-export default function JusticeReinvestmentPage() {
+function JusticeReinvestmentContent() {
   const [data, setData] = useState<ApiResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -86,6 +87,9 @@ export default function JusticeReinvestmentPage() {
   const [linkedOnly, setLinkedOnly] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const searchParams = useSearchParams();
+  const source = searchParams.get('source');
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -127,6 +131,16 @@ export default function JusticeReinvestmentPage() {
       <Link href="/" className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">
         &larr; Home
       </Link>
+
+      {source === 'judges-campaign' && (
+        <div className="mt-4 bg-bauhaus-red text-white p-4 border-4 border-bauhaus-black flex flex-col md:flex-row gap-4 items-start shadow-[4px_4px_0px_0px_rgba(10,10,10,1)]">
+          <div className="text-xl md:text-2xl font-black shrink-0 md:mt-1 tracking-tight">ACCOUNTABILITY GAP</div>
+          <div>
+            <p className="font-bold text-sm">You are viewing verified community-led programs. Parliamentary records show detention is discussed 5 times more often than these proven alternatives.</p>
+            <p className="text-xs mt-1 opacity-90 font-mono">As part of the JusticeHub judges initiative, use this map to discover structural alternative funding in your jurisdiction.</p>
+          </div>
+        </div>
+      )}
 
       {/* Hero */}
       <div className="mt-4 mb-6">
@@ -410,5 +424,13 @@ export default function JusticeReinvestmentPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function JusticeReinvestmentPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <JusticeReinvestmentContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,8 +11,8 @@ import type { User } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 
 export const metadata: Metadata = {
-  title: 'CivicGraph - Infrastructure for Fairer Markets',
-  description: 'Mapping how money flows through society - procurement intelligence, funding transparency, community-governed evidence',
+  title: 'CivicGraph - Funding Intelligence And Decision Infrastructure',
+  description: 'Track grants, understand power, test procurement context, and turn live data into evidence-backed briefs, reporting, and action.',
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -103,43 +103,50 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                   <div>
                     <div className="font-black text-lg text-white uppercase tracking-tight mb-2">CivicGraph</div>
                     <p className="text-sm text-bauhaus-muted leading-relaxed">
-                      Open source. Open data. Making Australian funding flows transparent and accessible to everyone.
+                      Decision infrastructure for funding, power, procurement, and reporting. Start with the next move, not the biggest dashboard.
                     </p>
                   </div>
                   <div>
-                    <div className="font-black text-xs text-bauhaus-yellow mb-3 uppercase tracking-widest">Explore</div>
+                    <div className="font-black text-xs text-bauhaus-yellow mb-3 uppercase tracking-widest">Pipeline</div>
                     <ul className="space-y-2 text-sm">
-                      <li><a href="/grants" className="text-bauhaus-muted hover:text-white transition-colors">Government Grants</a></li>
+                      <li><a href="/grants" className="text-bauhaus-muted hover:text-white transition-colors">Grant Search</a></li>
+                      <li><a href="/profile/matches" className="text-bauhaus-muted hover:text-white transition-colors">Matched Grants</a></li>
+                      <li><a href="/tracker" className="text-bauhaus-muted hover:text-white transition-colors">Grant Tracker</a></li>
+                      <li><a href="/alerts" className="text-bauhaus-muted hover:text-white transition-colors">Alerts</a></li>
+                      <li><a href="/pricing" className="text-bauhaus-muted hover:text-white transition-colors">Pricing</a></li>
+                    </ul>
+                  </div>
+                  <div>
+                    <div className="font-black text-xs text-bauhaus-yellow mb-3 uppercase tracking-widest">Prospecting</div>
+                    <ul className="space-y-2 text-sm">
                       <li><a href="/foundations" className="text-bauhaus-muted hover:text-white transition-colors">Foundations</a></li>
-                      <li><a href="/charities" className="text-bauhaus-muted hover:text-white transition-colors">All Charities</a></li>
-                      <li><a href="/social-enterprises" className="text-bauhaus-muted hover:text-white transition-colors">Social Enterprises</a></li>
-                      <li><a href="/corporate" className="text-bauhaus-muted hover:text-white transition-colors">Corporate Giving</a></li>
+                      <li><a href="/foundations/tracker" className="text-bauhaus-muted hover:text-white transition-colors">Foundation Tracker</a></li>
+                      <li><a href="/for/community" className="text-bauhaus-muted hover:text-white transition-colors">For Community Teams</a></li>
+                      <li><a href="/for/funders" className="text-bauhaus-muted hover:text-white transition-colors">For Funders</a></li>
+                      <li><a href="/reports/grant-frontier" className="text-bauhaus-muted hover:text-white transition-colors">Grant Frontier</a></li>
                     </ul>
                   </div>
                   <div>
                     <div className="font-black text-xs text-bauhaus-yellow mb-3 uppercase tracking-widest">Research</div>
                     <ul className="space-y-2 text-sm">
                       <li><a href="/reports" className="text-bauhaus-muted hover:text-white transition-colors">All Reports</a></li>
-                      <li><a href="/reports/big-philanthropy" className="text-bauhaus-muted hover:text-white transition-colors">$222 Billion</a></li>
-                      <li><a href="/reports/community-parity" className="text-bauhaus-muted hover:text-white transition-colors">Community Parity</a></li>
-                      <li><a href="/reports/community-power" className="text-bauhaus-muted hover:text-white transition-colors">Community Power</a></li>
-                      <li><a href="/reports/social-enterprise" className="text-bauhaus-muted hover:text-white transition-colors">Social Enterprise</a></li>
+                      <li><a href="/reports/big-philanthropy" className="text-bauhaus-muted hover:text-white transition-colors">Big Philanthropy</a></li>
+                      <li><a href="/reports/power-dynamics" className="text-bauhaus-muted hover:text-white transition-colors">Power Dynamics</a></li>
+                      <li><a href="/ask" className="text-bauhaus-muted hover:text-white transition-colors">Ask CivicGraph</a></li>
                     </ul>
                   </div>
                   <div>
-                    <div className="font-black text-xs text-bauhaus-yellow mb-3 uppercase tracking-widest">For</div>
+                    <div className="font-black text-xs text-bauhaus-yellow mb-3 uppercase tracking-widest">Platform</div>
                     <ul className="space-y-2 text-sm">
-                      <li><a href="/for/funders" className="text-bauhaus-muted hover:text-white transition-colors">Funders</a></li>
-                      <li><a href="/for/philanthropy" className="text-bauhaus-muted hover:text-white transition-colors">Philanthropy</a></li>
-                      <li><a href="/for/corporate" className="text-bauhaus-muted hover:text-white transition-colors">Corporates & Sponsors</a></li>
-                      <li><a href="/for/social-enterprises" className="text-bauhaus-muted hover:text-white transition-colors">Social Enterprises</a></li>
-                      <li><a href="/for/community" className="text-bauhaus-muted hover:text-white transition-colors">Community Orgs</a></li>
-                      <li><a href="/pricing" className="text-bauhaus-muted hover:text-white transition-colors">Pricing</a></li>
+                      <li><a href="/developers" className="text-bauhaus-muted hover:text-white transition-colors">API</a></li>
+                      <li><a href="/tender-intelligence" className="text-bauhaus-muted hover:text-white transition-colors">Procurement Intelligence</a></li>
+                      <li><a href="/places" className="text-bauhaus-muted hover:text-white transition-colors">Place Packs</a></li>
+                      <li><a href="/reports" className="text-bauhaus-muted hover:text-white transition-colors">Broader Research Layer</a></li>
                     </ul>
                   </div>
                 </div>
                 <div className="mt-8 pt-6 border-t-2 border-white/10 text-center text-xs text-bauhaus-muted uppercase tracking-widest">
-                  Built by ACT &middot; Open source &middot; Data updated daily
+                  Built by ACT &middot; Funding pipeline and prospect intelligence &middot; Data updated daily
                   <a href="/investors" className="ml-4 text-white/20 hover:text-white/60 transition-colors">Investors</a>
                   <a href="/ops/health" className="ml-4 text-white/20 hover:text-white/60 transition-colors">&middot;</a>
                 </div>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from 'react';
 import { createSupabaseBrowser } from '@/lib/supabase-browser';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { resolveAuthRedirect } from '@/lib/auth-redirect';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -11,7 +12,7 @@ function LoginForm() {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirect = searchParams.get('redirect');
+  const redirectPath = resolveAuthRedirect(searchParams);
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault();
@@ -30,7 +31,7 @@ function LoginForm() {
       return;
     }
 
-    router.push(redirect || '/tracker');
+    router.push(redirectPath);
     router.refresh();
   }
 
@@ -90,7 +91,7 @@ function LoginForm() {
 
             <p className="text-center text-sm text-bauhaus-muted font-medium">
               Don&apos;t have an account?{' '}
-              <a href={redirect ? `/register?redirect=${encodeURIComponent(redirect)}` : '/register'} className="text-bauhaus-blue hover:text-bauhaus-red font-bold">
+              <a href={redirectPath !== '/continue' ? `/register?redirect=${encodeURIComponent(redirectPath)}` : '/register'} className="text-bauhaus-blue hover:text-bauhaus-red font-bold">
                 Create one
               </a>
             </p>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { getServiceSupabase } from '@/lib/supabase';
-import { money, fmt } from '@/lib/format';
+import { fmt } from '@/lib/format';
 import { UnifiedSearch } from './components/unified-search';
 
 export const dynamic = 'force-dynamic';
@@ -42,531 +42,401 @@ async function safeCount(
 async function getStats() {
   const supabase = getServiceSupabase();
 
-  // Use 'estimated' for large tables (>100K rows) to avoid PostgREST timeouts
   const [
     totalGrants,
     totalFoundations,
     profiledFoundations,
-    embeddedGrants,
     openGrants,
     totalPrograms,
-    acncCharities,
-    communityOrgs,
-    withAmounts,
-    socialEnterprises,
     totalEntities,
     totalRelationships,
-    totalAustenderContracts,
-    totalPoliticalDonations,
     donorContractorStats,
   ] = await Promise.all([
     safeCount(supabase.from('grant_opportunities').select('*', { count: 'exact', head: true })),
     safeCount(supabase.from('foundations').select('*', { count: 'exact', head: true })),
-    safeCount(supabase.from('foundations').select('*', { count: 'exact', head: true }).not('enriched_at', 'is', null)),
-    safeCount(supabase.from('grant_opportunities').select('*', { count: 'exact', head: true }).not('embedding', 'is', null)),
-    safeCount(supabase.from('grant_opportunities').select('*', { count: 'exact', head: true }).gt('closes_at', new Date().toISOString())),
-    safeCount(supabase.from('foundation_programs').select('*', { count: 'exact', head: true }).in('status', ['open', 'closed'])),
-    safeCount(supabase.from('acnc_ais').select('*', { count: 'estimated', head: true })),
-    safeCount(supabase.from('community_orgs').select('*', { count: 'exact', head: true })),
-    safeCount(supabase.from('grant_opportunities').select('*', { count: 'exact', head: true }).not('amount_max', 'is', null)),
-    safeCount(supabase.from('social_enterprises').select('*', { count: 'exact', head: true })),
+    safeCount(
+      supabase.from('foundations').select('*', { count: 'exact', head: true }).not('enriched_at', 'is', null),
+    ),
+    safeCount(
+      supabase.from('grant_opportunities').select('*', { count: 'exact', head: true }).gt('closes_at', new Date().toISOString()),
+    ),
+    safeCount(
+      supabase.from('foundation_programs').select('*', { count: 'exact', head: true }).in('status', ['open', 'closed']),
+    ),
     safeCount(supabase.from('gs_entities').select('*', { count: 'estimated', head: true })),
     safeCount(supabase.from('gs_relationships').select('*', { count: 'estimated', head: true })),
-    safeCount(supabase.from('austender_contracts').select('*', { count: 'estimated', head: true })),
-    safeCount(supabase.from('political_donations').select('*', { count: 'estimated', head: true })),
     getDonorContractorHeadlineStats(supabase),
   ]);
 
-  // Grants by state — fetch source column for state scrapers and count client-side
-  const stateSources = ['nsw-grants','vic-grants','qld-grants','sa-grants','wa-grants','tas-grants','act-grants','nt-grants'];
-  const stateCountsArr = await Promise.all(
-    stateSources.map(async (src) => {
-      const cnt = await safeCount(
-        supabase.from('grant_opportunities').select('*', { count: 'exact', head: true }).eq('source', src),
-      );
-      return { source: src, cnt };
-    })
-  );
-  const byState = stateCountsArr.filter(s => s.cnt > 0).sort((a, b) => b.cnt - a.cnt);
-
-  // Distinct source count — fetch a sample of sources
   let sourceCount = 0;
   try {
-    const { data: sourceSample } = await supabase.from('grant_opportunities')
-      .select('source')
-      .limit(10000);
-    sourceCount = sourceSample ? new Set(sourceSample.map((r: { source: string }) => r.source)).size : 0;
-  } catch { /* fallback to 0 */ }
-
-  // Category breakdown
-  const knownCats = ['arts','community','technology','regenerative','enterprise','general','health','education','indigenous','justice','sport','research'];
-  const catCountsArr = await Promise.all(
-    knownCats.map(async (cat) => {
-      const cnt = await safeCount(
-        supabase.from('grant_opportunities').select('*', { count: 'exact', head: true }).contains('categories', [cat]),
-      );
-      return { cat, cnt };
-    })
-  );
-  const categories = catCountsArr.filter(c => c.cnt > 0).sort((a, b) => b.cnt - a.cnt).slice(0, 10);
+    const { data: sourceSample } = await supabase.from('grant_opportunities').select('source').limit(10000);
+    sourceCount = sourceSample ? new Set(sourceSample.map((row: { source: string }) => row.source)).size : 0;
+  } catch {
+    sourceCount = 0;
+  }
 
   return {
     totalGrants,
     totalFoundations,
     profiledFoundations,
-    embeddedGrants,
     openGrants,
     totalPrograms,
-    acncCharities,
-    communityOrgs,
-    socialEnterprises,
-    withAmounts,
     totalEntities,
     totalRelationships,
-    totalAustenderContracts,
-    totalPoliticalDonations,
     donorContractorCount: donorContractorStats.count,
-    dcTotalDonated: donorContractorStats.totalDonated,
-    dcTotalContracts: donorContractorStats.totalContracts,
-    byState,
     sourceCount,
-    categories,
   };
 }
 
-const STATE_LABELS: Record<string, string> = {
-  'nsw-grants': 'NSW',
-  'vic-grants': 'VIC',
-  'qld-grants': 'QLD',
-  'sa-grants': 'SA',
-  'wa-grants': 'WA',
-  'tas-grants': 'TAS',
-  'act-grants': 'ACT',
-  'nt-grants': 'NT',
-};
-
-const STATE_COLORS: Record<string, string> = {
-  'nsw-grants': 'bg-bauhaus-blue',
-  'vic-grants': 'bg-bauhaus-black',
-  'qld-grants': 'bg-bauhaus-red',
-  'sa-grants': 'bg-bauhaus-yellow',
-  'wa-grants': 'bg-bauhaus-blue',
-  'tas-grants': 'bg-bauhaus-red',
-  'act-grants': 'bg-bauhaus-black',
-  'nt-grants': 'bg-bauhaus-yellow',
-};
-
-const CAT_LABELS: Record<string, string> = {
-  arts: 'Arts & Culture',
-  community: 'Community',
-  technology: 'Technology',
-  regenerative: 'Environment',
-  enterprise: 'Business',
-  general: 'General',
-  health: 'Health',
-  education: 'Education',
-  indigenous: 'First Nations',
-  justice: 'Justice',
-  sport: 'Sport',
-  research: 'Research',
-  disaster_relief: 'Disaster Relief',
-};
-
 export default async function HomePage() {
   let stats = {
-    totalGrants: 0, totalFoundations: 0, profiledFoundations: 0,
-    embeddedGrants: 0, openGrants: 0, totalPrograms: 0,
-    acncCharities: 0, communityOrgs: 0, socialEnterprises: 0, withAmounts: 0,
-    totalEntities: 0, totalRelationships: 0,
-    totalAustenderContracts: 0, totalPoliticalDonations: 0,
-    donorContractorCount: 0, dcTotalDonated: 0, dcTotalContracts: 0,
-    byState: null as Array<{ source: string; cnt: number }> | null,
+    totalGrants: 0,
+    totalFoundations: 0,
+    profiledFoundations: 0,
+    openGrants: 0,
+    totalPrograms: 0,
+    totalEntities: 0,
+    totalRelationships: 0,
+    donorContractorCount: 0,
     sourceCount: 0,
-    categories: null as Array<{ cat: string; cnt: number }> | null,
   };
+
   try {
     stats = await getStats();
   } catch {
     // DB not yet configured
   }
 
-  // unused after homepage cleanup: embeddedPct, maxStateCnt, maxCatCnt
-  const heroEvidenceLine =
-    stats.totalEntities > 0 && stats.totalAustenderContracts > 0 && stats.totalPoliticalDonations > 0
-      ? `CivicGraph connects ${fmt(stats.totalEntities)} entities, ${fmt(stats.totalAustenderContracts)} contracts, and ${fmt(stats.totalPoliticalDonations)} donations into the decision layer for Australian public spending.`
-      : 'CivicGraph connects supplier intelligence, place-based funding data, and donation signals into the decision layer for Australian public spending.';
+  const discoveryLine =
+    stats.totalGrants > 0 && stats.totalFoundations > 0 && stats.totalPrograms > 0
+      ? `Search ${fmt(stats.totalGrants)} grant opportunities, track ${fmt(stats.totalPrograms)} foundation programs, and prospect across ${fmt(stats.totalFoundations)} funders from one workflow.`
+      : 'Track grants, foundation programs, and prospecting signals from one workflow.';
+
+  const evidenceLine =
+    stats.sourceCount > 0 && stats.totalEntities > 0 && stats.totalRelationships > 0
+      ? `Behind the pipeline sits ${fmt(stats.sourceCount)} connected sources, ${fmt(stats.totalEntities)} entities, and ${fmt(stats.totalRelationships)} relationship edges.`
+      : 'Behind the pipeline sits a connected public-data graph, not a static grants directory.';
 
   return (
-    <div>
-      {/* Hero */}
-      <section className="py-16 sm:py-24">
-        <p className="text-xs font-black text-bauhaus-red uppercase tracking-[0.3em] mb-4">
-          Decision Infrastructure for Government &amp; Social Sector
-        </p>
-        <h1 className="text-4xl sm:text-6xl lg:text-7xl font-black text-bauhaus-black mb-6 tracking-tight leading-[0.9]">
-          Know Who to Fund.<br />Know Who to Contract.<br /><span className="text-bauhaus-blue">Know It Worked.</span>
-        </h1>
-        <p className="text-lg text-bauhaus-muted max-w-xl mb-10 leading-relaxed font-medium">
-          Procurement intelligence. Place-based allocation analysis. Governed proof of outcomes.{' '}
-          {heroEvidenceLine}
-        </p>
-
-        <UnifiedSearch />
-
-        <div className="flex gap-0 flex-wrap mb-6">
-          <a href="/tender-intelligence" className="px-6 py-3 bg-bauhaus-black text-white font-black text-xs uppercase tracking-widest border-4 border-bauhaus-black hover:bg-bauhaus-red bauhaus-shadow-sm">
-            Procurement Intelligence
-          </a>
-          <a href="/places" className="px-6 py-3 bg-white text-bauhaus-black font-black text-xs uppercase tracking-widest border-4 border-bauhaus-black hover:bg-bauhaus-yellow">
-            Place Packs
-          </a>
-          <a href="/grants" className="px-6 py-3 bg-white text-bauhaus-black font-black text-xs uppercase tracking-widest border-4 border-bauhaus-black border-l-0 hover:bg-bauhaus-blue hover:text-white">
-            Search Grants
-          </a>
-        </div>
-        <div className="flex gap-2 flex-wrap mb-6 max-w-xl">
-          <span className="text-xs font-black text-bauhaus-muted uppercase tracking-widest self-center mr-1">Quick:</span>
-          {[
-            { label: 'Supplier discovery workflow', href: '/tender-intelligence#discover' },
-            { label: 'Social procurement analyser', href: '/procurement' },
-            { label: 'Intelligence pack preview', href: '/tender-intelligence#pack' },
-            { label: 'Funding gaps by postcode', href: '/places' },
-            { label: 'Due diligence report', href: '/reports/donor-contractors' },
-          ].map(q => (
-            <a
-              key={q.label}
-              href={q.href}
-              className="text-xs px-3 py-1.5 bg-link-light text-bauhaus-blue font-bold border-2 border-bauhaus-blue/20 hover:border-bauhaus-blue transition-colors"
-            >
-              {q.label}
-            </a>
-          ))}
-        </div>
-      </section>
-
-      {/* The Problem */}
-      <section className="border-4 border-bauhaus-black mb-16 bg-bauhaus-black text-white">
-        <div className="p-8 sm:p-12">
-          <h2 className="text-2xl sm:text-3xl font-black mb-6 leading-tight">
-            Every Procurement Decision Is Made With Incomplete Data
-          </h2>
-          <div className="space-y-4 text-base font-medium leading-relaxed text-white/85 max-w-2xl">
-            <p>
-              <strong className="text-bauhaus-yellow">$74 billion</strong> in government contracts awarded annually.
-              Procurement officers make supplier decisions from spreadsheets.
-              Commissioners allocate funding without seeing where money already flows.
-              Nobody connects the contract to the community outcome.
+    <div className="space-y-16 pb-10">
+      <section className="border-4 border-bauhaus-black bg-bauhaus-black text-white">
+        <div className="grid gap-0 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="p-8 sm:p-12 lg:p-14">
+            <p className="mb-5 text-xs font-black uppercase tracking-[0.35em] text-bauhaus-yellow">
+              Funding, Power, Procurement, And Reporting
             </p>
-            <p>
-              CivicGraph is the decision layer that connects supplier intelligence,
-              place-based funding data, and outcome evidence &mdash; so every allocation
-              decision is defensible, every renewal is justified, and every gap is visible.
+            <h1 className="mb-6 text-4xl font-black leading-[0.9] tracking-tight sm:text-6xl lg:text-7xl">
+              See What Is Happening.
+              <br />
+              Decide What To Do Next.
+            </h1>
+            <p className="max-w-2xl text-lg font-medium leading-relaxed text-white/72 sm:text-xl">
+              CivicGraph starts with an always-on funding pipeline, then uses the same graph to read
+              companies, procurement pathways, philanthropy, and place. The point is not to show off the
+              data. It is to help a team act, write the brief, and build a reporting or story surface from
+              the same evidence chain.
             </p>
-          </div>
-          <div className="flex gap-4 flex-wrap mt-8">
-            <a href="/tender-intelligence" className="px-6 py-3 bg-bauhaus-red text-white font-black text-xs uppercase tracking-widest border-4 border-white hover:bg-white hover:text-bauhaus-black transition-colors">
-              See Procurement Intelligence
-            </a>
-            <a href="/for/government" className="px-6 py-3 bg-transparent text-white font-black text-xs uppercase tracking-widest border-4 border-white/40 hover:border-white hover:bg-white hover:text-bauhaus-black transition-colors">
-              For Government
-            </a>
-          </div>
-        </div>
-      </section>
+            <p className="mt-5 max-w-2xl text-sm font-bold leading-relaxed text-white/55">
+              {discoveryLine} {evidenceLine}
+            </p>
 
-      {/* Entity Graph — the flagship finding */}
-      {stats.donorContractorCount > 0 && (
-        <section className="mb-16">
-          <a href="/reports/donor-contractors" className="group block">
-            <div className="border-4 border-bauhaus-black bg-bauhaus-red transition-all group-hover:-translate-y-1" style={{ boxShadow: '8px 8px 0px 0px var(--color-bauhaus-black)' }}>
-              <div className="p-8 sm:p-12">
-                <div className="text-xs font-black text-bauhaus-yellow uppercase tracking-widest mb-3">Entity Graph Investigation</div>
-                <h2 className="text-2xl sm:text-4xl font-black text-white mb-4 leading-tight">
-                  {stats.donorContractorCount} Entities Donate to Political Parties<br />
-                  AND Hold Government Contracts
-                </h2>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-6">
-                  <div>
-                    <div className="text-3xl sm:text-4xl font-black text-white">{money(stats.dcTotalDonated)}</div>
-                    <div className="text-white/60 text-sm font-bold mt-1">donated to parties</div>
-                  </div>
-                  <div>
-                    <div className="text-3xl sm:text-4xl font-black text-white">{money(stats.dcTotalContracts)}</div>
-                    <div className="text-white/60 text-sm font-bold mt-1">received in contracts</div>
-                  </div>
-                  <div>
-                    <div className="text-3xl sm:text-4xl font-black text-bauhaus-yellow">
-                      {stats.dcTotalDonated > 0 ? `${Math.round(stats.dcTotalContracts / stats.dcTotalDonated)}x` : '—'}
-                    </div>
-                    <div className="text-white/60 text-sm font-bold mt-1">return per dollar donated</div>
-                  </div>
-                </div>
-                <p className="text-white/70 text-sm font-medium max-w-2xl mb-4">
-                  Built from {stats.totalEntities.toLocaleString()} entities and {stats.totalRelationships.toLocaleString()} relationships
-                  — cross-referencing AEC political donations, AusTender contracts, ACNC charities,
-                  ORIC Indigenous corporations, ATO tax data, and ASIC company records by ABN.
+            <div className="mt-10 max-w-3xl">
+              <UnifiedSearch />
+            </div>
+
+            <div className="mt-8 flex flex-wrap gap-0">
+              <a
+                href="/register"
+                className="border-4 border-bauhaus-black bg-bauhaus-red px-6 py-3 text-xs font-black uppercase tracking-widest text-white transition-colors hover:bg-white hover:text-bauhaus-black"
+              >
+                Start Free
+              </a>
+              <a
+                href="/reports/civicgraph-thesis"
+                className="border-y-4 border-r-4 border-bauhaus-black bg-white px-6 py-3 text-xs font-black uppercase tracking-widest text-bauhaus-black transition-colors hover:bg-bauhaus-yellow"
+              >
+                Read The Thesis
+              </a>
+              <a
+                href="/pricing"
+                className="border-y-4 border-r-4 border-bauhaus-black bg-bauhaus-black px-6 py-3 text-xs font-black uppercase tracking-widest text-white transition-colors hover:bg-bauhaus-blue"
+              >
+                View Pricing
+              </a>
+            </div>
+          </div>
+
+          <div className="border-t-4 border-bauhaus-black bg-bauhaus-canvas lg:border-l-4 lg:border-t-0">
+            <div className="grid h-full grid-cols-1 divide-y-4 divide-bauhaus-black">
+              <div className="p-8 sm:p-10">
+                <p className="text-xs font-black uppercase tracking-widest text-bauhaus-muted">
+                  The Decision Loop
                 </p>
-                <span className="inline-block px-6 py-2.5 bg-white text-bauhaus-black font-black text-xs uppercase tracking-widest group-hover:bg-bauhaus-yellow transition-colors">
-                  Read the Full Investigation &rarr;
-                </span>
+                <div className="mt-4 space-y-4">
+                  {[
+                    {
+                      title: 'See',
+                      copy: 'Track opportunities, foundations, company records, and movement in the field from one graph.',
+                    },
+                    {
+                      title: 'Decide',
+                      copy: 'Compare fit, timing, procurement context, and power signals before you commit the team.',
+                    },
+                    {
+                      title: 'Brief',
+                      copy: 'Turn the same evidence into a board memo, partner pack, procurement note, or next-action export.',
+                    },
+                    {
+                      title: 'Tell',
+                      copy: 'Carry approved context into reporting and company-story surfaces rather than rebuilding the argument from scratch.',
+                    },
+                  ].map((item) => (
+                    <div key={item.title} className="border-4 border-bauhaus-black bg-white p-4">
+                      <p className="text-xs font-black uppercase tracking-widest text-bauhaus-red">{item.title}</p>
+                      <p className="mt-2 text-sm font-medium text-bauhaus-muted">{item.copy}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2">
+                {[
+                  { label: 'Open Now', value: fmt(stats.openGrants) || '0', tone: 'bg-bauhaus-blue text-white' },
+                  { label: 'Foundations', value: fmt(stats.totalFoundations) || '0', tone: 'bg-white text-bauhaus-black' },
+                  { label: 'Entities', value: fmt(stats.totalEntities) || '0', tone: 'bg-bauhaus-red text-white' },
+                  { label: 'Links', value: fmt(stats.totalRelationships) || '0', tone: 'bg-bauhaus-yellow text-bauhaus-black' },
+                ].map((item) => (
+                  <div key={item.label} className={`border-b-4 border-r-4 border-bauhaus-black p-6 last:border-r-0 [&:nth-child(n+3)]:border-b-0 ${item.tone}`}>
+                    <p className="text-3xl font-black tabular-nums sm:text-4xl">{item.value}</p>
+                    <p className="mt-1 text-[11px] font-black uppercase tracking-widest opacity-70">{item.label}</p>
+                  </div>
+                ))}
               </div>
             </div>
-          </a>
-        </section>
-      )}
-
-      {/* Live Stats — clean, 5 numbers only */}
-      <section className="border-4 border-bauhaus-black mb-16">
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-0">
-          <a href="/grants" className="group border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black">
-            <div className="p-6 text-center transition-all group-hover:bg-bauhaus-blue group-hover:text-white">
-              <div className="text-3xl sm:text-4xl font-black tabular-nums">{stats.totalGrants.toLocaleString()}</div>
-              <div className="text-xs font-black uppercase tracking-widest mt-1 text-bauhaus-muted group-hover:text-white/70">Grants</div>
-            </div>
-          </a>
-          <a href="/foundations" className="group border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black">
-            <div className="p-6 text-center transition-all group-hover:bg-bauhaus-red group-hover:text-white">
-              <div className="text-3xl sm:text-4xl font-black tabular-nums">{stats.totalFoundations.toLocaleString()}</div>
-              <div className="text-xs font-black uppercase tracking-widest mt-1 text-bauhaus-muted group-hover:text-white/70">Foundations</div>
-            </div>
-          </a>
-          <a href="/charities" className="group border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black">
-            <div className="p-6 text-center transition-all group-hover:bg-bauhaus-black group-hover:text-white">
-              <div className="text-3xl sm:text-4xl font-black tabular-nums">{stats.acncCharities.toLocaleString()}</div>
-              <div className="text-xs font-black uppercase tracking-widest mt-1 text-bauhaus-muted group-hover:text-white/70">Charities</div>
-            </div>
-          </a>
-          <a href="/entities" className="group border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black">
-            <div className="p-6 text-center transition-all group-hover:bg-bauhaus-yellow">
-              <div className="text-3xl sm:text-4xl font-black tabular-nums">{stats.totalEntities.toLocaleString()}</div>
-              <div className="text-xs font-black uppercase tracking-widest mt-1 text-bauhaus-muted group-hover:text-bauhaus-black">Entities</div>
-            </div>
-          </a>
-          <a href="/reports" className="group">
-            <div className="p-6 text-center transition-all group-hover:bg-bauhaus-red group-hover:text-white">
-              <div className="text-3xl sm:text-4xl font-black tabular-nums">{stats.totalRelationships.toLocaleString()}</div>
-              <div className="text-xs font-black uppercase tracking-widest mt-1 text-bauhaus-muted group-hover:text-white/70">Relationships</div>
-            </div>
-          </a>
-        </div>
-        <div className="border-t-4 border-bauhaus-black p-3 bg-bauhaus-canvas text-center">
-          <p className="text-[11px] text-bauhaus-muted font-bold">
-            {stats.sourceCount || 44} data sources &middot; {stats.openGrants.toLocaleString()} grants open now &middot; {stats.profiledFoundations.toLocaleString()} AI-profiled foundations &middot; Updated daily
-          </p>
-        </div>
-      </section>
-
-      {/* Three Product Families */}
-      <section className="border-t-4 border-bauhaus-black pt-16 pb-12">
-        <h2 className="text-2xl font-black text-center text-bauhaus-black mb-3">Three Products. One Decision Layer.</h2>
-        <p className="text-sm text-bauhaus-muted text-center mb-10 max-w-2xl mx-auto">
-          From finding the right supplier, to allocating resources where they&apos;re needed,
-          to proving the investment worked. Each layer makes the next more powerful.
-        </p>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-0">
-          <a href="/tender-intelligence" className="group border-4 border-bauhaus-black p-8 bg-white bauhaus-shadow-sm hover:bg-bauhaus-blue hover:text-white transition-colors">
-            <div className="text-xs font-black text-bauhaus-blue uppercase tracking-widest mb-4 group-hover:text-bauhaus-yellow">Product 1 &mdash; Available Now</div>
-            <h3 className="font-black text-bauhaus-black mb-2 text-lg group-hover:text-white">Procurement Intelligence</h3>
-            <p className="text-sm text-bauhaus-muted leading-relaxed mb-4 group-hover:text-white/70">
-              Discover suppliers. Check compliance. Generate bid-ready intelligence packs.
-              National contract history cross-referenced with {stats.totalEntities.toLocaleString()} entities.
-              Replace spreadsheets with a defensible market view.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {['Supplier Discovery', 'Compliance', 'Intelligence Packs', 'List Enrichment'].map(t => (
-                <span key={t} className="text-[10px] font-black uppercase tracking-widest px-2 py-1 border-2 border-bauhaus-blue/20 text-bauhaus-blue group-hover:border-white/30 group-hover:text-white/80">{t}</span>
-              ))}
-            </div>
-          </a>
-          <a href="/places" className="group border-4 border-l-0 max-md:border-l-4 max-md:border-t-0 border-bauhaus-black p-8 bg-bauhaus-black hover:bg-bauhaus-yellow transition-colors">
-            <div className="text-xs font-black text-bauhaus-yellow uppercase tracking-widest mb-4 group-hover:text-bauhaus-black">Product 2 &mdash; Available Now</div>
-            <h3 className="font-black text-white mb-2 text-lg group-hover:text-bauhaus-black">Allocation Intelligence</h3>
-            <p className="text-sm text-white/70 leading-relaxed mb-4 group-hover:text-bauhaus-black/70">
-              Place-based funding analysis. Gap scoring. Commissioning intelligence.
-              See where money flows, where it doesn&apos;t, and where
-              capability doesn&apos;t match need.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {['Place Packs', 'Gap Analysis', 'Commissioning', 'SEIFA + Remoteness'].map(t => (
-                <span key={t} className="text-[10px] font-black uppercase tracking-widest px-2 py-1 border-2 border-white/20 text-white/60 group-hover:border-bauhaus-black/20 group-hover:text-bauhaus-black/60">{t}</span>
-              ))}
-            </div>
-          </a>
-          <div className="border-4 border-l-0 max-md:border-l-4 max-md:border-t-0 border-bauhaus-black p-8 bg-bauhaus-red/10">
-            <div className="text-xs font-black text-bauhaus-red uppercase tracking-widest mb-4">Product 3 &mdash; Coming Soon</div>
-            <h3 className="font-black text-bauhaus-black mb-2 text-lg">Governed Proof</h3>
-            <p className="text-sm text-bauhaus-muted leading-relaxed mb-4">
-              Did procurement create community value? Did this commissioning strategy work?
-              Rights-governed, consent-based evidence that helps defend renewals,
-              justify policy, and prove long-term outcomes.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {['Outcome Evidence', 'Community Voice', 'Renewal Defence', 'Policy Proof'].map(t => (
-                <span key={t} className="text-[10px] font-black uppercase tracking-widest px-2 py-1 border-2 border-bauhaus-red/20 text-bauhaus-red/60">{t}</span>
-              ))}
-            </div>
           </div>
         </div>
-        <div className="border-4 border-t-0 border-bauhaus-black bg-bauhaus-canvas p-6 text-center">
-          <p className="text-xs font-black text-bauhaus-muted uppercase tracking-widest mb-1">Together, These Create</p>
-          <p className="text-lg font-black text-bauhaus-black">The Decision Layer for Australian Public Spending</p>
-          <p className="text-sm text-bauhaus-muted">Who gets funded. Who gets contracted. Where services go. How allocations are justified.</p>
-        </div>
       </section>
 
-      {/* Data Sources */}
-      <section className="border-t-4 border-bauhaus-black pt-16 pb-8">
-        <h2 className="text-2xl font-black text-center text-bauhaus-black mb-3">Data Sources</h2>
-        <p className="text-center text-sm text-bauhaus-muted mb-10 max-w-2xl mx-auto">
-          CivicGraph connects {stats.sourceCount || 44} data sources across government procurement, philanthropy,
-          political donations, corporate filings, and community organisations into a single market map.
-        </p>
-        <div className="flex flex-wrap justify-center gap-3 max-w-3xl mx-auto mb-12">
+      <section className="border-4 border-bauhaus-black bg-white">
+        <div className="grid gap-0 md:grid-cols-3">
           {[
-            { name: 'GrantConnect', color: 'bg-bauhaus-blue' },
-            { name: 'ACNC', color: 'bg-bauhaus-red' },
-            { name: 'data.gov.au', color: 'bg-bauhaus-black' },
-            { name: 'NSW.gov.au', color: 'bg-bauhaus-blue' },
-            { name: 'QLD Grants', color: 'bg-bauhaus-red' },
-            { name: 'VIC.gov.au', color: 'bg-bauhaus-black' },
-            { name: 'SA.gov.au', color: 'bg-bauhaus-yellow' },
-            { name: 'WA.gov.au', color: 'bg-bauhaus-blue' },
-            { name: 'TAS.gov.au', color: 'bg-bauhaus-red' },
-            { name: 'NT.gov.au', color: 'bg-bauhaus-yellow' },
-            { name: 'ACT.gov.au', color: 'bg-bauhaus-black' },
-            { name: 'ARC', color: 'bg-bauhaus-blue' },
-            { name: 'NHMRC', color: 'bg-bauhaus-red' },
-            { name: 'business.gov.au', color: 'bg-bauhaus-black' },
-            { name: 'ORIC', color: 'bg-bauhaus-red' },
-            { name: 'AusTender', color: 'bg-bauhaus-blue' },
-            { name: 'ASIC', color: 'bg-bauhaus-black' },
-            { name: 'ATO', color: 'bg-bauhaus-yellow' },
-            { name: 'ASX', color: 'bg-bauhaus-red' },
-            { name: 'AEC Donations', color: 'bg-bauhaus-red' },
-            { name: 'ABR', color: 'bg-bauhaus-yellow' },
-            { name: 'NDIS', color: 'bg-bauhaus-blue' },
-            { name: 'Modern Slavery Register', color: 'bg-bauhaus-black' },
-            { name: 'Lobbying Register', color: 'bg-bauhaus-blue' },
-            { name: 'State Procurement', color: 'bg-bauhaus-red' },
-          ].map(src => (
-            <span key={src.name} className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-bauhaus-black">
-              <span className={`w-2.5 h-2.5 ${src.color} border border-bauhaus-black`} />
-              {src.name}
-            </span>
+            {
+              title: 'For Funding Teams',
+              copy: 'Run the live pipeline, keep signal over noise, and generate the next brief without rebuilding the research every week.',
+            },
+            {
+              title: 'For Place-Based Funders And Commissioners',
+              copy: 'Use the same graph to understand who is credible, where money already flows, what procurement paths exist, and what is still missing.',
+            },
+            {
+              title: 'For Research, Reporting, And Story Teams',
+              copy: 'Move from raw company or field data into defensible public argument, partner reporting, and story-ready context.',
+            },
+          ].map((card, index) => (
+            <div
+              key={card.title}
+              className={`p-8 ${index < 2 ? 'border-b-4 border-bauhaus-black md:border-b-0 md:border-r-4' : ''}`}
+            >
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">Built For</p>
+              <h2 className="mt-3 text-2xl font-black tracking-tight text-bauhaus-black">{card.title}</h2>
+              <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">{card.copy}</p>
+            </div>
           ))}
         </div>
       </section>
 
-      {/* Reports teasers */}
-      <section className="border-t-4 border-bauhaus-black pt-16 pb-8">
-        <h2 className="text-2xl font-black text-center text-bauhaus-black mb-2">CivicGraph Intelligence</h2>
-        <p className="text-center text-bauhaus-muted mb-10 text-sm font-medium">Living investigations into how money flows — updated as new data arrives</p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 max-w-4xl mx-auto">
-          <a href="/reports/convergence" className="group block sm:col-span-2 lg:col-span-3">
-            <div className="bg-bauhaus-blue border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1" style={{ boxShadow: '6px 6px 0px 0px var(--color-bauhaus-black)' }}>
-              <div className="text-xs font-black text-bauhaus-yellow mb-1 uppercase tracking-widest">Flagship Investigation</div>
-              <h3 className="font-black text-white mb-1">One Child. Five Systems. Zero Coordination.</h3>
-              <p className="text-sm text-white/80">Child protection, youth justice, disability, education, welfare — the same communities appear in every system. The money maintains the system, not the person.</p>
+      <section className="border-4 border-bauhaus-black bg-bauhaus-canvas">
+        <div className="border-b-4 border-bauhaus-black bg-white p-8 text-center sm:p-10">
+          <p className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">How It Works</p>
+          <h2 className="mt-3 text-3xl font-black tracking-tight text-bauhaus-black sm:text-4xl">
+            One Workflow. Four Outputs.
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+            The product should not feel like a directory or a demo. It should feel like a decision workspace
+            that can generate the next move, the next brief, and the next narrative from one shared base.
+          </p>
+        </div>
+
+        <div className="grid gap-0 md:grid-cols-4">
+          {[
+            ['1. See Reality', 'Follow the live graph across grants, funders, entities, place, and procurement context.'],
+            ['2. Choose A Move', 'Rank what matters now instead of forcing people to browse disconnected modules.'],
+            ['3. Build The Brief', 'Generate a memo, pack, or report with a visible evidence chain.'],
+            ['4. Tell The Story', 'Carry the approved analysis into reporting and Empathy Ledger-style narrative work.'],
+          ].map(([title, copy], index) => (
+            <div
+              key={title}
+              className={`p-6 sm:p-8 ${index < 3 ? 'border-b-4 border-bauhaus-black md:border-b-0 md:border-r-4' : ''}`}
+            >
+              <p className="text-lg font-black text-bauhaus-black">{title}</p>
+              <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">{copy}</p>
             </div>
-          </a>
-          <a href="/reports/donor-contractors" className="group block sm:col-span-2 lg:col-span-3">
-            <div className="bg-bauhaus-red border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1" style={{ boxShadow: '6px 6px 0px 0px var(--color-bauhaus-black)' }}>
-              <div className="text-xs font-black text-bauhaus-yellow mb-1 uppercase tracking-widest">Entity Graph Investigation</div>
-              <h3 className="font-black text-white mb-1">Donate. Win Contracts. Repeat.</h3>
-              <p className="text-sm text-white/80">{stats.donorContractorCount} entities donated {money(stats.dcTotalDonated)} to political parties and received {money(stats.dcTotalContracts)} in government contracts.</p>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-4 border-bauhaus-black bg-white">
+        <div className="border-b-4 border-bauhaus-black p-8 sm:p-10">
+          <p className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-blue">Agent Support</p>
+          <h2 className="mt-3 text-3xl font-black tracking-tight text-bauhaus-black sm:text-4xl">
+            Same Evidence Chain. Different Agents.
+          </h2>
+          <p className="mt-4 max-w-3xl text-sm font-medium leading-relaxed text-bauhaus-muted">
+            Agents should not create a second system. They should keep the main loop moving: scout what changed,
+            link the relevant entities, draft the next pack, then prepare reporting or story outputs from the same
+            underlying context.
+          </p>
+        </div>
+        <div className="grid gap-0 md:grid-cols-4">
+          {[
+            ['Scout', 'Watches frontier pages, deadlines, and funder movement so the team sees what changed first.'],
+            ['Analyst', 'Connects company, foundation, procurement, and place data into a usable decision view.'],
+            ['Brief Builder', 'Turns the evidence into board notes, partner packs, and opportunity memos.'],
+            ['Story Layer', 'Prepares approved analysis for reporting and narrative outputs instead of leaving it trapped in ops.'],
+          ].map(([title, copy], index) => (
+            <div
+              key={title}
+              className={`p-6 sm:p-8 ${index < 3 ? 'border-b-4 border-bauhaus-black md:border-b-0 md:border-r-4' : ''}`}
+            >
+              <p className="text-lg font-black text-bauhaus-black">{title}</p>
+              <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">{copy}</p>
             </div>
-          </a>
-          <a href="/reports/big-philanthropy" className="group block sm:col-span-2 lg:col-span-3">
-            <div className="bg-bauhaus-black border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1" style={{ boxShadow: '6px 6px 0px 0px var(--color-bauhaus-red)' }}>
-              <div className="text-xs font-black text-bauhaus-yellow mb-1 uppercase tracking-widest">Data Investigation</div>
-              <h3 className="font-black text-white mb-1">Where Does Australia&apos;s $222 Billion Go?</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/60">National charity registry analysis with longitudinal ACNC reporting and funding-flow context.</p>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr]">
+        <div className="border-4 border-bauhaus-black bg-white p-8 sm:p-10">
+          <p className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-blue">Why It Wins</p>
+          <h2 className="mt-3 text-3xl font-black tracking-tight text-bauhaus-black">
+            Better Than A Static Grants Product
+          </h2>
+          <div className="mt-6 space-y-4">
+            {[
+              'Continuous frontier polling instead of one-off scraping.',
+              'Entity and relationship context, not just opportunity rows.',
+              'Foundation, procurement, place, and company data in one surface.',
+              'The same context can drive alerts, briefs, reporting, and stories.',
+            ].map((line) => (
+              <div key={line} className="flex gap-3 border-4 border-bauhaus-black bg-bauhaus-canvas p-4">
+                <span className="text-lg font-black text-bauhaus-red">+</span>
+                <p className="text-sm font-bold text-bauhaus-black">{line}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-bauhaus-black p-8 text-white sm:p-10">
+          <p className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-yellow">
+            From Signal To Story
+          </p>
+          <h2 className="mt-3 text-3xl font-black tracking-tight">
+            Company Data That Can Become A Brief Or A Story.
+          </h2>
+          <p className="mt-4 max-w-2xl text-sm font-medium leading-relaxed text-white/70">
+            CivicGraph should be able to start with an entity, a field, or a procurement pathway, then
+            carry that analysis forward into reporting and narrative work. That is where the bridge to
+            Empathy Ledger becomes valuable: shared context, governed voice, and a cleaner path from
+            operational evidence to public story.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {[
+              'Company profile',
+              'Funder fit',
+              'Procurement read',
+              'Place context',
+              'Evidence chain',
+              'Reporting narrative',
+            ].map((chip, index) => (
+              <span
+                key={chip}
+                className={`border-2 px-3 py-1 text-[10px] font-black uppercase tracking-widest ${
+                  index % 3 === 0
+                    ? 'border-bauhaus-yellow/40 bg-bauhaus-yellow/10 text-bauhaus-yellow'
+                    : index % 3 === 1
+                      ? 'border-white/20 bg-white/5 text-white/70'
+                      : 'border-bauhaus-blue/40 bg-bauhaus-blue/10 text-bauhaus-blue'
+                }`}
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+          <div className="mt-8 grid gap-4 sm:grid-cols-2">
+            {[
+              {
+                value: fmt(stats.donorContractorCount) || '0',
+                label: 'linked power cases already visible in the graph',
+              },
+              {
+                value: fmt(stats.totalRelationships) || '0',
+                label: 'relationship edges available for analysis, packs, and reporting',
+              },
+            ].map((item) => (
+              <div key={item.label} className="border-4 border-white/20 p-5">
+                <p className="text-3xl font-black text-bauhaus-yellow">{item.value}</p>
+                <p className="mt-2 text-xs font-black uppercase tracking-widest text-white/45">{item.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-4 border-bauhaus-black bg-white">
+        <div className="border-b-4 border-bauhaus-black p-8 sm:p-10">
+          <p className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-muted">Paid Plans Focus On Outcomes</p>
+          <h2 className="mt-3 text-3xl font-black tracking-tight text-bauhaus-black sm:text-4xl">
+            What People Pay For
+          </h2>
+        </div>
+        <div className="grid gap-0 md:grid-cols-3">
+          {[
+            {
+              title: 'Professional',
+              copy: 'Best for solo grant consultants and grants managers who need better matching, alerts, and a cleaner pipeline.',
+              tone: 'bg-white',
+            },
+            {
+              title: 'Organisation',
+              copy: 'Best for teams that need shared tracking, briefing, reporting, and a consistent prospecting workflow across multiple submissions.',
+              tone: 'bg-bauhaus-red text-white',
+            },
+            {
+              title: 'Intelligence / Enterprise',
+              copy: 'Good later for portfolio intelligence, procurement analysis, reporting pipelines, and API workflows. Valuable, but not the first wedge.',
+              tone: 'bg-bauhaus-canvas',
+            },
+          ].map((item, index) => (
+            <div
+              key={item.title}
+              className={`${item.tone} p-8 sm:p-10 ${index < 2 ? 'border-b-4 border-bauhaus-black md:border-b-0 md:border-r-4' : ''}`}
+            >
+              <p className="text-xs font-black uppercase tracking-widest text-bauhaus-blue">{item.title}</p>
+              <p className={`mt-4 text-sm font-medium leading-relaxed ${item.tone.includes('text-white') ? 'text-white/75' : 'text-bauhaus-muted'}`}>
+                {item.copy}
+              </p>
             </div>
-          </a>
-          <a href="/reports/community-parity" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-red group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-red mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">New</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">Community Parity</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">0.5% to First Nations. 12% to women. Who misses out.</p>
-            </div>
-          </a>
-          <a href="/reports/community-power" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-blue group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-blue mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">New</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">Community Power Playbook</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">Co-ops, social enterprise, and alternatives to grants.</p>
-            </div>
-          </a>
-          <a href="/reports/social-enterprise" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-red group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-red mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">New</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">Social Enterprise in Australia</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">A national market map for social enterprise, Indigenous business, and mission-led providers.</p>
-            </div>
-          </a>
-          <a href="/reports/youth-justice" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-red group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-red mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">Flagship</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">QLD Youth Justice</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">$343M/year on detention. $1.3M per child. 73% reoffend.</p>
-            </div>
-          </a>
-          <a href="/reports/power-dynamics" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-black group-hover:text-white">
-              <div className="text-xs font-black text-purple mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">Live</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">Power Dynamics</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">Who controls Australia&apos;s philanthropy?</p>
-            </div>
-          </a>
-          <a href="/reports/access-gap" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-yellow">
-              <div className="text-xs font-black text-bauhaus-yellow mb-1 uppercase tracking-widest group-hover:text-bauhaus-black">Live</div>
-              <h3 className="font-black text-bauhaus-black mb-1">The Access Gap</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-bauhaus-black/70">Small orgs spend 40% on admin. Large orgs spend 15%.</p>
-            </div>
-          </a>
-          <a href="/reports/money-flow" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-blue group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-blue mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">Live</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">Follow the Dollar</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">Trace funding flows from taxpayer to outcome.</p>
-            </div>
-          </a>
-          <a href="/reports/ndis" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-blue group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-blue mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">New</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">The Disability Dollar</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">350K NDIS records. Market concentration. Thin markets. Who provides, who misses out.</p>
-            </div>
-          </a>
-          <a href="/reports/research-funding" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-black group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-black mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">New</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">The $29 Billion Question</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">46K ARC + NHMRC grants. Who gets the research money, and where.</p>
-            </div>
-          </a>
-          <a href="/reports/state-procurement" className="group block">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-yellow">
-              <div className="text-xs font-black text-bauhaus-yellow mb-1 uppercase tracking-widest group-hover:text-bauhaus-black">New</div>
-              <h3 className="font-black text-bauhaus-black mb-1">State Procurement</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-bauhaus-black/70">200K state government contracts. Department breakdowns. Supplier intelligence.</p>
-            </div>
-          </a>
-          <a href="/reports/state-of-the-nation" className="group block sm:col-span-2 lg:col-span-3">
-            <div className="bg-bauhaus-red border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1" style={{ boxShadow: '6px 6px 0px 0px var(--color-bauhaus-black)' }}>
-              <div className="text-xs font-black text-bauhaus-yellow mb-1 uppercase tracking-widest">Live Data</div>
-              <h3 className="font-black text-white mb-1">State of the Nation</h3>
-              <p className="text-sm text-white/80">Every entity in Australia — charities, companies, Indigenous corporations, contracts, tax data. Live numbers.</p>
-            </div>
-          </a>
-          <a href="/reports/power-map" className="group block sm:col-span-2 lg:col-span-3">
-            <div className="bg-white border-4 border-bauhaus-black p-5 transition-all group-hover:-translate-y-1 bauhaus-shadow-sm group-hover:bg-bauhaus-black group-hover:text-white">
-              <div className="text-xs font-black text-bauhaus-black mb-1 uppercase tracking-widest group-hover:text-bauhaus-yellow">Deep Research</div>
-              <h3 className="font-black text-bauhaus-black mb-1 group-hover:text-white">Australia&apos;s Power Map</h3>
-              <p className="text-sm text-bauhaus-muted group-hover:text-white/80">How open data can reshape who holds power. Concentration, procurement, tax, and the case for radical transparency.</p>
-            </div>
-          </a>
+          ))}
+        </div>
+        <div className="border-t-4 border-bauhaus-black bg-bauhaus-black px-8 py-6 text-center text-white">
+          <p className="text-sm font-bold text-white/70">
+            Sell the pipeline first. Let the broader data graph strengthen the proof, not dilute the message.
+          </p>
+          <div className="mt-4 flex flex-col justify-center gap-4 sm:flex-row">
+            <a
+              href="/pricing"
+              className="inline-block border-4 border-white bg-white px-8 py-3 text-xs font-black uppercase tracking-widest text-bauhaus-black transition-colors hover:bg-bauhaus-yellow"
+            >
+              See Plans
+            </a>
+            <a
+              href="/register"
+              className="inline-block border-4 border-white px-8 py-3 text-xs font-black uppercase tracking-widest text-white transition-colors hover:bg-white hover:text-bauhaus-black"
+            >
+              Start Free
+            </a>
+          </div>
         </div>
       </section>
     </div>

--- a/apps/web/src/app/portfolio-control/page.tsx
+++ b/apps/web/src/app/portfolio-control/page.tsx
@@ -1,0 +1,489 @@
+import { redirect } from 'next/navigation';
+import { requireAdminPage } from '@/lib/admin-auth';
+import { createSupabaseServer } from '@/lib/supabase-server';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Portfolio Control — CivicGraph',
+  description: 'Weekly operating cockpit across Goods, procurement, grants/foundations, trust, and sidecar lanes.',
+};
+
+type SqlRow = Record<string, string | number | boolean | null>;
+
+function toNumber(value: string | number | boolean | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function runRow(query: string): Promise<SqlRow | null> {
+  const db = getServiceSupabase();
+  const { data, error } = await db.rpc('exec_sql', { query });
+  if (error) {
+    console.error('[portfolio-control] query failed', { query, error: error.message });
+    return null;
+  }
+  if (!Array.isArray(data) || data.length === 0) return null;
+  return (data[0] as SqlRow) || null;
+}
+
+async function runCount(query: string, column = 'count'): Promise<number | null> {
+  const row = await runRow(query);
+  if (!row) return null;
+  return toNumber(row[column] ?? null);
+}
+
+function formatInt(value: number | null): string {
+  if (value === null) return '—';
+  return value.toLocaleString('en-AU');
+}
+
+function formatPct(value: number | null, digits = 1): string {
+  if (value === null || Number.isNaN(value)) return '—';
+  return `${value.toFixed(digits)}%`;
+}
+
+function statusTone(level: 'good' | 'watch' | 'risk') {
+  if (level === 'good') {
+    return 'bg-green-100 text-green-900 border-green-300';
+  }
+  if (level === 'watch') {
+    return 'bg-yellow-100 text-yellow-900 border-yellow-300';
+  }
+  return 'bg-red-100 text-red-900 border-red-300';
+}
+
+function metricStatus(value: number | null, goodAt: number, watchAt: number): 'good' | 'watch' | 'risk' {
+  if (value === null) return 'watch';
+  if (value >= goodAt) return 'good';
+  if (value >= watchAt) return 'watch';
+  return 'risk';
+}
+
+export default async function PortfolioControlPage() {
+  await requireAdminPage('/portfolio-control');
+
+  const authDb = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await authDb.auth.getUser();
+
+  if (!user) {
+    redirect('/login?next=%2Fportfolio-control');
+  }
+
+  const [
+    entitiesTotal,
+    lowSourceEntities,
+    grantsOpen,
+    grantsTotal,
+    grantsMissingDeadlines,
+    foundationsTotal,
+    foundationsProfiled,
+    foundationsOpenPrograms,
+    shortlistsTotal,
+    shortlistItemsTotal,
+    shortlistPriority,
+    shortlistReviewing,
+    procurementTasksOpen,
+    procurementTasksDue48h,
+    workflowRuns7d,
+    packExports30d,
+    goodsCommunities,
+    goodsBuyers,
+    goodsHighFitBuyers,
+    goodsSignalsOpen,
+    ntCoverageGaps,
+    orgProfiles,
+    payingProfiles,
+    apiKeys,
+    alertPreferences,
+    discoveriesOpen,
+    enrichmentCandidates,
+    sn13Candidates,
+    sn13Pending,
+    buildEntityGraphFailed30d,
+    agentHealthRow,
+  ] = await Promise.all([
+    runCount('SELECT COUNT(*)::int AS count FROM gs_entities'),
+    runCount('SELECT COUNT(*)::int AS count FROM gs_entities WHERE COALESCE(source_count, 0) <= 1'),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM grant_opportunities
+      WHERE (status IS NULL OR LOWER(status) NOT IN ('closed', 'archived'))
+      AND (closes_at IS NULL OR closes_at >= CURRENT_DATE)
+    `),
+    runCount('SELECT COUNT(*)::int AS count FROM grant_opportunities'),
+    runCount('SELECT COUNT(*)::int AS count FROM grant_opportunities WHERE closes_at IS NULL'),
+    runCount('SELECT COUNT(*)::int AS count FROM foundations'),
+    runCount("SELECT COUNT(*)::int AS count FROM foundations WHERE TRIM(COALESCE(description, '')) <> ''"),
+    runCount('SELECT COUNT(*)::int AS count FROM foundations WHERE COALESCE(open_programs, 0) > 0'),
+    runCount('SELECT COUNT(*)::int AS count FROM procurement_shortlists'),
+    runCount('SELECT COUNT(*)::int AS count FROM procurement_shortlist_items'),
+    runCount("SELECT COUNT(*)::int AS count FROM procurement_shortlist_items WHERE decision_tag = 'priority'"),
+    runCount("SELECT COUNT(*)::int AS count FROM procurement_shortlist_items WHERE decision_tag = 'reviewing'"),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM procurement_tasks
+      WHERE LOWER(COALESCE(status, 'open')) NOT IN ('done', 'completed', 'cancelled', 'resolved')
+    `),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM procurement_tasks
+      WHERE due_at IS NOT NULL
+      AND due_at <= NOW() + INTERVAL '48 hours'
+      AND LOWER(COALESCE(status, 'open')) NOT IN ('done', 'completed', 'cancelled', 'resolved')
+    `),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM procurement_workflow_runs
+      WHERE created_at >= NOW() - INTERVAL '7 days'
+    `),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM procurement_pack_exports
+      WHERE created_at >= NOW() - INTERVAL '30 days'
+    `),
+    runCount("SELECT COUNT(*)::int AS count FROM goods_communities WHERE state IN ('NT', 'QLD')"),
+    runCount('SELECT COUNT(*)::int AS count FROM goods_procurement_entities'),
+    runCount('SELECT COUNT(*)::int AS count FROM goods_procurement_entities WHERE COALESCE(fit_score, 0) >= 70'),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM goods_procurement_signals
+      WHERE LOWER(COALESCE(status, 'open')) NOT IN ('resolved', 'closed', 'done')
+    `),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM v_nt_community_procurement_summary
+      WHERE needs_postcode_enrichment = true
+      OR COALESCE(buyer_match_count, 0) = 0
+    `),
+    runCount('SELECT COUNT(*)::int AS count FROM org_profiles'),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM org_profiles
+      WHERE LOWER(COALESCE(subscription_plan, 'community')) NOT IN ('community', 'free', 'none')
+    `),
+    runCount('SELECT COUNT(*)::int AS count FROM api_keys'),
+    runCount('SELECT COUNT(*)::int AS count FROM alert_preferences'),
+    runCount('SELECT COUNT(*)::int AS count FROM discoveries WHERE dismissed = false AND reviewed_at IS NULL'),
+    runCount('SELECT COUNT(*)::int AS count FROM enrichment_candidates'),
+    runCount("SELECT COUNT(*)::int AS count FROM enrichment_candidates WHERE source = 'sn13_ondemand'"),
+    runCount("SELECT COUNT(*)::int AS count FROM enrichment_candidates WHERE source = 'sn13_ondemand' AND status = 'pending'"),
+    runCount(`
+      SELECT COUNT(*)::int AS count
+      FROM agent_runs
+      WHERE agent_name = 'Build Entity Graph'
+      AND status = 'failed'
+      AND completed_at >= NOW() - INTERVAL '30 days'
+    `),
+    runRow(`
+      SELECT
+        COUNT(*) FILTER (WHERE status = 'success')::int AS success_count,
+        COUNT(*) FILTER (WHERE status = 'failed')::int AS failed_count,
+        COUNT(*)::int AS total_count
+      FROM agent_runs
+      WHERE completed_at >= NOW() - INTERVAL '7 days'
+    `),
+  ]);
+
+  const multiSourceEntities = entitiesTotal !== null && lowSourceEntities !== null
+    ? Math.max(0, entitiesTotal - lowSourceEntities)
+    : null;
+  const sourceCoveragePct = entitiesTotal && multiSourceEntities !== null
+    ? (multiSourceEntities / entitiesTotal) * 100
+    : null;
+  const grantsMissingDeadlinePct = grantsTotal && grantsMissingDeadlines !== null
+    ? (grantsMissingDeadlines / grantsTotal) * 100
+    : null;
+  const foundationProfilePct = foundationsTotal && foundationsProfiled !== null
+    ? (foundationsProfiled / foundationsTotal) * 100
+    : null;
+  const paidProfilePct = orgProfiles && payingProfiles !== null
+    ? (payingProfiles / orgProfiles) * 100
+    : null;
+
+  const successCount = toNumber(agentHealthRow?.success_count ?? null) ?? 0;
+  const failedCount = toNumber(agentHealthRow?.failed_count ?? null) ?? 0;
+  const totalCount = toNumber(agentHealthRow?.total_count ?? null) ?? 0;
+  const agentHealthPct = totalCount > 0 ? (successCount / totalCount) * 100 : null;
+
+  const risks: string[] = [];
+  const actions: string[] = [];
+  const wins: string[] = [];
+
+  if ((procurementTasksDue48h ?? 0) > 0) {
+    risks.push(`${formatInt(procurementTasksDue48h)} procurement tasks are due in 48h.`);
+    actions.push('Clear due procurement tasks and assign owners in Decision Desk before new discovery runs.');
+  } else {
+    wins.push('No procurement tasks are currently due within 48h.');
+  }
+
+  if ((buildEntityGraphFailed30d ?? 0) > 0) {
+    risks.push(`Build Entity Graph failed ${formatInt(buildEntityGraphFailed30d)} times in the last 30 days.`);
+    actions.push('Stabilise Build Entity Graph reliability before scaling additional enrichment work.');
+  }
+
+  if ((sn13Candidates ?? 0) === 0) {
+    risks.push('SN13 enrichment lane has produced zero candidates so far.');
+    actions.push('Run SN13 worker on a constrained cohort and review acceptance rate this week.');
+  } else {
+    wins.push(`SN13 lane has ${formatInt(sn13Candidates)} staged candidates (${formatInt(sn13Pending)} pending review).`);
+  }
+
+  if ((grantsMissingDeadlinePct ?? 0) > 50) {
+    risks.push(`${formatPct(grantsMissingDeadlinePct)} of grant records are missing deadlines.`);
+    actions.push('Prioritise deadline enrichment and dedup quality for grants before ranking refinements.');
+  }
+
+  if ((foundationProfilePct ?? 0) < 35) {
+    risks.push(`Foundation profiling coverage is low at ${formatPct(foundationProfilePct)}.`);
+    actions.push('Increase profiled foundations with a targeted nightly profile run.');
+  } else {
+    wins.push(`Foundation profile coverage is ${formatPct(foundationProfilePct)}.`);
+  }
+
+  if ((goodsHighFitBuyers ?? 0) < 25) {
+    risks.push(`High-fit buyer pool is only ${formatInt(goodsHighFitBuyers)} entities.`);
+    actions.push('Expand NT/QLD buyer scraping (store networks, housing, AMS, councils) this sprint.');
+  } else {
+    wins.push(`Goods buyer pipeline has ${formatInt(goodsHighFitBuyers)} high-fit targets.`);
+  }
+
+  if ((agentHealthPct ?? 0) < 80) {
+    risks.push(`Agent health is ${formatPct(agentHealthPct)} over 7 days.`);
+  } else {
+    wins.push(`Agent health is ${formatPct(agentHealthPct)} over 7 days.`);
+  }
+
+  const trustLaneTone = metricStatus(sourceCoveragePct, 15, 8);
+  const procurementLaneTone = (procurementTasksDue48h ?? 0) === 0 ? 'good' : (procurementTasksDue48h ?? 0) <= 5 ? 'watch' : 'risk';
+  const grantsLaneTone = metricStatus(foundationProfilePct, 40, 25);
+  const goodsLaneTone = metricStatus(goodsHighFitBuyers, 50, 20);
+  const sidecarLaneTone = (sn13Candidates ?? 0) > 0 ? 'good' : 'risk';
+
+  return (
+    <div className="max-w-[1400px] mx-auto p-6 space-y-6">
+      <div className="border border-black bg-white">
+        <div className="border-b border-black p-5 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-gray-600">Portfolio Control</p>
+            <h1 className="text-3xl font-black tracking-tight text-black mt-1">Operating Cockpit</h1>
+            <p className="text-sm text-gray-700 mt-2 max-w-3xl">
+              One weekly control surface across Goods, procurement, grants/foundations, data trust, and sidecar experimentation.
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs uppercase tracking-widest font-semibold text-gray-500">Allocation Rule</p>
+            <p className="text-lg font-black">70 / 20 / 10</p>
+            <p className="text-xs text-gray-600">Core Revenue / Moat / Sidecar</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-8 gap-0 divide-x divide-y md:divide-y-0 divide-black border-t border-black">
+          <MetricCell label="Entities" value={formatInt(entitiesTotal)} />
+          <MetricCell label="Multi-Source Coverage" value={formatPct(sourceCoveragePct)} />
+          <MetricCell label="Open Grants" value={formatInt(grantsOpen)} />
+          <MetricCell label="Profiled Foundations" value={formatPct(foundationProfilePct)} />
+          <MetricCell label="Shortlist Items" value={formatInt(shortlistItemsTotal)} />
+          <MetricCell label="High-Fit Buyers" value={formatInt(goodsHighFitBuyers)} />
+          <MetricCell label="Agent Health (7d)" value={formatPct(agentHealthPct)} />
+          <MetricCell label="Paying Profile % " value={formatPct(paidProfilePct)} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <TrackCard
+          title="Tier 1: Goods Buyer + Capital Engine"
+          tone={goodsLaneTone}
+          linkHref="/goods-workspace"
+          linkLabel="Open Goods Workspace"
+          metrics={[
+            { label: 'Communities (NT/QLD)', value: formatInt(goodsCommunities) },
+            { label: 'Buyer Targets', value: formatInt(goodsBuyers) },
+            { label: 'High-Fit Buyers', value: formatInt(goodsHighFitBuyers) },
+            { label: 'Open Signals', value: formatInt(goodsSignalsOpen) },
+            { label: 'NT Coverage Gaps', value: formatInt(ntCoverageGaps) },
+          ]}
+        />
+
+        <TrackCard
+          title="Tier 1: Procurement Operating System"
+          tone={procurementLaneTone}
+          linkHref="/tender-intelligence"
+          linkLabel="Open Tender Intelligence"
+          metrics={[
+            { label: 'Shortlists', value: formatInt(shortlistsTotal) },
+            { label: 'Priority Items', value: formatInt(shortlistPriority) },
+            { label: 'Reviewing Items', value: formatInt(shortlistReviewing) },
+            { label: 'Open Tasks', value: formatInt(procurementTasksOpen) },
+            { label: 'Due in 48h', value: formatInt(procurementTasksDue48h) },
+            { label: 'Workflow Runs (7d)', value: formatInt(workflowRuns7d) },
+            { label: 'Pack Exports (30d)', value: formatInt(packExports30d) },
+          ]}
+        />
+
+        <TrackCard
+          title="Tier 1: Grants + Foundations Conversion"
+          tone={grantsLaneTone}
+          linkHref="/grants"
+          linkLabel="Open Grants"
+          metrics={[
+            { label: 'Total Grants', value: formatInt(grantsTotal) },
+            { label: 'Open Grants', value: formatInt(grantsOpen) },
+            { label: 'Missing Deadlines', value: formatPct(grantsMissingDeadlinePct) },
+            { label: 'Foundations', value: formatInt(foundationsTotal) },
+            { label: 'Profiled Foundations', value: formatInt(foundationsProfiled) },
+            { label: 'Open Programs', value: formatInt(foundationsOpenPrograms) },
+          ]}
+        />
+
+        <TrackCard
+          title="Tier 2: Trust + Data Quality Moat"
+          tone={trustLaneTone}
+          linkHref="/mission-control"
+          linkLabel="Open Mission Control"
+          metrics={[
+            { label: 'Low-Source Entities', value: formatInt(lowSourceEntities) },
+            { label: 'Multi-Source Entities', value: formatInt(multiSourceEntities) },
+            { label: 'Candidate Queue', value: formatInt(enrichmentCandidates) },
+            { label: 'Open Discoveries', value: formatInt(discoveriesOpen) },
+            { label: 'Build Entity Graph Fails (30d)', value: formatInt(buildEntityGraphFailed30d) },
+          ]}
+        />
+
+        <TrackCard
+          title="Tier 3: Bittensor Sidecar (Optionality)"
+          tone={sidecarLaneTone}
+          linkHref="/mission-control"
+          linkLabel="Open Sidecar Control"
+          metrics={[
+            { label: 'SN13 Candidates', value: formatInt(sn13Candidates) },
+            { label: 'SN13 Pending Review', value: formatInt(sn13Pending) },
+            { label: 'API Keys Issued', value: formatInt(apiKeys) },
+            { label: 'Alert Preferences', value: formatInt(alertPreferences) },
+          ]}
+        />
+
+        <TrackCard
+          title="Revenue Readiness"
+          tone={metricStatus(paidProfilePct, 10, 3)}
+          linkHref="/pricing"
+          linkLabel="Open Pricing"
+          metrics={[
+            { label: 'Org Profiles', value: formatInt(orgProfiles) },
+            { label: 'Paying Profiles', value: formatInt(payingProfiles) },
+            { label: 'Paid Conversion', value: formatPct(paidProfilePct) },
+            { label: 'Pack Exports (30d)', value: formatInt(packExports30d) },
+          ]}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <ListCard
+          title="Top Risks Right Now"
+          badgeClass="bg-red-100 text-red-900 border-red-300"
+          badgeLabel={`${risks.length} risks`}
+          items={risks.length > 0 ? risks : ['No critical risks detected from current thresholds.']}
+        />
+        <ListCard
+          title="Next 7 Days"
+          badgeClass="bg-blue-100 text-blue-900 border-blue-300"
+          badgeLabel={`${actions.length} actions`}
+          items={actions.length > 0 ? actions : ['No immediate corrective actions suggested.']}
+        />
+        <ListCard
+          title="Working Signals"
+          badgeClass="bg-green-100 text-green-900 border-green-300"
+          badgeLabel={`${wins.length} wins`}
+          items={wins.length > 0 ? wins : ['No positive signal yet — focus on trust and delivery basics.']}
+        />
+      </div>
+
+      <div className="border border-black bg-white p-4">
+        <p className="text-xs text-gray-600 font-mono">
+          Generated {new Date().toLocaleString('en-AU')} · logged in as {user.email}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function MetricCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="p-4 bg-white">
+      <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-gray-500">{label}</p>
+      <p className="text-2xl font-black text-black mt-2 leading-none">{value}</p>
+    </div>
+  );
+}
+
+function TrackCard({
+  title,
+  tone,
+  linkHref,
+  linkLabel,
+  metrics,
+}: {
+  title: string;
+  tone: 'good' | 'watch' | 'risk';
+  linkHref: string;
+  linkLabel: string;
+  metrics: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <section className="border border-black bg-white">
+      <div className="p-4 border-b border-black flex items-start justify-between gap-3">
+        <h2 className="text-sm font-black uppercase tracking-wider text-black">{title}</h2>
+        <span className={`text-[10px] uppercase tracking-wider font-black px-2 py-1 border ${statusTone(tone)}`}>
+          {tone}
+        </span>
+      </div>
+      <div className="p-4 space-y-2">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="flex items-center justify-between text-sm">
+            <span className="text-gray-600">{metric.label}</span>
+            <span className="font-black text-black">{metric.value}</span>
+          </div>
+        ))}
+      </div>
+      <div className="p-4 border-t border-black">
+        <a
+          href={linkHref}
+          className="inline-flex items-center border border-black px-3 py-1.5 text-xs font-black uppercase tracking-wider hover:bg-black hover:text-white transition-colors"
+        >
+          {linkLabel}
+        </a>
+      </div>
+    </section>
+  );
+}
+
+function ListCard({
+  title,
+  badgeLabel,
+  badgeClass,
+  items,
+}: {
+  title: string;
+  badgeLabel: string;
+  badgeClass: string;
+  items: string[];
+}) {
+  return (
+    <section className="border border-black bg-white">
+      <div className="p-4 border-b border-black flex items-center justify-between gap-3">
+        <h2 className="text-sm font-black uppercase tracking-wider text-black">{title}</h2>
+        <span className={`text-[10px] uppercase tracking-wider font-black px-2 py-1 border ${badgeClass}`}>
+          {badgeLabel}
+        </span>
+      </div>
+      <ul className="p-4 space-y-3">
+        {items.map((item) => (
+          <li key={item} className="text-sm text-gray-800 leading-relaxed">• {item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/app/power/client.tsx
+++ b/apps/web/src/app/power/client.tsx
@@ -81,6 +81,8 @@ export function PowerPageClient() {
   const [health, setHealth] = useState<DataHealth | null>(null);
   const [accountability, setAccountability] = useState<any>(null);
   const [foundations, setFoundations] = useState<any>(null);
+  const [boardPower, setBoardPower] = useState<any[]>([]);
+  const [boardPowerTotal, setBoardPowerTotal] = useState(0);
 
   useEffect(() => {
     fetch('/api/power/health').then(r => r.json()).then(d => {
@@ -91,6 +93,12 @@ export function PowerPageClient() {
     }).catch(() => {});
     fetch('/api/power/foundations').then(r => r.json()).then(d => {
       if (!d.error) setFoundations(d);
+    }).catch(() => {});
+    fetch('/api/data/board-power?limit=50&min_seats=3').then(r => r.json()).then(d => {
+      if (!d.error) {
+        setBoardPower(d.results || []);
+        setBoardPowerTotal(d.total || 0);
+      }
     }).catch(() => {});
   }, []);
 
@@ -294,6 +302,70 @@ export function PowerPageClient() {
                   </div>
                 </div>
               ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── Board Power Leaderboard ── */}
+      {boardPower.length > 0 && (
+        <section className="px-4 sm:px-6 lg:px-8 pb-12">
+          <div className="max-w-7xl mx-auto">
+            <div className="mb-3">
+              <h2 className="text-2xl font-black text-bauhaus-black">Board Power Leaderboard</h2>
+              <p className="text-sm text-bauhaus-muted font-medium mt-1">
+                {boardPowerTotal.toLocaleString()} people sit on 3+ charity boards simultaneously.
+                Combined revenue shows how much money flows through their governance decisions.
+              </p>
+            </div>
+            <div className="border-4 border-bauhaus-black bg-white overflow-hidden overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left px-4 py-2 text-[10px] font-black uppercase tracking-widest">#</th>
+                    <th className="text-left px-4 py-2 text-[10px] font-black uppercase tracking-widest">Person</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Boards</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Combined Revenue</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Combined Assets</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Combined FTE</th>
+                    <th className="text-left px-4 py-2 text-[10px] font-black uppercase tracking-widest">Top Organisations</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {boardPower.map((p: any, i: number) => (
+                    <tr key={i} className={`border-b border-gray-100 hover:bg-blue-50/30 ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/30'}`}>
+                      <td className="px-4 py-2 text-bauhaus-muted font-medium">{i + 1}</td>
+                      <td className="px-4 py-2 font-bold text-bauhaus-black">{p.person_name}</td>
+                      <td className="px-4 py-2 text-right">
+                        <span className="inline-flex items-center justify-center w-7 h-7 bg-bauhaus-black text-white font-black text-sm">
+                          {p.board_seats}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2 text-right font-medium text-green-700">
+                        {Number(p.total_org_revenue) > 0 ? money(Number(p.total_org_revenue)) : '—'}
+                      </td>
+                      <td className="px-4 py-2 text-right font-medium text-bauhaus-muted">
+                        {Number(p.total_org_assets) > 0 ? money(Number(p.total_org_assets)) : '—'}
+                      </td>
+                      <td className="px-4 py-2 text-right font-medium text-bauhaus-muted">
+                        {Number(p.total_org_fte) > 0 ? Number(p.total_org_fte).toLocaleString() : '—'}
+                      </td>
+                      <td className="px-4 py-2">
+                        <div className="flex flex-wrap gap-1">
+                          {(p.top_organizations || []).slice(0, 3).map((org: string, j: number) => (
+                            <span key={j} className="text-[10px] font-bold bg-bauhaus-canvas text-bauhaus-muted px-1.5 py-0.5 border border-bauhaus-black/10">
+                              {org.length > 30 ? org.substring(0, 30) + '...' : org}
+                            </span>
+                          ))}
+                          {(p.org_count || 0) > 3 && (
+                            <span className="text-[10px] text-bauhaus-muted font-bold">+{p.org_count - 3}</span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           </div>
         </section>

--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,7 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { trackProductEvent } from '@/lib/product-events-client'
+import { startCheckoutForTier } from '@/lib/start-checkout'
 
 type FeatureStatus = 'comingSoon' | 'custom'
 
@@ -32,74 +35,75 @@ const tiers: Tier[] = [
   {
     key: 'community',
     name: 'COMMUNITY',
-    tagline: 'Find funding. Track applications.',
+    tagline: 'Search grants. Watch funders.',
     price: 0,
     priceNote: 'forever',
-    description: 'For grassroots NFPs, First Nations orgs, and CLCs under $500K revenue',
+    description: 'For grassroots nonprofits, First Nations organisations, and small teams under $500K revenue.',
     features: [
-      { label: 'Full grant search' },
-      { label: 'Foundation profiles' },
-      { label: 'Save & track grants' },
-      { label: 'Basic email alerts' },
+      { label: 'Search grant opportunities' },
+      { label: 'View foundation profiles' },
+      { label: 'Save & shortlist opportunities' },
+      { label: 'Basic alerts' },
       { label: '1 team member' },
     ],
     cta: 'Get Started',
-    ctaHref: '/auth/signup',
+    ctaHref: '/register',
     highlight: false,
   },
   {
     key: 'professional',
     name: 'PROFESSIONAL',
-    tagline: 'AI-scored matching. Pipeline tracking.',
+    tagline: 'Match. Monitor. Manage the pipeline.',
     price: 79,
     priceNote: '/month',
-    description: 'For established NFPs and social enterprises',
+    description: 'For grant consultants, freelance writers, and solo grants or fundraising leads.',
     features: [
       { label: 'Everything in Community' },
-      { label: 'AI grant match scoring (0–100)' },
-      { label: 'Custom alert rules & keywords' },
-      { label: 'Pipeline tracking with Kanban' },
-      { label: 'Foundation relationship tracker' },
+      { label: 'Org-fit match scoring' },
+      { label: 'Advanced alerts and watchlists' },
+      { label: 'Pipeline tracking' },
+      { label: 'Foundation prospect notes' },
+      { label: 'Weekly digest' },
       { label: 'CSV export' },
-      { label: 'PDF export', status: 'comingSoon' },
       { label: '5 team members' },
-    ],
-    cta: 'Start Free Trial',
-    highlight: false,
-  },
-  {
-    key: 'organisation',
-    name: 'ORGANISATION',
-    tagline: 'Procurement + allocation intelligence.',
-    price: 249,
-    priceNote: '/month',
-    description: 'For larger NFPs, peak bodies, procurement teams, and multi-program orgs',
-    features: [
-      { label: 'Everything in Professional' },
-      { label: 'Tender Intelligence — supplier discovery' },
-      { label: 'Compliance scoring inside intelligence packs' },
-      { label: 'Intelligence pack generation' },
-      { label: 'Place-based funding analysis' },
-      { label: 'Board-ready export reports', status: 'comingSoon' },
-      { label: '25 team members' },
     ],
     cta: 'Start Free Trial',
     highlight: true,
   },
   {
+    key: 'organisation',
+    name: 'ORGANISATION',
+    tagline: 'Shared workflow for funding teams.',
+    price: 249,
+    priceNote: '/month',
+    description: 'For grant teams, development teams, and advisory firms managing multiple active opportunities.',
+    features: [
+      { label: 'Everything in Professional' },
+      { label: 'Shared team workspace' },
+      { label: 'Org-wide pipeline dashboard' },
+      { label: 'Board or client export reports' },
+      { label: 'Calendar integration' },
+      { label: 'Funder shortlist collaboration' },
+      { label: 'Priority support' },
+      { label: '25 team members' },
+    ],
+    cta: 'Start Free Trial',
+    highlight: false,
+  },
+  {
     key: 'funder',
     name: 'FUNDER',
-    tagline: 'Portfolio intelligence. Gap analysis.',
+    tagline: 'Prospecting and portfolio intelligence.',
     price: 499,
     priceNote: '/month',
-    description: 'For foundations, corporate giving, philanthropic advisors, and commissioners',
+    description: 'For foundations, philanthropic advisors, and commissioning teams that need a wider market view.',
     features: [
       { label: 'Everything in Organisation' },
-      { label: 'Portfolio view — saved foundations & summary' },
-      { label: 'Gap analysis — where money isn\'t going' },
-      { label: 'Commissioning intelligence by place' },
-      { label: 'Foundation scorecard & benchmarking', status: 'comingSoon' },
+      { label: 'Portfolio intelligence' },
+      { label: 'Gap analysis and market scanning' },
+      { label: 'Prospect discovery across entities' },
       { label: 'Read-only API access' },
+      { label: 'Benchmarking workflows', status: 'comingSoon' },
       { label: 'White-label option', status: 'custom' },
       { label: 'Unlimited team members' },
     ],
@@ -110,18 +114,18 @@ const tiers: Tier[] = [
   {
     key: 'enterprise',
     name: 'ENTERPRISE',
-    tagline: 'Managed deployment for teams with governance requirements.',
+    tagline: 'Custom deployment for governed teams.',
     price: 1999,
     priceNote: '/month',
-    description: 'For state/federal government, large foundations, and sector-wide deployments',
+    description: 'For large networks, government teams, and deployments with integration or governance requirements.',
     features: [
       { label: 'Everything in Funder' },
       { label: 'Expanded API access', status: 'custom' },
-      { label: 'Custom procurement dashboards', status: 'custom' },
-      { label: 'Governed proof layer', status: 'comingSoon' },
-      { label: 'White-label deployment', status: 'custom' },
+      { label: 'Custom dashboards', status: 'custom' },
       { label: 'SSO / SAML integration', status: 'custom' },
+      { label: 'White-label deployment', status: 'custom' },
       { label: 'Dedicated onboarding & support' },
+      { label: 'Unlimited everything' },
     ],
     cta: 'Contact Us',
     ctaHref: 'mailto:hello@civicgraph.au?subject=Enterprise%20enquiry',
@@ -129,33 +133,31 @@ const tiers: Tier[] = [
   },
 ]
 
-const ANNUAL_DISCOUNT = 0.17
-
-function formatPrice(price: number, annual: boolean): string {
+function formatPrice(price: number): string {
   if (price === 0) return 'Free'
-  const effective = annual ? Math.round(price * (1 - ANNUAL_DISCOUNT)) : price
-  return `$${effective}`
+  return `$${price}`
 }
 
 export default function PricingPage() {
   const [loading, setLoading] = useState<string | null>(null)
-  const [annual, setAnnual] = useState(false)
+  const searchParams = useSearchParams()
+  const billingSource = searchParams.get('billing_source')?.trim().slice(0, 80) || null
+  const checkoutSource = billingSource || 'pricing_page'
+
+  useEffect(() => {
+    void trackProductEvent('upgrade_prompt_viewed', {
+      source: checkoutSource,
+      metadata: billingSource ? { origin: 'billing_reminder' } : {},
+      onceKey: `${checkoutSource}:viewed`,
+    })
+  }, [billingSource, checkoutSource])
 
   const handleSubscribe = async (tier: string) => {
     setLoading(tier)
     try {
-      const res = await fetch('/api/billing/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tier, billing: annual ? 'annual' : 'monthly' }),
-      })
-      const data = await res.json()
-      if (data.url) {
-        window.location.href = data.url
-      } else if (data.error) {
-        if (res.status === 401) {
-          window.location.href = '/auth/signup?plan=' + tier
-        }
+      const result = await startCheckoutForTier(tier as Parameters<typeof startCheckoutForTier>[0], checkoutSource)
+      if (!result.ok) {
+        console.error('Checkout error:', result.error)
       }
     } catch (err) {
       console.error('Checkout error:', err)
@@ -166,321 +168,188 @@ export default function PricingPage() {
 
   return (
     <div className="min-h-screen bg-bauhaus-canvas">
-
-      {/* ===== HERO: THE DECISION PROBLEM ===== */}
-      <section className="bg-bauhaus-black text-white py-24 px-6">
-        <div className="max-w-5xl mx-auto text-center">
-          <p className="text-sm text-white/40 uppercase tracking-[0.3em] font-black mb-8">
-            Decision Infrastructure for Public Spending
+      <section className="border-b-4 border-bauhaus-black bg-bauhaus-black px-6 py-24 text-white">
+        <div className="mx-auto max-w-5xl text-center">
+          <p className="mb-8 text-sm font-black uppercase tracking-[0.3em] text-bauhaus-yellow">
+            Pricing For Funding Teams
           </p>
-          <h1 className="text-5xl md:text-8xl font-black tracking-tight mb-8">
-            BETTER DATA.<br />BETTER DECISIONS.<br />BETTER OUTCOMES.
+          <h1 className="text-5xl font-black tracking-tight md:text-8xl">
+            BUILD A BETTER
+            <br />
+            FUNDING PIPELINE.
           </h1>
-          <p className="text-xl md:text-2xl font-medium text-white/60 max-w-3xl mx-auto mb-4">
-            Procurement intelligence. Place-based allocation analysis. External evidence links.
-            CivicGraph brings public spending, market, and funding data into a working research
-            and triage layer for government, funders, and community organisations.
+          <p className="mx-auto mt-8 max-w-3xl text-xl font-medium text-white/65 md:text-2xl">
+            CivicGraph helps nonprofits and grant consultants find the right opportunities, monitor
+            the right funders, and run a live pipeline instead of rebuilding research from scratch every week.
           </p>
-          <p className="text-lg text-white/40 mt-8">
-            From finding the right supplier to pressure-testing where money should go next.
+          <p className="mx-auto mt-6 max-w-2xl text-base font-bold text-white/45">
+            Start free. Upgrade when you need better matching, better monitoring, and a shared workflow.
           </p>
         </div>
       </section>
 
-      {/* ===== THREE PRODUCT FAMILIES ===== */}
-      <section className="py-16 px-6 bg-white border-b-4 border-bauhaus-black">
-        <div className="max-w-5xl mx-auto text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-black tracking-tight mb-4">
-            THREE PRODUCTS. ONE DECISION LAYER.
-          </h2>
-          <p className="text-bauhaus-muted max-w-2xl mx-auto">
-            Procurement intelligence to find the right suppliers. Allocation intelligence
-            to decide where money should go. Governed proof is rolling out carefully.
-          </p>
-        </div>
-        <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-4">
-          {[
-            { label: 'Procurement Intelligence', sub: 'Supplier discovery, compliance scoring, intelligence packs', stat: 'National contract history', color: 'bg-bauhaus-blue text-white' },
-            { label: 'Allocation Intelligence', sub: 'Place packs, gap analysis, commissioning data', stat: '2,900 postcodes', color: 'bg-bauhaus-black text-white' },
-            { label: 'Governed Proof', sub: 'Outcome evidence, community voice, renewal defence', stat: 'Coming soon', color: 'bg-bauhaus-red/10 text-bauhaus-black' },
-          ].map((item) => (
-            <div key={item.label} className={`border-4 border-bauhaus-black p-6 ${item.color}`}>
-              <p className="text-2xl md:text-3xl font-black">{item.stat}</p>
-              <p className="text-sm font-bold mt-2">{item.label}</p>
-              <p className="text-xs mt-1 opacity-70">{item.sub}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ===== WHO IS THIS FOR ===== */}
-      <section className="py-16 px-6 border-b-4 border-bauhaus-black">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl font-black tracking-tight text-center mb-12">
-            WHO MAKES ALLOCATION DECISIONS?
-          </h2>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="border-4 border-bauhaus-black p-8 bg-white bauhaus-shadow">
-              <h3 className="text-lg font-black mb-2">PROCUREMENT OFFICERS</h3>
-              <p className="text-sm text-bauhaus-muted mb-4">You need to find suppliers fast and defend your choices:</p>
-              <ul className="space-y-3 text-sm">
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Supplier discovery across the national entity graph</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Compliance scoring from connected public registries</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Bid-ready intelligence packs in seconds</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Indigenous procurement targets with verified data</li>
-              </ul>
-            </div>
-            <div className="border-4 border-bauhaus-black p-8 bg-white bauhaus-shadow">
-              <h3 className="text-lg font-black mb-2">COMMISSIONERS &amp; FUNDERS</h3>
-              <p className="text-sm text-bauhaus-muted mb-4">You need to know where money should go next:</p>
-              <ul className="space-y-3 text-sm">
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Place-based funding analysis by postcode</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Gap scoring — where need exceeds provision</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Portfolio view across saved foundations</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Benchmarking workflows in research preview</li>
-              </ul>
-            </div>
-            <div className="border-4 border-bauhaus-black p-8 bg-white bauhaus-shadow">
-              <h3 className="text-lg font-black mb-2">COMMUNITY ORGANISATIONS</h3>
-              <p className="text-sm text-bauhaus-muted mb-4">You need to find funding and win it:</p>
-              <ul className="space-y-3 text-sm">
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> AI-scored grant matching (0&ndash;100)</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Pipeline tracking across all applications</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Foundation relationship CRM</li>
-                <li className="flex gap-3"><span className="text-money font-black">&#10003;</span> Free forever for orgs under $500K</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ===== WHY FUNDERS SHOULD CARE: THE ACCOUNTABILITY DATA ===== */}
-      <section className="py-16 px-6 bg-bauhaus-black text-white">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-black tracking-tight text-center mb-4">
-            DATA NOBODY ELSE HAS
-          </h2>
-          <p className="text-center text-white/50 mb-12 max-w-3xl mx-auto">
-            We&apos;ve connected ACNC financial records, AusTender procurement data, AEC political
-            donations, ATO tax transparency, and ASIC corporate filings. This is what we found.
-          </p>
-
-          <div className="grid md:grid-cols-3 gap-6 mb-12">
-            <div className="border-4 border-white/20 p-6">
-              <p className="text-4xl font-black text-bauhaus-yellow">$2.5B</p>
-              <p className="text-sm font-bold mt-2">Annual Tax Subsidy</p>
-              <p className="text-xs text-white/50 mt-2">
-                That&apos;s what taxpayers contribute to the philanthropic sector through DGR
-                deductions. 82% goes to the top 10% of organisations.
-              </p>
-            </div>
-            <div className="border-4 border-white/20 p-6">
-              <p className="text-4xl font-black text-bauhaus-red">89%</p>
-              <p className="text-sm font-bold mt-2">Executive Pay &gt; Grants</p>
-              <p className="text-xs text-white/50 mt-2">
-                89% of foundations pay their executives more than they distribute in grants.
-                We show exactly who.
-              </p>
-            </div>
-            <div className="border-4 border-white/20 p-6">
-              <p className="text-4xl font-black text-bauhaus-blue">$494B</p>
-              <p className="text-sm font-bold mt-2">In Foundation Assets</p>
-              <p className="text-xs text-white/50 mt-2">
-                Sitting in endowments. The average giving ratio across large foundations
-                is just 5%. Some are below 1%. We track every one.
-              </p>
-            </div>
-          </div>
-
-          <div className="border-4 border-white/20 p-8">
-            <div className="flex items-center gap-3 mb-4">
-              <h3 className="font-black text-bauhaus-yellow">FOUNDATION SCORECARD PREVIEW</h3>
-              <span className="text-[10px] font-black px-2 py-0.5 border border-bauhaus-yellow/40 bg-bauhaus-yellow/10 text-bauhaus-yellow uppercase tracking-widest">
-                Research Preview
-              </span>
-            </div>
-            <p className="text-sm text-white/60 mb-6">
-              We are prototyping scorecards from ACNC filings and foundation profile data. Giving
-              ratio, executive compensation, asset growth, grant distribution, and geographic reach
-              are visible in the research layer today. Self-serve benchmarking is still rolling out.
-            </p>
-            <div className="grid md:grid-cols-3 gap-4">
-              <div className="border-2 border-white/10 p-4">
-                <div className="flex justify-between items-start mb-2">
-                  <span className="text-sm font-bold">Foundation A</span>
-                  <span className="bg-money text-white text-xs font-black px-2 py-1">A+</span>
-                </div>
-                <p className="text-xs text-white/50">176% giving ratio. Drawing down endowment to fund impact. Walking the talk.</p>
-              </div>
-              <div className="border-2 border-white/10 p-4">
-                <div className="flex justify-between items-start mb-2">
-                  <span className="text-sm font-bold">Foundation B</span>
-                  <span className="bg-bauhaus-yellow text-bauhaus-black text-xs font-black px-2 py-1">D</span>
-                </div>
-                <p className="text-xs text-white/50">$7.6B assets. 3.1% giving ratio. $3.4M executive pay. Room for improvement.</p>
-              </div>
-              <div className="border-2 border-white/10 p-4">
-                <div className="flex justify-between items-start mb-2">
-                  <span className="text-sm font-bold">Foundation C</span>
-                  <span className="bg-bauhaus-red text-white text-xs font-black px-2 py-1">F</span>
-                </div>
-                <p className="text-xs text-white/50">$76M assets. 0% giving ratio. $1.5M executive pay. The data speaks for itself.</p>
-              </div>
-            </div>
-            <p className="text-xs text-white/30 mt-4">
-              Illustrative scoring preview based on ACNC filings. Named subscriber benchmarking is still being tightened before wider rollout.
+      <section className="border-b-4 border-bauhaus-black bg-white px-6 py-16">
+        <div className="mx-auto max-w-6xl">
+          <div className="mb-12 text-center">
+            <h2 className="text-3xl font-black tracking-tight md:text-4xl">WHAT YOU ARE BUYING</h2>
+            <p className="mx-auto mt-4 max-w-2xl text-bauhaus-muted">
+              Not just access to a list of grants. A system for finding, prioritising, and managing the funding work that matters.
             </p>
           </div>
-        </div>
-      </section>
-
-      {/* ===== WHAT CHANGES ===== */}
-      <section className="py-16 px-6">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-black tracking-tight text-center mb-4">
-            WHAT CHANGES WITH BETTER DECISION DATA
-          </h2>
-          <p className="text-center text-bauhaus-muted mb-12 max-w-2xl mx-auto">
-            From spreadsheets to decision infrastructure.
-          </p>
-          <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+          <div className="grid gap-6 md:grid-cols-4">
             {[
-              {
-                before: 'Procurement officers build supplier lists from memory and Google',
-                after: 'Discovery engine across the national entity graph with compliance scoring and contract history.',
-              },
-              {
-                before: 'Commissioners allocate funding without seeing where money already flows',
-                after: 'Place packs show funding, providers, gaps, and disadvantage by postcode.',
-              },
-              {
-                before: 'Community orgs apply blindly to hundreds of grants',
-                after: 'AI scores every grant against your mission. Apply to the ones you\'ll win.',
-              },
-              {
-                before: 'Nobody can prove procurement created community value',
-                after: 'Pilot governed proof workflows connect contracts to outcomes. Wider rollout is coming soon.',
-              },
-              {
-                before: 'Indigenous procurement targets are met on paper, not in practice',
-                after: 'Verified Indigenous entity data from ORIC, Supply Nation, and community classification.',
-              },
-              {
-                before: 'Small orgs can\'t afford the intelligence tools that primes take for granted',
-                after: 'Cross-subsidy: enterprise pays, community access is free. Better data for everyone.',
-              },
-            ].map((item) => (
-              <div key={item.before} className="border-4 border-bauhaus-black bg-white p-6">
-                <p className="text-sm text-bauhaus-red line-through mb-2">{item.before}</p>
-                <p className="text-sm font-bold">{item.after}</p>
+              ['Find', 'Surface better-fit grants and foundation programs.'],
+              ['Monitor', 'Catch new rounds, deadline moves, and changed program pages.'],
+              ['Prospect', 'Track likely-fit funders before a round is obvious.'],
+              ['Track', 'Keep your shortlist, notes, and next actions in one place.'],
+            ].map(([title, copy], index) => (
+              <div
+                key={title}
+                className={`border-4 border-bauhaus-black p-6 ${index === 1 ? 'bg-bauhaus-blue text-white' : index === 2 ? 'bg-bauhaus-red text-white' : 'bg-bauhaus-canvas text-bauhaus-black'}`}
+              >
+                <p className="text-xl font-black">{title}</p>
+                <p className={`mt-3 text-sm font-medium leading-relaxed ${index === 1 || index === 2 ? 'text-white/75' : 'text-bauhaus-muted'}`}>
+                  {copy}
+                </p>
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* ===== TIERS ===== */}
-      <section className="py-16 px-6 bg-bauhaus-canvas border-y-4 border-bauhaus-black">
-        <div className="max-w-5xl mx-auto text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-black tracking-tight mb-4">
-            CHOOSE YOUR LEVEL OF INTELLIGENCE
+      <section className="border-b-4 border-bauhaus-black px-6 py-16">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="mb-12 text-center text-3xl font-black tracking-tight md:text-4xl">
+            WHO THIS FITS BEST
           </h2>
-          <p className="text-bauhaus-muted max-w-2xl mx-auto mb-8">
-            Community organisations access core features free. Procurement intelligence,
-            allocation analysis, and carefully staged evidence workflows unlock at higher tiers.
+          <div className="grid gap-6 md:grid-cols-3">
+            <div className="border-4 border-bauhaus-black bg-white p-8 bauhaus-shadow">
+              <h3 className="text-lg font-black">GRANT CONSULTANTS</h3>
+              <p className="mt-3 text-sm text-bauhaus-muted">
+                Best if you manage multiple client pipelines and need a faster way to spot, track, and explain the next best opportunities.
+              </p>
+            </div>
+            <div className="border-4 border-bauhaus-black bg-white p-8 bauhaus-shadow">
+              <h3 className="text-lg font-black">GRANTS MANAGERS</h3>
+              <p className="mt-3 text-sm text-bauhaus-muted">
+                Best if you own fundraising or grants inside one organisation and need a better monitoring and prospecting stack.
+              </p>
+            </div>
+            <div className="border-4 border-bauhaus-black bg-white p-8 bauhaus-shadow">
+              <h3 className="text-lg font-black">FUNDING TEAMS</h3>
+              <p className="mt-3 text-sm text-bauhaus-muted">
+                Best if you need a shared workflow for multiple people, board reporting, and a more disciplined way to manage the pipeline.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b-4 border-bauhaus-black bg-bauhaus-canvas px-6 py-16">
+        <div className="mx-auto mb-12 max-w-5xl text-center">
+          <h2 className="mb-4 text-3xl font-black tracking-tight md:text-4xl">
+            CHOOSE THE PIPELINE YOU NEED
+          </h2>
+          <p className="mx-auto max-w-2xl text-bauhaus-muted">
+            Start with search and alerts. Upgrade when you want stronger matching, a cleaner prospecting workflow, and team coordination.
           </p>
-          <div className="border-4 border-bauhaus-black bg-white p-4 max-w-3xl mx-auto text-left mb-8">
-            <p className="text-[11px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">
+
+          <div className="mx-auto mt-8 mb-8 max-w-3xl border-4 border-bauhaus-black bg-white p-4 text-left">
+            <p className="mb-1 text-[11px] font-black uppercase tracking-widest text-bauhaus-muted">
               Feature availability
             </p>
-            <p className="text-sm text-bauhaus-black font-medium leading-relaxed">
-              Unmarked features are usable in the product today. <span className="font-black">Coming soon</span> means
-              in active rollout. <span className="font-black">Custom deployment</span> means available through managed or
-              enterprise delivery, not a self-serve workflow.
+            <p className="text-sm font-medium text-bauhaus-black">
+              Unmarked features are available now. <span className="font-black">Coming soon</span> means rolling out.
+              <span className="font-black"> Custom deployment</span> means available through managed or enterprise delivery.
             </p>
           </div>
 
-          {/* Annual/Monthly Toggle */}
-          <div className="flex items-center justify-center gap-4 mb-8">
-            <span className={`text-sm font-black uppercase tracking-widest ${!annual ? 'text-bauhaus-black' : 'text-bauhaus-muted'}`}>
-              Monthly
-            </span>
-            <button
-              onClick={() => setAnnual(!annual)}
-              className={`relative w-14 h-7 rounded-full border-2 border-bauhaus-black transition-colors ${
-                annual ? 'bg-money' : 'bg-white'
-              }`}
-              aria-label="Toggle annual billing"
-            >
-              <span
-                className={`absolute top-0.5 w-5 h-5 rounded-full bg-bauhaus-black transition-transform ${
-                  annual ? 'translate-x-7' : 'translate-x-1'
-                }`}
-              />
-            </button>
-            <span className={`text-sm font-black uppercase tracking-widest ${annual ? 'text-bauhaus-black' : 'text-bauhaus-muted'}`}>
-              Annual
-            </span>
-            {annual && (
-              <span className="text-xs font-black text-money bg-money/10 px-2 py-1 border-2 border-money">
-                2 MONTHS FREE
-              </span>
-            )}
+          <div className="mb-8 inline-flex items-center justify-center border-4 border-bauhaus-black bg-white px-4 py-3 text-left">
+            <div>
+              <p className="text-[11px] font-black uppercase tracking-widest text-bauhaus-muted">
+                Billing note
+              </p>
+              <p className="mt-1 text-sm font-medium text-bauhaus-black">
+                Self-serve pricing is monthly today. Annual billing is not yet available in checkout.
+              </p>
+            </div>
           </div>
         </div>
-        <div className="max-w-7xl mx-auto">
-          <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-6">
+
+        <div className="mx-auto max-w-7xl">
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-5">
             {tiers.map((tier) => (
               <div
                 key={tier.key}
-                className={`border-4 border-bauhaus-black bg-white flex flex-col ${
-                  tier.highlight ? 'bauhaus-shadow relative' : ''
+                className={`flex flex-col border-4 border-bauhaus-black bg-white ${
+                  tier.highlight ? 'relative bauhaus-shadow' : ''
                 }`}
               >
                 {tier.highlight && (
-                  <div className="bg-bauhaus-red text-white text-center py-2 text-xs font-black uppercase tracking-widest">
-                    Most Popular
+                  <div className="bg-bauhaus-red py-2 text-center text-xs font-black uppercase tracking-widest text-white">
+                    Best First Paid Plan
                   </div>
                 )}
 
-                <div className={`p-6 border-b-4 border-bauhaus-black ${
-                  tier.key === 'community' ? 'bg-bauhaus-black text-white' :
-                  tier.key === 'funder' ? 'bg-bauhaus-yellow' :
-                  tier.key === 'enterprise' ? 'bg-bauhaus-blue text-white' : 'bg-white'
-                }`}>
+                <div
+                  className={`border-b-4 border-bauhaus-black p-6 ${
+                    tier.key === 'community'
+                      ? 'bg-bauhaus-black text-white'
+                      : tier.key === 'funder'
+                        ? 'bg-bauhaus-yellow'
+                        : tier.key === 'enterprise'
+                          ? 'bg-bauhaus-blue text-white'
+                          : 'bg-white'
+                  }`}
+                >
                   <h3 className="text-lg font-black tracking-widest">{tier.name}</h3>
-                  <p className={`text-xs mt-1 ${
-                    tier.key === 'community' || tier.key === 'enterprise' ? 'text-white/60' : 'text-bauhaus-muted'
-                  }`}>
+                  <p
+                    className={`mt-1 text-xs ${
+                      tier.key === 'community' || tier.key === 'enterprise'
+                        ? 'text-white/65'
+                        : 'text-bauhaus-muted'
+                    }`}
+                  >
                     {tier.tagline}
                   </p>
                   <div className="mt-4">
-                    <span className="text-4xl font-black">{formatPrice(tier.price, annual)}</span>
-                    <span className={`text-sm ml-1 ${
-                      tier.key === 'community' || tier.key === 'enterprise' ? 'text-white/60' : 'text-bauhaus-muted'
-                    }`}>
-                      {tier.price === 0 ? 'forever' : annual ? '/mo (billed annually)' : '/month'}
+                    <span className="text-4xl font-black">{formatPrice(tier.price)}</span>
+                    <span
+                      className={`ml-1 text-sm ${
+                        tier.key === 'community' || tier.key === 'enterprise'
+                          ? 'text-white/65'
+                          : 'text-bauhaus-muted'
+                      }`}
+                    >
+                      {tier.price === 0 ? 'forever' : '/month'}
                     </span>
                   </div>
+                  {(tier.key === 'professional' || tier.key === 'organisation') && (
+                    <p className="mt-3 text-[11px] font-black uppercase tracking-widest text-bauhaus-red">
+                      14-day free trial
+                    </p>
+                  )}
                 </div>
 
                 <div className="px-6 pt-4">
                   <p className="text-xs text-bauhaus-muted">{tier.description}</p>
                 </div>
 
-                <div className="p-6 flex-1">
+                <div className="flex-1 p-6">
                   <ul className="space-y-2.5">
                     {tier.features.map((feature) => (
                       <li key={feature.label} className="flex gap-2 text-sm">
-                        <span className="text-money font-black text-xs mt-0.5">{'\u25CF'}</span>
+                        <span className="mt-0.5 text-xs font-black text-money">{'\u25CF'}</span>
                         <div className="flex flex-wrap items-center gap-2">
                           <span>{feature.label}</span>
                           {feature.status && (
-                            <span className={`text-[9px] font-black px-1.5 py-0.5 uppercase tracking-widest border ${
-                              feature.status === 'comingSoon'
-                                ? 'border-bauhaus-yellow bg-warning-light text-bauhaus-black'
-                                : 'border-bauhaus-blue bg-link-light text-bauhaus-blue'
-                            }`}>
+                            <span
+                              className={`border px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest ${
+                                feature.status === 'comingSoon'
+                                  ? 'border-bauhaus-yellow bg-warning-light text-bauhaus-black'
+                                  : 'border-bauhaus-blue bg-link-light text-bauhaus-blue'
+                              }`}
+                            >
                               {FEATURE_STATUS_LABELS[feature.status]}
                             </span>
                           )}
@@ -494,14 +363,14 @@ export default function PricingPage() {
                   {tier.ctaHref ? (
                     <Link
                       href={tier.ctaHref}
-                      className={`block w-full py-3 text-center font-black text-sm uppercase tracking-widest border-4 border-bauhaus-black transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none ${
+                      className={`block w-full border-4 border-bauhaus-black py-3 text-center text-sm font-black uppercase tracking-widest transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none ${
                         tier.key === 'community'
                           ? 'bg-bauhaus-black text-white hover:bg-bauhaus-black/90'
                           : tier.key === 'enterprise'
-                          ? 'bg-bauhaus-blue text-white bauhaus-shadow-sm'
-                          : tier.key === 'funder'
-                          ? 'bg-bauhaus-yellow text-bauhaus-black bauhaus-shadow-sm'
-                          : 'bg-white text-bauhaus-black bauhaus-shadow-sm'
+                            ? 'bg-bauhaus-blue text-white bauhaus-shadow-sm'
+                            : tier.key === 'funder'
+                              ? 'bg-bauhaus-yellow text-bauhaus-black bauhaus-shadow-sm'
+                              : 'bg-white text-bauhaus-black bauhaus-shadow-sm'
                       }`}
                     >
                       {tier.cta}
@@ -510,7 +379,7 @@ export default function PricingPage() {
                     <button
                       onClick={() => handleSubscribe(tier.key)}
                       disabled={loading === tier.key}
-                      className={`block w-full py-3 text-center font-black text-sm uppercase tracking-widest border-4 border-bauhaus-black transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none disabled:opacity-50 ${
+                      className={`block w-full border-4 border-bauhaus-black py-3 text-center text-sm font-black uppercase tracking-widest transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none disabled:opacity-50 ${
                         tier.highlight
                           ? 'bg-bauhaus-red text-white bauhaus-shadow-sm'
                           : 'bg-white text-bauhaus-black bauhaus-shadow-sm'
@@ -526,259 +395,100 @@ export default function PricingPage() {
         </div>
       </section>
 
-      {/* ===== FOR FOUNDATIONS: THE REAL PITCH ===== */}
-      <section className="py-20 px-6 bg-bauhaus-black text-white">
-        <div className="max-w-4xl mx-auto">
-          <p className="text-xs text-white/40 uppercase tracking-[0.3em] font-black text-center mb-4">
-            For Foundations, Corporate Giving & Philanthropic Advisors
-          </p>
-          <h2 className="text-3xl md:text-5xl font-black tracking-tight text-center mb-6">
-            YOUR BRAND IS YOUR GIVING RATIO.
-          </h2>
-          <p className="text-center text-white/50 mb-16 max-w-2xl mx-auto">
-            In a world where every ACNC filing is public, your reputation isn&apos;t what you
-            say about yourself — it&apos;s what the data says. CivicGraph surfaces that data.
-            Be on the right side of it.
-          </p>
-
-          <div className="grid md:grid-cols-2 gap-8">
-            <div className="border-4 border-white/20 p-8">
-              <h3 className="font-black text-bauhaus-yellow mb-4 text-lg">FIND WHO OTHERS MISS</h3>
-              <p className="text-sm text-white/70 mb-4">
-                The best community organisations don&apos;t have grant writers. They have
-                Elders, youth workers, and practitioners who are too busy doing the work
-                to fill in your 47-page application form.
-              </p>
-              <p className="text-sm text-white/70">
-                CivicGraph lets you find them by what they do, not by how well they write.
-                Search by mission alignment, geography, community served, and track record.
-                Then reach out directly.
-              </p>
-            </div>
-            <div className="border-4 border-white/20 p-8">
-              <div className="flex items-center gap-3 mb-4">
-                <h3 className="font-black text-bauhaus-yellow text-lg">BENCHMARK YOURSELF</h3>
-                <span className="text-[10px] font-black px-2 py-0.5 border border-bauhaus-yellow/40 bg-bauhaus-yellow/10 text-bauhaus-yellow uppercase tracking-widest">
-                  Preview
-                </span>
-              </div>
-              <p className="text-sm text-white/70 mb-4">
-                What&apos;s your giving ratio? How does your executive compensation compare to
-                your grant distribution? What percentage of your funding reaches First Nations
-                communities? Regional areas? Women-led organisations?
-              </p>
-              <p className="text-sm text-white/70">
-                We&apos;re tightening this workflow before broader release. Early partners can pressure-test
-                where they sit and what data still needs verification.
-              </p>
-            </div>
-            <div className="border-4 border-white/20 p-8">
-              <h3 className="font-black text-bauhaus-yellow mb-4 text-lg">SEE THE WHOLE SYSTEM</h3>
-              <p className="text-sm text-white/70 mb-4">
-                Where is money flowing in your sector? Which communities are over-funded?
-                Which are invisible? Where do you overlap with other foundations — and
-                where is nobody funding at all?
-              </p>
-              <p className="text-sm text-white/70">
-                Portfolio-level intelligence that turns isolated giving into coordinated impact.
-              </p>
-            </div>
-            <div className="border-4 border-white/20 p-8">
-              <h3 className="font-black text-bauhaus-yellow mb-4 text-lg">FUND THE INFRASTRUCTURE</h3>
-              <p className="text-sm text-white/70 mb-4">
-                Your $499/month doesn&apos;t just buy you tools. It funds free access for every
-                grassroots organisation on the platform. The more funders who join, the more
-                community orgs can participate.
-              </p>
-              <p className="text-sm text-white/70">
-                That&apos;s not CSR. That&apos;s building the commons. And it&apos;s good for you too —
-                more orgs on the platform means better discovery, better data, better outcomes.
-              </p>
-            </div>
+      <section className="border-b-4 border-bauhaus-black bg-white px-6 py-16">
+        <div className="mx-auto max-w-5xl">
+          <div className="mb-12 text-center">
+            <h2 className="text-3xl font-black tracking-tight md:text-4xl">
+              THE FASTEST WAY TO GET VALUE
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-bauhaus-muted">
+              The best first use case is simple: set up your organisation, review matched opportunities,
+              save a shortlist, and start receiving better alerts.
+            </p>
           </div>
 
-          <div className="text-center mt-12">
-            <a
-              href="mailto:hello@civicgraph.au?subject=Funder%20tier%20enquiry"
-              className="inline-block py-4 px-10 font-black text-sm uppercase tracking-widest border-4 border-bauhaus-yellow bg-bauhaus-yellow text-bauhaus-black bauhaus-shadow-sm transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
-            >
-              Talk to Us About Funder Access
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* ===== THE DECISION STACK ===== */}
-      <section className="py-16 px-6 bg-white border-b-4 border-bauhaus-black">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-black tracking-tight text-center mb-4">
-            THE DECISION STACK
-          </h2>
-          <p className="text-center text-bauhaus-muted mb-12 max-w-2xl mx-auto">
-            Each layer makes the next more powerful. Start with procurement.
-            Expand into allocation. Add proof as the workflow matures.
-          </p>
-
-          <div className="flex flex-col md:flex-row items-stretch gap-0">
+          <div className="grid gap-6 md:grid-cols-4">
             {[
-              { label: '1. PROCUREMENT', desc: 'Find suppliers. Check compliance. Generate packs.', color: 'bg-bauhaus-blue text-white' },
-              { label: '2. ALLOCATION', desc: 'Place analysis. Gap scoring. Commissioning data.', color: 'bg-bauhaus-black text-white' },
-              { label: '3. PROOF', desc: 'Outcome evidence workflows (pilot). Renewal defence. Policy justification.', color: 'bg-bauhaus-red text-white' },
-              { label: 'RESULT', desc: 'Defensible decisions at every stage.', color: 'bg-money text-white' },
-            ].map((step, i) => (
-              <div key={step.label} className="flex-1 flex flex-col">
-                <div className={`${step.color} p-6 border-4 border-bauhaus-black flex-1`}>
-                  <p className="text-xs font-black uppercase tracking-widest mb-2">{step.label}</p>
-                  <p className="text-xs opacity-70">{step.desc}</p>
-                </div>
-                {i < 3 && (
-                  <div className="flex justify-center py-2 md:hidden">
-                    <span className="text-xl font-black">&darr;</span>
-                  </div>
-                )}
+              ['1', 'Create your org profile'],
+              ['2', 'Review matched grants and funders'],
+              ['3', 'Shortlist your active pipeline'],
+              ['4', 'Get weekly updates and next actions'],
+            ].map(([step, copy], index) => (
+              <div
+                key={step}
+                className={`border-4 border-bauhaus-black p-6 ${
+                  index === 1 ? 'bg-bauhaus-blue text-white' : index === 2 ? 'bg-bauhaus-red text-white' : 'bg-bauhaus-canvas'
+                }`}
+              >
+                <p className="text-4xl font-black">{step}</p>
+                <p className={`mt-4 text-sm font-bold ${index === 1 || index === 2 ? 'text-white/80' : 'text-bauhaus-black'}`}>
+                  {copy}
+                </p>
               </div>
             ))}
           </div>
-
-          <div className="mt-8 border-4 border-bauhaus-black p-6 bg-bauhaus-canvas">
-            <p className="text-sm text-center">
-              <strong>Every product decision passes one filter:</strong> does this help become default
-              infrastructure for procurement or allocation decisions? That&apos;s what we build.
-            </p>
-          </div>
         </div>
       </section>
 
-      {/* ===== CROSS-SUBSIDY ===== */}
-      <section className="py-16 px-6">
-        <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-3xl font-black tracking-tight mb-4">
-            HOW CROSS-SUBSIDY WORKS
-          </h2>
-          <p className="text-bauhaus-muted mb-8 max-w-2xl mx-auto">
-            The organisations doing the hardest work in the hardest places shouldn&apos;t also
-            have to pay for the tools to find funding.
-          </p>
-          <div className="border-4 border-bauhaus-black bg-white p-8 bauhaus-shadow max-w-2xl mx-auto">
-            <div className="grid grid-cols-3 gap-4 mb-6 items-center">
-              <div>
-                <p className="text-4xl font-black text-bauhaus-blue">$499</p>
-                <p className="text-xs text-bauhaus-muted uppercase tracking-widest mt-1">1 Funder pays</p>
-              </div>
-              <div className="flex items-center justify-center">
-                <span className="text-3xl font-black">=</span>
-              </div>
-              <div>
-                <p className="text-4xl font-black text-money">$0</p>
-                <p className="text-xs text-bauhaus-muted uppercase tracking-widest mt-1">Dozens use free</p>
-              </div>
-            </div>
-            <p className="text-sm text-bauhaus-muted">
-              Foundations and corporates already have the budgets. And they get a better
-              product because more orgs on the platform means better data, better discovery,
-              and better outcomes. Everyone wins.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* ===== THE BIG WHY ===== */}
-      <section className="py-20 px-6 bg-bauhaus-black text-white">
-        <div className="max-w-3xl mx-auto text-center">
-          <h2 className="text-3xl md:text-5xl font-black tracking-tight mb-8">
-            OWN THE LAYER WHERE
-            <br />
-            <span className="text-bauhaus-yellow">INSTITUTIONS DECIDE.</span>
-          </h2>
-          <p className="text-white/50 text-lg mb-6">
-            Who gets funded. Who gets contracted. Where services go. How allocations
-            are justified. These are the decisions that shape communities — and they&apos;re
-            currently made with incomplete data from disconnected systems.
-          </p>
-          <p className="text-white/50 text-lg mb-6">
-            CivicGraph connects AusTender contracts, ACNC finances, AEC donations,
-            ATO tax data, and ASIC filings into a single decision layer.
-            National entity graph. Connected relationship data. Public-source evidence for market decisions.
-          </p>
-          <p className="text-white/70 text-xl font-bold mt-8">
-            Lead with the budget problem.
-            <br />
-            Add the proof layer after you own the decision.
-          </p>
-        </div>
-      </section>
-
-      {/* ===== FAQ ===== */}
-      <section className="py-16 px-6">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-3xl font-black tracking-tight text-center mb-12">FAQ</h2>
+      <section className="border-b-4 border-bauhaus-black px-6 py-16">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="mb-12 text-center text-3xl font-black tracking-tight">FAQ</h2>
           {[
             {
               q: 'Is the Community tier really free?',
-              a: 'Yes, forever. Community organisations under $500K revenue get full search, save, and alert features at no cost. Funded by paying subscribers who believe in equitable access.',
+              a: 'Yes. Community organisations under $500K revenue can search, save, and set up basic alerts at no cost.',
             },
             {
-              q: 'What does the AI grant writing assistant do?',
-              a: 'It reads the grant criteria and your organisation\'s profile — mission, past projects, geographic focus — then drafts an application in your voice, tailored to the funder\'s language and priorities. Not a generic template. A real draft that sounds like you, optimised for them.',
+              q: 'Who should buy Professional first?',
+              a: 'Professional is the best first paid plan for consultants and solo grants managers who need better fit scoring, watchlists, and a cleaner working pipeline.',
+            },
+            {
+              q: 'What makes Organisation different?',
+              a: 'Organisation adds the shared workflow: more team members, a broader pipeline dashboard, collaboration, and reporting.',
+            },
+            {
+              q: 'Is this only for open grants?',
+              a: 'No. The stronger value is prospecting: foundation programs, prior grantee signals, and monitoring likely-fit funders before a round is obvious.',
             },
             {
               q: 'How is this different from other grant platforms?',
-              a: 'Most platforms help you search grants. CivicGraph connects grants, contracts, donations, and procurement across the national entity graph. Three layers: raw financial data, entity relationships, and community evidence. Plus the cross-subsidy model means the best orgs aren\'t priced out.',
-            },
-            {
-              q: 'Can funders search for charities proactively?',
-              a: 'Yes. The Funder tier lets foundations and corporates search by mission alignment, geography, community served, and track record — then reach out directly. No more "advertise and wait." Find the orgs already doing the work.',
-            },
-            {
-              q: 'Where does your data come from?',
-              a: 'ACNC registers, AusTender, AEC political donations, ATO tax transparency, ASIC corporate filings, ORIC Indigenous corporations, state grant portals, and AI-enriched foundation profiles. Coverage varies by workflow, and the platform surfaces connected public sources rather than pretending every dataset is equally complete.',
-            },
-            {
-              q: 'Do you sell our data?',
-              a: 'No. Your application data, relationship notes, and pipeline are private. The only shared data is what\'s already public — ACNC records, published grant opportunities, and foundation profiles.',
-            },
-            {
-              q: 'Why should our foundation pay when the data is public?',
-              a: 'The data is public. The intelligence isn\'t. We\'ve spent thousands of hours aggregating, cleaning, enriching, and cross-referencing data that exists in dozens of disconnected registries. And your subscription funds free access for community orgs — that\'s part of the value.',
+              a: 'Most tools stop at listings. CivicGraph is building a live pipeline and prospect intelligence layer backed by connected public-source data.',
             },
             {
               q: 'Is there an annual discount?',
-              a: 'Yes — pay annually and get 2 months free (17% off). Toggle the billing switch above the pricing cards to see annual prices.',
+              a: 'Not in self-serve checkout yet. Pricing currently runs monthly while annual billing is being wired properly.',
             },
           ].map((faq) => (
             <div key={faq.q} className="border-b-2 border-bauhaus-black/10 py-6">
-              <h3 className="font-black text-sm uppercase tracking-widest mb-2">{faq.q}</h3>
+              <h3 className="mb-2 text-sm font-black uppercase tracking-widest">{faq.q}</h3>
               <p className="text-sm text-bauhaus-muted">{faq.a}</p>
             </div>
           ))}
         </div>
       </section>
 
-      {/* ===== FINAL CTA ===== */}
-      <section className="py-20 px-6 bg-bauhaus-red text-white text-center">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-3xl md:text-5xl font-black tracking-tight mb-6">
-            BETTER DECISIONS START
+      <section className="bg-bauhaus-red px-6 py-20 text-center text-white">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-3xl font-black tracking-tight md:text-5xl">
+            STOP REBUILDING
             <br />
-            WITH BETTER DATA.
+            YOUR GRANT RESEARCH STACK.
           </h2>
-          <p className="text-white/70 text-lg mb-10">
-            Procurement officers, commissioners, funders, and community organisations
-            — CivicGraph gives you the decision intelligence to allocate resources
-            where they&apos;ll create the most value.
+          <p className="mt-6 text-lg text-white/75">
+            Start with search and alerts. Upgrade when you need a stronger funding pipeline.
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <div className="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
             <Link
-              href="/auth/signup"
-              className="inline-block py-4 px-10 font-black text-sm uppercase tracking-widest border-4 border-white bg-white text-bauhaus-red bauhaus-shadow-sm transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
+              href="/register"
+              className="inline-block border-4 border-white bg-white px-10 py-4 text-sm font-black uppercase tracking-widest text-bauhaus-red bauhaus-shadow-sm transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
             >
               Get Started Free
             </Link>
             <a
-              href="mailto:hello@civicgraph.au?subject=Funder%20tier%20enquiry"
-              className="inline-block py-4 px-10 font-black text-sm uppercase tracking-widest border-4 border-white text-white transition-all hover:bg-white hover:text-bauhaus-red"
+              href="mailto:hello@civicgraph.au?subject=CivicGraph%20pricing%20enquiry"
+              className="inline-block border-4 border-white px-10 py-4 text-sm font-black uppercase tracking-widest text-white transition-all hover:bg-white hover:text-bauhaus-red"
             >
-              Talk to Us
+              Talk To Us
             </a>
           </div>
         </div>

--- a/apps/web/src/app/rankings/page.tsx
+++ b/apps/web/src/app/rankings/page.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { money } from '@/lib/format';
+
+interface RankedCharity {
+  abn: string;
+  name: string;
+  gs_id: string;
+  entity_type: string;
+  sector: string | null;
+  state: string | null;
+  charity_size: string | null;
+  is_community_controlled: boolean;
+  revenue: number;
+  expenses: number;
+  assets: number;
+  fte: number;
+  volunteers: number;
+  vol_fte_ratio: number;
+  rev_per_fte: number;
+  cagr: number;
+  network_connections: number;
+  score_composite: number;
+  score_revenue: number;
+  score_growth: number;
+  score_leverage: number;
+  score_efficiency: number;
+  score_network: number;
+  score_health: number;
+  rank_composite: number;
+  rank_revenue: number;
+  rank_growth: number;
+  total_ranked: number;
+}
+
+const SORTS = [
+  { key: 'score_composite', label: 'Composite' },
+  { key: 'revenue', label: 'Revenue' },
+  { key: 'cagr', label: 'Growth' },
+  { key: 'fte', label: 'FTE' },
+  { key: 'volunteers', label: 'Volunteers' },
+  { key: 'vol_fte_ratio', label: 'Vol:FTE' },
+  { key: 'rev_per_fte', label: 'Rev/FTE' },
+  { key: 'network_connections', label: 'Network' },
+  { key: 'assets', label: 'Assets' },
+];
+
+const STATES = ['ALL', 'NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
+const SIZES = ['ALL', 'Small', 'Medium', 'Large'];
+
+const DIMENSIONS = [
+  { key: 'score_revenue', label: 'Rev', color: 'bg-green-500' },
+  { key: 'score_growth', label: 'Growth', color: 'bg-blue-500' },
+  { key: 'score_leverage', label: 'Lever', color: 'bg-purple-500' },
+  { key: 'score_efficiency', label: 'Effic', color: 'bg-amber-500' },
+  { key: 'score_network', label: 'Net', color: 'bg-red-500' },
+  { key: 'score_health', label: 'Hlth', color: 'bg-teal-500' },
+] as const;
+
+function ScoreBar({ score, color }: { score: number; color: string }) {
+  return (
+    <div className="w-full h-1.5 bg-gray-100" title={`${score.toFixed(0)}/100`}>
+      <div className={`h-full ${color} transition-all`} style={{ width: `${Math.min(100, score)}%` }} />
+    </div>
+  );
+}
+
+function Percentile({ rank, total }: { rank: number; total: number }) {
+  const pct = ((total - rank + 1) / total * 100).toFixed(1);
+  return (
+    <span className="text-[10px] font-bold text-bauhaus-blue">
+      Top {pct}%
+    </span>
+  );
+}
+
+export default function RankingsPage() {
+  const [data, setData] = useState<RankedCharity[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [sortBy, setSortBy] = useState('score_composite');
+  const [stateFilter, setStateFilter] = useState('ALL');
+  const [sizeFilter, setSizeFilter] = useState('ALL');
+  const [ccOnly, setCcOnly] = useState(false);
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [page, setPage] = useState(0);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const limit = 50;
+
+  useEffect(() => {
+    setLoading(true);
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(page * limit),
+      sort: sortBy,
+    });
+    if (stateFilter !== 'ALL') params.set('state', stateFilter);
+    if (sizeFilter !== 'ALL') params.set('size', sizeFilter);
+    if (ccOnly) params.set('cc', 'true');
+    if (search) params.set('q', search);
+
+    fetch(`/api/data/rankings?${params}`)
+      .then(r => r.json())
+      .then(d => {
+        setData(d.results || []);
+        setTotal(d.total || 0);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [sortBy, stateFilter, sizeFilter, ccOnly, search, page]);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput);
+    setPage(0);
+  };
+
+  return (
+    <main className="min-h-screen bg-gray-50 text-bauhaus-black">
+      {/* Header */}
+      <div className="border-b-4 border-bauhaus-black bg-bauhaus-black text-white">
+        <div className="mx-auto max-w-7xl px-4 py-6">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-bold uppercase tracking-widest text-bauhaus-red">CivicGraph</p>
+            <div className="flex gap-2">
+              <Link href="/entity/top" className="text-xs text-gray-400 hover:text-white transition-colors border border-gray-600 px-3 py-1">Power Index</Link>
+              <Link href="/charities" className="text-xs text-gray-400 hover:text-white transition-colors border border-gray-600 px-3 py-1">Charities</Link>
+              <Link href="/power" className="text-xs text-gray-400 hover:text-white transition-colors border border-gray-600 px-3 py-1">Power</Link>
+            </div>
+          </div>
+          <h1 className="text-3xl font-black uppercase tracking-wider">Charity Rankings</h1>
+          <p className="text-gray-400 text-sm mt-1 max-w-2xl">
+            {total.toLocaleString()} charities scored across 6 dimensions — revenue, growth, leverage, efficiency, network connections, and financial health.
+          </p>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="mx-auto max-w-7xl px-4 py-4 space-y-3">
+        {/* Search */}
+        <form onSubmit={handleSearch} className="flex gap-0">
+          <input
+            type="text"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            placeholder="Search by name..."
+            className="flex-1 max-w-xs px-4 py-2 border-4 border-bauhaus-black text-sm font-bold bg-white focus:bg-bauhaus-yellow focus:outline-none"
+          />
+          <button type="submit" className="px-4 py-2 bg-bauhaus-black text-white text-xs font-black uppercase tracking-widest hover:bg-bauhaus-red border-4 border-bauhaus-black cursor-pointer">
+            Search
+          </button>
+          {search && (
+            <button
+              type="button"
+              onClick={() => { setSearch(''); setSearchInput(''); setPage(0); }}
+              className="px-3 py-2 text-xs font-bold text-gray-500 hover:text-bauhaus-red border-4 border-l-0 border-bauhaus-black cursor-pointer"
+            >
+              Clear
+            </button>
+          )}
+        </form>
+
+        {/* Filters row */}
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-1">
+            {STATES.map(s => (
+              <button
+                key={s}
+                onClick={() => { setStateFilter(s); setPage(0); }}
+                className={`text-[10px] px-3 py-1.5 font-bold uppercase tracking-wider transition-all cursor-pointer ${
+                  stateFilter === s
+                    ? 'bg-bauhaus-black text-white'
+                    : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mr-1">Size:</span>
+            {SIZES.map(s => (
+              <button
+                key={s}
+                onClick={() => { setSizeFilter(s); setPage(0); }}
+                className={`text-[10px] px-2 py-1 font-bold uppercase tracking-wider transition-all cursor-pointer ${
+                  sizeFilter === s
+                    ? 'bg-bauhaus-black text-white'
+                    : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={() => { setCcOnly(!ccOnly); setPage(0); }}
+            className={`text-[10px] px-3 py-1 font-bold uppercase tracking-wider transition-all cursor-pointer ${
+              ccOnly ? 'bg-bauhaus-red text-white' : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
+            }`}
+          >
+            Community Controlled
+          </button>
+        </div>
+
+        {/* Sort */}
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mr-1">Sort:</span>
+          {SORTS.map(s => (
+            <button
+              key={s.key}
+              onClick={() => { setSortBy(s.key); setPage(0); }}
+              className={`text-[10px] px-2 py-1 font-bold uppercase tracking-wider transition-all cursor-pointer ${
+                sortBy === s.key
+                  ? 'bg-bauhaus-black text-white'
+                  : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="mx-auto max-w-7xl px-4 pb-8">
+        <div className="bg-white border-2 border-bauhaus-black shadow-sm overflow-x-auto">
+          {loading ? (
+            <div className="flex items-center justify-center h-40 text-gray-400">
+              <span className="inline-block w-5 h-5 border-2 border-gray-300 border-t-bauhaus-red rounded-full animate-spin mr-2" />
+              Loading...
+            </div>
+          ) : (
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b-2 border-gray-200 bg-gray-50/50">
+                  <th className="text-left py-3 pl-4 pr-2 font-black uppercase tracking-widest text-[10px] text-gray-400 w-10">#</th>
+                  <th className="text-left py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">Charity</th>
+                  <th className="text-right py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">Score</th>
+                  <th className="text-center py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400 w-48">Dimensions</th>
+                  <th className="text-right py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">Revenue</th>
+                  <th className="text-right py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">Growth</th>
+                  <th className="text-right py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">FTE</th>
+                  <th className="text-right py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">Network</th>
+                  <th className="text-left py-3 pr-4 font-black uppercase tracking-widest text-[10px] text-gray-400">State</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((c, i) => {
+                  const rank = page * limit + i + 1;
+                  const isExpanded = expanded === c.abn;
+                  return (
+                    <tr key={c.abn} className="group">
+                      <td colSpan={9} className="p-0">
+                        <div
+                          className={`grid grid-cols-[40px_1fr_80px_192px_100px_70px_60px_60px_50px] items-center border-b border-gray-100 hover:bg-blue-50/30 transition-colors cursor-pointer ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/30'}`}
+                          onClick={() => setExpanded(isExpanded ? null : c.abn)}
+                        >
+                          <div className="py-3 pl-4 pr-2 text-xs text-gray-400 font-mono">{rank}</div>
+                          <div className="py-3 pr-4">
+                            <Link
+                              href={`/entity/${encodeURIComponent(c.gs_id)}`}
+                              className="font-medium text-bauhaus-blue hover:underline"
+                              onClick={e => e.stopPropagation()}
+                            >
+                              {c.name}
+                            </Link>
+                            <div className="flex items-center gap-1.5 mt-0.5">
+                              <span className="text-[10px] px-1.5 py-0.5 bg-gray-100 text-gray-500 border border-gray-200">
+                                {c.charity_size || '?'}
+                              </span>
+                              {c.is_community_controlled && (
+                                <span className="text-[9px] px-1.5 py-0.5 bg-bauhaus-red/10 text-bauhaus-red font-bold">CC</span>
+                              )}
+                              <Percentile rank={Number(c.rank_composite)} total={Number(c.total_ranked)} />
+                            </div>
+                          </div>
+                          <div className="py-3 pr-4 text-right font-mono font-black text-lg">{Number(c.score_composite).toFixed(1)}</div>
+                          <div className="py-3 pr-4 space-y-0.5">
+                            {DIMENSIONS.map(d => (
+                              <ScoreBar key={d.key} score={Number(c[d.key as keyof RankedCharity])} color={d.color} />
+                            ))}
+                          </div>
+                          <div className="py-3 pr-4 text-right font-mono text-green-700">
+                            {Number(c.revenue) > 0 ? money(Number(c.revenue)) : '-'}
+                          </div>
+                          <div className="py-3 pr-4 text-right font-mono text-blue-600">
+                            {Number(c.cagr) !== 0 ? `${Number(c.cagr).toFixed(0)}%` : '-'}
+                          </div>
+                          <div className="py-3 pr-4 text-right font-mono text-gray-500">
+                            {Number(c.fte) > 0 ? Number(c.fte).toLocaleString() : '-'}
+                          </div>
+                          <div className="py-3 pr-4 text-right font-mono text-gray-500">
+                            {Number(c.network_connections) > 0 ? c.network_connections : '-'}
+                          </div>
+                          <div className="py-3 pr-4 text-xs text-gray-500">{c.state ?? '-'}</div>
+                        </div>
+
+                        {/* Expanded detail */}
+                        {isExpanded && (
+                          <div className="border-b-2 border-bauhaus-black bg-gray-50 px-6 py-4">
+                            <div className="grid grid-cols-3 gap-6">
+                              {/* Score breakdown */}
+                              <div>
+                                <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-400 mb-2">Score Breakdown</h4>
+                                <div className="space-y-1.5">
+                                  {DIMENSIONS.map(d => (
+                                    <div key={d.key} className="flex items-center gap-2">
+                                      <span className="text-[10px] w-12 text-gray-500 font-bold">{d.label}</span>
+                                      <div className="flex-1 h-2 bg-gray-200">
+                                        <div className={`h-full ${d.color}`} style={{ width: `${Math.min(100, Number(c[d.key as keyof RankedCharity]))}%` }} />
+                                      </div>
+                                      <span className="text-[10px] font-mono w-8 text-right">{Number(c[d.key as keyof RankedCharity]).toFixed(0)}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+
+                              {/* Financials */}
+                              <div>
+                                <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-400 mb-2">Financials (FY2023)</h4>
+                                <div className="space-y-1 text-xs">
+                                  <div className="flex justify-between"><span className="text-gray-500">Revenue</span><span className="font-mono font-bold">{money(Number(c.revenue))}</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">Expenses</span><span className="font-mono">{money(Number(c.expenses))}</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">Assets</span><span className="font-mono">{money(Number(c.assets))}</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">5yr CAGR</span><span className="font-mono text-blue-600">{Number(c.cagr).toFixed(1)}%</span></div>
+                                </div>
+                              </div>
+
+                              {/* Workforce */}
+                              <div>
+                                <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-400 mb-2">Workforce</h4>
+                                <div className="space-y-1 text-xs">
+                                  <div className="flex justify-between"><span className="text-gray-500">FTE Staff</span><span className="font-mono font-bold">{Number(c.fte).toLocaleString()}</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">Volunteers</span><span className="font-mono">{Number(c.volunteers).toLocaleString()}</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">Vol:FTE Ratio</span><span className="font-mono">{Number(c.vol_fte_ratio).toFixed(1)}:1</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">Rev/FTE</span><span className="font-mono">{money(Number(c.rev_per_fte))}</span></div>
+                                  <div className="flex justify-between"><span className="text-gray-500">Network</span><span className="font-mono">{c.network_connections} connections</span></div>
+                                </div>
+                              </div>
+                            </div>
+                            <div className="mt-3 flex gap-2">
+                              <Link
+                                href={`/entity/${encodeURIComponent(c.gs_id)}`}
+                                className="text-[10px] px-3 py-1.5 bg-bauhaus-blue text-white font-bold uppercase tracking-wider hover:bg-bauhaus-black transition-colors"
+                              >
+                                Full Profile
+                              </Link>
+                              <Link
+                                href={`/charities/${c.abn}`}
+                                className="text-[10px] px-3 py-1.5 bg-white text-bauhaus-black font-bold uppercase tracking-wider border border-gray-300 hover:border-bauhaus-black transition-colors"
+                              >
+                                Charity Detail
+                              </Link>
+                            </div>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Dimension legend */}
+        <div className="flex items-center gap-3 mt-3 text-[10px] text-gray-400">
+          <span className="font-bold uppercase tracking-wider">Dimensions:</span>
+          {DIMENSIONS.map(d => (
+            <span key={d.key} className="flex items-center gap-1">
+              <span className={`w-2 h-2 ${d.color}`} />
+              {d.label}
+            </span>
+          ))}
+        </div>
+
+        {/* Pagination */}
+        {total > limit && (
+          <div className="flex items-center justify-between mt-4">
+            <button
+              onClick={() => setPage(Math.max(0, page - 1))}
+              disabled={page === 0}
+              className="text-xs px-4 py-2 border border-gray-200 bg-white hover:border-bauhaus-black transition-all disabled:opacity-30 disabled:cursor-not-allowed font-bold uppercase tracking-wider cursor-pointer"
+            >
+              Previous
+            </button>
+            <span className="text-xs text-gray-500">
+              Page {page + 1} of {Math.ceil(total / limit)}
+            </span>
+            <button
+              onClick={() => setPage(page + 1)}
+              disabled={(page + 1) * limit >= total}
+              className="text-xs px-4 py-2 border border-gray-200 bg-white hover:border-bauhaus-black transition-all disabled:opacity-30 disabled:cursor-not-allowed font-bold uppercase tracking-wider cursor-pointer"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -2,7 +2,8 @@
 
 import { Suspense, useState } from 'react';
 import { createSupabaseBrowser } from '@/lib/supabase-browser';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { resolveAuthRedirect } from '@/lib/auth-redirect';
 
 export default function RegisterPage() {
   return (
@@ -18,8 +19,10 @@ function RegisterForm() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const router = useRouter();
   const searchParams = useSearchParams();
-  const redirect = searchParams.get('redirect');
+  const redirectPath = resolveAuthRedirect(searchParams);
+  const plan = searchParams.get('plan');
 
   async function handleRegister(e: React.FormEvent) {
     e.preventDefault();
@@ -33,9 +36,12 @@ function RegisterForm() {
     }
 
     const supabase = createSupabaseBrowser();
-    const { error: authError } = await supabase.auth.signUp({
+    const { data, error: authError } = await supabase.auth.signUp({
       email,
       password,
+      options: {
+        emailRedirectTo: `${window.location.origin}${redirectPath}`,
+      },
     });
 
     if (authError) {
@@ -51,11 +57,19 @@ function RegisterForm() {
       body: JSON.stringify({ email }),
     }).catch(() => {});
 
+    if (data.session) {
+      router.push(redirectPath);
+      router.refresh();
+      return;
+    }
+
     setSuccess(true);
     setLoading(false);
   }
 
-  const loginHref = redirect ? `/login?redirect=${encodeURIComponent(redirect)}` : '/login';
+  const loginHref = redirectPath !== '/continue'
+    ? `/login?redirect=${encodeURIComponent(redirectPath)}`
+    : '/login';
 
   if (success) {
     return (
@@ -70,6 +84,9 @@ function RegisterForm() {
             <h1 className="text-xl font-black text-bauhaus-black mb-3">Check Your Email</h1>
             <p className="text-sm text-bauhaus-muted font-medium leading-relaxed mb-4">
               We&apos;ve sent a confirmation link to <span className="font-black text-bauhaus-black">{email}</span>. Click the link to activate your account.
+            </p>
+            <p className="text-xs text-bauhaus-muted font-medium leading-relaxed mb-4">
+              After confirmation, we&apos;ll take you straight into profile setup and matched grants.
             </p>
             <a
               href={loginHref}
@@ -92,11 +109,16 @@ function RegisterForm() {
               Create Account
             </h1>
             <p className="text-xs text-bauhaus-muted mt-1 uppercase tracking-wider">
-              Claim your charity profile
+              Start your funding pipeline
             </p>
           </div>
 
           <form onSubmit={handleRegister} className="p-6 space-y-4">
+            {plan && (
+              <div className="bg-link-light border-4 border-bauhaus-blue p-3 text-xs font-black text-bauhaus-blue uppercase tracking-widest">
+                Selected plan: {plan}
+              </div>
+            )}
             {error && (
               <div className="bg-danger-light border-4 border-bauhaus-red p-3 text-sm font-bold text-bauhaus-red">
                 {error}

--- a/apps/web/src/app/snow-foundation/page.tsx
+++ b/apps/web/src/app/snow-foundation/page.tsx
@@ -1,0 +1,614 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Snow Foundation Demo | CivicGraph',
+  description: 'Public demo route for the Snow Foundation portfolio intelligence and evidence walkthrough.',
+};
+
+const SNOW_FOUNDATION_ID = 'd242967e-0e68-4367-9785-06cf0ec7485e';
+const SNOW_ORGANISATION_ID = '4a1c31e8-89b7-476d-a74b-0c8b37efc850';
+const PRF_FOUNDATION_ID = '4ee5baca-c898-4318-ae2b-d79b95379cc7';
+const MINDEROO_FOUNDATION_ID = '8f8704be-d6e8-40f3-b561-ac6630ce5b36';
+const IAN_POTTER_FOUNDATION_ID = 'b9e090e5-1672-48ff-815a-2a6314ebe033';
+
+interface SnowFoundationRow {
+  id: string;
+  name: string;
+  acnc_abn: string;
+  description: string | null;
+  website: string | null;
+  total_giving_annual: number | null;
+  profile_confidence: string;
+  thematic_focus: string[] | null;
+  geographic_focus: string[] | null;
+  giving_philosophy: string | null;
+  gs_entity_id: string | null;
+}
+
+interface PowerProfileRow {
+  openness_score: number | null;
+  approachability_score: number | null;
+  gatekeeping_score: number | null;
+  capital_holder_class: string | null;
+  capital_source_class: string | null;
+}
+
+interface FoundationGranteeRow {
+  grantee_name: string;
+  grant_amount: number | null;
+}
+
+interface BoardRoleRow {
+  person_name: string;
+  role_type: string | null;
+  person_entity_id: string | null;
+  source: string | null;
+}
+
+interface ProgramYearRow {
+  id: string;
+  report_year: number | null;
+  fiscal_year: string | null;
+  summary: string | null;
+  reported_amount: number | null;
+  partners: Array<{ name?: string; role?: string }> | null;
+  places: Array<{ name?: string; type?: string }> | null;
+  foundation_programs:
+    | {
+        name: string;
+        program_type: string | null;
+      }
+    | Array<{
+    name: string;
+    program_type: string | null;
+      }>
+    | null;
+}
+
+function formatMoney(value: number | null | undefined): string {
+  if (value == null) return 'Unknown';
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}K`;
+  return `$${Math.round(value).toLocaleString('en-AU')}`;
+}
+
+function formatDecimal(value: number | null | undefined): string {
+  if (value == null) return 'Unknown';
+  return value.toFixed(2);
+}
+
+function labelise(value: string | null | undefined): string {
+  if (!value) return 'Unknown';
+  return value.replace(/_/g, ' ');
+}
+
+function getProgramYearFoundationProgram(row: ProgramYearRow) {
+  if (Array.isArray(row.foundation_programs)) return row.foundation_programs[0] ?? null;
+  return row.foundation_programs ?? null;
+}
+
+function getEmpathyLedgerBaseUrl(): string {
+  const base =
+    process.env.NEXT_PUBLIC_EMPATHY_LEDGER_URL ||
+    process.env.VITE_EMPATHY_LEDGER_URL ||
+    'http://127.0.0.1:3030';
+
+  return base.replace(/\/$/, '');
+}
+
+function StatCard({ label, value, subtext }: { label: string; value: string; subtext?: string }) {
+  return (
+    <div className="border-4 border-bauhaus-black bg-white p-5">
+      <div className="text-xs font-black uppercase tracking-[0.25em] text-bauhaus-muted">{label}</div>
+      <div className="mt-2 text-3xl font-black text-bauhaus-black">{value}</div>
+      {subtext ? <div className="mt-2 text-sm font-medium text-bauhaus-muted">{subtext}</div> : null}
+    </div>
+  );
+}
+
+function ScreenCard({
+  step,
+  title,
+  href,
+  platform,
+  description,
+  transition,
+}: {
+  step: string;
+  title: string;
+  href: string;
+  platform: string;
+  description: string;
+  transition?: string;
+}) {
+  const isInternal = href.startsWith('/');
+
+  return (
+    <div className="border-4 border-bauhaus-black bg-white">
+      <div className="border-b-4 border-bauhaus-black bg-bauhaus-yellow px-4 py-3">
+        <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-black">{step}</div>
+        <div className="mt-1 text-xl font-black text-bauhaus-black">{title}</div>
+      </div>
+      <div className="space-y-4 p-4">
+        <div className="inline-flex items-center gap-2 border-2 border-bauhaus-black px-2 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-bauhaus-muted">
+          <span>{platform}</span>
+        </div>
+        <p className="text-sm font-medium leading-relaxed text-bauhaus-muted">{description}</p>
+        {transition ? (
+          <div className="border-l-4 border-bauhaus-red pl-3 text-sm font-bold text-bauhaus-black">
+            {transition}
+          </div>
+        ) : null}
+        {isInternal ? (
+          <Link
+            href={href}
+            className="inline-flex items-center border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+          >
+            Open screen
+          </Link>
+        ) : (
+          <a
+            href={href}
+            className="inline-flex items-center border-2 border-bauhaus-black px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+          >
+            Open screen
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default async function SnowFoundationDemoPage() {
+  const supabase = getServiceSupabase();
+  const empathyBaseUrl = getEmpathyLedgerBaseUrl();
+
+  const { data: foundation } = await supabase
+    .from('foundations')
+    .select('id, name, acnc_abn, description, website, total_giving_annual, profile_confidence, thematic_focus, geographic_focus, giving_philosophy, gs_entity_id')
+    .eq('id', SNOW_FOUNDATION_ID)
+    .single<SnowFoundationRow>();
+
+  if (!foundation) {
+    return (
+      <div className="border-4 border-bauhaus-red bg-danger-light p-6">
+        <div className="text-sm font-black uppercase tracking-[0.3em] text-bauhaus-red">Snow demo unavailable</div>
+        <p className="mt-3 text-sm font-medium text-bauhaus-red">
+          The Snow Foundation record did not resolve from the current CivicGraph database.
+        </p>
+      </div>
+    );
+  }
+
+  const [powerProfileResult, programCountResult, openProgramCountResult, granteeRowsResult, boardRolesResult, foundationPeopleResult, programYearsResult] = await Promise.all([
+    supabase
+      .from('foundation_power_profiles')
+      .select('openness_score, approachability_score, gatekeeping_score, capital_holder_class, capital_source_class')
+      .eq('foundation_id', foundation.id)
+      .maybeSingle<PowerProfileRow>(),
+    supabase
+      .from('foundation_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundation.id)
+      .in('status', ['open', 'closed']),
+    supabase
+      .from('foundation_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundation.id)
+      .eq('status', 'open'),
+    supabase
+      .from('foundation_grantees')
+      .select('grantee_name, grant_amount')
+      .eq('foundation_id', foundation.id)
+      .eq('grant_year', 2024)
+      .order('grant_amount', { ascending: false, nullsFirst: false }),
+    supabase
+      .from('person_roles')
+      .select('person_name, role_type, person_entity_id, source')
+      .eq('company_abn', foundation.acnc_abn)
+      .is('cessation_date', null)
+      .order('role_type', { ascending: true })
+      .order('person_name', { ascending: true }),
+    supabase
+      .from('foundation_people')
+      .select('id', { count: 'exact', head: true })
+      .eq('foundation_id', foundation.id),
+    supabase
+      .from('foundation_program_years')
+      .select('id, report_year, fiscal_year, summary, reported_amount, partners, places, foundation_programs(name, program_type)')
+      .eq('foundation_id', foundation.id)
+      .order('report_year', { ascending: false, nullsFirst: false }),
+  ]);
+
+  const powerProfile = powerProfileResult.data;
+  const granteeRows = (granteeRowsResult.data || []) as FoundationGranteeRow[];
+  const boardRoles = ((boardRolesResult.data || []) as BoardRoleRow[]).sort((a, b) => {
+    const order = (value: string | null) => {
+      if (value === 'chair') return 0;
+      if (value === 'director') return 1;
+      return 2;
+    };
+    const rank = order(a.role_type) - order(b.role_type);
+    return rank !== 0 ? rank : a.person_name.localeCompare(b.person_name);
+  });
+  const verifiedValue = granteeRows.reduce((sum, row) => sum + Number(row.grant_amount || 0), 0);
+  const topGrantees = granteeRows.slice(0, 3);
+  const linkedBoardProfiles = boardRoles.filter((row) => row.person_entity_id).length;
+  const foundationPeopleCount = foundationPeopleResult.count || 0;
+  const programYears = (programYearsResult.data || []) as ProgramYearRow[];
+
+  const routeCards = [
+    {
+      step: 'Screen 1',
+      title: 'Snow Foundation detail',
+      href: `/foundations/${foundation.id}`,
+      platform: 'CivicGraph',
+      description:
+        'Start with the repaired Snow profile. This anchors the walkthrough on a single public capital holder, with annual giving, ABN, program surface, and profile quality in one place.',
+      transition: 'This is Snow on its own. The next view places Snow inside the wider funding landscape.',
+    },
+    {
+      step: 'Screen 2',
+      title: 'Snow in the funder search',
+      href: '/foundations?q=Snow%20Foundation',
+      platform: 'CivicGraph',
+      description:
+        'Move from the isolated card to the wider capital map. This shows Snow as one node in a broader philanthropic field rather than a standalone profile.',
+      transition: 'The question is not just who Snow is. The question is what signal path and action path this portfolio can support.',
+    },
+    {
+      step: 'Screen 3',
+      title: 'Clarity handoff for Deadly Hearts Trek',
+      href: '/clarity?subject=Deadly%20Hearts%20Trek&state=NT&output=story-handoff&lanes=clarity,entity,place',
+      platform: 'CivicGraph',
+      description:
+        'This is the public accountability layer between capital and story. It shows the narrative handoff with the active evidence lanes visible instead of implied.',
+      transition: 'Now we move from the portfolio map into the community evidence layer.',
+    },
+    {
+      step: 'Screen 4',
+      title: 'Snow dashboard',
+      href: `${empathyBaseUrl}/organisations/${SNOW_ORGANISATION_ID}/dashboard`,
+      platform: 'Empathy Ledger',
+      description:
+        'Open only the curated dashboard. The point is to show that a real Snow tenant and real project layer exist, not to wander the tenant.',
+      transition: 'The dashboard proves the tenant exists. The transcript layer is where the real texture lives.',
+    },
+    {
+      step: 'Screen 5',
+      title: 'Snow transcripts',
+      href: `${empathyBaseUrl}/organisations/${SNOW_ORGANISATION_ID}/transcripts`,
+      platform: 'Empathy Ledger',
+      description:
+        'This is the strongest live evidence surface. It gives the portfolio view community texture instead of stopping at grant metadata and foundation description.',
+      transition: 'The final move is from transcript material into structured project understanding.',
+    },
+    {
+      step: 'Screen 6',
+      title: 'Snow analysis view',
+      href: `${empathyBaseUrl}/organisations/${SNOW_ORGANISATION_ID}/analysis`,
+      platform: 'Empathy Ledger',
+      description:
+        'Close on the structured interpretation layer. This is where the project evidence becomes an intelligible outcomes frame rather than raw transcript material.',
+    },
+  ];
+
+  return (
+    <div className="pb-16">
+      <section className="border-b-4 border-bauhaus-black pb-10">
+        <div className="text-xs font-black uppercase tracking-[0.35em] text-bauhaus-red">Public demo route</div>
+        <h1 className="mt-4 text-4xl font-black leading-[0.9] text-bauhaus-black sm:text-6xl">
+          Snow Foundation
+          <br />
+          Portfolio demo
+        </h1>
+        <p className="mt-5 max-w-3xl text-lg font-medium leading-relaxed text-bauhaus-muted">
+          This is the public Snow walkthrough for CivicGraph and Empathy Ledger. It strips out the internal
+          composer surfaces and keeps only the verified path from capital holder, to evidence chain, to
+          community transcript, to structured analysis.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.25em]">
+          <span className="border-2 border-bauhaus-black px-3 py-2 text-bauhaus-black">External-safe route</span>
+          <span className="border-2 border-bauhaus-blue bg-link-light px-3 py-2 text-bauhaus-blue">No login required on CivicGraph</span>
+          <span className="border-2 border-bauhaus-red bg-bauhaus-red/5 px-3 py-2 text-bauhaus-red">Curated, not exploratory</span>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.22em]">
+          <Link
+            href={`/foundations/compare?left=${SNOW_FOUNDATION_ID}&right=${PRF_FOUNDATION_ID}`}
+            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+          >
+            Compare Snow with PRF
+          </Link>
+          <Link
+            href={`/foundations/compare?left=${SNOW_FOUNDATION_ID}&right=${MINDEROO_FOUNDATION_ID}`}
+            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+          >
+            Compare Snow with Minderoo
+          </Link>
+          <Link
+            href={`/foundations/compare?left=${SNOW_FOUNDATION_ID}&right=${IAN_POTTER_FOUNDATION_ID}`}
+            className="border-2 border-bauhaus-blue/25 bg-link-light px-3 py-2 text-bauhaus-blue transition-colors hover:border-bauhaus-blue hover:bg-bauhaus-blue hover:text-white"
+          >
+            Compare Snow with Ian Potter
+          </Link>
+          <Link
+            href="/foundations/compare"
+            className="border-2 border-bauhaus-black/20 bg-bauhaus-canvas px-3 py-2 text-bauhaus-black transition-colors hover:border-bauhaus-black hover:bg-bauhaus-black hover:text-white"
+          >
+            Open compare surface
+          </Link>
+        </div>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-0 md:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          label="Annual giving"
+          value={formatMoney(foundation.total_giving_annual)}
+          subtext="Repaired to the Snow annual report baseline."
+        />
+        <StatCard
+          label="Verified 2024 grants"
+          value={String(granteeRows.length)}
+          subtext={`${formatMoney(verifiedValue)} extracted into the public grant layer.`}
+        />
+        <StatCard
+          label="Open programs"
+          value={String(openProgramCountResult.count || 0)}
+          subtext={`${programCountResult.count || 0} tracked program records on the profile.`}
+        />
+        <StatCard
+          label="Power posture"
+          value={formatDecimal(powerProfile?.openness_score)}
+          subtext={`Approachability ${formatDecimal(powerProfile?.approachability_score)} · Gatekeeping ${formatDecimal(powerProfile?.gatekeeping_score)}`}
+        />
+      </section>
+
+      <section id="governance-graph" className="mt-10 grid grid-cols-1 gap-6 xl:grid-cols-[1fr_1fr]">
+        <div className="border-4 border-bauhaus-black bg-white">
+          <div className="border-b-4 border-bauhaus-black bg-bauhaus-blue px-6 py-4">
+            <div className="text-xs font-black uppercase tracking-[0.28em] text-white">Governance graph</div>
+            <h2 className="mt-2 text-2xl font-black text-white">Structured Snow board roles</h2>
+          </div>
+          <div className="p-6">
+            <div className="mb-4 grid grid-cols-3 gap-0 border-4 border-bauhaus-black">
+              <StatCard label="Board roles" value={String(boardRoles.length)} subtext="Active ACNC-linked roles on the Snow entity." />
+              <StatCard label="Person links" value={String(linkedBoardProfiles)} subtext="Canonical person entities currently linked." />
+              <StatCard label="Foundation people" value={String(foundationPeopleCount)} subtext="Rows in the Snow-specific extraction table." />
+            </div>
+            <div className="space-y-3">
+              {boardRoles.map((member) => (
+                <div key={`${member.person_name}-${member.role_type || 'unknown'}`} className="flex items-start justify-between gap-4 border-b-2 border-bauhaus-black/10 pb-3 last:border-b-0 last:pb-0">
+                  <div className="min-w-0">
+                    <Link href={`/person/${encodeURIComponent(member.person_name)}`} className="text-sm font-black text-bauhaus-black hover:text-bauhaus-blue">
+                      {member.person_name}
+                    </Link>
+                    <div className="mt-1 text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                      {(member.role_type || 'role').replace(/_/g, ' ')}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-[10px] font-black uppercase tracking-[0.16em] text-bauhaus-muted">
+                    {member.source === 'acnc_register' ? 'ACNC register' : member.source || 'Linked'}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 border-l-4 border-bauhaus-red pl-3 text-sm font-bold text-bauhaus-black">
+              {linkedBoardProfiles === 0
+                ? 'Snow already has board roles in CivicGraph, but none of the visible roles are attached to canonical person entities yet.'
+                : linkedBoardProfiles === boardRoles.length
+                  ? 'All visible Snow board roles now resolve to canonical person entities in CivicGraph, but the richer Snow-specific people table is still thin.'
+                  : `${linkedBoardProfiles} of ${boardRoles.length} visible Snow board roles now resolve to canonical person entities in CivicGraph, with the remainder still needing cleanup.`}
+            </div>
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-white">
+          <div className="border-b-4 border-bauhaus-black bg-bauhaus-red px-6 py-4">
+            <div className="text-xs font-black uppercase tracking-[0.28em] text-white">What is missing</div>
+            <h2 className="mt-2 text-2xl font-black text-white">To make Snow fully legible</h2>
+          </div>
+          <div className="space-y-4 p-6 text-sm font-medium leading-relaxed text-bauhaus-muted">
+            <p>
+              CivicGraph already has the funder shell, the grant/program layer, ACNC financial history, and structured board
+              roles. The weak points are the person entity layer, the Snow-specific people extraction layer, and the bridge into
+              the story/project system.
+            </p>
+            <div className="grid grid-cols-1 gap-3">
+              <div className="border-2 border-bauhaus-black p-3">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Missing in CivicGraph</div>
+                <div className="mt-2 text-bauhaus-black">Canonical person entities for Snow board members, executive/staff roles, and explicit project or service links to funded work like RHD.</div>
+              </div>
+              <div className="border-2 border-bauhaus-black p-3">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Missing in Empathy Ledger</div>
+                <div className="mt-2 text-bauhaus-black">Contact-grade staff/leadership records and annual report records. The story/project layer exists, but the people/portfolio layer is still thin.</div>
+              </div>
+              <div className="border-2 border-bauhaus-black p-3">
+                <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-red">Missing in the bridge</div>
+                <div className="mt-2 text-bauhaus-black">A clean mapping from funder → project → supported service → storyteller, so Snow can see not just who it funded, but who can speak from that work.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <div className="border-4 border-bauhaus-black bg-white p-6">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">What this page proves</div>
+          <div className="mt-4 space-y-4 text-sm font-medium leading-relaxed text-bauhaus-muted">
+            <p>
+              Snow is not being pitched here as a generic funder record. This is a working portfolio case:
+              funder profile, public program surface, verified 2024 grant layer, explicit story handoff, and a
+              paired evidence tenant.
+            </p>
+            <p>
+              The internal briefing and report-builder pages still matter, but they are operator tools. This page
+              exists so the external walkthrough can stay public, simple, and accountable to surfaces that are
+              actually demo-safe.
+            </p>
+          </div>
+          <div className="mt-6 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-[0.2em]">
+            <span className="border-2 border-bauhaus-black px-2 py-1 text-bauhaus-black">
+              {labelise(powerProfile?.capital_holder_class)}
+            </span>
+            <span className="border-2 border-bauhaus-black px-2 py-1 text-bauhaus-black">
+              {labelise(powerProfile?.capital_source_class)}
+            </span>
+            {(foundation.thematic_focus || []).slice(0, 4).map((focus) => (
+              <span key={focus} className="border-2 border-bauhaus-black/20 px-2 py-1 text-bauhaus-muted">
+                {focus}
+              </span>
+            ))}
+            {(foundation.geographic_focus || []).slice(0, 3).map((focus) => (
+              <span key={focus} className="border-2 border-bauhaus-blue/30 px-2 py-1 text-bauhaus-blue">
+                {focus}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-bauhaus-yellow p-6">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-black">Operator notes</div>
+          <ul className="mt-4 space-y-3 text-sm font-medium leading-relaxed text-bauhaus-black">
+            <li>Do not open the raw story list or unfinished admin views.</li>
+            <li>Do not use the Snow member layer as contact-grade data.</li>
+            <li>Keep the narrative on portfolio intelligence plus community evidence, not on dashboard novelty.</li>
+            <li>Use this page as the starting screen instead of the internal briefing or report-builder routes.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="mt-10 border-4 border-bauhaus-black bg-white">
+        <div className="border-b-4 border-bauhaus-black bg-bauhaus-black px-6 py-5">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-bauhaus-yellow">Live Snow baseline</div>
+          <h2 className="mt-2 text-2xl font-black text-white">Verified portfolio signals in CivicGraph</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-6 p-6 lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="space-y-3 text-sm font-medium leading-relaxed text-bauhaus-muted">
+            <p>
+              <span className="font-black text-bauhaus-black">{foundation.name}</span> is anchored here as ABN{' '}
+              <span className="font-black text-bauhaus-black">{foundation.acnc_abn}</span> with{' '}
+              <span className="font-black text-bauhaus-black">{formatMoney(foundation.total_giving_annual)}</span> in annual
+              giving and <span className="font-black text-bauhaus-black">{openProgramCountResult.count || 0}</span> open
+              programs currently visible.
+            </p>
+            <p>
+              The 2024 verified grantee layer currently holds{' '}
+              <span className="font-black text-bauhaus-black">{granteeRows.length}</span> rows worth{' '}
+              <span className="font-black text-bauhaus-black">{formatMoney(verifiedValue)}</span> from Snow&apos;s
+              annual-report-backed 2024 giving. That is the verified capital layer this walkthrough stands on before
+              it moves into Clarity and then into the Empathy Ledger evidence surfaces.
+            </p>
+            {foundation.giving_philosophy ? (
+              <p className="border-l-4 border-bauhaus-red pl-3 text-bauhaus-black">
+                {foundation.giving_philosophy}
+              </p>
+            ) : null}
+          </div>
+          <div className="border-4 border-bauhaus-black bg-bauhaus-canvas p-4">
+            <div className="text-xs font-black uppercase tracking-[0.25em] text-bauhaus-muted">Top verified 2024 grantees</div>
+            <div className="mt-4 space-y-3">
+              {topGrantees.map((row) => (
+                <div key={row.grantee_name} className="flex items-start justify-between gap-4 border-b-2 border-bauhaus-black/10 pb-3">
+                  <div className="text-sm font-black leading-tight text-bauhaus-black">{row.grantee_name}</div>
+                  <div className="shrink-0 text-sm font-black text-bauhaus-blue">{formatMoney(row.grant_amount)}</div>
+                </div>
+              ))}
+              {topGrantees.length === 0 ? (
+                <div className="text-sm font-medium text-bauhaus-muted">No verified 2024 grantee rows available.</div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="year-memory" className="mt-10 border-4 border-bauhaus-black bg-white">
+        <div className="border-b-4 border-bauhaus-black bg-bauhaus-blue px-6 py-5">
+          <div className="text-xs font-black uppercase tracking-[0.3em] text-white">Cross-system year memory</div>
+          <h2 className="mt-2 text-2xl font-black text-white">Snow program strands now persist by year</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-4 p-6 lg:grid-cols-2">
+          {programYears.map((row) => {
+            const foundationProgram = getProgramYearFoundationProgram(row);
+            const partnerLabel = (row.partners || []).map((partner) => partner.name).filter(Boolean).join(', ');
+            const placeLabel = (row.places || []).map((place) => place.name).filter(Boolean).join(', ');
+
+            return (
+              <div key={row.id} className="border-4 border-bauhaus-black bg-bauhaus-canvas p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[10px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                      {row.fiscal_year || row.report_year || 'Program year'}
+                    </div>
+                    <h3 className="mt-1 text-lg font-black text-bauhaus-black">
+                      {foundationProgram?.name || 'Unnamed program'}
+                    </h3>
+                  </div>
+                  {row.reported_amount != null ? (
+                    <span className="border-2 border-money bg-money-light px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-money">
+                      {formatMoney(row.reported_amount)}
+                    </span>
+                  ) : null}
+                </div>
+                {row.summary ? (
+                  <p className="mt-3 text-sm font-medium leading-relaxed text-bauhaus-muted">
+                    {row.summary}
+                  </p>
+                ) : null}
+                <div className="mt-3 space-y-1 text-xs font-bold text-bauhaus-muted">
+                  {partnerLabel ? <p>Partners: {partnerLabel}</p> : null}
+                  {placeLabel ? <p>Places: {placeLabel}</p> : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="border-t-4 border-bauhaus-black bg-bauhaus-yellow px-6 py-4 text-sm font-bold leading-relaxed text-bauhaus-black">
+          This is the first real proof that Snow is no longer just a funder card plus a story tenant. The recurring program layer now exists in both CivicGraph and Empathy Ledger, with shared 2023-24 memory for the same five portfolio strands.
+        </div>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-6 xl:grid-cols-[1fr_1fr]">
+        <div className="border-4 border-bauhaus-black bg-white p-6">
+          <div className="text-xs font-black uppercase tracking-[0.28em] text-bauhaus-red">How this helps Snow-like orgs</div>
+          <div className="mt-4 space-y-4 text-sm font-medium leading-relaxed text-bauhaus-muted">
+            <p>
+              For funders like Snow, the value is not another dashboard. The value is one chain: who holds capital, who governs
+              it, where it goes, which places and projects it touches, and which people can speak to what changed.
+            </p>
+            <p>
+              Once that chain exists, the same system helps other foundations, place-based funders, and program teams do board
+              reporting, partner mapping, procurement and grant opportunity scanning, and community evidence handoff from one base
+              record.
+            </p>
+          </div>
+        </div>
+
+        <div className="border-4 border-bauhaus-black bg-bauhaus-yellow p-6">
+          <div className="text-xs font-black uppercase tracking-[0.28em] text-bauhaus-black">Best operating model</div>
+          <div className="mt-4 space-y-3 text-sm font-medium leading-relaxed text-bauhaus-black">
+            <p><span className="font-black">Organization</span>: Snow as the capital holder and reporting shell.</p>
+            <p><span className="font-black">Contacts</span>: board, staff, leadership, partner reps, and key grantee relationships.</p>
+            <p><span className="font-black">Projects</span>: RHD, South Coast, women and justice, or any specific portfolio strand.</p>
+            <p><span className="font-black">Storytellers</span>: people attached to projects, not only to the parent org.</p>
+            <p><span className="font-black">Annual reports</span>: import the portfolio facts once, then attach funded services and projects explicitly.</p>
+            <p><span className="font-black">Bridge</span>: each funded service or project should be linkable to transcripts, analysis, and board-ready memos.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-10">
+        <div className="mb-4 text-xs font-black uppercase tracking-[0.3em] text-bauhaus-red">Demo sequence</div>
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          {routeCards.map((card) => (
+            <ScreenCard key={card.step} {...card} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/tender-intelligence/page.tsx
+++ b/apps/web/src/app/tender-intelligence/page.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { BriefingLoopBar } from '@/app/components/briefing-loop-bar';
+import { buildTenderBriefingState } from '@/app/components/briefing-page-params';
 import { decisionTagBadgeClass, decisionTagLabel, SHORTLIST_DECISIONS } from '@/lib/procurement-shortlist';
 import { getDecisionPackBlockers, type PackReadinessBlocker } from '@/lib/procurement-pack-readiness';
 import { createSupabaseBrowser } from '@/lib/supabase-browser';
@@ -99,12 +101,26 @@ import {
   ExportButton,
 } from './tender-intelligence-utils';
 
-
 export default function TenderIntelligencePage() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const selectedShortlistId = searchParams.get('shortlistId');
+  const {
+    briefingComposeHref,
+    briefingLanes,
+    briefingState,
+    briefingSubject,
+    hasBriefingContext,
+    loop,
+    notice: briefingNotice,
+    seed: briefingSeed,
+  } = buildTenderBriefingState({
+    subject: searchParams.get('subject') || '',
+    state: searchParams.get('state') || '',
+    output: searchParams.get('output') || '',
+    lanes: searchParams.get('lanes') || '',
+  });
   const [authResolved, setAuthResolved] = useState(false);
   const [authed, setAuthed] = useState(false);
   const [shellAuthenticated, setShellAuthenticated] = useState(false);
@@ -115,6 +131,7 @@ export default function TenderIntelligencePage() {
   const [operationBlockers, setOperationBlockers] = useState<string[]>([]);
   const [operationNotice, setOperationNotice] = useState('');
   const [workspaceBusyId, setWorkspaceBusyId] = useState<string | null>(null);
+  const [appliedBriefingSeed, setAppliedBriefingSeed] = useState('');
   const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
   const [supplierCommentDrafts, setSupplierCommentDrafts] = useState<Record<string, string>>({});
   const [taskCompletionDrafts, setTaskCompletionDrafts] = useState<Record<string, { outcome: NonNullable<ProcurementTask['completion_outcome']>; note: string }>>({});
@@ -284,6 +301,22 @@ export default function TenderIntelligencePage() {
   const [publicTab, setPublicTab] = useState<TabKey>('discover');
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    if (!briefingSeed || briefingSeed === appliedBriefingSeed) return;
+
+    if (briefingSubject) {
+      setWorkspaceSearch(briefingSubject);
+    }
+
+    if (briefingState) {
+      setDiscoverState(briefingState);
+      setPackState(briefingState);
+    }
+
+    setOperationNotice(briefingNotice);
+    setAppliedBriefingSeed(briefingSeed);
+  }, [appliedBriefingSeed, briefingNotice, briefingSeed, briefingState, briefingSubject]);
+
   // Discover state
   const [discoverState, setDiscoverState] = useState('');
   const [discoverLga, setDiscoverLga] = useState('');
@@ -309,7 +342,10 @@ export default function TenderIntelligencePage() {
     if (nextTab !== tab) {
       setTab(nextTab);
     }
-  }, [searchParams, tab]);
+    if (nextTab !== publicTab) {
+      setPublicTab(nextTab);
+    }
+  }, [publicTab, searchParams, tab]);
 
   const replaceWorkspaceQuery = useCallback((updates: { tab?: TabKey | null; shortlistId?: string | null }) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -2589,7 +2625,7 @@ export default function TenderIntelligencePage() {
 
       {/* Tabs */}
       <div className="border-b-4 border-bauhaus-black bg-white print:hidden">
-        <div className="max-w-5xl mx-auto flex">
+        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row">
           {[
             { key: 'discover' as TabKey, label: 'Supplier Discovery' },
             { key: 'enrich' as TabKey, label: 'List Enrichment' },
@@ -2598,7 +2634,7 @@ export default function TenderIntelligencePage() {
             <button
               key={t.key}
               onClick={() => setActiveTab(t.key)}
-              className={`px-6 py-4 text-xs font-black uppercase tracking-widest border-r-4 border-bauhaus-black transition-colors ${
+              className={`px-6 py-4 text-xs font-black uppercase tracking-widest border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black transition-colors text-left sm:text-center ${
                 tab === t.key
                   ? 'bg-bauhaus-black text-white'
                   : 'text-bauhaus-muted hover:bg-bauhaus-canvas'
@@ -2630,6 +2666,17 @@ export default function TenderIntelligencePage() {
               </div>
             )}
           </div>
+
+          {hasBriefingContext && loop && (
+            <BriefingLoopBar
+              refineHref={briefingComposeHref}
+              output={loop.output}
+              subject={loop.subject}
+              state={loop.state}
+              lanes={loop.lanes}
+              message={loop.message}
+            />
+          )}
 
           {workspaceError && (
             <div className="border-4 border-bauhaus-red bg-bauhaus-red/10 px-4 py-3 text-sm font-bold text-bauhaus-red">

--- a/apps/web/src/lib/auth-redirect.ts
+++ b/apps/web/src/lib/auth-redirect.ts
@@ -1,0 +1,23 @@
+type RedirectSearchParams = Pick<URLSearchParams, 'get' | 'entries'>;
+
+function sanitizeRedirectTarget(value: string | null): string | null {
+  if (!value) return null;
+  if (!value.startsWith('/')) return null;
+  if (value.startsWith('//')) return null;
+  return value;
+}
+
+export function resolveAuthRedirect(searchParams: RedirectSearchParams, fallback = '/continue'): string {
+  const redirectTarget = sanitizeRedirectTarget(searchParams.get('redirect') || searchParams.get('next'));
+  if (!redirectTarget) return fallback;
+  if (redirectTarget.includes('?')) return redirectTarget;
+
+  const extraParams = new URLSearchParams();
+  for (const [key, value] of searchParams.entries()) {
+    if (key === 'next' || key === 'redirect') continue;
+    extraParams.append(key, value);
+  }
+
+  const query = extraParams.toString();
+  return query ? `${redirectTarget}?${query}` : redirectTarget;
+}

--- a/apps/web/src/lib/org-profile.ts
+++ b/apps/web/src/lib/org-profile.ts
@@ -4,10 +4,13 @@ import { getServiceSupabase } from '@/lib/supabase';
 export interface OrgProfileSummary {
   id: string;
   name: string;
+  slug: string | null;
   abn: string | null;
   subscription_plan: string | null;
   org_type: string | null;
   geographic_focus: string[] | null;
+  mission: string | null;
+  description: string | null;
 }
 
 export interface OrgProfileContext {
@@ -61,7 +64,7 @@ export async function getCurrentOrgProfileContext(
   if (impersonateSlug) {
     const { data: impOrg } = await serviceDb
       .from('org_profiles')
-      .select('id, name, abn, subscription_plan, org_type, geographic_focus')
+      .select('id, name, slug, abn, subscription_plan, org_type, geographic_focus, mission, description')
       .eq('slug', impersonateSlug)
       .maybeSingle();
 
@@ -77,7 +80,7 @@ export async function getCurrentOrgProfileContext(
 
   const { data: ownedProfile } = await serviceDb
     .from('org_profiles')
-    .select('id, name, abn, subscription_plan, org_type, geographic_focus')
+    .select('id, name, slug, abn, subscription_plan, org_type, geographic_focus, mission, description')
     .eq('user_id', userId)
     .maybeSingle();
 
@@ -97,10 +100,13 @@ export async function getCurrentOrgProfileContext(
       org_profile:org_profile_id(
         id,
         name,
+        slug,
         abn,
         subscription_plan,
         org_type,
-        geographic_focus
+        geographic_focus,
+        mission,
+        description
       )
     `)
     .eq('user_id', userId)


### PR DESCRIPTION
## Summary
New product surfaces:
- \`/funding-workspace\` — page + \`context-form\` + \`shortlist-button\`
- \`/goods-intelligence\`
- \`/goods-workspace\` — page + client + \`goods-community-map\`
- \`/portfolio-control\`
- \`/rankings\`
- \`/snow-foundation\`

Refreshed shells + marketing:
- Root \`layout.tsx\`, home \`page.tsx\`
- \`/pricing\`, \`/login\`, \`/register\`, \`/power\`, \`/tender-intelligence\`, \`/justice-reinvestment\`

Libs:
- New \`lib/auth-redirect.ts\`
- Extended \`lib/org-profile.ts\` \`OrgProfileSummary\` (mission, description, slug)

Originally #17 — closed when the alerts-infra base branch was deleted; rebased onto main.

> Note: \`/goods-workspace\` UI calls \`/api/goods-workspace/*\` endpoints that live in the **org-project-foundations** bucket (schema-blocked). Frontend compiles, but those endpoints 404 until that bucket lands.

## Test plan
- [x] typecheck clean
- [ ] CI green
- [ ] Each new page renders
- [ ] Home + pricing + login + register flow