### PR TITLE
fix(multicultural): add /share/multicultural-sector locked surface

### DIFF
--- a/apps/web/src/app/reports/multicultural-sector/page.tsx
+++ b/apps/web/src/app/reports/multicultural-sector/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { headers } from 'next/headers';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
 
@@ -191,13 +192,17 @@ async function getReport() {
 
 export default async function MulticulturalSectorPage() {
   const r = await getReport();
+  const hdrs = await headers();
+  const isShare = (hdrs.get('x-pathname') ?? '').startsWith('/share/');
 
   return (
     <div>
       <div className="mb-10">
-        <Link href="/reports" className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">
-          &larr; All Reports
-        </Link>
+        {!isShare && (
+          <Link href="/reports" className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">
+            &larr; All Reports
+          </Link>
+        )}
         <div className="text-xs font-black text-bauhaus-yellow mt-4 mb-1 uppercase tracking-widest">Living Report — First Cut</div>
         <h1 className="text-3xl sm:text-4xl font-black text-bauhaus-black mb-3 uppercase tracking-tight">
           The Multicultural Settlement Sector
@@ -261,9 +266,13 @@ export default async function MulticulturalSectorPage() {
                 return (
                   <tr key={e.gs_id} className={i % 2 === 0 ? 'bg-white' : 'bg-bauhaus-canvas'}>
                     <td className="p-3 font-black text-bauhaus-black">
-                      <Link href={`/org/${e.gs_id}`} className="hover:underline">
-                        {e.canonical_name}
-                      </Link>
+                      {isShare ? (
+                        <span>{e.canonical_name}</span>
+                      ) : (
+                        <Link href={`/org/${e.gs_id}`} className="hover:underline">
+                          {e.canonical_name}
+                        </Link>
+                      )}
                     </td>
                     <td className="p-3 font-mono text-xs">{e.state ?? '—'}</td>
                     <td className="p-3 text-right font-mono">{e.total != null ? money(e.total) : '—'}</td>

--- a/apps/web/src/app/share/multicultural-sector/page.tsx
+++ b/apps/web/src/app/share/multicultural-sector/page.tsx
@@ -1,0 +1,23 @@
+import Dashboard from '../../reports/multicultural-sector/page';
+
+export const metadata = {
+  title: "Multicultural Settlement Sector · CivicGraph",
+  description: "22 ethnic communities councils, $X revenue, single-funder dependency. Director interlocks and procurement footprint mapped end-to-end.",
+  openGraph: {
+    title: "The Multicultural Settlement Sector — Federation, Funded by One Wallet",
+    description: "22 organisations. 99%+ government revenue. AI-assisted investigative report by CivicGraph.",
+    type: 'article',
+  },
+};
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Share-mode landing for the Multicultural Settlement Sector cluster report.
+ * Same Server Component as /reports/multicultural-sector — share-mode detection
+ * via headers().get('x-pathname') hides the breadcrumb and renders org names
+ * as plain text instead of <Link> so visitors can't drill into /org/* pages.
+ */
+export default function ShareMulticulturalSector() {
+  return <Dashboard />;
+}


### PR DESCRIPTION
## Summary
- Adds `/share/multicultural-sector` mirroring the `qld-youth-justice` + `fecca-eccv` share-mode pattern
- Wires share-mode detection (via `x-pathname` header) into `/reports/multicultural-sector/page.tsx`: hides /reports breadcrumb and renders the 22-org cluster names as plain text instead of `<Link>` to `/org/*` paid pages

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Visit `/reports/multicultural-sector` — entity names link to `/org/*` as before
- [ ] Visit `/share/multicultural-sector` — breadcrumb hidden, entity names plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)