### PR TITLE
feat: Empathy Ledger anchor card (Phase A portfolio integration)

### DIFF
--- a/apps/web/src/app/api/data/entity/[identifier]/route.ts
+++ b/apps/web/src/app/api/data/entity/[identifier]/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/supabase';
+import { safe, esc, validateAbn, validateGsId } from '@/lib/sql';
+import { rateLimit } from '@/lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const limiter = rateLimit({ windowMs: 60_000, max: 60 });
+
+type EntityRow = {
+  id: string;
+  gs_id: string;
+  canonical_name: string;
+  abn: string | null;
+  entity_type: string | null;
+  sector: string | null;
+  state: string | null;
+  lga_name: string | null;
+  is_community_controlled: boolean | null;
+  website: string | null;
+  description: string | null;
+};
+
+type CardSummary = {
+  total_government_funding: number;
+  contract_count: number;
+  donation_count: number;
+  grant_count: number;
+  alma_intervention_count: number;
+  year_range: { first: number | null; last: number | null };
+};
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+function jsonWithHeaders(data: unknown, init?: ResponseInit): NextResponse {
+  const res = NextResponse.json(data, init);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
+  res.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+  return res;
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+/**
+ * Public entity card endpoint — lightweight entity summary for embedding
+ * in Empathy Ledger stories, Goods supplier pages, partner sites, etc.
+ *
+ * Accepts ABN (11 digits) or gs_id as the {identifier} path segment.
+ *
+ * Response shape:
+ *   { entity: {...}, summary: {...}, url: string }
+ *
+ * CORS: open (public data). Cache: 5min CDN + SWR.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ identifier: string }> }
+) {
+  const limited = limiter(request);
+  if (limited) {
+    for (const [k, v] of Object.entries(CORS_HEADERS)) limited.headers.set(k, v);
+    return limited;
+  }
+
+  const { identifier } = await params;
+  if (!identifier) {
+    return jsonWithHeaders({ error: 'Missing identifier' }, { status: 400 });
+  }
+
+  const abn = validateAbn(identifier);
+  const gsId = abn ? null : validateGsId(identifier);
+  if (!abn && !gsId) {
+    return jsonWithHeaders(
+      { error: 'Invalid identifier. Provide an 11-digit ABN or a gs_id.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const supabase = getServiceSupabase();
+
+    const where = abn
+      ? `abn = '${esc(abn)}'`
+      : `gs_id = '${esc(gsId as string)}'`;
+
+    const entityRows = await safe(
+      supabase.rpc('exec_sql', {
+        query: `SELECT id, gs_id, canonical_name, abn, entity_type, sector, state, lga_name,
+                       is_community_controlled, website, description
+                  FROM gs_entities WHERE ${where} LIMIT 1`,
+      })
+    ) as EntityRow[] | null;
+
+    const e = entityRows?.[0];
+    if (!e) {
+      return jsonWithHeaders({ error: 'Entity not found' }, { status: 404 });
+    }
+
+    const [contractStats, donationStats, grantStats, almaStats] = await Promise.all([
+      e.abn
+        ? safe(
+            supabase.rpc('exec_sql', {
+              query: `SELECT COALESCE(SUM(contract_value), 0)::bigint as total,
+                             COUNT(*)::int as count,
+                             EXTRACT(YEAR FROM MIN(contract_start))::int as first_year,
+                             EXTRACT(YEAR FROM MAX(contract_start))::int as last_year
+                        FROM austender_contracts WHERE supplier_abn = '${esc(e.abn)}'`,
+            })
+          )
+        : Promise.resolve(null),
+      e.abn
+        ? safe(
+            supabase.rpc('exec_sql', {
+              query: `SELECT COALESCE(SUM(amount), 0)::bigint as total,
+                             COUNT(*)::int as count
+                        FROM political_donations WHERE donor_abn = '${esc(e.abn)}'`,
+            })
+          )
+        : Promise.resolve(null),
+      e.abn
+        ? safe(
+            supabase.rpc('exec_sql', {
+              query: `SELECT COALESCE(SUM(amount_dollars), 0)::bigint as total,
+                             COUNT(*)::int as count
+                        FROM justice_funding WHERE recipient_abn = '${esc(e.abn)}'`,
+            })
+          )
+        : Promise.resolve(null),
+      safe(
+        supabase.rpc('exec_sql', {
+          query: `SELECT COUNT(*)::int as count
+                    FROM alma_interventions WHERE gs_entity_id = '${esc(e.id)}'`,
+        })
+      ),
+    ]);
+
+    type ContractStat = { total: number | null; count: number | null; first_year: number | null; last_year: number | null };
+    type SumCountStat = { total: number | null; count: number | null };
+    type CountStat = { count: number | null };
+
+    const contract = (contractStats as ContractStat[] | null)?.[0] ?? null;
+    const donation = (donationStats as SumCountStat[] | null)?.[0] ?? null;
+    const grant = (grantStats as SumCountStat[] | null)?.[0] ?? null;
+    const alma = (almaStats as CountStat[] | null)?.[0] ?? null;
+
+    const contractTotal = Number(contract?.total ?? 0);
+    const grantTotal = Number(grant?.total ?? 0);
+
+    const summary: CardSummary = {
+      total_government_funding: contractTotal + grantTotal,
+      contract_count: Number(contract?.count ?? 0),
+      donation_count: Number(donation?.count ?? 0),
+      grant_count: Number(grant?.count ?? 0),
+      alma_intervention_count: Number(alma?.count ?? 0),
+      year_range: {
+        first: contract?.first_year ?? null,
+        last: contract?.last_year ?? null,
+      },
+    };
+
+    const origin = new URL(request.url).origin;
+
+    return jsonWithHeaders({
+      entity: {
+        gs_id: e.gs_id,
+        canonical_name: e.canonical_name,
+        abn: e.abn,
+        entity_type: e.entity_type,
+        sector: e.sector,
+        state: e.state,
+        lga_name: e.lga_name,
+        is_community_controlled: e.is_community_controlled ?? false,
+        website: e.website,
+        description: e.description,
+      },
+      summary,
+      url: `${origin}/entities/${encodeURIComponent(e.gs_id)}`,
+      embed_url: `${origin}/embed/entity/${encodeURIComponent(e.abn ?? e.gs_id)}`,
+    });
+  } catch (err) {
+    console.error('[api/data/entity/identifier] error', err);
+    return jsonWithHeaders({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/embed/entity/[identifier]/page.tsx
+++ b/apps/web/src/app/embed/entity/[identifier]/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import {
+  CivicGraphEntityCard,
+  type CivicGraphEntityCardData,
+} from '@/components/civicgraph-entity-card';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'CivicGraph Entity Card',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Iframe-embed route for the CivicGraph entity card.
+ *
+ * Usage in Empathy Ledger, Goods, or partner sites:
+ *   <iframe src="https://civicgraph.com.au/embed/entity/12345678901"
+ *           style="width:100%; height:280px; border:0;" />
+ *
+ * Accepts ABN (11 digits) or gs_id. Returns a minimal HTML shell with only
+ * the card so it renders cleanly inside an iframe at any width.
+ */
+export default async function EntityEmbedPage({
+  params,
+}: {
+  params: Promise<{ identifier: string }>;
+}) {
+  const { identifier } = await params;
+
+  const origin = process.env.NEXT_PUBLIC_SITE_URL
+    || process.env.VERCEL_URL
+    || 'http://localhost:3003';
+  const baseUrl = origin.startsWith('http') ? origin : `https://${origin}`;
+
+  let data: CivicGraphEntityCardData | null = null;
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/data/entity/${encodeURIComponent(identifier)}`,
+      { cache: 'no-store' }
+    );
+    if (!res.ok) {
+      if (res.status === 404) notFound();
+      throw new Error(`Upstream ${res.status}`);
+    }
+    data = await res.json();
+  } catch {
+    notFound();
+  }
+
+  if (!data) notFound();
+
+  return (
+    <main className="min-h-screen bg-transparent p-2">
+      <CivicGraphEntityCard data={data} variant="full" />
+    </main>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { getServiceSupabase } from '@/lib/supabase';
 import { resolveSubscriptionTier } from '@/lib/subscription';
 import { isAdminEmail } from '@/lib/admin';
 import type { User } from '@supabase/supabase-js';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 
 export const metadata: Metadata = {
   title: 'CivicGraph - Funding Intelligence And Decision Infrastructure',
@@ -16,6 +16,28 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // Iframe-embed routes (/embed/*) and API routes render without chrome so they
+  // drop cleanly into partner sites and JSON responses stay clean.
+  const hdrs = await headers();
+  const pathname = hdrs.get('x-pathname') ?? '';
+  const isChromeless = pathname.startsWith('/embed');
+
+  if (isChromeless) {
+    return (
+      <html lang="en">
+        <head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+          <link href="https://api.fontshare.com/v2/css?f[]=satoshi@700,800,900&display=swap" rel="stylesheet" />
+        </head>
+        <body className="font-sans antialiased bg-transparent">
+          {children}
+        </body>
+      </html>
+    );
+  }
+
   let user: User | null = null;
   let subscriptionPlan: string | null = null;
   let userOrgSlug: string | null = null;

--- a/apps/web/src/components/civicgraph-entity-card.tsx
+++ b/apps/web/src/components/civicgraph-entity-card.tsx
@@ -1,0 +1,161 @@
+/**
+ * CivicGraphEntityCard — a compact, embeddable entity summary card.
+ *
+ * Used on:
+ *   1. /embed/entity/[identifier]     (iframe embed for EL / partner sites)
+ *   2. Any CivicGraph page that wants a small entity anchor
+ *   3. As a rendering helper for the /api/data/entity/[identifier] contract
+ *
+ * This is a server component — no interactivity. Keep it that way so it
+ * renders fast and works inside an iframe without hydration cost.
+ */
+
+type EntitySummary = {
+  total_government_funding: number;
+  contract_count: number;
+  donation_count: number;
+  grant_count: number;
+  alma_intervention_count: number;
+  year_range: { first: number | null; last: number | null };
+};
+
+type EntityBasics = {
+  gs_id: string;
+  canonical_name: string;
+  abn: string | null;
+  entity_type: string | null;
+  sector: string | null;
+  state: string | null;
+  lga_name: string | null;
+  is_community_controlled: boolean;
+  website?: string | null;
+  description?: string | null;
+};
+
+export type CivicGraphEntityCardData = {
+  entity: EntityBasics;
+  summary: EntitySummary;
+  url: string;
+};
+
+function formatCurrency(amount: number): string {
+  if (amount === 0) return '$0';
+  if (amount >= 1_000_000_000) return `$${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(0)}K`;
+  return `$${amount.toFixed(0)}`;
+}
+
+function formatAbn(abn: string | null): string | null {
+  if (!abn || abn.length !== 11) return abn;
+  return `${abn.slice(0, 2)} ${abn.slice(2, 5)} ${abn.slice(5, 8)} ${abn.slice(8, 11)}`;
+}
+
+function entityTypeLabel(type: string | null): string {
+  if (!type) return 'Organisation';
+  return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function CivicGraphEntityCard({
+  data,
+  variant = 'full',
+}: {
+  data: CivicGraphEntityCardData;
+  variant?: 'full' | 'compact';
+}) {
+  const { entity, summary, url } = data;
+
+  const tagline: string[] = [];
+  if (entity.is_community_controlled) tagline.push('Community-controlled');
+  if (entity.entity_type) tagline.push(entityTypeLabel(entity.entity_type));
+  if (entity.lga_name) tagline.push(entity.lga_name);
+  else if (entity.state) tagline.push(entity.state);
+
+  const hasSystems = summary.contract_count + summary.donation_count + summary.grant_count + summary.alma_intervention_count > 0;
+
+  return (
+    <div className="border-4 border-bauhaus-black bg-white">
+      <div className="border-b-4 border-bauhaus-black bg-bauhaus-canvas px-5 py-3">
+        <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+          About this organisation
+        </p>
+      </div>
+
+      <div className="px-5 py-4">
+        <h3 className="text-lg font-black uppercase tracking-tight text-bauhaus-black">
+          {entity.canonical_name}
+        </h3>
+        {tagline.length > 0 && (
+          <p className="mt-1 text-xs font-medium text-bauhaus-muted">
+            {tagline.join(' · ')}
+          </p>
+        )}
+        {formatAbn(entity.abn) && (
+          <p className="mt-1 text-[11px] font-mono text-bauhaus-muted">
+            ABN {formatAbn(entity.abn)}
+          </p>
+        )}
+
+        {variant === 'full' && entity.description && (
+          <p className="mt-3 text-sm text-bauhaus-black/80">{entity.description}</p>
+        )}
+
+        {hasSystems ? (
+          <dl className="mt-4 grid grid-cols-2 gap-3 border-t-2 border-bauhaus-black/10 pt-4 sm:grid-cols-4">
+            <div>
+              <dt className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                Gov funding
+              </dt>
+              <dd className="mt-1 text-lg font-black text-bauhaus-black">
+                {formatCurrency(summary.total_government_funding)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                Contracts
+              </dt>
+              <dd className="mt-1 text-lg font-black text-bauhaus-black">
+                {summary.contract_count}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                Grants
+              </dt>
+              <dd className="mt-1 text-lg font-black text-bauhaus-black">
+                {summary.grant_count}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                Evidence
+              </dt>
+              <dd className="mt-1 text-lg font-black text-bauhaus-black">
+                {summary.alma_intervention_count > 0 ? `${summary.alma_intervention_count} ALMA` : '—'}
+              </dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="mt-4 border-t-2 border-bauhaus-black/10 pt-4 text-xs text-bauhaus-muted">
+            No cross-system records yet. This entity is in the graph but has no linked
+            procurement, donations, grants, or evidence records.
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t-4 border-bauhaus-black bg-bauhaus-black px-5 py-3">
+        <p className="text-[10px] font-black uppercase tracking-widest text-white/60">
+          CivicGraph
+        </p>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] font-black uppercase tracking-widest text-white transition-colors hover:text-bauhaus-yellow"
+        >
+          Full dossier &rarr;
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,7 +2,12 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
 export async function middleware(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request });
+  // Expose the pathname to server components so the root layout can
+  // conditionally skip chrome (nav/footer) for iframe-embed routes.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-pathname', request.nextUrl.pathname);
+
+  let supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
   let user = null;
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -56,5 +61,10 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/home', '/home/:path*', '/tracker/:path*', '/foundations/tracker/:path*', '/foundations/tracker', '/ops/:path*', '/ops', '/profile/:path*', '/profile', '/login', '/org/:path*', '/org'],
+  // Run middleware everywhere so x-pathname is set for server components.
+  // Auth gating still only applies to the protected prefixes above.
+  matcher: [
+    // Skip static files, Next internals, and images
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|svg|webp|ico|css|js)$).*)',
+  ],
 };

--- a/docs/integrations/empathy-ledger-anchor-card.md
+++ b/docs/integrations/empathy-ledger-anchor-card.md
@@ -1,0 +1,134 @@
+# Empathy Ledger → CivicGraph Anchor Card
+
+How to anchor Empathy Ledger stories to a CivicGraph entity so every story
+is connected to the system it sits inside.
+
+## Why this exists
+
+Every EL story has a human at the centre, but the human is usually acting
+inside an org, a program, or a system. Anchoring the story to a CivicGraph
+entity gives the reader two levers:
+
+1. The story (EL — the why)
+2. The system (CivicGraph — the how and who)
+
+Together they are journalism. Apart they are not.
+
+## Two ways to integrate
+
+### Option A — Iframe embed (zero code, fastest)
+
+Drop this into any EL story page at the bottom:
+
+```html
+<iframe
+  src="https://civicgraph.com.au/embed/entity/12345678901"
+  width="100%"
+  height="280"
+  style="border: 0; max-width: 100%;"
+  title="CivicGraph entity card"
+  loading="lazy"
+></iframe>
+```
+
+Replace the number with the featured org's ABN (11 digits) or a CivicGraph
+`gs_id` (e.g. `GS-ORG-...`). That's it. The card renders chrome-free, with
+its own styling, linking out to the full dossier.
+
+### Option B — JSON API (render in EL's own React / Svelte / whatever)
+
+Fetch the data, render in EL's design system:
+
+```ts
+const r = await fetch(
+  `https://civicgraph.com.au/api/data/entity/${abn}`,
+  { next: { revalidate: 300 } } // if using Next.js; otherwise cache for 5min
+);
+if (r.ok) {
+  const { entity, summary, url } = await r.json();
+  // render however EL likes
+}
+```
+
+Response shape:
+
+```json
+{
+  "entity": {
+    "gs_id": "GS-ORG-...",
+    "canonical_name": "Sample Community Org",
+    "abn": "12345678901",
+    "entity_type": "charity",
+    "sector": "community",
+    "state": "NT",
+    "lga_name": "Alice Springs",
+    "is_community_controlled": true,
+    "website": "https://...",
+    "description": "..."
+  },
+  "summary": {
+    "total_government_funding": 2100000,
+    "contract_count": 8,
+    "donation_count": 0,
+    "grant_count": 3,
+    "alma_intervention_count": 1,
+    "year_range": { "first": 2022, "last": 2025 }
+  },
+  "url": "https://civicgraph.com.au/entities/GS-ORG-...",
+  "embed_url": "https://civicgraph.com.au/embed/entity/12345678901"
+}
+```
+
+## What EL needs to do story-side
+
+Add an optional field to every story:
+
+- `civicgraph_identifier` (string) — can be an ABN or a gs_id
+
+If set, render the card (iframe or JSON+render). If unset, render nothing.
+No breaking change to existing stories.
+
+### Where to find identifiers
+
+If the story features an org with an ABN, use the ABN. It's the most stable
+identifier and EL editors can look it up on the ACNC register.
+
+If the story features a program or project that isn't a standalone legal
+entity, use the parent org's ABN. The card intentionally surfaces the org
+context, not the program context.
+
+## Constraints and rate limits
+
+- **Rate limit:** 60 requests/minute per IP on the JSON API. The iframe
+  embed is CDN-cached so doesn't hit the limit meaningfully.
+- **CORS:** open (`Access-Control-Allow-Origin: *`). Public data only.
+- **Cache:** 5min CDN + stale-while-revalidate 10min. Data updates daily
+  from the CivicGraph pipeline, so there is no freshness concern at the
+  card level.
+- **Missing entity:** returns HTTP 404. The iframe renders the Next.js
+  404 page (which looks out of place). Check the JSON API first if you
+  want to conditionally hide the card for unknown identifiers.
+
+## Reverse direction (CivicGraph → EL)
+
+When CivicGraph entity pages want to show "Stories on Empathy Ledger", EL
+should expose an equivalent endpoint:
+
+```
+GET https://empathyledger.{domain}/api/stories/by-entity/{identifier}
+```
+
+Returns an array of `{ title, slug, published_at, excerpt, cover_image_url }`
+for stories tagged with that identifier. Implementation on the EL side is
+the blocker for the reverse link — the CivicGraph side is ready to consume.
+
+## Testing
+
+Once deployed, verify with any real org ABN. Example test ABN (Oonchiumpa):
+
+```
+https://civicgraph.com.au/api/data/entity/53658668627
+https://civicgraph.com.au/embed/entity/53658668627
+```
+
+If both return sensible data, integration is live.


### PR DESCRIPTION
## Summary

Phase A of the portfolio integration work. Makes every Empathy Ledger story able to anchor to a CivicGraph entity so the human story sits next to the system behind it. Same pattern will extend to Goods supplier pages and any partner site.

**Base branch:** \`scope-cut-portfolio-mode\` (stacks on #25). Rebase onto main once #25 lands.

## What's new

| Surface | Path | Purpose |
|---|---|---|
| JSON API | \`/api/data/entity/[identifier]\` | Card-sized entity summary by ABN or gs_id. CORS-open. |
| Iframe embed | \`/embed/entity/[identifier]\` | Chrome-free card for drop-in embedding |
| Component | \`src/components/civicgraph-entity-card.tsx\` | Reusable server-component card renderer |
| Middleware | \`x-pathname\` header | Lets root layout detect \`/embed/*\` and skip chrome |
| Docs | \`docs/integrations/empathy-ledger-anchor-card.md\` | Integration guide for the EL team |

## How EL will use this

**Dead simplest (zero code in EL):**

\`\`\`html
<iframe
  src=\"https://civicgraph.com.au/embed/entity/53658668627\"
  width=\"100%\" height=\"280\" style=\"border:0\"
  loading=\"lazy\"></iframe>
\`\`\`

**Native render (EL fetches JSON, renders in its own design system):**

\`\`\`ts
const r = await fetch(\`/api/data/entity/\${abn}\`);
const { entity, summary, url } = await r.json();
\`\`\`

Response shape + full contract documented in \`docs/integrations/empathy-ledger-anchor-card.md\`.

## Architecture notes

- JSON API and embed share the same \`<CivicGraphEntityCard>\` component. Change the card once, both surfaces update.
- Middleware matcher expanded to run on everything except static assets. Auth gating still scoped to the protected prefix list, so no behavior change there.
- Rate limit: 60 req/min per IP. Embed iframe is CDN-cached so realistic traffic stays well under.
- The reverse direction (CivicGraph entity page shows \"Stories on Empathy Ledger\") is deferred — it needs EL to expose a stories-by-entity endpoint. The doc specifies the contract.

## Test plan

- [x] Type check passes (\`npx tsc --noEmit\`)
- [ ] Boot dev server, hit \`/api/data/entity/53658668627\` — returns Oonchiumpa card data
- [ ] Hit \`/embed/entity/53658668627\` — renders card with no site nav/footer
- [ ] Confirm CORS headers in browser devtools
- [ ] Hit \`/api/data/entity/99999999999\` — 404
- [ ] Hit \`/api/data/entity/invalid\` — 400
- [ ] Hit any non-embed page (e.g. \`/home\`) — nav/footer still render (chrome check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)