### PR TITLE
feat(reports): IPP Scoreboard + Double-Dippers + LGA Indigenous Proxy

### DIFF
--- a/apps/web/src/app/reports/double-dippers/page.tsx
+++ b/apps/web/src/app/reports/double-dippers/page.tsx
@@ -1,0 +1,269 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+import { ReportEmailCapture } from '@/components/report-email-capture';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'The Double-Dippers — CivicGraph',
+  description:
+    '4,218 entities receive both Australian government grants AND government contracts. Combined: $678 billion in public funding across two separate channels. Who they are, what they get, and which are community-controlled.',
+  openGraph: {
+    title: 'The Double-Dippers',
+    description: '4,218 entities · $678B in combined public funding via grants + contracts. CivicGraph cross-channel investigation.',
+    type: 'article',
+    siteName: 'CivicGraph',
+  },
+  twitter: { card: 'summary_large_image', title: 'The Double-Dippers — $678B across grants + contracts' },
+};
+
+function money(n: number | null | undefined): string {
+  if (n == null || n === 0) return '$0';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `$${(n / 1e3).toFixed(0)}K`;
+  return `$${n.toLocaleString()}`;
+}
+
+type Row = {
+  abn: string;
+  recipient_name: string | null;
+  supplier_name: string | null;
+  grant_count: number;
+  grant_total: number;
+  contract_count: number;
+  contract_total: number;
+  combined_public_funding: number;
+  funding_profile: string;
+  gs_id: string | null;
+  entity_type: string | null;
+  state: string | null;
+  is_community_controlled: boolean | null;
+};
+
+async function getData() {
+  const db = getServiceSupabase();
+
+  const [{ data: top }, { data: indigenous }, { data: profileBreakdown }, { data: stats }] = await Promise.all([
+    db.from('mv_grant_contract_overlap')
+      .select('*')
+      .order('combined_public_funding', { ascending: false })
+      .limit(30),
+    db.from('mv_grant_contract_overlap')
+      .select('*')
+      .eq('is_community_controlled', true)
+      .order('combined_public_funding', { ascending: false })
+      .limit(20),
+    db.rpc('exec_sql', {
+      query: `SELECT funding_profile, COUNT(*) as count,
+                     SUM(grant_total)::bigint as grants,
+                     SUM(contract_total)::bigint as contracts,
+                     SUM(combined_public_funding)::bigint as combined
+                FROM mv_grant_contract_overlap
+               GROUP BY funding_profile ORDER BY combined DESC`,
+    }),
+    db.rpc('exec_sql', {
+      query: `SELECT COUNT(*) as total,
+                     SUM(grant_total)::bigint as total_grants,
+                     SUM(contract_total)::bigint as total_contracts,
+                     SUM(combined_public_funding)::bigint as combined,
+                     COUNT(*) FILTER (WHERE is_community_controlled) as cc_count
+                FROM mv_grant_contract_overlap`,
+    }),
+  ]);
+
+  return {
+    top: (top ?? []) as Row[],
+    indigenous: (indigenous ?? []) as Row[],
+    profileBreakdown: (profileBreakdown ?? []) as Array<{ funding_profile: string; count: number; grants: number; contracts: number; combined: number }>,
+    stats: ((stats ?? []) as Array<{ total: number; total_grants: number; total_contracts: number; combined: number; cc_count: number }>)[0],
+  };
+}
+
+export default async function DoubleDippersPage() {
+  const data = await getData();
+
+  return (
+    <div className="max-w-5xl mx-auto py-8 px-4">
+      <Link href="/reports" className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">
+        &larr; All Reports
+      </Link>
+
+      {/* Hero */}
+      <div className="mt-6 mb-8">
+        <div className="text-[10px] font-black text-bauhaus-red uppercase tracking-[0.25em] mb-1">Cross-Channel Investigation</div>
+        <h1 className="text-3xl sm:text-4xl font-black text-bauhaus-black mb-3">The Double-Dippers</h1>
+        <p className="text-lg text-bauhaus-muted leading-relaxed max-w-3xl">
+          <strong className="text-bauhaus-red">{data.stats?.total?.toLocaleString()}</strong> Australian
+          entities receive both government grants AND government contracts. Two separate funding channels,
+          one combined relationship with the public purse — totalling{' '}
+          <strong className="text-bauhaus-black">{money(data.stats?.combined)}</strong> across the dataset.
+        </p>
+      </div>
+
+      {/* Hero Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-0 mb-10 border-4 border-bauhaus-black">
+        <div className="p-5 border-r-2 border-b-2 sm:border-b-0 border-bauhaus-black/10">
+          <div className="text-3xl font-black text-bauhaus-black">{data.stats?.total?.toLocaleString()}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">Cross-channel entities</div>
+        </div>
+        <div className="p-5 border-b-2 sm:border-b-0 sm:border-r-2 border-bauhaus-black/10">
+          <div className="text-3xl font-black text-bauhaus-black">{money(data.stats?.total_grants)}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">In grants received</div>
+        </div>
+        <div className="p-5 border-r-2 border-bauhaus-black/10">
+          <div className="text-3xl font-black text-bauhaus-black">{money(data.stats?.total_contracts)}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">In contracts won</div>
+        </div>
+        <div className="p-5">
+          <div className="text-3xl font-black text-bauhaus-red">{data.stats?.cc_count}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">Community-controlled</div>
+        </div>
+      </div>
+
+      {/* Profile breakdown */}
+      <section className="mb-10">
+        <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+          Funding profile breakdown
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-0 border-4 border-bauhaus-black">
+          {data.profileBreakdown.map((p, i) => (
+            <div key={p.funding_profile} className={`p-5 ${i < data.profileBreakdown.length - 1 ? 'border-b-4 sm:border-b-0 sm:border-r-4 border-bauhaus-black' : ''}`}>
+              <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red mb-2">
+                {p.funding_profile.replace('_', ' ')}
+              </div>
+              <div className="text-3xl font-black text-bauhaus-black">{p.count.toLocaleString()}</div>
+              <div className="text-xs text-bauhaus-muted font-medium mt-1">entities</div>
+              <div className="text-sm text-bauhaus-black mt-3">
+                <span className="font-mono font-bold">{money(p.combined)}</span> combined
+              </div>
+              <div className="text-[11px] text-bauhaus-muted mt-1">
+                {money(p.grants)} grants · {money(p.contracts)} contracts
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-bauhaus-muted mt-3">
+          <strong>Contract-heavy:</strong> contracts &gt; grants. <strong>Grant-heavy:</strong> grants &gt; contracts.
+          <strong> Balanced:</strong> close to equal across both channels.
+        </p>
+      </section>
+
+      {/* Top 30 */}
+      <section className="mb-10">
+        <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+          Top 30 entities by combined public funding
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-bauhaus-black text-white text-left">
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Entity</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">State</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Grants</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Contracts</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Combined</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Profile</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.top.map((r, i) => (
+                <tr key={r.abn} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                  <td className="px-4 py-3 font-medium text-bauhaus-black max-w-xs">
+                    {r.gs_id ? (
+                      <Link href={`/entities/${encodeURIComponent(r.gs_id)}`} className="font-bold hover:text-bauhaus-red">
+                        {r.recipient_name || r.supplier_name}
+                      </Link>
+                    ) : (
+                      <span>{r.recipient_name || r.supplier_name}</span>
+                    )}
+                    {r.is_community_controlled && (
+                      <span className="ml-2 border border-bauhaus-red px-1 text-[9px] font-black uppercase tracking-widest text-bauhaus-red">CC</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-xs font-mono text-bauhaus-muted">{r.state ?? '—'}</td>
+                  <td className="px-4 py-3 text-right font-mono">{money(r.grant_total)}</td>
+                  <td className="px-4 py-3 text-right font-mono">{money(r.contract_total)}</td>
+                  <td className="px-4 py-3 text-right font-mono font-bold">{money(r.combined_public_funding)}</td>
+                  <td className="px-4 py-3 text-[10px] uppercase tracking-widest text-bauhaus-muted">{r.funding_profile.replace('_', ' ')}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Indigenous double-dippers */}
+      {data.indigenous.length > 0 && (
+        <section className="mb-10">
+          <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+            Top community-controlled double-dippers
+          </h2>
+          <p className="text-sm text-bauhaus-muted mb-4">
+            Indigenous-led organisations that successfully draw public funding from BOTH grants and
+            contracts. Some of the strongest examples of community-controlled enterprise capability
+            recognised by both channels.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white text-left">
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Entity</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">State</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Grants</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Contracts</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Combined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.indigenous.map((r, i) => (
+                  <tr key={r.abn} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                    <td className="px-4 py-3 font-medium text-bauhaus-black max-w-xs">
+                      {r.gs_id ? (
+                        <Link href={`/entities/${encodeURIComponent(r.gs_id)}`} className="font-bold hover:text-bauhaus-red">
+                          {r.recipient_name || r.supplier_name}
+                        </Link>
+                      ) : (
+                        <span>{r.recipient_name || r.supplier_name}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-bauhaus-muted">{r.state ?? '—'}</td>
+                    <td className="px-4 py-3 text-right font-mono">{money(r.grant_total)}</td>
+                    <td className="px-4 py-3 text-right font-mono">{money(r.contract_total)}</td>
+                    <td className="px-4 py-3 text-right font-mono font-bold text-emerald-700">{money(r.combined_public_funding)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <ReportEmailCapture
+        reportSlug="double-dippers"
+        source="report-double-dippers"
+        headline="Get the next investigation when it drops"
+        description="The Double-Dippers is one of several cross-system investigations from the CivicGraph atlas. Subscribe for the next one — IPP scoreboard updates, consulting class deep-dives, and where philanthropic money actually flows."
+      />
+
+      {/* Methodology */}
+      <section className="mb-8">
+        <div className="bg-bauhaus-canvas p-4">
+          <h3 className="text-sm font-black text-bauhaus-black uppercase tracking-widest mb-2">Methodology</h3>
+          <ul className="text-xs text-bauhaus-muted space-y-1">
+            <li><strong>Source:</strong> Inner-join of <code>justice_funding</code> (71K grant records) and <code>austender_contracts</code> (770K contracts) by ABN. Only entities present in BOTH sets appear.</li>
+            <li><strong>Grants:</strong> federal + state government grant disbursements from the justice_funding dataset (broader than just justice — covers all flagged government funding).</li>
+            <li><strong>Contracts:</strong> AusTender procurement contracts, federal + state.</li>
+            <li><strong>Funding profile:</strong> contract_heavy (contracts &gt; grants), grant_heavy (grants &gt; contracts), balanced (close to equal).</li>
+            <li><strong>Limitations:</strong> some entities may use multiple ABNs (e.g. parent + subsidiaries) and appear as separate rows. Time-windowed crossover analysis (donation in year Y → contract in year Y+1) is in <code>mv_donation_contract_timing</code>, not here.</li>
+            <li><strong>Source MV:</strong> <code>mv_grant_contract_overlap</code> (4,218 rows).</li>
+          </ul>
+          <p className="text-[10px] text-bauhaus-muted mt-3">
+            All data sourced from public records. Last updated: April 2026.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/reports/indigenous-proxy/page.tsx
+++ b/apps/web/src/app/reports/indigenous-proxy/page.tsx
@@ -210,6 +210,19 @@ async function getData() {
     states: (stateRes || []) as StateSplit[],
     trends: (trendRes || []) as YearTrend[],
     programs: (programRes || []) as ProgramSplit[],
+    lgaProxy: ((await safe(db.from('mv_lga_indigenous_proxy_score')
+      .select('state, lga_name, total_indigenous_tagged_funding, community_controlled_share_pct, proxy_share_pct, unique_recipients')
+      .gte('total_indigenous_tagged_funding', 1000000)
+      .gte('proxy_share_pct', 80)
+      .order('total_indigenous_tagged_funding', { ascending: false })
+      .limit(15), 'lga-proxy')) || []) as Array<{
+        state: string;
+        lga_name: string;
+        total_indigenous_tagged_funding: number;
+        community_controlled_share_pct: number | null;
+        proxy_share_pct: number;
+        unique_recipients: number;
+      }>,
   };
 }
 
@@ -479,6 +492,50 @@ export default async function IndigenousProxyPage() {
           </div>
         </div>
       </section>
+
+      {/* LGA Proxy Score — from mv_lga_indigenous_proxy_score */}
+      {data.lgaProxy.length > 0 && (
+        <section className="mb-10">
+          <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+            Worst LGAs — Where The Proxy Problem Hits Hardest
+          </h2>
+          <p className="text-sm text-bauhaus-muted mb-4">
+            Local Government Areas where 80%+ of Indigenous-tagged funding flows to
+            non-Indigenous-controlled organisations. The story isn&rsquo;t even — some LGAs concentrate
+            the leakage in spectacular ways.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white text-left">
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">State</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">LGA</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Funding</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">CC Share</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Proxy Share</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Recipients</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.lgaProxy.map((l, i) => (
+                  <tr key={`${l.state}-${l.lga_name}`} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                    <td className="px-4 py-3 font-mono text-xs text-bauhaus-muted">{l.state}</td>
+                    <td className="px-4 py-3 font-medium text-bauhaus-black">{l.lga_name}</td>
+                    <td className="px-4 py-3 text-right font-mono font-bold">{money(l.total_indigenous_tagged_funding)}</td>
+                    <td className="px-4 py-3 text-right font-mono text-emerald-700">{l.community_controlled_share_pct ?? 0}%</td>
+                    <td className="px-4 py-3 text-right font-mono text-bauhaus-red font-bold">{l.proxy_share_pct}%</td>
+                    <td className="px-4 py-3 text-right font-mono text-xs">{l.unique_recipients}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-[10px] text-bauhaus-muted mt-3">
+            Source: <code>mv_lga_indigenous_proxy_score</code> — joins justice_funding (Indigenous topic) ×
+            gs_entities (community-controlled flag) × LGA. Filtered to LGAs with ≥$1M funding and ≥80% proxy share.
+          </p>
+        </section>
+      )}
 
       {/* Year-over-Year Trends */}
       {data.trends.length > 0 && (

--- a/apps/web/src/app/reports/ipp-scoreboard/page.tsx
+++ b/apps/web/src/app/reports/ipp-scoreboard/page.tsx
@@ -1,0 +1,312 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+import { ReportEmailCapture } from '@/components/report-email-capture';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Indigenous Procurement Policy Scoreboard — CivicGraph',
+  description:
+    'Federal and state government agencies ranked by Indigenous Procurement Policy performance. Many spend hundreds of millions in contracts with zero Indigenous suppliers. The 3% IPP target was set in 2015 — most agencies still miss it.',
+  openGraph: {
+    title: 'Federal Agencies Failing IPP Targets',
+    description:
+      'Agencies ranked by Indigenous Procurement Policy performance. Many at 0% Indigenous spend with hundreds of millions in contract value.',
+    type: 'article',
+    siteName: 'CivicGraph',
+  },
+  twitter: { card: 'summary_large_image', title: 'IPP Scoreboard — agencies failing the 3% target' },
+};
+
+function money(n: number | null | undefined): string {
+  if (n == null || n === 0) return '$0';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `$${(n / 1e3).toFixed(0)}K`;
+  return `$${n.toLocaleString()}`;
+}
+
+type AgencyRow = {
+  agency: string;
+  year: number;
+  total_contracts: number;
+  total_value: number;
+  indigenous_contracts: number;
+  indigenous_value: number;
+  indigenous_share_pct: number;
+  ipp_status: string;
+};
+
+type YearSummary = {
+  year: number;
+  agencies: number;
+  meeting_target: number;
+  total_spend: number;
+  indigenous_spend: number;
+  share_pct: number;
+};
+
+const TARGET_YEAR = 2025;
+
+async function getData() {
+  const db = getServiceSupabase();
+
+  const [{ data: latestData }, { data: yearData }, { data: bestData }] = await Promise.all([
+    db.from('mv_indigenous_procurement_score')
+      .select('agency, year, total_contracts, total_value, indigenous_contracts, indigenous_value, indigenous_share_pct, ipp_status')
+      .eq('year', TARGET_YEAR)
+      .gte('total_value', 50_000_000)
+      .order('total_value', { ascending: false })
+      .limit(50),
+    db.rpc('exec_sql', {
+      query: `
+        SELECT year, COUNT(*) as agencies,
+               COUNT(*) FILTER (WHERE ipp_status = 'meets_ipp_target') as meeting_target,
+               SUM(total_value)::bigint as total_spend,
+               SUM(indigenous_value)::bigint as indigenous_spend,
+               CASE WHEN SUM(total_value) > 0
+                 THEN ROUND((SUM(indigenous_value)::numeric / SUM(total_value)::numeric) * 100, 2)
+                 ELSE 0 END as share_pct
+          FROM mv_indigenous_procurement_score
+         WHERE year BETWEEN 2019 AND 2025
+         GROUP BY year ORDER BY year DESC`,
+    }),
+    db.from('mv_indigenous_procurement_score')
+      .select('agency, year, total_value, indigenous_value, indigenous_share_pct')
+      .eq('year', TARGET_YEAR)
+      .gte('total_value', 10_000_000)
+      .order('indigenous_share_pct', { ascending: false })
+      .limit(15),
+  ]);
+
+  const latest = (latestData ?? []) as AgencyRow[];
+  const years = (yearData ?? []) as YearSummary[];
+  const best = (bestData ?? []) as AgencyRow[];
+
+  // Worst-offender ranking — agencies with $50M+ at 0% Indigenous spend
+  const zeroIndigenous = latest.filter((a) => a.indigenous_value === 0);
+  const lowIndigenous = latest.filter((a) => a.indigenous_value > 0 && a.indigenous_share_pct < 3);
+  const meetingTarget = latest.filter((a) => a.indigenous_share_pct >= 3);
+
+  return {
+    latest,
+    years,
+    best,
+    zeroIndigenous,
+    lowIndigenous,
+    meetingTarget,
+    targetYear: TARGET_YEAR,
+  };
+}
+
+export default async function IppScoreboardPage() {
+  const data = await getData();
+  const currentYear = data.years[0];
+
+  return (
+    <div className="max-w-5xl mx-auto py-8 px-4">
+      <Link href="/reports" className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">
+        &larr; All Reports
+      </Link>
+
+      {/* Hero */}
+      <div className="mt-6 mb-8">
+        <div className="text-[10px] font-black text-bauhaus-red uppercase tracking-[0.25em] mb-1">
+          Procurement Investigation
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-black text-bauhaus-black mb-3">
+          The IPP Scoreboard: Agencies Failing the 3% Target
+        </h1>
+        <p className="text-lg text-bauhaus-muted leading-relaxed max-w-3xl">
+          The Indigenous Procurement Policy was set in 2015 with a 3% target for
+          contracts to Indigenous-led businesses. <strong className="text-bauhaus-red">
+            In {data.targetYear}, only {currentYear?.meeting_target} of {currentYear?.agencies} federal+state agencies met that target
+          </strong>. National share: {currentYear?.share_pct}%. Many agencies sit on hundreds of millions in
+          contracts at 0% Indigenous spend.
+        </p>
+      </div>
+
+      {/* Hero Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-0 mb-10 border-4 border-bauhaus-black">
+        <div className="p-5 border-r-2 border-b-2 sm:border-b-0 border-bauhaus-black/10">
+          <div className="text-3xl font-black text-bauhaus-black">{money(currentYear?.total_spend)}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">Total {data.targetYear} contracts</div>
+        </div>
+        <div className="p-5 border-b-2 sm:border-b-0 sm:border-r-2 border-bauhaus-black/10">
+          <div className="text-3xl font-black text-bauhaus-red">{currentYear?.share_pct}%</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">Indigenous share (target: 3%)</div>
+        </div>
+        <div className="p-5 border-r-2 border-bauhaus-black/10">
+          <div className="text-3xl font-black text-bauhaus-black">{currentYear?.meeting_target}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">Agencies meeting 3% target</div>
+        </div>
+        <div className="p-5">
+          <div className="text-3xl font-black text-bauhaus-red">{data.zeroIndigenous.length}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mt-1">$50M+ agencies at 0% Indigenous</div>
+        </div>
+      </div>
+
+      {/* Year-over-year trend */}
+      <section className="mb-10">
+        <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+          Year-Over-Year Trend
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-bauhaus-black text-white text-left">
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Year</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Total Contracts</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Indigenous</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Share</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Meeting Target</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Agencies</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.years.map((y, i) => (
+                <tr key={y.year} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                  <td className="px-4 py-3 font-mono font-bold">{y.year}</td>
+                  <td className="px-4 py-3 text-right font-mono font-bold">{money(y.total_spend)}</td>
+                  <td className="px-4 py-3 text-right font-mono">{money(y.indigenous_spend)}</td>
+                  <td className="px-4 py-3 text-right font-mono">
+                    <span className={Number(y.share_pct) >= 3 ? 'text-emerald-700 font-bold' : 'text-bauhaus-red'}>{y.share_pct}%</span>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono">{y.meeting_target} / {y.agencies}</td>
+                  <td className="px-4 py-3 text-right font-mono text-bauhaus-muted">{y.agencies}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Worst offenders — 0% indigenous */}
+      <section className="mb-10">
+        <div className="border-4 border-bauhaus-red p-6 bg-red-50 mb-6">
+          <h2 className="text-xl font-black uppercase tracking-widest mb-2">
+            $50M+ agencies with 0% Indigenous spend ({data.targetYear})
+          </h2>
+          <p className="text-sm text-bauhaus-black">
+            These agencies awarded $50M or more in contracts in {data.targetYear} but zero of those
+            contracts went to Indigenous-led suppliers. Each name + dollar figure is one investigative
+            story.
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-bauhaus-black text-white text-left">
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Agency</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Total Contracts</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Total Value</th>
+                <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Indigenous</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.zeroIndigenous.slice(0, 20).map((r, i) => (
+                <tr key={r.agency} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                  <td className="px-4 py-3 font-medium text-bauhaus-black max-w-md">{r.agency}</td>
+                  <td className="px-4 py-3 text-right font-mono">{r.total_contracts.toLocaleString()}</td>
+                  <td className="px-4 py-3 text-right font-mono font-bold">{money(r.total_value)}</td>
+                  <td className="px-4 py-3 text-right font-mono text-bauhaus-red font-bold">$0</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Below 3% but non-zero */}
+      {data.lowIndigenous.length > 0 && (
+        <section className="mb-10">
+          <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+            Agencies with some Indigenous spend, still below 3%
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white text-left">
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Agency</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Total</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Indigenous</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Share</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.lowIndigenous.slice(0, 20).map((r, i) => (
+                  <tr key={r.agency} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                    <td className="px-4 py-3 font-medium text-bauhaus-black max-w-md">{r.agency}</td>
+                    <td className="px-4 py-3 text-right font-mono font-bold">{money(r.total_value)}</td>
+                    <td className="px-4 py-3 text-right font-mono text-bauhaus-red">{money(r.indigenous_value)}</td>
+                    <td className="px-4 py-3 text-right font-mono text-bauhaus-red font-bold">{r.indigenous_share_pct}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Best performers */}
+      <section className="mb-10">
+        <h2 className="text-xl font-black uppercase tracking-widest border-b-4 border-bauhaus-black pb-2 mb-6">
+          Best performers (≥3% Indigenous share)
+        </h2>
+        {data.best.filter(b => b.indigenous_share_pct >= 3).length === 0 ? (
+          <p className="text-sm text-bauhaus-muted">No agencies hitting 3% in the &gt;$10M tier this year.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white text-left">
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs">Agency</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Total</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Indigenous</th>
+                  <th className="px-4 py-3 font-black uppercase tracking-wider text-xs text-right">Share</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.best.filter(b => b.indigenous_share_pct >= 3).slice(0, 15).map((r, i) => (
+                  <tr key={r.agency} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas/40'}>
+                    <td className="px-4 py-3 font-medium text-bauhaus-black max-w-md">{r.agency}</td>
+                    <td className="px-4 py-3 text-right font-mono">{money(r.total_value)}</td>
+                    <td className="px-4 py-3 text-right font-mono text-emerald-700">{money(r.indigenous_value)}</td>
+                    <td className="px-4 py-3 text-right font-mono text-emerald-700 font-bold">{r.indigenous_share_pct}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Email capture */}
+      <ReportEmailCapture
+        reportSlug="ipp-scoreboard"
+        source="report-ipp-scoreboard"
+        headline="Get the next investigation when it drops"
+        description="The IPP Scoreboard is one of several cross-system investigations. Subscribe — Consulting Class follow-ups, board interlocks, and where philanthropic money actually flows."
+      />
+
+      {/* Methodology */}
+      <section className="mb-8">
+        <div className="bg-bauhaus-canvas p-4">
+          <h3 className="text-sm font-black text-bauhaus-black uppercase tracking-widest mb-2">Methodology</h3>
+          <ul className="text-xs text-bauhaus-muted space-y-1">
+            <li><strong>Source:</strong> AusTender contracts (federal + state, 770K records) joined to <code>gs_entities</code> by supplier ABN.</li>
+            <li><strong>Indigenous supplier:</strong> any of: <code>is_community_controlled</code>, <code>is_supply_nation_certified</code>, <code>entity_type=indigenous_corp</code>, or tagged <code>bbf-listed</code>. Combined coverage ~13,300 entities.</li>
+            <li><strong>Target:</strong> The IPP target is 3% of contract value to Indigenous-led suppliers (federal Commonwealth Procurement Policy 2015; state targets vary).</li>
+            <li><strong>Excluded:</strong> agencies with under $100K total spend per year (signal-to-noise).</li>
+            <li><strong>Limitations:</strong> some Indigenous-led suppliers may not yet carry the flag in our graph; this UNDER-reports Indigenous share. The opposite direction (over-reporting) requires false certification, which is rare. The 3% target is a federal Commonwealth-level metric; individual agency targets may differ. State agencies appear here because most state procurement policies mirror or exceed the federal target.</li>
+            <li><strong>Source MV:</strong> <code>mv_indigenous_procurement_score</code> (2,168 agency-year rows, 2019-2025).</li>
+          </ul>
+          <p className="text-[10px] text-bauhaus-muted mt-3">
+            This is a living investigation. All data is sourced from public AusTender records. Last updated: April 2026.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -286,6 +286,50 @@ export default function ReportsPage() {
         </a>
       </section>
 
+      {/* ===== FLAGSHIP: IPP SCOREBOARD ===== */}
+      <section className="mb-6">
+        <a href="/reports/ipp-scoreboard" className="group block">
+          <div className="bg-white border-4 border-bauhaus-black p-8 transition-all group-hover:-translate-y-1" style={{ boxShadow: '8px 8px 0px 0px var(--color-bauhaus-red)' }}>
+            <div className="text-xs font-black text-bauhaus-red mb-2 uppercase tracking-widest">Procurement Investigation &mdash; NEW</div>
+            <h3 className="text-2xl font-black text-bauhaus-black mb-3">The IPP Scoreboard</h3>
+            <p className="text-base text-bauhaus-muted leading-relaxed mb-4">
+              Indigenous Procurement Policy was set in 2015 with a 3% target. In 2025, only 33 of 278
+              federal+state agencies hit it. National share: 1.06%. Many agencies awarded $50M+ in
+              contracts at zero Indigenous spend &mdash; named, ranked.
+            </p>
+            <div className="flex gap-6 text-bauhaus-muted/60 text-sm font-bold">
+              <span>278 agencies in 2025</span>
+              <span>&middot;</span>
+              <span>$65.4B contract spend</span>
+              <span>&middot;</span>
+              <span>1.06% Indigenous share</span>
+            </div>
+          </div>
+        </a>
+      </section>
+
+      {/* ===== FLAGSHIP: DOUBLE-DIPPERS ===== */}
+      <section className="mb-6">
+        <a href="/reports/double-dippers" className="group block">
+          <div className="bg-white border-4 border-bauhaus-black p-8 transition-all group-hover:-translate-y-1" style={{ boxShadow: '8px 8px 0px 0px var(--color-bauhaus-blue)' }}>
+            <div className="text-xs font-black text-bauhaus-blue mb-2 uppercase tracking-widest">Cross-Channel Investigation &mdash; NEW</div>
+            <h3 className="text-2xl font-black text-bauhaus-black mb-3">The Double-Dippers</h3>
+            <p className="text-base text-bauhaus-muted leading-relaxed mb-4">
+              4,218 Australian entities receive both government grants AND government contracts.
+              Two separate funding channels, one combined relationship with the public purse.
+              Total: $678 billion across the dataset.
+            </p>
+            <div className="flex gap-6 text-bauhaus-muted/60 text-sm font-bold">
+              <span>4,218 cross-channel orgs</span>
+              <span>&middot;</span>
+              <span>$40.9B grants + $637.9B contracts</span>
+              <span>&middot;</span>
+              <span>215 community-controlled</span>
+            </div>
+          </div>
+        </a>
+      </section>
+
       {/* ===== FLAGSHIP: PROCUREMENT OLIGOPOLY ===== */}
       <section className="mb-6">
         <a href="/reports/procurement-oligopoly" className="group block">


### PR DESCRIPTION
## Summary

Three new investigation surfaces consuming the compound MVs built earlier today.

## Reports shipped

| Route | MV consumed | Headline finding |
|---|---|---|
| \`/reports/ipp-scoreboard\` | \`mv_indigenous_procurement_score\` | 33 of 278 agencies meet 3% IPP target in 2025; many at \$50M+ with 0% Indigenous spend |
| \`/reports/double-dippers\` | \`mv_grant_contract_overlap\` | 4,218 entities receive both grants AND contracts (\$678B combined) |
| \`/reports/indigenous-proxy\` | \`mv_lga_indigenous_proxy_score\` (added section) | Worst LGAs where Indigenous money goes to proxy orgs (Gold Coast 96.7%, Ipswich 99.9%, etc.) |

## Test plan

- [x] Type check passes
- [ ] Boot dev server, load each report, verify data renders
- [ ] Email capture works on each
- [ ] OG metadata present in HTML
- [ ] Reports index lists new cards with correct copy