### PR TITLE
Goods control-sheet + QLD Kickstarter Round 1 migrations

### DIFF
--- a/apps/web/src/app/api/tracker/route.ts
+++ b/apps/web/src/app/api/tracker/route.ts
@@ -54,7 +54,19 @@ export async function GET(request: NextRequest) {
     let orgProfileId = impersonateOrgId;
 
     if (!orgProfileId) {
-      // Fallback: user's own org membership
+      // Prefer the user's own org profile, then fall back to org membership.
+      const { data: ownOrg } = await serviceDb
+        .from('org_profiles')
+        .select('id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (ownOrg?.id) {
+        orgProfileId = ownOrg.id;
+      }
+    }
+
+    if (!orgProfileId) {
       const { data: membership } = await serviceDb
         .from('org_members')
         .select('org_profile_id')
@@ -147,15 +159,22 @@ export async function GET(request: NextRequest) {
       prospect: 'discovered',
       upcoming: 'discovered',
       drafting: 'researching',
+      researching: 'researching',
+      pursuing: 'pursuing',
+      negotiating: 'negotiating',
+      approved: 'approved',
       submitted: 'submitted',
       awarded: 'awarded',
+      won: 'awarded',
       rejected: 'rejected',
+      lost: 'lost',
+      expired: 'expired',
     };
     const pipelineAsSaved = (pipelineItems ?? []).map(p => {
       const linkedGrant = p.grant_opportunity_id ? grantsMap[p.grant_opportunity_id] : null;
       return {
         id: p.id,
-        grant_id: p.grant_opportunity_id,
+        grant_id: p.grant_opportunity_id || p.id,
         stars: 0,
         color: null,
         stage: stageMap[p.status] || 'discovered',

--- a/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
@@ -9,8 +9,12 @@ import {
 } from '@/lib/services/fast-local-org';
 import {
   goodsCapitalRows,
+  goodsCoreWorkAreas,
+  goodsFocusedGrantRows,
+  goodsFundingPipelineRows,
   goodsGovernanceRows,
   goodsImpactRows,
+  goodsMoneySnapshot,
   goodsOperatingFacts,
   goodsOperatingOutputs,
   goodsPeopleRows,
@@ -122,6 +126,277 @@ function FastProjectDashboard({
     if (routeType === 'capital') return '#project-capital-routes';
     return '#project-pipeline';
   };
+
+  if (goodsProject) {
+    const qbeHref =
+      wikiSourceHrefByLabel.get('Catalysing Impact Application Draft') ??
+      `/org/${slug}/wiki/goods-operating-system#sources`;
+    const proofDocs = [
+      'Goods Asset Register README',
+      'Goods Expanded Asset CSV',
+      'Catalysing Impact Application Draft',
+      'Goods Path to Thousands 2026',
+      'Goods Market Intelligence 2026',
+      'ACT Project Codes',
+    ];
+    const receivedRows = goodsFundingPipelineRows.filter((row) => row.status.includes('received'));
+    const liveRows = goodsFundingPipelineRows.filter((row) => !row.status.includes('received'));
+    const blockingRows = goodsCoreWorkAreas.filter((row) => row.status.includes('blocking'));
+
+    return (
+      <main className="min-h-screen bg-gray-50 text-bauhaus-black">
+        <div className="border-b-4 border-bauhaus-black bg-bauhaus-black text-white">
+          <div className="mx-auto max-w-7xl px-4 py-7">
+            <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
+              <Link href={`/org/${slug}`} className="hover:text-white">
+                {profile.name}
+              </Link>
+              <span>/</span>
+              <span className="text-white">{project.name}</span>
+            </nav>
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Goods control sheet</p>
+                <h1 className="mt-2 text-3xl font-black uppercase tracking-wider">{project.name}</h1>
+                <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-300">
+                  Money, funders, blockers, documents, and focused opportunities. Use the full dashboard only when
+                  you need the deeper evidence trail.
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <Link
+                  href={qbeHref}
+                  className="border border-bauhaus-red bg-bauhaus-red px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
+                >
+                  QBE program
+                </Link>
+                <Link
+                  href={`/org/${slug}/wiki/goods-operating-system`}
+                  className="border border-white/20 bg-white/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
+                >
+                  Goods OS wiki
+                </Link>
+                <Link
+                  href={`/org/${slug}/${projectSlug}?full=1`}
+                  className="border border-white/20 bg-white/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
+                >
+                  Full data view
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+          <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            {goodsMoneySnapshot.map((fact) => (
+              <div key={fact.label} className="border-4 border-bauhaus-black bg-white p-4">
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">{fact.label}</p>
+                <div className="mt-2 text-2xl font-black tabular-nums text-bauhaus-black">{fact.value}</div>
+                <p className="mt-2 text-xs leading-relaxed text-gray-600">{fact.detail}</p>
+                <p className="mt-3 text-[10px] font-black uppercase tracking-widest text-gray-400">{fact.source}</p>
+              </div>
+            ))}
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-[1fr_360px]">
+            <div className="border-4 border-bauhaus-black bg-white p-5">
+              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Do next</p>
+              <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Fix the blockers before chasing more grants</h2>
+              <div className="mt-5 grid gap-3 md:grid-cols-2">
+                {goodsCoreWorkAreas.slice(0, 4).map((row) => (
+                  <div key={row.area} className="border border-gray-200 bg-gray-50 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="text-sm font-black text-bauhaus-black">{row.area}</h3>
+                      <span
+                        className={
+                          row.status.includes('blocking')
+                            ? 'border border-bauhaus-red px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-red'
+                            : 'border border-gray-300 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-gray-600'
+                        }
+                      >
+                        {row.status}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-xs leading-relaxed text-gray-700">{row.next}</p>
+                    <p className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">{row.proof}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <aside className="border-4 border-bauhaus-black bg-bauhaus-black p-5 text-white">
+              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Today</p>
+              <h2 className="mt-2 text-xl font-black uppercase tracking-wide">One clear sequence</h2>
+              <ol className="mt-5 space-y-4">
+                <li>
+                  <div className="text-sm font-black">1. Cost sheet</div>
+                  <p className="mt-1 text-xs leading-relaxed text-gray-300">Last 50 beds delivered cost before QBE/SEFA.</p>
+                </li>
+                <li>
+                  <div className="text-sm font-black">2. QBE pack</div>
+                  <p className="mt-1 text-xs leading-relaxed text-gray-300">Ask, budget, proof, risks, and next 90 days.</p>
+                </li>
+                <li>
+                  <div className="text-sm font-black">3. CRM follow-up</div>
+                  <p className="mt-1 text-xs leading-relaxed text-gray-300">Only qualified Snow/QBE/buyer next touches go into HighLevel.</p>
+                </li>
+              </ol>
+              <div className="mt-6 grid grid-cols-2 gap-2">
+                {goodsOperatingFacts.slice(0, 4).map((fact) => (
+                  <div key={fact.label} className="border border-white/20 p-3">
+                    <div className="text-xl font-black tabular-nums">{fact.value}</div>
+                    <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-400">{fact.label}</div>
+                  </div>
+                ))}
+              </div>
+            </aside>
+          </section>
+
+          <section className="border-4 border-bauhaus-black bg-white">
+            <div className="border-b-4 border-bauhaus-black p-5">
+              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Funding + foundation pipeline</p>
+              <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Received, live, upcoming</h2>
+            </div>
+            <div className="grid gap-0 lg:grid-cols-[0.85fr_1.15fr]">
+              <div className="border-b-4 border-bauhaus-black p-5 lg:border-b-0 lg:border-r-4">
+                <h3 className="text-sm font-black uppercase tracking-widest">Already accessed</h3>
+                <div className="mt-4 divide-y divide-gray-200 border border-gray-200">
+                  {receivedRows.map((row) => (
+                    <div key={`${row.name}-${row.status}`} className="grid gap-2 p-3 md:grid-cols-[1fr_auto]">
+                      <div>
+                        <div className="text-sm font-black">{row.name}</div>
+                        <div className="mt-1 text-xs text-gray-500">{row.lane} / {row.status}</div>
+                      </div>
+                      <div className="text-sm font-black tabular-nums text-bauhaus-blue">{row.value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="p-5">
+                <h3 className="text-sm font-black uppercase tracking-widest">Live and next options</h3>
+                <div className="mt-4 divide-y divide-gray-200 border border-gray-200">
+                  {liveRows.map((row) => (
+                    <div key={`${row.name}-${row.value}`} className="grid gap-3 p-3 xl:grid-cols-[1fr_150px_1.4fr]">
+                      <div>
+                        <div className="text-sm font-black">{row.name}</div>
+                        <div className="mt-1 text-xs text-gray-500">{row.lane} / {row.status}</div>
+                      </div>
+                      <div>
+                        <div className="text-sm font-black tabular-nums text-bauhaus-blue">{row.value}</div>
+                        <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-400">{row.timing}</div>
+                      </div>
+                      <p className="text-xs leading-relaxed text-gray-600">{row.next}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-[1fr_0.85fr]">
+            <div className="border-4 border-bauhaus-black bg-white p-5">
+              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Core work areas</p>
+              <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">The work board should be these, not a grant pile</h2>
+              <div className="mt-5 grid gap-3 md:grid-cols-2">
+                {goodsCoreWorkAreas.map((row) => (
+                  <div key={row.area} className="border border-gray-200 bg-gray-50 p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-sm font-black">{row.area}</h3>
+                      <span className="border border-gray-300 bg-white px-2 py-1 text-[10px] font-black uppercase tracking-widest text-gray-600">
+                        {row.status}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs leading-relaxed text-gray-700">{row.next}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="border-4 border-bauhaus-black bg-white p-5">
+              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Blockers</p>
+              <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Do not promote until clear</h2>
+              <div className="mt-5 space-y-3">
+                {blockingRows.map((row) => (
+                  <div key={row.area} className="border border-bauhaus-red bg-red-50 p-4">
+                    <div className="text-sm font-black">{row.area}</div>
+                    <p className="mt-2 text-xs leading-relaxed text-gray-700">{row.next}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="border-4 border-bauhaus-black bg-white p-5">
+            <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Documentation</p>
+                <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Open the document that answers the question</h2>
+              </div>
+              <Link
+                href={`/org/${slug}/wiki/goods-operating-system#sources`}
+                className="w-fit border border-gray-300 bg-white px-3 py-2 text-[11px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-canvas"
+              >
+                All docs
+              </Link>
+            </div>
+            <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {goodsSourceDocuments
+                .filter((doc) => proofDocs.includes(doc.label))
+                .map((doc) => {
+                  const href = wikiSourceHrefByLabel.get(doc.source) ?? `/org/${slug}/wiki/goods-operating-system#sources`;
+                  return (
+                    <Link
+                      key={doc.label}
+                      href={href}
+                      className="border border-gray-200 bg-gray-50 p-4 hover:border-bauhaus-blue hover:bg-link-light/40"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="text-sm font-black">{doc.label}</div>
+                        <span className="shrink-0 border border-gray-300 bg-white px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">
+                          {doc.output}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-xs leading-relaxed text-gray-600">{doc.bestFor}</p>
+                    </Link>
+                  );
+                })}
+            </div>
+          </section>
+
+          <section className="border-4 border-bauhaus-black bg-white p-5">
+            <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Focused opportunity scan</p>
+                <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Grants sit at the bottom, after the route is clear</h2>
+              </div>
+              <Link
+                href="/opportunities/ecosystem?project=goods"
+                className="w-fit border border-bauhaus-black bg-bauhaus-black px-3 py-2 text-[11px] font-black uppercase tracking-widest text-white hover:bg-bauhaus-red"
+              >
+                Opportunity cockpit
+              </Link>
+            </div>
+            <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+              {goodsFocusedGrantRows.map((row) => (
+                <Link
+                  key={row.lane}
+                  href={row.href}
+                  className="border border-gray-200 bg-gray-50 p-4 hover:border-bauhaus-blue hover:bg-link-light/40"
+                >
+                  <span className="border border-gray-300 bg-white px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">
+                    {row.lane}
+                  </span>
+                  <div className="mt-3 text-sm font-black">{row.target}</div>
+                  <p className="mt-2 text-xs leading-relaxed text-gray-600">{row.use}</p>
+                  <p className="mt-3 text-xs font-black leading-relaxed text-bauhaus-black">{row.action}</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="min-h-screen bg-gray-50 text-bauhaus-black">

--- a/apps/web/src/app/org/[slug]/wiki/workshop-alignment/money-people-kanban.tsx
+++ b/apps/web/src/app/org/[slug]/wiki/workshop-alignment/money-people-kanban.tsx
@@ -1,0 +1,584 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+type Total = {
+  label: string;
+  value: string;
+};
+
+type OperatingFact = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+type MoneyRow = {
+  group: string;
+  name: string;
+  amount: string;
+  status: string;
+  owner: string;
+  next: string;
+};
+
+type PeopleRow = {
+  group: string;
+  name: string;
+  org: string;
+  role: string;
+  status: string;
+  next: string;
+};
+
+type TargetRow = {
+  lane: string;
+  target: string;
+  money: string;
+  status: string;
+  firstMove: string;
+};
+
+type BlockerRow = {
+  area: string;
+  status: string;
+  next: string;
+  proof: string;
+};
+
+type ActionRow = {
+  label: string;
+  work: string;
+  owner: string;
+  href: string;
+};
+
+type CardSource = 'money' | 'people' | 'target' | 'blocker' | 'action';
+type BoardLane = 'blocked' | 'active' | 'receivable' | 'received' | 'upcoming' | 'parked';
+type ViewMode = 'board' | 'money' | 'people' | 'targets';
+type SourceFilter = 'all' | CardSource;
+
+type BoardCard = {
+  id: string;
+  source: CardSource;
+  lane: BoardLane;
+  title: string;
+  subtitle: string;
+  value: string;
+  status: string;
+  owner: string;
+  next: string;
+  proof?: string;
+  href?: string;
+};
+
+const columns: Array<{ lane: BoardLane; title: string; helper: string }> = [
+  { lane: 'blocked', title: 'Fix first', helper: 'Needs proof, cost, entity, or owner before action.' },
+  { lane: 'active', title: 'Live now', helper: 'Current asks, partner moves, and live relationships.' },
+  { lane: 'receivable', title: 'Collect', helper: 'Invoices, money trail, receipts, and write-off decisions.' },
+  { lane: 'received', title: 'Received proof', helper: 'Use as credibility for QBE, Snow, buyers, and foundations.' },
+  { lane: 'upcoming', title: 'Upcoming', helper: 'Possible funders, buyers, capital routes, and open paths.' },
+  { lane: 'parked', title: 'Parked', helper: 'Not today, done, or held until the next evidence pass.' },
+];
+
+function statusClass(status: string) {
+  const text = status.toLowerCase();
+  if (text.includes('block') || text.includes('not ready') || text.includes('unsafe')) {
+    return 'border-bauhaus-red bg-red-50 text-bauhaus-red';
+  }
+  if (text.includes('received') || text.includes('authorised') || text.includes('done') || text.includes('active partner')) {
+    return 'border-emerald-700 bg-emerald-50 text-emerald-800';
+  }
+  if (text.includes('live') || text.includes('shortlisted') || text.includes('submitted') || text.includes('active')) {
+    return 'border-bauhaus-blue bg-link-light text-bauhaus-blue';
+  }
+  return 'border-gray-300 bg-gray-50 text-gray-700';
+}
+
+function sourceLabel(source: CardSource) {
+  if (source === 'money') return '$';
+  if (source === 'people') return 'person';
+  if (source === 'target') return 'path';
+  if (source === 'blocker') return 'blocker';
+  return 'task';
+}
+
+function laneFromMoney(row: MoneyRow): BoardLane {
+  const status = row.status.toLowerCase();
+  const group = row.group.toLowerCase();
+  if (status.includes('unsafe') || status.includes('not ready') || status.includes('block')) return 'blocked';
+  if (group.includes('receivable') || status.includes('authorised') || status.includes('draft')) return 'receivable';
+  if (group.includes('received') || group.includes('recorded') || status.includes('received') || status.includes('recorded')) return 'received';
+  if (group.includes('active') || group.includes('pitch') || status.includes('shortlisted') || status.includes('submitted') || status.includes('under review')) return 'active';
+  return 'upcoming';
+}
+
+function laneFromPerson(row: PeopleRow): BoardLane {
+  const status = row.status.toLowerCase();
+  if (status.includes('not ready') || status.includes('block')) return 'blocked';
+  if (status.includes('active') || status.includes('owner now') || status.includes('strategic') || status.includes('engaged') || status.includes('relationship')) return 'active';
+  if (status.includes('application') || status.includes('shortlisted') || status.includes('upcoming')) return 'upcoming';
+  return 'upcoming';
+}
+
+function laneFromTarget(row: TargetRow): BoardLane {
+  const status = row.status.toLowerCase();
+  if (status.includes('not ready') || status.includes('needs')) return 'blocked';
+  if (status.includes('warm proof')) return 'received';
+  if (status.includes('live') || status.includes('submitted')) return 'active';
+  return 'upcoming';
+}
+
+function laneFromBlocker(row: BlockerRow): BoardLane {
+  const status = row.status.toLowerCase();
+  if (status.includes('ready')) return 'active';
+  return 'blocked';
+}
+
+function makeInitialCards(input: {
+  moneyRows: MoneyRow[];
+  peopleRows: PeopleRow[];
+  targetRows: TargetRow[];
+  blockerRows: BlockerRow[];
+  actionRows: ActionRow[];
+}) {
+  const moneyCards: BoardCard[] = input.moneyRows.map((row, index) => ({
+    id: `money-${index}-${row.name}`,
+    source: 'money',
+    lane: laneFromMoney(row),
+    title: row.name,
+    subtitle: row.group,
+    value: row.amount,
+    status: row.status,
+    owner: row.owner,
+    next: row.next,
+  }));
+
+  const peopleCards: BoardCard[] = input.peopleRows.map((row, index) => ({
+    id: `people-${index}-${row.name}`,
+    source: 'people',
+    lane: laneFromPerson(row),
+    title: row.name,
+    subtitle: `${row.group} / ${row.org}`,
+    value: row.role,
+    status: row.status,
+    owner: row.org,
+    next: row.next,
+  }));
+
+  const targetCards: BoardCard[] = input.targetRows.map((row, index) => ({
+    id: `target-${index}-${row.target}`,
+    source: 'target',
+    lane: laneFromTarget(row),
+    title: row.target,
+    subtitle: row.lane,
+    value: row.money,
+    status: row.status,
+    owner: row.lane,
+    next: row.firstMove,
+  }));
+
+  const blockerCards: BoardCard[] = input.blockerRows.map((row, index) => ({
+    id: `blocker-${index}-${row.area}`,
+    source: 'blocker',
+    lane: laneFromBlocker(row),
+    title: row.area,
+    subtitle: row.proof,
+    value: row.proof,
+    status: row.status,
+    owner: 'Goods / ACT',
+    next: row.next,
+    proof: row.proof,
+  }));
+
+  const actionCards: BoardCard[] = input.actionRows.map((row, index) => ({
+    id: `action-${index}-${row.work}`,
+    source: 'action',
+    lane: 'active',
+    title: row.work,
+    subtitle: `Do now ${row.label}`,
+    value: row.owner,
+    status: 'next action',
+    owner: row.owner,
+    next: `Open ${row.work}`,
+    href: row.href,
+  }));
+
+  return [...moneyCards, ...peopleCards, ...targetCards, ...blockerCards, ...actionCards];
+}
+
+function nextLane(lane: BoardLane): BoardLane {
+  if (lane === 'blocked') return 'active';
+  if (lane === 'active') return 'receivable';
+  if (lane === 'receivable') return 'received';
+  if (lane === 'received') return 'parked';
+  if (lane === 'upcoming') return 'active';
+  return 'parked';
+}
+
+function previousLane(lane: BoardLane): BoardLane {
+  if (lane === 'parked') return 'received';
+  if (lane === 'received') return 'receivable';
+  if (lane === 'receivable') return 'active';
+  if (lane === 'active') return 'blocked';
+  return 'upcoming';
+}
+
+function cardMatchesFilter(card: BoardCard, filter: SourceFilter) {
+  return filter === 'all' || card.source === filter;
+}
+
+function BoardCardView({
+  card,
+  onOpen,
+  onMove,
+}: {
+  card: BoardCard;
+  onOpen: (card: BoardCard) => void;
+  onMove: (card: BoardCard) => void;
+}) {
+  return (
+    <article className="border border-gray-200 bg-white p-3 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <span className="border border-gray-300 px-2 py-1 text-[9px] font-black uppercase tracking-widest text-gray-600">
+          {sourceLabel(card.source)}
+        </span>
+        <span className={`border px-2 py-1 text-[9px] font-black uppercase tracking-widest ${statusClass(card.status)}`}>
+          {card.status}
+        </span>
+      </div>
+      <button type="button" onClick={() => onOpen(card)} className="mt-3 block w-full text-left">
+        <h3 className="text-sm font-black leading-tight text-bauhaus-black">{card.title}</h3>
+        <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-500">{card.subtitle}</div>
+        <div className="mt-3 break-words text-sm font-black text-bauhaus-blue">{card.value}</div>
+        <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-gray-700">{card.next}</p>
+      </button>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={() => onOpen(card)}
+          className="border border-gray-300 bg-white px-2 py-2 text-[10px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-gray-50"
+        >
+          Detail
+        </button>
+        <button
+          type="button"
+          onClick={() => onMove(card)}
+          className="border border-bauhaus-black bg-bauhaus-black px-2 py-2 text-[10px] font-black uppercase tracking-widest text-white hover:bg-bauhaus-red"
+        >
+          Move
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function TableCardRows({
+  cards,
+  onOpen,
+}: {
+  cards: BoardCard[];
+  onOpen: (card: BoardCard) => void;
+}) {
+  return (
+    <div className="overflow-x-auto border border-gray-200 bg-white">
+      <table className="w-full min-w-[920px] border-collapse text-left">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 text-[10px] font-black uppercase tracking-widest text-gray-500">
+            <th className="px-4 py-3">Lane</th>
+            <th className="px-4 py-3">Item</th>
+            <th className="px-4 py-3">Value</th>
+            <th className="px-4 py-3">Status</th>
+            <th className="px-4 py-3">Owner</th>
+            <th className="px-4 py-3">Next</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {cards.map((card) => (
+            <tr key={card.id} className="align-top hover:bg-link-light/60">
+              <td className="px-4 py-3 text-[10px] font-black uppercase tracking-widest text-gray-500">{card.lane}</td>
+              <td className="px-4 py-3">
+                <button type="button" onClick={() => onOpen(card)} className="text-left">
+                  <div className="text-sm font-black text-bauhaus-black">{card.title}</div>
+                  <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-500">{card.subtitle}</div>
+                </button>
+              </td>
+              <td className="px-4 py-3 text-sm font-black text-bauhaus-blue">{card.value}</td>
+              <td className="px-4 py-3">
+                <span className={`inline-flex border px-2 py-1 text-[9px] font-black uppercase tracking-widest ${statusClass(card.status)}`}>
+                  {card.status}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-xs font-black text-gray-700">{card.owner}</td>
+              <td className="px-4 py-3 text-xs text-gray-700">{card.next}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function MoneyPeopleKanban({
+  orgSlug,
+  totals,
+  operatingFacts,
+  moneyRows,
+  peopleRows,
+  targetRows,
+  blockerRows,
+  actionRows,
+}: {
+  orgSlug: string;
+  totals: Total[];
+  operatingFacts: OperatingFact[];
+  moneyRows: MoneyRow[];
+  peopleRows: PeopleRow[];
+  targetRows: TargetRow[];
+  blockerRows: BlockerRow[];
+  actionRows: ActionRow[];
+}) {
+  const [cards, setCards] = useState(() => makeInitialCards({ moneyRows, peopleRows, targetRows, blockerRows, actionRows }));
+  const [selected, setSelected] = useState<BoardCard | null>(null);
+  const [view, setView] = useState<ViewMode>('board');
+  const [filter, setFilter] = useState<SourceFilter>('money');
+
+  const visibleCards = useMemo(() => cards.filter((card) => cardMatchesFilter(card, filter)), [cards, filter]);
+  const cardsByLane = useMemo(() => {
+    return columns.map((column) => ({
+      ...column,
+      cards: visibleCards.filter((card) => card.lane === column.lane),
+    }));
+  }, [visibleCards]);
+
+  const moneyCards = useMemo(() => cards.filter((card) => card.source === 'money'), [cards]);
+  const peopleCards = useMemo(() => cards.filter((card) => card.source === 'people'), [cards]);
+  const targetCards = useMemo(() => cards.filter((card) => card.source === 'target' || card.source === 'blocker' || card.source === 'action'), [cards]);
+
+  function moveCard(card: BoardCard, lane: BoardLane) {
+    setCards((current) => current.map((item) => (item.id === card.id ? { ...item, lane } : item)));
+    setSelected((current) => (current?.id === card.id ? { ...current, lane } : current));
+  }
+
+  return (
+    <div>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {totals.map((item) => (
+          <div key={item.label} className="border-4 border-bauhaus-black bg-white p-4">
+            <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">{item.label}</div>
+            <div className="mt-2 text-3xl font-black text-bauhaus-black">{item.value}</div>
+          </div>
+        ))}
+      </section>
+
+      <section className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {operatingFacts.map((fact) => (
+          <div key={fact.label} className="border border-gray-200 bg-white p-4">
+            <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">{fact.label}</div>
+            <div className="mt-2 text-3xl font-black text-bauhaus-blue">{fact.value}</div>
+            <div className="mt-2 text-xs text-gray-600">{fact.detail}</div>
+          </div>
+        ))}
+      </section>
+
+      <section className="mt-6 border-4 border-bauhaus-black bg-white">
+        <div className="flex flex-col gap-4 border-b-4 border-bauhaus-black p-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="text-[10px] font-black uppercase tracking-[0.28em] text-bauhaus-red">Kanban board</div>
+            <h2 className="mt-1 text-2xl font-black uppercase tracking-wide">Money, people, paths</h2>
+            <div className="mt-1 text-sm text-gray-600">Money opens first. Switch to People, Paths, Blockers, Tasks, or All when you need the wider pile.</div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {[
+              ['board', 'Board'],
+              ['money', '$ table'],
+              ['people', 'People'],
+              ['targets', 'Targets'],
+            ].map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setView(key as ViewMode)}
+                className={`border px-4 py-3 text-[10px] font-black uppercase tracking-widest ${
+                  view === key
+                    ? 'border-bauhaus-black bg-bauhaus-black text-white'
+                    : 'border-gray-300 bg-white text-bauhaus-black hover:bg-gray-50'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 border-b border-gray-200 p-4">
+          {[
+            ['all', 'All'],
+            ['money', '$'],
+            ['people', 'People'],
+            ['target', 'Paths'],
+            ['blocker', 'Blockers'],
+            ['action', 'Tasks'],
+          ].map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setFilter(key as SourceFilter)}
+              className={`border px-3 py-2 text-[10px] font-black uppercase tracking-widest ${
+                filter === key
+                  ? 'border-bauhaus-blue bg-link-light text-bauhaus-blue'
+                  : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {view === 'board' ? (
+          <div className="bg-gray-50 p-4">
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {cardsByLane.map((column) => (
+                <section key={column.lane} className="min-h-[420px] border border-gray-200 bg-white">
+                  <div className="border-b border-gray-200 bg-white p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-xs font-black uppercase tracking-widest text-bauhaus-black">{column.title}</h3>
+                      <span className="text-xl font-black text-bauhaus-blue">{column.cards.length}</span>
+                    </div>
+                    <p className="mt-2 min-h-10 text-[11px] leading-relaxed text-gray-500">{column.helper}</p>
+                  </div>
+                  <div className="space-y-3 p-3">
+                    {column.cards.map((card) => (
+                      <BoardCardView
+                        key={card.id}
+                        card={card}
+                        onOpen={setSelected}
+                        onMove={(item) => moveCard(item, nextLane(item.lane))}
+                      />
+                    ))}
+                    {column.cards.length === 0 ? (
+                      <div className="border border-dashed border-gray-300 bg-gray-50 p-4 text-xs text-gray-500">No cards here.</div>
+                    ) : null}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {view === 'money' ? <TableCardRows cards={moneyCards} onOpen={setSelected} /> : null}
+        {view === 'people' ? <TableCardRows cards={peopleCards} onOpen={setSelected} /> : null}
+        {view === 'targets' ? <TableCardRows cards={targetCards} onOpen={setSelected} /> : null}
+      </section>
+
+      <section className="mt-6 grid gap-3 md:grid-cols-3">
+        <Link href={`/org/${orgSlug}/goods`} className="border border-gray-200 bg-white p-4 hover:bg-link-light">
+          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Goods</div>
+          <div className="mt-2 text-lg font-black">Project workspace</div>
+        </Link>
+        <Link href={`/org/${orgSlug}/contacts`} className="border border-gray-200 bg-white p-4 hover:bg-link-light">
+          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">People</div>
+          <div className="mt-2 text-lg font-black">Contacts and GHL handoff</div>
+        </Link>
+        <Link href="/opportunities/ecosystem?project=goods" className="border border-gray-200 bg-white p-4 hover:bg-link-light">
+          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Options</div>
+          <div className="mt-2 text-lg font-black">Grants, buyers, foundations</div>
+        </Link>
+      </section>
+
+      {selected ? (
+        <div className="fixed inset-0 z-50 flex justify-end bg-black/30" role="dialog" aria-modal="true">
+          <button type="button" aria-label="Close detail" className="absolute inset-0 cursor-default" onClick={() => setSelected(null)} />
+          <aside className="relative z-10 flex h-full w-full max-w-xl flex-col border-l-4 border-bauhaus-black bg-white shadow-2xl">
+            <div className="flex items-start justify-between gap-4 border-b-4 border-bauhaus-black p-5">
+              <div>
+                <div className="text-[10px] font-black uppercase tracking-[0.28em] text-bauhaus-red">Detail</div>
+                <h3 className="mt-2 text-2xl font-black leading-tight text-bauhaus-black">{selected.title}</h3>
+                <div className="mt-2 text-xs font-black uppercase tracking-widest text-gray-500">{selected.subtitle}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="border border-gray-300 px-3 py-2 text-xs font-black uppercase tracking-widest hover:bg-gray-50"
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-5">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="border border-gray-200 bg-gray-50 p-4">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Value</div>
+                  <div className="mt-2 break-words text-lg font-black text-bauhaus-blue">{selected.value}</div>
+                </div>
+                <div className="border border-gray-200 bg-gray-50 p-4">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Status</div>
+                  <span className={`mt-2 inline-flex border px-2 py-1 text-[9px] font-black uppercase tracking-widest ${statusClass(selected.status)}`}>
+                    {selected.status}
+                  </span>
+                </div>
+                <div className="border border-gray-200 bg-gray-50 p-4">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Owner</div>
+                  <div className="mt-2 text-sm font-black text-bauhaus-black">{selected.owner}</div>
+                </div>
+                <div className="border border-gray-200 bg-gray-50 p-4">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Lane</div>
+                  <div className="mt-2 text-sm font-black uppercase tracking-widest text-bauhaus-black">{selected.lane}</div>
+                </div>
+              </div>
+
+              <div className="mt-4 border border-gray-200 p-4">
+                <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Next move</div>
+                <p className="mt-2 text-sm leading-relaxed text-gray-700">{selected.next}</p>
+              </div>
+
+              {selected.proof ? (
+                <div className="mt-4 border border-gray-200 p-4">
+                  <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Proof</div>
+                  <p className="mt-2 text-sm font-black text-bauhaus-black">{selected.proof}</p>
+                </div>
+              ) : null}
+
+              <div className="mt-5 grid gap-2">
+                <button
+                  type="button"
+                  onClick={() => moveCard(selected, previousLane(selected.lane))}
+                  className="border border-gray-300 bg-white px-4 py-3 text-xs font-black uppercase tracking-widest text-bauhaus-black hover:bg-gray-50"
+                >
+                  Move back
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveCard(selected, nextLane(selected.lane))}
+                  className="border border-bauhaus-black bg-bauhaus-black px-4 py-3 text-xs font-black uppercase tracking-widest text-white hover:bg-bauhaus-red"
+                >
+                  Move forward
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveCard(selected, 'parked')}
+                  className="border border-bauhaus-red bg-white px-4 py-3 text-xs font-black uppercase tracking-widest text-bauhaus-red hover:bg-red-50"
+                >
+                  Park
+                </button>
+                {selected.href ? (
+                  <Link
+                    href={selected.href}
+                    className="border border-bauhaus-blue bg-link-light px-4 py-3 text-center text-xs font-black uppercase tracking-widest text-bauhaus-blue hover:bg-white"
+                  >
+                    Open surface
+                  </Link>
+                ) : null}
+              </div>
+
+              <div className="mt-5 border border-gray-200 bg-gray-50 p-4 text-xs leading-relaxed text-gray-600">
+                Local board move only. This does not write to Supabase, finance, HighLevel, Xero, or Notion.
+              </div>
+            </div>
+          </aside>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/org/[slug]/wiki/workshop-alignment/page.tsx
+++ b/apps/web/src/app/org/[slug]/wiki/workshop-alignment/page.tsx
@@ -2,86 +2,29 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
-import { getWikiSupportIndex, wikiSupportSourceSlug } from '@/lib/services/wiki-support-index';
 import {
-  WORKSHOP_AREAS,
-  WORKSHOP_TEMPLATES,
-  getWorkshopSourceDocuments,
-} from '@/lib/services/act-workshop-wiki';
+  goodsCoreWorkAreas,
+  goodsMoneyPileRows,
+  goodsOperatingFacts,
+  goodsPeoplePileRows,
+  goodsTargetPileRows,
+} from '@/lib/services/goods-operating-system';
+import { MoneyPeopleKanban } from './money-people-kanban';
 
 export const revalidate = 3600;
-
-const DOCUMENT_PACK = [
-  {
-    label: 'Vision, strategy, or business plan',
-    detail: 'Use this to prove the ambition, route, project priorities, and operating model.',
-    areas: ['vision-ambition', 'strategy-risk'],
-  },
-  {
-    label: 'Revenue, costs, and yearly financial summary',
-    detail: 'Use this to support sustainability, use of funds, contract pricing, and capital readiness.',
-    areas: ['financial-performance', 'business-model', 'investors-capital'],
-  },
-  {
-    label: 'Recent pitch deck or grant application',
-    detail: 'Use this as reusable language for the problem, proof, ask, and delivery plan.',
-    areas: ['social-objective-impact', 'investors-capital'],
-  },
-  {
-    label: 'Theory of change or impact measures',
-    detail: 'Use this to connect ACT project work to evidence, outcomes, and system gaps.',
-    areas: ['social-objective-impact', 'governance-reporting'],
-  },
-  {
-    label: 'Constitution, governance docs, or risk register',
-    detail: 'Use this to answer vehicle, accountability, reporting, and risk questions.',
-    areas: ['governance-reporting', 'legal-structure', 'strategy-risk'],
-  },
-  {
-    label: 'Team structure and key delivery roles',
-    detail: 'Use this to show delivery capacity, advisors, community partners, and follow-up ownership.',
-    areas: ['people-organisation', 'process-technology'],
-  },
-];
-
-const RUN_STEPS = [
-  {
-    label: 'Pick the output',
-    detail: 'Grant section, foundation brief, procurement offer, capital ask, board note, or CRM follow-up.',
-  },
-  {
-    label: 'Choose the project lane',
-    detail: 'Goods, CivicGraph, JusticeHub, Empathy Ledger, PICC/Palm Island, Harvest, or ACT shared service.',
-  },
-  {
-    label: 'Pull proof',
-    detail: 'Use wiki source docs, pipeline records, funder relationships, contacts, finance/project codes, and field evidence.',
-  },
-  {
-    label: 'Create the next action',
-    detail: 'Assign owner, route, due date, source link, and where it should live next: GrantScope, GHL, wiki, or board pack.',
-  },
-];
-
-function sourcePathLabel(path: string) {
-  return path
-    .replace('/Users/benknight/Code/', '')
-    .replace(/^act-global-infrastructure\//, 'act-global-infrastructure / ')
-    .replace(/^Goods Asset Register\//, 'Goods Asset Register / ');
-}
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   if (shouldUseFastLocalOrg() && isActSlug(slug)) {
     return {
-      title: `Workshop Wiki - ${ACT_FAST_PROFILE.name} - CivicGraph`,
-      description: 'ACT workshop operating board for fundability, governance, shared services, contracts, and capital routes.',
+      title: `Money + People - ${ACT_FAST_PROFILE.name} - CivicGraph`,
+      description: 'ACT money, people, targets, and blockers.',
     };
   }
   const profile = await getOrgProfileBySlug(slug);
   return {
-    title: profile ? `Workshop Wiki - ${profile.name} - CivicGraph` : 'Workshop Wiki - CivicGraph',
-    description: 'ACT workshop operating board for fundability, governance, shared services, contracts, and capital routes.',
+    title: profile ? `Money + People - ${profile.name} - CivicGraph` : 'Money + People - CivicGraph',
+    description: 'ACT money, people, targets, and blockers.',
   };
 }
 
@@ -92,533 +35,69 @@ export default async function WorkshopAlignmentWikiPage({ params }: { params: Pr
     : await getOrgProfileBySlug(slug);
   if (!profile) notFound();
 
-  const wikiSupportIndex = getWikiSupportIndex();
-  const projectsBySlug = new Map(wikiSupportIndex.projects.map((project) => [project.slug, project]));
-  const sourceInventory = wikiSupportIndex.source_inventory.filter((source) => source.exists);
-
-  const operatingMoves = [
-    {
-      title: 'Build the Goods support pack',
-      route: 'Grant + procurement + foundation + capital',
-      outcome: 'Turn Goods into a fundable and contractable offer with evidence, route, budget, vehicle, and next relationship move.',
-      creates: ['Goods funder brief', 'procurement offer', 'use-of-funds table', 'foundation approach'],
-      evidence: ['Goods market intelligence', 'path to thousands', 'asset register', 'Snow submission review'],
-      primary: { label: 'Goods operating wiki', href: `/org/${slug}/wiki/goods-operating-system` },
-      secondary: { label: 'Goods grants', href: '/grants?type=open_opportunity&project=goods&sort=closing_asc' },
-    },
-    {
-      title: 'Move CivicGraph opportunities',
-      route: 'Pipeline + funder relationships',
-      outcome: 'Decide which opportunities deserve action now, which need evidence, and which should become CRM follow-ups.',
-      creates: ['pipeline decision', 'foundation brief', 'GHL next touch', 'application evidence list'],
-      evidence: ['matched grants', 'foundation contacts', 'source frontier', 'relationship signals'],
-      primary: { label: 'Open pipeline', href: `/org/${slug}/civicgraph#project-pipeline` },
-      secondary: { label: 'Open contacts', href: `/org/${slug}/contacts` },
-    },
-    {
-      title: 'Package ACT shared service',
-      route: 'Operating model + service offer',
-      outcome: 'Explain what ACT provides across projects so grant, foundation, and procurement asks do not read like disconnected projects.',
-      creates: ['shared service offer menu', 'systems map', '90 day support plan', 'board note'],
-      evidence: ['ACT operational thesis', 'knowledge ops loop', 'project codes', 'repo connections'],
-      primary: { label: 'ACT dashboard', href: `/org/${slug}` },
-      secondary: { label: 'Source inventory', href: '#source-documents' },
-    },
-    {
-      title: 'Prepare the workshop pack',
-      route: 'Governance + evidence + action register',
-      outcome: 'Walk into the workshop with the right evidence, gaps, owners, and support asks across the ten assessment areas.',
-      creates: ['evidence register', 'document pack', 'risk and blocker board', 'owner table'],
-      evidence: ['financial summary', 'strategy docs', 'governance docs', 'team roles', 'grant drafts'],
-      primary: { label: 'Document pack', href: '#document-pack' },
-      secondary: { label: 'Ten areas', href: '#workshop-areas' },
-    },
+  const totals = [
+    { label: 'Goods received', value: '$445,685' },
+    { label: 'ACT-GD recorded', value: '$537,595' },
+    { label: 'Receivables', value: '~$507K' },
+    { label: 'Live asks', value: '$2.4M+' },
+    { label: 'Minderoo pitch', value: '$900K' },
+    { label: 'QBE ask', value: '~$210K' },
+    { label: 'REAL EOI', value: '$1.2M' },
+    { label: 'PFI path', value: '$640K+' },
   ];
 
-  const liveSurfaces = [
-    {
-      label: 'Org dashboard',
-      href: `/org/${slug}`,
-      detail: 'Calm top-level operating view, project lanes, workshop alignment, and wiki support index.',
-    },
-    {
-      label: 'Goods workspace',
-      href: `/org/${slug}/goods`,
-      detail: 'Goods evidence, procurement routes, foundation moves, grant fit, and capital readiness.',
-    },
-    {
-      label: 'CivicGraph pipeline',
-      href: `/org/${slug}/civicgraph#project-pipeline`,
-      detail: 'Tracked opportunities, time-sensitive work, best matches, and pipeline decisions.',
-    },
-    {
-      label: 'Grant finder',
-      href: '/grants?type=open_opportunity&sort=closing_asc',
-      detail: 'Open opportunities across the expanded public-source grant frontier.',
-    },
-    {
-      label: 'Contacts and GHL',
-      href: `/org/${slug}/contacts`,
-      detail: 'Funder, partner, governance, advocacy, and CRM follow-up surface.',
-    },
-    {
-      label: 'Capture notes',
-      href: '/start',
-      detail: 'Capture workshop notes or ideas, then tag them back to project lanes and next actions.',
-    },
+  const actionRows = [
+    { label: '1', work: 'Last 50 bed cost sheet', owner: 'Ben', href: `/org/${slug}/goods` },
+    { label: '2', work: 'Entity option memo', owner: 'Ben / Nic', href: `/org/${slug}/goods` },
+    { label: '3', work: 'QBE pack', owner: 'Ben', href: `/org/${slug}/wiki/sources/catalysing-impact-application-draft-grant-application` },
+    { label: '4', work: 'Buyer offer', owner: 'Goods / ACT', href: '/opportunities/ecosystem?project=goods&lane=procurement' },
+    { label: '5', work: 'GHL follow-ups', owner: 'Ben', href: `/org/${slug}/contacts` },
   ];
 
   return (
     <main className="min-h-screen bg-gray-50 text-bauhaus-black">
-      <div className="border-b-4 border-bauhaus-black bg-bauhaus-black text-white">
-        <div className="mx-auto max-w-7xl px-4 py-8">
-          <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
-            <Link href={`/org/${slug}`} className="hover:text-white">
+      <div className="border-b-4 border-bauhaus-black bg-white">
+        <div className="mx-auto max-w-7xl px-4 py-6">
+          <nav className="mb-3 flex flex-wrap items-center gap-2 text-xs font-black uppercase tracking-widest text-gray-500">
+            <Link href={`/org/${slug}`} className="hover:text-bauhaus-red">
               {profile.name}
             </Link>
             <span>/</span>
-            <span className="text-white">Workshop operating board</span>
+            <span className="text-bauhaus-black">Money + people pile</span>
           </nav>
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <p className="text-sm font-black uppercase tracking-widest text-bauhaus-red">ACT shared service system</p>
-              <h1 className="mt-2 max-w-4xl text-3xl font-black uppercase tracking-wider">
-                Turn the wiki into fundable work
-              </h1>
-              <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-300">
-                This page has one job: help you decide what to do next. Pick an output, pull the proof from the ACT wiki
-                and project systems, then turn it into a grant section, foundation brief, procurement offer, board note,
-                or GHL follow-up.
-              </p>
+              <h1 className="text-4xl font-black uppercase tracking-wide">Money + people pile</h1>
+              <div className="mt-2 text-sm font-black uppercase tracking-widest text-bauhaus-red">
+                All dollars. All people. Current blockers.
+              </div>
             </div>
-            <div className="flex shrink-0 flex-wrap gap-2">
-              <Link
-                href={`/org/${slug}`}
-                className="border border-white/20 bg-white/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
-              >
-                Back to dashboard
+            <div className="flex flex-wrap gap-2">
+              <Link href={`/org/${slug}/goods`} className="border border-bauhaus-black bg-bauhaus-black px-4 py-3 text-[11px] font-black uppercase tracking-widest text-white hover:bg-bauhaus-red">
+                Goods
               </Link>
-              <Link
-                href="/start"
-                className="border border-bauhaus-red bg-bauhaus-red px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
-              >
-                Capture notes
+              <Link href={`/org/${slug}/contacts`} className="border border-bauhaus-blue bg-white px-4 py-3 text-[11px] font-black uppercase tracking-widest text-bauhaus-blue hover:bg-link-light">
+                Contacts
+              </Link>
+              <Link href="/opportunities/ecosystem?project=goods" className="border border-gray-300 bg-white px-4 py-3 text-[11px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-canvas">
+                Opportunities
               </Link>
             </div>
           </div>
         </div>
       </div>
 
-      <div className="mx-auto max-w-7xl px-4 py-8">
-        <section className="border-4 border-bauhaus-black bg-white shadow-sm">
-          <div className="grid gap-0 lg:grid-cols-[0.82fr_1.18fr]">
-            <div className="border-b-4 border-bauhaus-black p-5 lg:border-b-0 lg:border-r-4">
-              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Start here</p>
-              <h2 className="mt-2 text-2xl font-black text-bauhaus-black">Do not read this top to bottom</h2>
-              <p className="mt-2 text-sm leading-relaxed text-gray-700">
-                The ten questions are the assessment frame. The useful work is choosing the next output and making the
-                evidence usable across grants, foundations, procurement, capital, governance, and CRM follow-up.
-              </p>
-              <div className="mt-5 space-y-2">
-                {RUN_STEPS.map((step, index) => (
-                  <div key={step.label} className="border border-gray-200 bg-gray-50 p-3">
-                    <div className="flex items-start gap-3">
-                      <span className="flex h-7 w-7 shrink-0 items-center justify-center bg-bauhaus-black text-[10px] font-black text-white">
-                        {index + 1}
-                      </span>
-                      <div>
-                        <div className="text-sm font-black text-bauhaus-black">{step.label}</div>
-                        <p className="mt-1 text-xs leading-relaxed text-gray-600">{step.detail}</p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="grid gap-3 p-5 md:grid-cols-2">
-              {operatingMoves.map((move) => (
-                <article key={move.title} className="flex min-h-[280px] flex-col border border-gray-200 bg-gray-50 p-4">
-                  <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">{move.route}</div>
-                  <h3 className="mt-2 text-lg font-black text-bauhaus-black">{move.title}</h3>
-                  <p className="mt-2 text-xs leading-relaxed text-gray-700">{move.outcome}</p>
-
-                  <div className="mt-4 grid gap-3 text-xs leading-relaxed text-gray-600 sm:grid-cols-2">
-                    <div>
-                      <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Creates</div>
-                      <ul className="mt-1 space-y-1">
-                        {move.creates.map((item) => (
-                          <li key={`${move.title}-${item}`}>{item}</li>
-                        ))}
-                      </ul>
-                    </div>
-                    <div>
-                      <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">Pull proof</div>
-                      <ul className="mt-1 space-y-1">
-                        {move.evidence.map((item) => (
-                          <li key={`${move.title}-${item}`}>{item}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  </div>
-
-                  <div className="mt-auto flex flex-wrap gap-2 pt-4">
-                    <Link
-                      href={move.primary.href}
-                      className="border border-bauhaus-black bg-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white hover:bg-bauhaus-red"
-                    >
-                      {move.primary.label}
-                    </Link>
-                    <Link
-                      href={move.secondary.href}
-                      className="border border-gray-300 bg-white px-3 py-2 text-[10px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-canvas"
-                    >
-                      {move.secondary.label}
-                    </Link>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="mt-6 border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-4 flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
-            <div>
-              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Live surfaces</p>
-              <h2 className="mt-1 text-2xl font-black text-bauhaus-black">Where the work actually happens</h2>
-            </div>
-            <a
-              href="#workshop-areas"
-              className="w-fit border border-gray-300 bg-white px-3 py-2 text-[11px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-canvas"
-            >
-              Open assessment frame
-            </a>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {liveSurfaces.map((surface) => (
-              <Link
-                key={surface.label}
-                href={surface.href}
-                className="border border-gray-200 bg-gray-50 p-4 hover:border-bauhaus-blue hover:bg-link-light/40"
-              >
-                <div className="text-sm font-black text-bauhaus-black">{surface.label}</div>
-                <p className="mt-2 text-xs leading-relaxed text-gray-600">{surface.detail}</p>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <nav className="sticky top-0 z-20 mt-6 border-4 border-bauhaus-black bg-white/95 p-3 backdrop-blur">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[10px] font-black uppercase tracking-widest text-gray-400">Jump to</span>
-            <a
-              href="#document-pack"
-              className="border border-gray-200 bg-gray-50 px-3 py-2 text-[10px] font-black uppercase tracking-wider text-bauhaus-black hover:border-bauhaus-blue hover:bg-link-light hover:text-bauhaus-blue"
-            >
-              Document pack
-            </a>
-            <a
-              href="#project-tags"
-              className="border border-gray-200 bg-gray-50 px-3 py-2 text-[10px] font-black uppercase tracking-wider text-bauhaus-black hover:border-bauhaus-blue hover:bg-link-light hover:text-bauhaus-blue"
-            >
-              Project tags
-            </a>
-            <a
-              href="#templates"
-              className="border border-gray-200 bg-gray-50 px-3 py-2 text-[10px] font-black uppercase tracking-wider text-bauhaus-black hover:border-bauhaus-blue hover:bg-link-light hover:text-bauhaus-blue"
-            >
-              Templates
-            </a>
-            <a
-              href="#source-documents"
-              className="border border-gray-200 bg-gray-50 px-3 py-2 text-[10px] font-black uppercase tracking-wider text-bauhaus-black hover:border-bauhaus-blue hover:bg-link-light hover:text-bauhaus-blue"
-            >
-              Sources
-            </a>
-            {WORKSHOP_AREAS.map((area, index) => (
-              <a
-                key={area.id}
-                href={`#${area.id}`}
-                className="border border-gray-200 bg-gray-50 px-3 py-2 text-[10px] font-black uppercase tracking-wider text-bauhaus-black hover:border-bauhaus-blue hover:bg-link-light hover:text-bauhaus-blue"
-              >
-                {index + 1}
-              </a>
-            ))}
-          </div>
-        </nav>
-
-        <section id="document-pack" className="mt-6 scroll-mt-28 border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-4">
-            <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Document pack</p>
-            <h2 className="mt-1 text-2xl font-black text-bauhaus-black">Bring evidence, gaps, and owners</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
-              Drafts are useful. The goal is to tag what exists, what is missing, which project owns it, and what output
-              it can support next.
-            </p>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-            {DOCUMENT_PACK.map((doc) => (
-              <div key={doc.label} className="border border-gray-200 bg-gray-50 p-4">
-                <div className="text-sm font-black text-bauhaus-black">{doc.label}</div>
-                <p className="mt-2 text-xs leading-relaxed text-gray-600">{doc.detail}</p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {doc.areas.map((areaId) => {
-                    const area = WORKSHOP_AREAS.find((item) => item.id === areaId);
-                    return area ? (
-                      <a
-                        key={`${doc.label}-${areaId}`}
-                        href={`#${areaId}`}
-                        className="bg-white px-2 py-1 text-[10px] font-black uppercase tracking-wider text-bauhaus-blue hover:bg-link-light"
-                      >
-                        {area.label}
-                      </a>
-                    ) : null;
-                  })}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section id="project-tags" className="mt-6 scroll-mt-28 border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-4 flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
-            <div>
-              <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Project tagging map</p>
-              <h2 className="mt-1 text-2xl font-black text-bauhaus-black">Every claim needs a project lane</h2>
-              <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
-                This prevents ACT shared service work from becoming generic. Notes, source documents, opportunities,
-                templates, and follow-ups should point back to a lane.
-              </p>
-            </div>
-            <Link
-              href={`/org/${slug}#projects`}
-              className="w-fit border border-gray-300 bg-white px-3 py-2 text-[11px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-canvas"
-            >
-              Project dashboard
-            </Link>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {wikiSupportIndex.projects.slice(0, 12).map((project) => (
-              <Link
-                key={project.slug}
-                href={`/org/${slug}/${project.slug}`}
-                className="border border-gray-200 bg-gray-50 p-4 hover:border-bauhaus-blue hover:bg-link-light/40"
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-black text-bauhaus-black">{project.name}</span>
-                  {project.code ? (
-                    <span className="bg-white px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">
-                      {project.code}
-                    </span>
-                  ) : null}
-                </div>
-                <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-gray-600">{project.summary}</p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {project.routes.slice(0, 4).map((route) => (
-                    <span
-                      key={`${project.slug}-${route.type}`}
-                      className="bg-white px-2 py-1 text-[10px] font-black uppercase tracking-wider text-gray-500"
-                    >
-                      {route.type}
-                    </span>
-                  ))}
-                </div>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <section id="templates" className="mt-6 scroll-mt-28 border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-4">
-            <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Reusable outputs</p>
-            <h2 className="mt-1 text-2xl font-black text-bauhaus-black">What this page should produce</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
-              These are the actual assets to make from the wiki. Each one should have a project tag, evidence source,
-              owner, and next action.
-            </p>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {WORKSHOP_TEMPLATES.map((template) => (
-              <div key={template.title} className="border border-gray-200 bg-gray-50 p-4">
-                <div className="text-sm font-black text-bauhaus-black">{template.title}</div>
-                <p className="mt-2 text-xs leading-relaxed text-gray-600">{template.use}</p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {template.sections.map((section) => (
-                    <span
-                      key={`${template.title}-${section}`}
-                      className="bg-white px-2 py-1 text-[10px] font-black uppercase tracking-wider text-gray-500"
-                    >
-                      {section}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section id="workshop-areas" className="mt-6 scroll-mt-28 border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-4">
-            <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Assessment frame</p>
-            <h2 className="mt-1 text-2xl font-black text-bauhaus-black">Ten workshop questions</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
-              Open these when you need the workshop lens. They are not the work queue; they are the structure for
-              deciding what evidence and support each output needs.
-            </p>
-          </div>
-
-          <div className="space-y-3">
-            {WORKSHOP_AREAS.map((area, index) => {
-              const sources = getWorkshopSourceDocuments(wikiSupportIndex, area.sourceRoles);
-              const taggedProjects = area.projectSlugs
-                .map((projectSlug) => projectsBySlug.get(projectSlug))
-                .filter((project): project is (typeof wikiSupportIndex.projects)[number] => Boolean(project));
-
-              return (
-                <details
-                  key={area.id}
-                  id={area.id}
-                  open={index === 0}
-                  className="scroll-mt-28 border border-gray-200 bg-gray-50 open:bg-white"
-                >
-                  <summary className="cursor-pointer list-none px-4 py-4 hover:bg-link-light/40">
-                    <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-                      <div>
-                        <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">
-                          Area {index + 1}
-                        </div>
-                        <h3 className="mt-1 text-lg font-black text-bauhaus-black">{area.label}</h3>
-                        <p className="mt-1 max-w-4xl text-xs leading-relaxed text-gray-600">{area.question}</p>
-                      </div>
-                      <div className="flex shrink-0 flex-wrap gap-2">
-                        <span className="bg-white px-2 py-1 text-[10px] font-black uppercase tracking-wider text-gray-500">
-                          {taggedProjects.length} project tags
-                        </span>
-                        <span className="bg-white px-2 py-1 text-[10px] font-black uppercase tracking-wider text-gray-500">
-                          {sources.length} source docs
-                        </span>
-                      </div>
-                    </div>
-                  </summary>
-
-                  <div className="grid gap-4 border-t border-gray-200 p-4 lg:grid-cols-[1.05fr_0.95fr]">
-                    <div className="space-y-4">
-                      <div className="border-l-4 border-bauhaus-blue bg-link-light/40 p-4">
-                        <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">
-                          Shared service strength
-                        </div>
-                        <p className="mt-2 text-sm leading-relaxed text-bauhaus-black">{area.sharedStrength}</p>
-                      </div>
-                      <div className="border border-gray-200 bg-gray-50 p-4">
-                        <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">
-                          Next decision
-                        </div>
-                        <p className="mt-2 text-sm leading-relaxed text-gray-700">{area.nextAction}</p>
-                      </div>
-                      <div className="grid gap-3 md:grid-cols-2">
-                        <div className="border border-gray-200 bg-white p-4">
-                          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-black">
-                            Templates
-                          </div>
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            {area.templates.map((template) => (
-                              <a
-                                key={template}
-                                href="#templates"
-                                className="bg-gray-50 px-2 py-1 text-[10px] font-black uppercase tracking-wider text-gray-600 hover:bg-bauhaus-canvas"
-                              >
-                                {template}
-                              </a>
-                            ))}
-                          </div>
-                        </div>
-                        <div className="border border-gray-200 bg-white p-4">
-                          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-black">
-                            Project tags
-                          </div>
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            {taggedProjects.map((project) => (
-                              <Link
-                                key={project.slug}
-                                href={`/org/${slug}/${project.slug}`}
-                                className="bg-gray-50 px-2 py-1 text-[10px] font-black uppercase tracking-wider text-bauhaus-blue hover:bg-link-light"
-                              >
-                                {project.code ? `${project.code} ` : ''}
-                                {project.name}
-                              </Link>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="border border-gray-200 bg-white p-4">
-                      <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-black">
-                        Source documents
-                      </div>
-                      <div className="mt-3 space-y-3">
-                        {sources.length > 0 ? (
-                          sources.map((source) => (
-                            <div key={`${area.id}-${source.path}`} className="border border-gray-200 bg-gray-50 p-3">
-                              <Link
-                                href={`/org/${slug}/wiki/sources/${wikiSupportSourceSlug(source)}`}
-                                className="text-sm font-black text-bauhaus-blue hover:underline"
-                              >
-                                {source.label}
-                              </Link>
-                              <div className="mt-1 text-[10px] font-black uppercase tracking-wider text-bauhaus-blue">
-                                {source.role}
-                              </div>
-                              <div className="mt-2 break-all font-mono text-[11px] leading-relaxed text-gray-500">
-                                {sourcePathLabel(source.path)}
-                              </div>
-                            </div>
-                          ))
-                        ) : (
-                          <p className="text-sm leading-relaxed text-gray-600">
-                            No source role is tagged yet. Add one in the wiki support index so this area has durable
-                            proof.
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </details>
-              );
-            })}
-          </div>
-        </section>
-
-        <section id="source-documents" className="mt-6 scroll-mt-28 border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-4">
-            <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Source wiki documents</p>
-            <h2 className="mt-1 text-2xl font-black text-bauhaus-black">Current source inventory</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
-              These are the source documents currently feeding the support index. The next useful step is to tag precise
-              facts, claims, examples, and reusable wording back to project lanes.
-            </p>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            {sourceInventory.map((source) => (
-              <div key={source.path} className="border border-gray-200 bg-gray-50 p-3">
-                <Link
-                  href={`/org/${slug}/wiki/sources/${wikiSupportSourceSlug(source)}`}
-                  className="text-sm font-black text-bauhaus-blue hover:underline"
-                >
-                  {source.label}
-                </Link>
-                <div className="mt-1 flex flex-wrap gap-2 text-[10px] font-black uppercase tracking-wider text-gray-500">
-                  <span>{source.role}</span>
-                  <span>{source.lines} lines</span>
-                </div>
-                <div className="mt-2 break-all font-mono text-[11px] leading-relaxed text-gray-500">
-                  {sourcePathLabel(source.path)}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        <MoneyPeopleKanban
+          orgSlug={slug}
+          totals={totals}
+          operatingFacts={goodsOperatingFacts}
+          moneyRows={goodsMoneyPileRows}
+          peopleRows={goodsPeoplePileRows}
+          targetRows={goodsTargetPileRows}
+          blockerRows={goodsCoreWorkAreas}
+          actionRows={actionRows}
+        />
       </div>
     </main>
   );

--- a/apps/web/src/app/tracker/kanban-board.tsx
+++ b/apps/web/src/app/tracker/kanban-board.tsx
@@ -147,10 +147,10 @@ export function KanbanBoard({
         <div className="mb-4 flex flex-col gap-3 border-4 border-bauhaus-black bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0">
             <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
-              Review gate active
+              Noise hidden
             </div>
             <p className="mt-1 text-sm font-medium leading-5 text-bauhaus-muted">
-              Holding back {learningHiddenCount.toLocaleString()} low-confidence discovered grants so the board starts with the better candidates. Researching, pursuing, and deadline work stay visible.
+              {learningHiddenCount.toLocaleString()} weak or cleanup records are hidden so this board stays usable. Active work and urgent deadlines stay visible.
             </p>
           </div>
           <button
@@ -158,7 +158,7 @@ export function KanbanBoard({
             onClick={() => setShowLearningHidden((value) => !value)}
             className="min-h-10 shrink-0 border-2 border-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-widest text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
           >
-            {showLearningHidden ? 'Hide non-reviewable' : 'Show hidden'}
+            {showLearningHidden ? 'Hide noise' : 'Show all'}
           </button>
         </div>
       )}

--- a/apps/web/src/app/tracker/tracker-client.tsx
+++ b/apps/web/src/app/tracker/tracker-client.tsx
@@ -8,92 +8,12 @@ import { KanbanBoard } from './kanban-board';
 import { GrantActionsProvider } from '@/app/components/grant-card-actions';
 import { GrantListWithPreview } from '@/app/components/grant-list-with-preview';
 
-type AutoReviewResult = {
-  ok: boolean;
-  lens: TriageLens;
-  reviewed: number;
-  applied: {
-    expired: number;
-    sourceCleanup: number;
-    lost: number;
-    keptReviewable: number;
-  };
-  message: string;
-};
-
-type DirectiveActionKind =
-  | 'no'
-  | 'later'
-  | 'research'
-  | 'partner_path'
-  | 'apply_path'
-  | 'add_evidence_gap'
-  | 'send_to_ghl';
-
-type DirectiveSource = 'wiki' | 'grant' | 'foundation' | 'procurement' | 'crm' | 'notion' | 'goods';
-
-type OpportunityDirectiveRoute = {
-  id: string;
-  signalId: string;
-  title: string;
-  source: DirectiveSource;
-  sourceRef: string;
-  sourceUrl: string | null;
-  project: string;
-  project_code: string;
-  project_name: string;
-  pathway: 'grant' | 'foundation' | 'procurement' | 'buyer' | 'capital' | 'relationship' | 'monitor';
-  recommended_role: 'lead' | 'partner' | 'contractor' | 'monitor';
-  fit_score: number;
-  readiness_score: number;
-  relationship_score: number;
-  urgency_score: number;
-  overall_score: number;
-  why_recommended: string;
-  why_not: string | null;
-  evidence_gaps: string[];
-  next_action: string;
-  ghl: {
-    recommendedPipeline: string;
-    suggestedStage: string;
-    existingOpportunityId: string | null;
-    contactId: string | null;
-    tags: string[];
-  };
-  signal: {
-    id: string;
-    title: string;
-    source: DirectiveSource;
-    sourceRef: string;
-    sourceUrl: string | null;
-    lane: string;
-    project: string;
-    projects: string[];
-    organisation: string | null;
-    amount: string | null;
-    deadline: string | null;
-  };
-};
-
-type OpportunityDirectiveResponse = {
-  topDirective: OpportunityDirectiveRoute | null;
-  routes: OpportunityDirectiveRoute[];
-  learningSummary?: {
-    decisionCount: number;
-    negativeCount: number;
-    positiveCount: number;
-    moreInfoCount: number;
-  };
-};
-
 const TERMINAL_STAGES = new Set(['realized', 'lost', 'expired']);
 const DECISION_STAGES = new Set(['discovered', 'researching', 'pursuing']);
 const REVIEW_GATE_THRESHOLD = 65;
 const OBVIOUS_NO_GO_THRESHOLD = 35;
 
 type TriageLens = 'ACT' | 'Goods' | 'JusticeHub' | 'Empathy Ledger';
-
-const TRIAGE_LENSES: TriageLens[] = ['ACT', 'Goods', 'JusticeHub', 'Empathy Ledger'];
 
 const TRIAGE_KEYWORDS: Record<TriageLens, string[]> = {
   ACT: [
@@ -380,28 +300,6 @@ function assessGrantForReview(
   };
 }
 
-function sortForTriage(
-  a: SavedGrantRow,
-  b: SavedGrantRow,
-  learning: ReviewLearning,
-  lens: TriageLens
-): number {
-  const aAssessment = assessGrantForReview(a, learning, lens);
-  const bAssessment = assessGrantForReview(b, learning, lens);
-  if (aAssessment.score !== bAssessment.score) return bAssessment.score - aAssessment.score;
-  return sortForDecision(a, b);
-}
-
-function recordNoFeedback(grantId: string, sourceContext: string) {
-  fetch(`/api/grants/${grantId}/feedback`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ vote: -1, reason: 'Not relevant', source_context: sourceContext }),
-  }).catch(() => {
-    // The lost stage remains the source of truth for hiding this item from review.
-  });
-}
-
 function DecisionGrantRow({ item }: { item: SavedGrantRow }) {
   return (
     <Link
@@ -420,516 +318,9 @@ function DecisionGrantRow({ item }: { item: SavedGrantRow }) {
   );
 }
 
-function QuickTriagePanel({
-  item,
-  remainingCount,
-  suppressedCount,
-  activeLens,
-  assessment,
-  onNo,
-  onLater,
-  onResearch,
-}: {
-  item: SavedGrantRow | null;
-  remainingCount: number;
-  suppressedCount: number;
-  activeLens: TriageLens;
-  assessment: ReviewAssessment | null;
-  onNo: (grantId: string) => void;
-  onLater: (grantId: string) => void;
-  onResearch: (grantId: string) => void;
-}) {
-  if (!item) {
-    return (
-      <section className="mb-6 border-4 border-bauhaus-black bg-white p-4">
-        <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-          Smart shortlist
-        </div>
-        <div className="mt-2 text-lg font-black uppercase tracking-tight text-bauhaus-black">
-          No strong {activeLens} grant ready.
-        </div>
-        <p className="mt-1 text-sm font-medium text-bauhaus-muted">
-          Run Find best grants again, switch the project lens above, or scout the frontier when you want the system to pull in fresher candidates.
-        </p>
-      </section>
-    );
-  }
-
-  const score = Math.max(item.stars || 0, item.grant.fit_score || 0, item.grant.relevance_score || 0);
-  const description = item.grant.description?.trim();
-  const tags = [...(item.grant.focus_areas ?? []), ...(item.grant.categories ?? [])].filter(Boolean).slice(0, 4);
-
-  return (
-    <section className="mb-6 overflow-hidden border-4 border-bauhaus-black bg-white">
-      <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_280px]">
-        <div className="min-w-0 p-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
-              Smart shortlist
-            </div>
-            <div className="border border-bauhaus-black/20 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
-              {activeLens}
-            </div>
-            <div className="border border-bauhaus-black/20 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
-              {remainingCount.toLocaleString()} suggested
-            </div>
-            {suppressedCount > 0 && (
-              <div className="border border-bauhaus-red/30 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-red">
-                {suppressedCount.toLocaleString()} low-confidence held back
-              </div>
-            )}
-          </div>
-          <h2 className="mt-3 text-xl font-black uppercase leading-tight tracking-tight text-bauhaus-black">
-            {item.grant.name}
-          </h2>
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-bauhaus-muted">
-            <span>{item.grant.provider}</span>
-            {formatMoney(item.grant.amount_max) && (
-              <span className="font-black text-bauhaus-blue">{formatMoney(item.grant.amount_max)}</span>
-            )}
-            <span className="font-black uppercase tracking-widest">{deadlineLabel(item)}</span>
-            {score > 0 && <span>{score} signal</span>}
-            {assessment && <span>{assessment.score} ACT review score</span>}
-          </div>
-          {description && (
-            <p className="mt-3 line-clamp-2 text-sm font-medium leading-6 text-bauhaus-muted">
-              {description}
-            </p>
-          )}
-          {tags.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="border border-bauhaus-black/15 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-          {assessment && (assessment.reasons.length > 0 || assessment.penalties.length > 0) && (
-            <div className="mt-3 grid gap-2 text-xs font-medium leading-5 text-bauhaus-muted sm:grid-cols-2">
-              {assessment.reasons.length > 0 && (
-                <div className="border border-bauhaus-black/10 bg-bauhaus-canvas p-2">
-                  <span className="font-black text-bauhaus-black">Why shown: </span>
-                  {assessment.reasons.slice(0, 2).join('; ')}
-                </div>
-              )}
-              {assessment.penalties.length > 0 && (
-                <div className="border border-bauhaus-red/20 bg-red-50 p-2 text-bauhaus-red">
-                  <span className="font-black">Caution: </span>
-                  {assessment.penalties.slice(0, 2).join('; ')}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-        <div className="border-t-2 border-bauhaus-black/10 p-4 lg:border-l-2 lg:border-t-0">
-          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-            Decision
-          </div>
-          <div className="mt-3 grid gap-2">
-            <button
-              type="button"
-              onClick={() => onNo(item.grant_id)}
-              className="min-h-11 border-2 border-bauhaus-red px-4 py-3 text-[11px] font-black uppercase tracking-widest text-bauhaus-red transition-colors hover:bg-bauhaus-red hover:text-white"
-            >
-              No
-            </button>
-            <button
-              type="button"
-              onClick={() => onLater(item.grant_id)}
-              className="min-h-11 border-2 border-bauhaus-black/25 px-4 py-3 text-[11px] font-black uppercase tracking-widest text-bauhaus-muted transition-colors hover:border-bauhaus-black hover:text-bauhaus-black"
-            >
-              Later
-            </button>
-            <button
-              type="button"
-              onClick={() => onResearch(item.grant_id)}
-              className="min-h-11 border-2 border-bauhaus-black bg-bauhaus-black px-4 py-3 text-[11px] font-black uppercase tracking-widest text-white transition-colors hover:bg-white hover:text-bauhaus-black"
-            >
-              Research
-            </button>
-            <Link
-              href={`/grants/${item.grant.id}`}
-              className="min-h-11 border-2 border-bauhaus-blue px-4 py-3 text-center text-[11px] font-black uppercase tracking-widest text-bauhaus-blue transition-colors hover:bg-bauhaus-blue hover:text-white"
-            >
-              Open details
-            </Link>
-          </div>
-          <p className="mt-3 text-xs font-medium leading-5 text-bauhaus-muted">
-            No teaches the model. Later skips this card for now. Research moves it into real work.
-          </p>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function OpportunityDirectivePanel({
-  route,
-  loading,
-  actingKind,
-  actionMessage,
-  learningCount,
-  onAction,
-}: {
-  route: OpportunityDirectiveRoute | null;
-  loading: boolean;
-  actingKind: DirectiveActionKind | null;
-  actionMessage: string | null;
-  learningCount: number;
-  onAction: (kind: DirectiveActionKind) => void;
-}) {
-  const actions: Array<{
-    kind: DirectiveActionKind;
-    label: string;
-    description: string;
-    tone: 'no' | 'quiet' | 'work' | 'crm';
-  }> = [
-    { kind: 'no', label: 'Not for us', description: 'Reject this and make similar ideas less likely.', tone: 'no' },
-    { kind: 'later', label: 'Park it', description: 'Keep it out of today without saying it is bad.', tone: 'quiet' },
-    { kind: 'research', label: 'Investigate', description: 'Make this a real research task.', tone: 'work' },
-    { kind: 'partner_path', label: 'Find partner', description: 'Treat ACT as a partner, not the lead applicant.', tone: 'quiet' },
-    { kind: 'apply_path', label: 'Start application', description: 'Treat ACT as lead once gaps are closed.', tone: 'work' },
-    { kind: 'add_evidence_gap', label: 'Add missing info', description: 'Tell the system what proof is still missing.', tone: 'quiet' },
-    { kind: 'send_to_ghl', label: 'Send to HighLevel', description: 'Create/update CRM only after confirmation.', tone: 'crm' },
-  ];
-
-  const buttonClass = (tone: 'no' | 'quiet' | 'work' | 'crm') => {
-    if (tone === 'no') return 'border-bauhaus-red text-bauhaus-red hover:bg-bauhaus-red hover:text-white';
-    if (tone === 'work') return 'border-bauhaus-black bg-bauhaus-black text-white hover:bg-white hover:text-bauhaus-black';
-    if (tone === 'crm') return 'border-bauhaus-blue text-bauhaus-blue hover:bg-bauhaus-blue hover:text-white';
-    return 'border-bauhaus-black/25 text-bauhaus-muted hover:border-bauhaus-black hover:text-bauhaus-black';
-  };
-
-  const pathwayLabel = (pathway: OpportunityDirectiveRoute['pathway']) => {
-    const labels: Record<OpportunityDirectiveRoute['pathway'], string> = {
-      grant: 'grant application',
-      foundation: 'foundation relationship',
-      procurement: 'buyer/procurement path',
-      buyer: 'buyer follow-up',
-      capital: 'capital raise',
-      relationship: 'relationship follow-up',
-      monitor: 'watch only',
-    };
-    return labels[pathway];
-  };
-
-  const roleLabel = (role: OpportunityDirectiveRoute['recommended_role']) => {
-    const labels: Record<OpportunityDirectiveRoute['recommended_role'], string> = {
-      lead: 'ACT leads',
-      partner: 'ACT partners',
-      contractor: 'ACT supplies',
-      monitor: 'ACT watches',
-    };
-    return labels[role];
-  };
-
-  const firstGap = route?.evidence_gaps?.[0] ?? null;
-  const plainNextStep = route
-    ? firstGap
-      ? `Before this can move forward, capture the missing piece: ${firstGap}.`
-      : route.next_action
-    : null;
-
-  if (loading) {
-    return (
-      <section className="mb-6 border-4 border-bauhaus-black bg-white p-4">
-        <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-          ACT opportunity router
-        </div>
-        <div className="mt-2 text-lg font-black uppercase tracking-tight text-bauhaus-black">
-          Finding the next route...
-        </div>
-      </section>
-    );
-  }
-
-  if (!route) {
-    return (
-      <section className="mb-6 border-4 border-bauhaus-black bg-white p-4">
-        <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-          ACT opportunity router
-        </div>
-        <div className="mt-2 text-lg font-black uppercase tracking-tight text-bauhaus-black">
-          No directive route yet.
-        </div>
-        <p className="mt-1 text-sm font-medium leading-6 text-bauhaus-muted">
-          The router needs fresher source rows, decision memory, or a lower threshold before it can recommend the next best ACT move.
-        </p>
-      </section>
-    );
-  }
-
-  return (
-    <section className="mb-6 overflow-hidden border-4 border-bauhaus-black bg-white">
-      <div className="grid gap-0 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <div className="min-w-0 p-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
-              Recommended move
-            </div>
-            <span className="border border-bauhaus-black/20 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
-              Project: {route.project_name}
-            </span>
-            <span className="border border-bauhaus-black/20 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
-              Path: {pathwayLabel(route.pathway)}
-            </span>
-            <span className="border border-bauhaus-black/20 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
-              {roleLabel(route.recommended_role)}
-            </span>
-          </div>
-          <h2 className="mt-3 text-xl font-black uppercase leading-tight tracking-tight text-bauhaus-black">
-            {route.title}
-          </h2>
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-bauhaus-muted">
-            {route.signal.organisation && <span>{route.signal.organisation}</span>}
-            {route.signal.amount && <span className="font-black text-bauhaus-blue">{route.signal.amount}</span>}
-            {route.signal.deadline && <span className="font-black uppercase tracking-widest">{route.signal.deadline}</span>}
-            <span>{route.overall_score}/100 confidence</span>
-          </div>
-          <div className="mt-4 border-l-4 border-bauhaus-blue bg-blue-50 p-4">
-            <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-blue">What this means</div>
-            <p className="mt-2 text-sm font-medium leading-6 text-bauhaus-black">
-              CivicGraph is saying: focus on <span className="font-black">{route.project_name}</span> now, through a{' '}
-              <span className="font-black">{pathwayLabel(route.pathway)}</span>. The suggested role is{' '}
-              <span className="font-black">{roleLabel(route.recommended_role).toLowerCase()}</span>.
-            </p>
-          </div>
-          <div className="mt-3 grid gap-3 lg:grid-cols-3">
-            <div className="border border-bauhaus-black/10 bg-bauhaus-canvas p-3">
-              <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">Why it was picked</div>
-              <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
-                Good project fit, enough evidence to look at, and a clear pathway. Raw reason: {route.why_recommended}
-              </p>
-            </div>
-            <div className="border border-bauhaus-black/10 bg-bauhaus-canvas p-3">
-              <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">Missing before action</div>
-              <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
-                {route.evidence_gaps.length ? route.evidence_gaps.slice(0, 3).join('; ') : 'No critical gap detected.'}
-              </p>
-            </div>
-            <div className="border border-bauhaus-black/10 bg-bauhaus-canvas p-3">
-              <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">Where it would go</div>
-              <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
-                {route.ghl.contactId
-                  ? `HighLevel contact exists. Pipeline: ${route.ghl.recommendedPipeline}.`
-                  : `If you progress it, use ${route.ghl.recommendedPipeline}. Choose a contact before CRM write.`}
-              </p>
-            </div>
-          </div>
-          <div className="mt-3 border-2 border-bauhaus-black bg-white p-4 text-sm font-medium leading-6 text-bauhaus-black">
-            <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-red">What to do now</div>
-            <p className="mt-2">
-              <span className="font-black">{plainNextStep}</span>
-              {' '}If that sounds worth doing, click <span className="font-black">Investigate</span>. If it is not right, click <span className="font-black">Not for us</span>.
-            </p>
-          </div>
-          {route.why_not && (
-            <div className="mt-3 border-l-4 border-bauhaus-red bg-red-50 p-3 text-xs font-medium leading-5 text-bauhaus-red">
-              {route.why_not}
-            </div>
-          )}
-        </div>
-        <div className="border-t-2 border-bauhaus-black/10 p-4 xl:border-l-2 xl:border-t-0">
-          <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-            Choose one
-          </div>
-          <p className="mt-2 text-sm font-medium leading-6 text-bauhaus-black">
-            You are only deciding what happens to this recommendation. You are not submitting a grant from here.
-          </p>
-          <div className="mt-3 grid gap-2">
-            {actions.map((action) => (
-              <button
-                key={action.kind}
-                type="button"
-                onClick={() => onAction(action.kind)}
-                disabled={actingKind !== null}
-                className={`min-h-12 border-2 px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${buttonClass(action.tone)}`}
-              >
-                <span className="block text-[10px] font-black uppercase tracking-widest">
-                  {actingKind === action.kind ? 'Working...' : action.label}
-                </span>
-                <span className="mt-1 block text-xs font-medium normal-case tracking-normal opacity-80">
-                  {action.description}
-                </span>
-              </button>
-            ))}
-          </div>
-          <p className="mt-3 text-xs font-medium leading-5 text-bauhaus-muted">
-            HighLevel actions always ask for confirmation and never send email/SMS.
-          </p>
-          <div className="mt-3 border border-bauhaus-black/10 bg-bauhaus-canvas p-3 text-xs font-medium leading-5 text-bauhaus-muted">
-            Decisions learned: <span className="font-black text-bauhaus-black">{learningCount.toLocaleString()}</span>
-          </div>
-          {actionMessage && (
-            <div className="mt-3 border border-bauhaus-black/10 p-3 text-xs font-medium leading-5 text-bauhaus-muted">
-              {actionMessage}
-            </div>
-          )}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function TrackerProcess({
-  cleanableCount,
-  deadlineCount,
-  reviewCount,
-  hiddenBeforeReviewCount,
-  activeCount,
-  discoveredCount,
-  autoReviewing,
-  viewMode,
-  activeLens,
-  autoReview,
-  preSweepError,
-  onRunAutoReview,
-  onLensChange,
-}: {
-  cleanableCount: number;
-  deadlineCount: number;
-  reviewCount: number;
-  hiddenBeforeReviewCount: number;
-  activeCount: number;
-  discoveredCount: number;
-  autoReviewing: boolean;
-  viewMode: 'personal' | 'org';
-  activeLens: TriageLens;
-  autoReview: AutoReviewResult | null;
-  preSweepError: string | null;
-  onRunAutoReview: () => void;
-  onLensChange: (lens: TriageLens) => void;
-}) {
-  const steps = [
-    {
-      title: 'Can auto-decide',
-      count: cleanableCount,
-      detail: 'Expired, weak-source, no-deadline, or obvious no-fit records the system can move before you read.',
-    },
-    {
-      title: 'Urgent',
-      count: deadlineCount,
-      detail: 'Tracked grants closing in seven days that need a real pursue, park, or no decision.',
-    },
-    {
-      title: 'Suggested',
-      count: reviewCount,
-      detail: `Best remaining ${activeLens} candidates after project fit, source quality, and your No decisions.`,
-    },
-    {
-      title: 'Active',
-      count: activeCount,
-      detail: 'Applications and real research already in motion.',
-    },
-  ];
-
-  return (
-    <div className="mb-6 overflow-hidden border-4 border-bauhaus-black bg-white">
-      <div className="border-b-2 border-bauhaus-black/10 p-4">
-        <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
-          <div className="max-w-3xl">
-            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
-              Intelligent grant review
-            </div>
-            <h2 className="mt-2 text-xl font-black uppercase tracking-tight text-bauhaus-black">
-              Do not review the backlog manually.
-            </h2>
-            <p className="mt-2 text-sm font-medium leading-6 text-bauhaus-muted">
-              Pick a project lens and let CivicGraph reject obvious no-fit grants, keep uncertain ones ranked, and show only the next decision. Your job is to say <span className="font-black text-bauhaus-black">No</span>, <span className="font-black text-bauhaus-black">Later</span>, or <span className="font-black text-bauhaus-black">Research</span> on the shortlist.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {TRIAGE_LENSES.map((lens) => (
-                <button
-                  key={lens}
-                  type="button"
-                  onClick={() => onLensChange(lens)}
-                  className={`min-h-10 border-2 px-3 py-2 text-[10px] font-black uppercase tracking-widest transition-colors ${
-                    activeLens === lens
-                      ? 'border-bauhaus-black bg-bauhaus-black text-white'
-                      : 'border-bauhaus-black/20 text-bauhaus-muted hover:border-bauhaus-black hover:text-bauhaus-black'
-                  }`}
-                >
-                  {lens}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="w-full max-w-sm border-2 border-bauhaus-black bg-bauhaus-canvas p-3">
-            <button
-              type="button"
-              onClick={onRunAutoReview}
-              disabled={autoReviewing || viewMode !== 'personal'}
-              className="min-h-12 w-full border-2 border-bauhaus-red bg-bauhaus-red px-4 py-3 text-[11px] font-black uppercase tracking-widest text-white transition-colors hover:bg-white hover:text-bauhaus-red disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {autoReviewing ? 'Finding...' : 'Find best grants'}
-            </button>
-            <p className="mt-3 text-xs font-medium leading-5 text-bauhaus-muted">
-              Runs against your current tracker only. It does not submit, email, change active applications, or write to CRM.
-            </p>
-          </div>
-        </div>
-
-        {autoReview && (
-          <div className="mt-4 border border-bauhaus-red/20 bg-red-50 p-3 text-xs font-medium leading-5 text-bauhaus-red">
-            {autoReview.message} Lens: {activeLens}.
-          </div>
-        )}
-        {preSweepError && (
-          <div className="mt-3 text-xs font-black text-bauhaus-red">{preSweepError}</div>
-        )}
-        {viewMode !== 'personal' && (
-          <div className="mt-3 text-xs font-medium text-bauhaus-muted">
-            Team cleanup is read-only here. Run deeper source cleanup from Home or Data Clarity.
-          </div>
-        )}
-      </div>
-
-      <div className="grid gap-0 md:grid-cols-2 xl:grid-cols-4">
-        {steps.map((step, index) => (
-          <div key={step.title} className={`min-w-0 p-4 ${index > 0 ? 'border-t-2 border-bauhaus-black/10 md:border-l-2 md:border-t-0' : ''} ${index === 2 ? 'md:border-t-2 xl:border-t-0' : ''}`}>
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">
-                  {step.title}
-                </div>
-              </div>
-              <div className="shrink-0 text-2xl font-black tabular-nums text-bauhaus-black">
-                {step.count.toLocaleString()}
-              </div>
-            </div>
-            <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
-              {step.detail}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {discoveredCount > 50 && (
-        <div className="border-t-2 border-bauhaus-black/10 px-4 py-3 text-xs font-medium text-bauhaus-muted">
-          Raw discovered backlog is {discoveredCount.toLocaleString()}. You should not read it card by card. The system is holding back {hiddenBeforeReviewCount.toLocaleString()} low-confidence records and ranking the rest into the shortlist.
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function TrackerClient() {
   const [grants, setGrants] = useState<SavedGrantRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [autoReviewing, setAutoReviewing] = useState(false);
-  const [autoReview, setAutoReview] = useState<AutoReviewResult | null>(null);
-  const [preSweepError, setPreSweepError] = useState<string | null>(null);
-  const [triageSkippedIds, setTriageSkippedIds] = useState<Set<string>>(() => new Set());
-  const [triageLens, setTriageLens] = useState<TriageLens>('ACT');
-  const [directive, setDirective] = useState<OpportunityDirectiveRoute | null>(null);
-  const [directiveLearningCount, setDirectiveLearningCount] = useState(0);
-  const [directiveLoading, setDirectiveLoading] = useState(true);
-  const [directiveAction, setDirectiveAction] = useState<DirectiveActionKind | null>(null);
-  const [directiveMessage, setDirectiveMessage] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'personal' | 'org'>('personal');
   const [didInit, setDidInit] = useState(false);
   const router = useRouter();
@@ -966,26 +357,6 @@ export function TrackerClient() {
     void loadGrants();
   }, [loadGrants]);
 
-  const loadDirective = useCallback(async () => {
-    setDirectiveLoading(true);
-    try {
-      const response = await fetch('/api/opportunity-intelligence?minScore=55');
-      if (!response.ok) throw new Error('Opportunity router failed');
-      const data = (await response.json()) as OpportunityDirectiveResponse;
-      setDirective(data.topDirective ?? data.routes?.[0] ?? null);
-      setDirectiveLearningCount(data.learningSummary?.decisionCount ?? 0);
-    } catch {
-      setDirective(null);
-      setDirectiveMessage('The opportunity router could not load. The tracker still works, but the directive layer is unavailable.');
-    } finally {
-      setDirectiveLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void loadDirective();
-  }, [loadDirective]);
-
   const onboardingMode = searchParams.get('onboarding') === '1' && viewMode === 'personal';
   const completedMode = searchParams.get('completed') === '1' && viewMode === 'personal';
   const hasProgressedGrant = grants.some((grant) => grant.stage !== 'discovered');
@@ -995,6 +366,7 @@ export function TrackerClient() {
   const activeCount = grants.filter((grant) =>
     ['pursuing', 'submitted', 'negotiating', 'approved'].includes(grant.stage)
   ).length;
+  const workInMotionCount = researchingCount + activeCount;
   const reviewLearning = useMemo(() => buildReviewLearning(grants), [grants]);
   const workingGrants = grants.filter((grant) => !TERMINAL_STAGES.has(grant.stage) && DECISION_STAGES.has(grant.stage));
   const deadlineDecisionGrants = workingGrants
@@ -1005,32 +377,16 @@ export function TrackerClient() {
     })
     .sort(sortForDecision);
   const machineCleanCandidates = grants.filter(isMachineCleanCandidate);
-  const ungatedHumanReadyGrants = grants
-    .filter((grant) => grant.stage === 'discovered' && !isMachineCleanCandidate(grant))
-    .sort(sortForDecision);
-  const humanReadyGrants = ungatedHumanReadyGrants
-    .filter((grant) => assessGrantForReview(grant, reviewLearning, triageLens).isReviewable)
-    .sort((a, b) => sortForTriage(a, b, reviewLearning, triageLens));
-  const fallbackSuggestedGrants = ungatedHumanReadyGrants
-    .filter((grant) => assessGrantForReview(grant, reviewLearning, triageLens).score >= OBVIOUS_NO_GO_THRESHOLD)
-    .sort((a, b) => sortForTriage(a, b, reviewLearning, triageLens));
-  const suggestedGrants = humanReadyGrants.length > 0 ? humanReadyGrants : fallbackSuggestedGrants;
-  const humanReadyTop5 = suggestedGrants.slice(0, 5);
-  const quickTriageQueue = suggestedGrants.filter((grant) => !triageSkippedIds.has(grant.grant_id));
-  const quickTriageGrant = quickTriageQueue[0] ?? null;
-  const quickTriageAssessment = quickTriageGrant
-    ? assessGrantForReview(quickTriageGrant, reviewLearning, triageLens)
-    : null;
   const learningHiddenGrantIds = useMemo(() => {
     const hidden = new Set<string>();
     for (const grant of grants) {
       if (grant.stage !== 'discovered' || isMachineCleanCandidate(grant)) continue;
-      if (assessGrantForReview(grant, reviewLearning, triageLens).score < OBVIOUS_NO_GO_THRESHOLD) {
+      if (assessGrantForReview(grant, reviewLearning, 'ACT').score < OBVIOUS_NO_GO_THRESHOLD) {
         hidden.add(grant.grant_id);
       }
     }
     return hidden;
-  }, [grants, reviewLearning, triageLens]);
+  }, [grants, reviewLearning]);
   const reviewHiddenGrantIds = useMemo(() => {
     const hidden = new Set<string>(learningHiddenGrantIds);
     for (const grant of machineCleanCandidates) {
@@ -1039,130 +395,6 @@ export function TrackerClient() {
     return hidden;
   }, [learningHiddenGrantIds, machineCleanCandidates]);
   const hiddenBeforeReviewCount = reviewHiddenGrantIds.size;
-  const visibleHumanReadyCount = suggestedGrants.length;
-  const visibleMachinePassCount = machineCleanCandidates.length + learningHiddenGrantIds.size;
-
-  const runAutoReview = async () => {
-    if (viewMode !== 'personal') return;
-    setAutoReviewing(true);
-    setPreSweepError(null);
-    try {
-      const response = await fetch('/api/tracker/auto-review', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ lens: triageLens }),
-      });
-      if (!response.ok) {
-        const data = await response.json().catch(() => null);
-        throw new Error(data?.error || 'Machine review failed');
-      }
-      const data = await response.json();
-      setAutoReview(data);
-      setTriageSkippedIds(new Set());
-      await loadGrants(false);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Machine review failed';
-      setPreSweepError(`${message}. Nothing was changed after the failed request.`);
-    } finally {
-      setAutoReviewing(false);
-    }
-  };
-
-  const updateGrantStage = useCallback(
-    async (grantId: string, stage: string) => {
-      const previousGrants = grants;
-      const now = new Date().toISOString();
-      const nextGrants = previousGrants.map((grant) =>
-        grant.grant_id === grantId ? { ...grant, stage, updated_at: now } : grant
-      );
-
-      setPreSweepError(null);
-      setGrants(nextGrants);
-
-      try {
-        const response = await fetch(`/api/tracker/${grantId}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ stage }),
-        });
-        if (!response.ok) throw new Error('Stage update failed');
-      } catch {
-        setGrants(previousGrants);
-        setPreSweepError('Could not update that grant. Try again from the card.');
-      }
-    },
-    [grants]
-  );
-
-  const handleQuickNo = useCallback(
-    (grantId: string) => {
-      setTriageSkippedIds((previous) => {
-        const next = new Set(previous);
-        next.delete(grantId);
-        return next;
-      });
-      recordNoFeedback(grantId, 'tracker_quick_triage');
-      void updateGrantStage(grantId, 'lost');
-    },
-    [updateGrantStage]
-  );
-
-  const handleQuickLater = useCallback((grantId: string) => {
-    setTriageSkippedIds((previous) => new Set(previous).add(grantId));
-  }, []);
-
-  const handleQuickResearch = useCallback(
-    (grantId: string) => {
-      setTriageSkippedIds((previous) => {
-        const next = new Set(previous);
-        next.delete(grantId);
-        return next;
-      });
-      void updateGrantStage(grantId, 'researching');
-    },
-    [updateGrantStage]
-  );
-
-  const handleDirectiveAction = useCallback(
-    async (kind: DirectiveActionKind) => {
-      if (!directive || directiveAction) return;
-      const confirmWrite =
-        kind === 'send_to_ghl'
-          ? window.confirm('Create or update this opportunity in HighLevel? This will not send email or SMS.')
-          : false;
-      if (kind === 'send_to_ghl' && !confirmWrite) return;
-
-      setDirectiveAction(kind);
-      setDirectiveMessage(null);
-      try {
-        const response = await fetch('/api/opportunity-intelligence/actions', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            kind,
-            signalId: directive.signalId,
-            signal: directive.signal,
-            route: directive,
-            confirmWrite,
-            reason: kind === 'no' ? 'Not aligned enough for ACT right now' : undefined,
-            evidenceGaps: directive.evidence_gaps,
-          }),
-        });
-        const receipt = await response.json().catch(() => null);
-        if (!response.ok) {
-          throw new Error(receipt?.detail || receipt?.error || receipt?.warnings?.[0] || 'Action failed');
-        }
-        const warning = Array.isArray(receipt?.warnings) && receipt.warnings.length ? ` ${receipt.warnings[0]}` : '';
-        setDirectiveMessage(`${receipt?.status || 'planned'}: ${receipt?.nextStep || 'Action recorded.'}${warning}`);
-        await loadDirective();
-      } catch (error) {
-        setDirectiveMessage(error instanceof Error ? error.message : 'Could not record that route decision.');
-      } finally {
-        setDirectiveAction(null);
-      }
-    },
-    [directive, directiveAction, loadDirective]
-  );
 
   useEffect(() => {
     if (onboardingMode && hasProgressedGrant) {
@@ -1196,14 +428,14 @@ export function TrackerClient() {
               </div>
             )}
             <h1 className="text-2xl font-black text-bauhaus-black uppercase tracking-tight">
-              {showGuidedOnboarding ? 'Build Your Grant Pipeline' : completedMode ? 'Your Tracker Is Live' : 'Today’s Opportunity Decision'}
+              {showGuidedOnboarding ? 'Build Your Grant Pipeline' : completedMode ? 'Your Tracker Is Live' : 'Grant Tracker'}
             </h1>
             <p className="mt-1 text-sm font-medium text-bauhaus-muted">
               {showGuidedOnboarding
                 ? 'Your shortlisted grants are here. Move the strongest options out of Discovered and use the board as your working queue.'
                 : completedMode
                 ? 'You have moved at least one grant into active pipeline work. From here, use the tracker as your working system and the home dashboard as your daily summary.'
-                : 'Start here. CivicGraph chooses one recommended move, then you either reject it, park it, investigate it, or turn it into real pipeline work.'}
+                : 'This page is only for work you may actually move. Decide urgent deadlines first, then use the board. Use Home or the Opportunity Cockpit to find new opportunities.'}
             </p>
           </div>
           {(showGuidedOnboarding || completedMode) && (
@@ -1221,79 +453,84 @@ export function TrackerClient() {
 
       {!showGuidedOnboarding && !completedMode && (
         <>
-          <OpportunityDirectivePanel
-            route={directive}
-            loading={directiveLoading}
-            actingKind={directiveAction}
-            actionMessage={directiveMessage}
-            learningCount={directiveLearningCount}
-            onAction={handleDirectiveAction}
-          />
+          <section className="mb-6 overflow-hidden border-4 border-bauhaus-black bg-white">
+            <div className="border-b-2 border-bauhaus-black/10 p-4">
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-red">
+                Today
+              </div>
+              <h2 className="mt-2 text-xl font-black uppercase tracking-tight text-bauhaus-black">
+                Use the board. Only decide urgent grants first.
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm font-medium leading-6 text-bauhaus-muted">
+                This page is not the discovery engine. Home and the cockpit find the next opportunity; this page is where real grant work moves.
+              </p>
+            </div>
+            <div className="grid gap-0 md:grid-cols-3">
+              <div className="border-b-2 border-bauhaus-black/10 p-4 md:border-b-0 md:border-r-2">
+                <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">
+                  Decide first
+                </div>
+                <div className="mt-2 text-3xl font-black text-bauhaus-black">{deadlineDecisionGrants.length}</div>
+                <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
+                  Tracked grants closing this week. Open the first one, then choose pursue, park, or no-go.
+                </p>
+                {deadlineDecisionGrants[0] && (
+                  <Link
+                    href={`/grants/${deadlineDecisionGrants[0].grant.id}`}
+                    className="mt-3 inline-flex border-2 border-bauhaus-black bg-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white transition-colors hover:bg-white hover:text-bauhaus-black"
+                  >
+                    Open first deadline
+                  </Link>
+                )}
+              </div>
+              <div className="border-b-2 border-bauhaus-black/10 p-4 md:border-b-0 md:border-r-2">
+                <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">
+                  Work in motion
+                </div>
+                <div className="mt-2 text-3xl font-black text-bauhaus-black">{workInMotionCount}</div>
+                <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
+                  Researching, pursuing, submitted, negotiating, or approved. This is the board work below.
+                </p>
+                <a
+                  href="#work-board"
+                  className="mt-3 inline-flex border-2 border-bauhaus-black px-3 py-2 text-[10px] font-black uppercase tracking-widest text-bauhaus-black transition-colors hover:bg-bauhaus-black hover:text-white"
+                >
+                  Go to board
+                </a>
+              </div>
+              <div className="p-4">
+                <div className="text-[10px] font-black uppercase tracking-[0.24em] text-bauhaus-muted">
+                  Not work here
+                </div>
+                <div className="mt-2 text-3xl font-black text-bauhaus-black">{hiddenBeforeReviewCount}</div>
+                <p className="mt-2 text-xs font-medium leading-5 text-bauhaus-muted">
+                  Low-fit or cleanup records are held out of the board. Use the cockpit when you need the next recommended opportunity.
+                </p>
+                <Link
+                  href="/opportunities/ecosystem"
+                  className="mt-3 inline-flex border-2 border-bauhaus-red px-3 py-2 text-[10px] font-black uppercase tracking-widest text-bauhaus-red transition-colors hover:bg-bauhaus-red hover:text-white"
+                >
+                  Open cockpit
+                </Link>
+              </div>
+            </div>
+          </section>
 
-          <TrackerProcess
-            cleanableCount={visibleMachinePassCount}
-            deadlineCount={deadlineDecisionGrants.length}
-            reviewCount={visibleHumanReadyCount}
-            hiddenBeforeReviewCount={hiddenBeforeReviewCount}
-            activeCount={activeCount}
-            discoveredCount={discoveredCount}
-            autoReviewing={autoReviewing}
-            viewMode={viewMode}
-            activeLens={triageLens}
-            autoReview={autoReview}
-            preSweepError={preSweepError}
-            onRunAutoReview={runAutoReview}
-            onLensChange={setTriageLens}
-          />
-
-          <QuickTriagePanel
-            item={quickTriageGrant}
-            remainingCount={quickTriageQueue.length}
-            suppressedCount={hiddenBeforeReviewCount}
-            activeLens={triageLens}
-            assessment={quickTriageAssessment}
-            onNo={handleQuickNo}
-            onLater={handleQuickLater}
-            onResearch={handleQuickResearch}
-          />
-
-          <div className="mb-6 grid min-w-0 gap-4 xl:grid-cols-2">
-            <section className="min-w-0 overflow-hidden border-4 border-bauhaus-black bg-white">
+          {deadlineDecisionGrants.length > 0 && (
+            <section className="mb-6 min-w-0 overflow-hidden border-4 border-bauhaus-black bg-white">
               <div className="border-b-2 border-bauhaus-black/10 px-4 py-3">
                 <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-                  Decide this week
+                  Deadline decisions
                 </div>
                 <p className="mt-1 text-xs font-medium text-bauhaus-muted">
-                  These close soon. Open one, decide pursue / park / no-go, then move it on the board.
+                  Only these need attention before the board. Open each one, decide, then move on.
                 </p>
               </div>
-              {deadlineDecisionGrants.length > 0 ? (
-                deadlineDecisionGrants.slice(0, 5).map((item) => (
-                  <DecisionGrantRow key={item.id} item={item} />
-                ))
-              ) : (
-                <div className="p-4 text-sm font-medium text-bauhaus-muted">No tracked grants closing this week.</div>
-              )}
+              {deadlineDecisionGrants.slice(0, 5).map((item) => (
+                <DecisionGrantRow key={item.id} item={item} />
+              ))}
             </section>
-
-            <section className="min-w-0 overflow-hidden border-4 border-bauhaus-black bg-white">
-              <div className="border-b-2 border-bauhaus-black/10 px-4 py-3">
-                <div className="text-[10px] font-black uppercase tracking-[0.3em] text-bauhaus-muted">
-                  Suggested next 5
-                </div>
-                <p className="mt-1 text-xs font-medium text-bauhaus-muted">
-                  These are the best current {triageLens} candidates. Review only these before going back to search.
-                </p>
-              </div>
-              {humanReadyTop5.length > 0 ? (
-                humanReadyTop5.map((item) => (
-                  <DecisionGrantRow key={item.id} item={item} />
-                ))
-              ) : (
-                <div className="p-4 text-sm font-medium text-bauhaus-muted">Nothing reviewable after cleanup.</div>
-              )}
-            </section>
-          </div>
+          )}
         </>
       )}
 
@@ -1342,7 +579,7 @@ export function TrackerClient() {
         </div>
       )}
 
-      <div className="flex gap-0 mb-6 border-4 border-bauhaus-black w-fit">
+      <div id="work-board" className="flex gap-0 mb-6 border-4 border-bauhaus-black w-fit scroll-mt-24">
         <button
           onClick={() => setViewMode('personal')}
           className={`px-4 py-2 text-[11px] font-black uppercase tracking-widest transition-colors ${

--- a/apps/web/src/lib/opportunity-intelligence.ts
+++ b/apps/web/src/lib/opportunity-intelligence.ts
@@ -328,7 +328,7 @@ export interface OpportunityIntelligenceActionReceipt {
   createdAt: string;
   writeMode: 'planned' | 'confirmed';
   externalWrites: Array<{
-    system: 'ghl' | 'supabase';
+    system: 'ghl' | 'supabase' | 'supabase_decision' | 'supabase_pipeline';
     id: string;
     status: 'created' | 'updated' | 'recorded' | 'skipped';
   }>;
@@ -2370,6 +2370,85 @@ async function recordGhlSyncLog(payload: Record<string, unknown>) {
   await db.from('ghl_sync_log').insert(payload);
 }
 
+function safeUuid(value: string | null | undefined) {
+  if (!value) return null;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+    ? value
+    : null;
+}
+
+async function resolveOrgProfileId(request: OpportunityActionRequest, context?: OpportunityActionContext) {
+  if (request.orgProfileId) return request.orgProfileId;
+  if (!context?.userId) return null;
+
+  const db = getServiceSupabase();
+  const { data } = await db
+    .from('org_profiles')
+    .select('id')
+    .eq('user_id', context.userId)
+    .maybeSingle();
+
+  return data?.id ? String(data.id) : null;
+}
+
+async function upsertRoutePipelineItem(
+  request: OpportunityActionRequest,
+  context: OpportunityActionContext | undefined,
+  status: 'researching' | 'pursuing',
+) {
+  const route = request.route;
+  if (!route) throw new Error('A route payload is required to create pipeline work.');
+
+  const orgProfileId = await resolveOrgProfileId(request, context);
+  if (!orgProfileId) throw new Error('No org profile found for this user.');
+
+  const db = getServiceSupabase();
+  const sourceType = route.source;
+  const sourceRef = route.sourceRef || route.signalId || route.id;
+  const pipelinePayload = {
+    org_profile_id: orgProfileId,
+    name: route.title,
+    amount_display: request.signal?.amount ?? null,
+    amount_numeric: parseMoneyLabel(request.signal?.amount) || null,
+    funder: request.signal?.organisation ?? null,
+    deadline: request.signal?.deadline ?? null,
+    status,
+    grant_opportunity_id: route.source === 'grant' ? safeUuid(route.sourceRef) : null,
+    notes: request.note ?? route.next_action,
+    source_type: sourceType,
+    source_ref: sourceRef,
+    pathway: route.pathway,
+    recommended_role: route.recommended_role,
+    project_code: route.project_code,
+    last_synced_at: new Date().toISOString(),
+  };
+
+  const existing = await db
+    .from('org_pipeline')
+    .select('id')
+    .eq('org_profile_id', orgProfileId)
+    .eq('source_type', sourceType)
+    .eq('source_ref', sourceRef)
+    .maybeSingle();
+
+  if (existing.data?.id) {
+    const { error } = await db
+      .from('org_pipeline')
+      .update(pipelinePayload)
+      .eq('id', existing.data.id);
+    if (error) throw new Error(error.message);
+    return { id: String(existing.data.id), operation: 'updated' as const, orgProfileId };
+  }
+
+  const { data, error } = await db
+    .from('org_pipeline')
+    .insert(pipelinePayload)
+    .select('id')
+    .single();
+  if (error) throw new Error(error.message);
+  return { id: String(data?.id ?? sourceRef), operation: 'created' as const, orgProfileId };
+}
+
 async function sendRouteToGhl(request: OpportunityActionRequest) {
   const route = request.route;
   if (!route) throw new Error('send_to_ghl requires a route payload');
@@ -2566,9 +2645,19 @@ export async function createOpportunityIntelligenceAction(
   if (WRITE_DECISIONS.has(request.kind)) {
     try {
       const decisionId = await recordOpportunityDecision(request, context, receipt.id);
-      if (decisionId) externalWrites.push({ system: 'supabase', id: decisionId, status: 'recorded' });
+      if (decisionId) externalWrites.push({ system: 'supabase_decision', id: decisionId, status: 'recorded' });
     } catch (error) {
       warnings.push(`Decision memory was not recorded: ${error instanceof Error ? error.message : 'unknown error'}`);
+    }
+  }
+
+  if (request.kind === 'research' || request.kind === 'partner_path' || request.kind === 'apply_path') {
+    try {
+      const pipelineStatus = request.kind === 'research' ? 'researching' : 'pursuing';
+      const result = await upsertRoutePipelineItem(request, context, pipelineStatus);
+      externalWrites.push({ system: 'supabase_pipeline', id: result.id, status: result.operation });
+    } catch (error) {
+      warnings.push(`Pipeline work item was not created: ${error instanceof Error ? error.message : 'unknown error'}`);
     }
   }
 
@@ -2595,7 +2684,7 @@ export async function createOpportunityIntelligenceAction(
           last_synced_at: new Date().toISOString(),
         }).select('id').single();
         if (error) throw new Error(error.message);
-        externalWrites.push({ system: 'supabase', id: String(data?.id ?? request.route.id), status: 'created' });
+        externalWrites.push({ system: 'supabase_pipeline', id: String(data?.id ?? request.route.id), status: 'created' });
       } catch (error) {
         warnings.push(`Pipeline promotion failed: ${error instanceof Error ? error.message : 'unknown error'}`);
       }
@@ -2639,5 +2728,11 @@ function nextStepForAction(kind: OpportunityActionKind, targetSystem?: Opportuni
   if (kind === 'request_ingestion' || kind === 'ingest') return 'Queue ingestion with source URL, source owner, and dedupe keys.';
   if (kind === 'contact') return `Queue a human next touch${targetSystem ? ` in ${targetSystem}` : ''}; do not auto-send.`;
   if (kind === 'qualify') return 'Check eligibility, evidence, applicant, budget, co-contribution, and source confidence.';
+  if (kind === 'research') return 'Create a visible research item in the internal pipeline and keep learning from the decision.';
+  if (kind === 'partner_path') return 'Create a visible partner-path item in the internal pipeline.';
+  if (kind === 'apply_path') return 'Create a visible application-path item in the internal pipeline.';
+  if (kind === 'later') return 'Park this route for now and make it less urgent in the next ranking pass.';
+  if (kind === 'no') return 'Record the no decision and make similar routes less likely.';
+  if (kind === 'add_evidence_gap') return 'Record the missing proof so future scans keep asking for it.';
   return 'Monitor the signal and refresh source health before acting.';
 }

--- a/apps/web/src/lib/services/goods-operating-system.ts
+++ b/apps/web/src/lib/services/goods-operating-system.ts
@@ -5,6 +5,358 @@ export const goodsOperatingFacts = [
   { label: 'Scale target', value: '5,000+', detail: 'stretch beds plus 500+ washing machines in the 2026 plan' },
 ];
 
+export const goodsMoneySnapshot = [
+  {
+    label: 'Money received',
+    value: '$445,685',
+    detail: 'Philanthropic funding received for Goods from Snow, FRRR, VFFF, AMP Spark, and The Funding Network.',
+    source: 'Goods project wiki',
+  },
+  {
+    label: 'Revenue recorded',
+    value: '$537,595',
+    detail: 'Total revenue recorded against the ACT-GD code in the Goods wiki.',
+    source: 'ACT-GD finance code',
+  },
+  {
+    label: 'Spend estimate',
+    value: '$400 target',
+    detail: 'Target delivered cost per bed. This is not safe for QBE/SEFA until replaced with actual last-50-bed cost.',
+    source: 'Unit economics claim',
+  },
+  {
+    label: 'Active asks',
+    value: '$2.4M+',
+    detail: 'REAL $1.2M, QBE ~$210K, Snow ~$200K, PFI $640K, Centrecorp ~$150K, plus SEFA working capital.',
+    source: 'Goods funding stack',
+  },
+  {
+    label: 'Cost proof needed',
+    value: '50 beds',
+    detail: 'Before QBE or SEFA, validate delivered cost on the last 50 beds and attach the budget/use-of-funds sheet.',
+    source: 'Unit economics claim',
+  },
+];
+
+export const goodsFundingPipelineRows = [
+  {
+    name: 'Snow Foundation',
+    lane: 'Foundation',
+    status: 'received + active partner',
+    value: 'part of $445,685',
+    timing: 'now',
+    next: 'Confirm payment trail, relationship owner, and Pty migration note before the next ask.',
+  },
+  {
+    name: 'FRRR',
+    lane: 'Foundation/grant',
+    status: 'received',
+    value: 'part of $445,685',
+    timing: 'historical',
+    next: 'Keep as proof of rural/regional credibility and reporting discipline.',
+  },
+  {
+    name: 'Vincent Fairfax Family Foundation',
+    lane: 'Foundation',
+    status: 'received',
+    value: 'part of $445,685',
+    timing: 'historical',
+    next: 'Use as a warm proof point for values-aligned foundation asks.',
+  },
+  {
+    name: 'AMP Spark',
+    lane: 'Foundation/corporate',
+    status: 'received',
+    value: 'part of $445,685',
+    timing: 'historical',
+    next: 'Use as corporate-philanthropy evidence for QBE and other program partners.',
+  },
+  {
+    name: 'The Funding Network',
+    lane: 'Foundation/network',
+    status: 'received',
+    value: 'part of $445,685',
+    timing: 'historical',
+    next: 'Use as public supporter proof and update story with latest asset deployment.',
+  },
+  {
+    name: 'QBE Catalysing Impact',
+    lane: 'QBE program',
+    status: 'shortlisted / term-sheet pending',
+    value: '~$210K',
+    timing: 'live',
+    next: 'Finish delivered-cost sheet, budget/use of funds, and funder-ready proof pack.',
+  },
+  {
+    name: 'Snow Foundation',
+    lane: 'Grant + impact investment',
+    status: 'proposal under review',
+    value: '~$200K',
+    timing: 'live',
+    next: 'Use QBE outcome and unit economics to unlock the impact investment track.',
+  },
+  {
+    name: 'REAL Innovation Fund (DEWR)',
+    lane: 'Production facility',
+    status: 'EOI submitted via Oonchiumpa consortium',
+    value: '$1.2M over 4 years',
+    timing: 'live',
+    next: 'Treat as the primary production-facility pathway, not a generic grant.',
+  },
+  {
+    name: 'QLD Partnering for Impact',
+    lane: 'Repayable investment',
+    status: 'EOI pathway',
+    value: '$640K of $3.2M',
+    timing: 'upcoming',
+    next: 'Prepare repayment logic, governance vehicle, and community benefit model.',
+  },
+  {
+    name: 'SEFA',
+    lane: 'Impact loan',
+    status: 'advanced discussion',
+    value: 'working capital',
+    timing: 'upcoming',
+    next: 'Do not progress without unit economics, buyer pipeline, and repayment logic.',
+  },
+  {
+    name: 'Centrecorp',
+    lane: 'Beds / regional buyer',
+    status: 'board pathway',
+    value: '~$150K',
+    timing: 'upcoming',
+    next: 'Package Tennant Creek proof, delivery costs, and purchase pathway.',
+  },
+];
+
+export const goodsJourneyStages = [
+  {
+    label: 'Proof live',
+    status: 'done',
+    measure: '389 assets / 8 communities',
+    next: 'Keep asset and QR evidence clean.',
+  },
+  {
+    label: 'QBE readiness',
+    status: 'current blocker',
+    measure: '~$210K ask',
+    next: 'Cost sheet + entity option memo.',
+  },
+  {
+    label: 'Funder pipeline',
+    status: 'live',
+    measure: '$445,685 received',
+    next: 'Snow/QBE/FRRR proof and relationship owners.',
+  },
+  {
+    label: 'Production route',
+    status: 'submitted',
+    measure: '$1.2M REAL EOI',
+    next: 'Oonchiumpa consortium and facility logic.',
+  },
+  {
+    label: 'Buyer offer',
+    status: 'not packaged',
+    measure: 'housing / ACCHO / hostel / mining',
+    next: 'Product bundle, price, freight, support.',
+  },
+  {
+    label: 'Scale capital',
+    status: 'not ready',
+    measure: 'PFI / SEFA / Centrecorp',
+    next: 'Repayment logic and buyer pipeline.',
+  },
+];
+
+export const goodsRelationshipMapRows = [
+  {
+    name: 'Benjamin Knight',
+    role: 'ACT build / systems / evidence',
+    status: 'owner needed now',
+    next: 'Close cost sheet, proof pack, and source trail.',
+  },
+  {
+    name: 'Nicholas Marchesi OAM',
+    role: 'ACT co-founder / design direction',
+    status: 'strategic lead',
+    next: 'Confirm Goods story, offer shape, and relationship framing.',
+  },
+  {
+    name: 'Snow Foundation',
+    role: 'Sally Grimsley-Ballard / Alexandra Lagelee Kean',
+    status: 'received + active partner',
+    next: 'Confirm payment trail, relationship owner, and Pty migration note.',
+  },
+  {
+    name: 'QBE Catalysing Impact',
+    role: 'program partner / live ask',
+    status: 'shortlisted',
+    next: 'Send only after delivered-cost sheet and entity option memo are clear.',
+  },
+  {
+    name: 'Oonchiumpa',
+    role: 'Kristy Bloomfield + Tanya Turner',
+    status: 'consortium pathway',
+    next: 'Keep REAL production-facility logic aligned to community governance.',
+  },
+  {
+    name: 'Centrecorp Foundation',
+    role: 'regional buyer / board pathway',
+    status: 'upcoming',
+    next: 'Package Tennant Creek proof, delivery costs, and purchase route.',
+  },
+  {
+    name: 'SEFA',
+    role: 'impact loan / working capital',
+    status: 'not ready',
+    next: 'Do not progress before unit economics, buyer pipeline, and repayment logic.',
+  },
+  {
+    name: 'HighLevel',
+    role: 'CRM follow-up system',
+    status: 'confirm-first',
+    next: 'Only send named contact, owner, message angle, due date, and source link.',
+  },
+];
+
+export const goodsMoneyPileRows = [
+  { group: 'received', name: 'Goods philanthropic funding', amount: '$445,685', status: 'received', owner: 'Goods / ACT', next: 'Use as proof for QBE, Snow, foundations, and buyers.' },
+  { group: 'recorded', name: 'ACT-GD revenue code', amount: '$537,595', status: 'recorded', owner: 'ACT finance', next: 'Reconcile to receipts, invoices, Dext, and Xero.' },
+  { group: 'need proof', name: 'Delivered bed cost target', amount: '$400 target', status: 'unsafe claim', owner: 'Ben', next: 'Replace with last-50-bed delivered cost.' },
+  { group: 'active ask', name: 'QBE Catalysing Impact', amount: '~$210K', status: 'shortlisted', owner: 'Ben / Nic', next: 'Finish QBE pack, cost sheet, and entity memo.' },
+  { group: 'active ask', name: 'Snow Foundation', amount: '~$200K', status: 'under review', owner: 'Ben / Nic', next: 'Use QBE outcome and unit economics for the next ask.' },
+  { group: 'active ask', name: 'REAL Innovation Fund (DEWR)', amount: '$1.2M over 4 years', status: 'submitted', owner: 'Oonchiumpa consortium', next: 'Keep production-facility pathway live.' },
+  { group: 'upcoming', name: 'QLD Partnering for Impact', amount: '$640K of $3.2M', status: 'EOI pathway', owner: 'ACT / Goods', next: 'Prepare repayment, governance, and benefit model.' },
+  { group: 'upcoming', name: 'SEFA', amount: 'working capital', status: 'not ready', owner: 'ACT / Goods', next: 'Wait for unit economics, buyer pipeline, and repayment logic.' },
+  { group: 'upcoming', name: 'Centrecorp Goods route', amount: '~$150K', status: 'board pathway', owner: 'Ben', next: 'Package Tennant Creek proof and purchase route.' },
+  { group: 'pitch', name: 'Minderoo Foundation Goods pitch', amount: '$900K', status: 'mid-May pitch', owner: 'Ben / Nic', next: 'Align to Goods, JusticeHub, and ACT shared service proof.' },
+  { group: 'receivable', name: 'Snow Foundation INV-0321', amount: '$132,000', status: 'authorised', owner: 'Ben', next: 'Pty migration call with Sally/Alexandra.' },
+  { group: 'receivable', name: 'Centrecorp Foundation INV-0314', amount: '$84,700', status: 'draft', owner: 'Ben', next: 'Send, void, or reissue decision.' },
+  { group: 'receivable', name: 'Rotary eClub Outback Australia INV-0222', amount: '$82,500', status: 'authorised 380d', owner: 'Ben', next: 'Chase or write-off decision.' },
+  { group: 'receivable', name: 'PICC INV-0317 / INV-0324', amount: '$113,300', status: 'authorised', owner: 'ACT / PICC', next: 'Partner receivables follow-up.' },
+  { group: 'receivable', name: 'Regional Arts Australia INV-0301 / INV-0302', amount: '$33,000', status: 'authorised 129d', owner: 'Ben', next: 'Chase needed.' },
+  { group: 'receivable', name: 'Just Reinvest INV-0295', amount: '$27,500', status: 'authorised', owner: 'JusticeHub', next: 'Confirm payment path.' },
+  { group: 'receivable', name: 'Brodie Germaine Fitness INV-0325', amount: '$15,400', status: 'authorised', owner: 'BG Fit / ACT', next: 'Confirm payment path.' },
+  { group: 'receivable', name: 'Aleisha J Keating retainers', amount: '$11,700', status: 'authorised', owner: 'ACT finance', next: 'Decide if retainer continues under Pty.' },
+  { group: 'receivable', name: 'Homeland School INV-0303', amount: '$4,950', status: 'authorised', owner: 'JusticeHub', next: 'Confirm payment path.' },
+  { group: 'receivable', name: 'SMART Recovery INV-0322', amount: '$2,200', status: 'authorised', owner: 'ACT finance', next: 'Confirm payment path.' },
+  { group: 'Harvest', name: 'Harvest capital improvement fund', amount: '$250K', status: 'planned', owner: 'Harvest / ACT', next: 'Keep separate from Goods asks.' },
+  { group: 'Farm', name: 'Farm lease base rent', amount: '$50K / year', status: 'planned cost', owner: 'Farm / ACT', next: 'Keep as cost exposure, not funder revenue.' },
+];
+
+export const goodsPeoplePileRows = [
+  { group: 'founder', name: 'Benjamin Knight', org: 'ACT', role: 'build / systems / evidence', status: 'owner now', next: 'Cost sheet, proof pack, source trail.' },
+  { group: 'founder', name: 'Nicholas Marchesi OAM', org: 'ACT', role: 'co-founder / design direction', status: 'strategic lead', next: 'Story, offer shape, relationship framing.' },
+  { group: 'accounting', name: 'Standard Ledger', org: 'Service provider', role: 'accounting / ABN / GST / BAS / R&D coordination', status: 'engaged', next: 'Pty Xero, ABN, R&D, shareholder agreement referral.' },
+  { group: 'bank', name: 'NAB', org: 'Bank', role: 'Pty bank account', status: 'application in flight', next: 'Confirm account readiness.' },
+  { group: 'funder', name: 'QBE Catalysing Impact', org: 'QBE', role: 'live Goods ask', status: 'shortlisted', next: 'Do not send without cost sheet and entity memo.' },
+  { group: 'funder', name: 'Lucy Stronach', org: 'Minderoo Foundation', role: 'mid-May pitch contact', status: 'active target', next: 'Package Goods + ACT shared service proof.' },
+  { group: 'funder', name: 'Sally Grimsley-Ballard / Alexandra Lagelee Kean', org: 'Snow Foundation', role: 'multi-tranche partner', status: 'active partner', next: 'Payment trail and Pty migration call.' },
+  { group: 'funder', name: 'William Frazer', org: 'Paul Ramsay Foundation', role: 'partner-tagged in GHL', status: 'relationship', next: 'Keep warm for JusticeHub / civic infrastructure.' },
+  { group: 'funder', name: 'June Canavan Foundation', org: 'June Canavan Foundation', role: 'relationship unverified', status: 'possible', next: 'Verify relationship and fit.' },
+  { group: 'funder', name: 'Rachel Fyfe / Jessica Duffy', org: 'Dusseldorp Forum', role: 'active partner', status: 'active', next: 'Keep in youth justice / systems-change path.' },
+  { group: 'community', name: 'Kristy Bloomfield + Tanya Turner', org: 'Oonchiumpa', role: 'community governance / REAL consortium', status: 'active partner', next: 'Keep production-facility logic aligned.' },
+  { group: 'community', name: 'Rachel Atkinson', org: 'PICC', role: 'Palm Island partner', status: 'active partner', next: 'Partner receivables and place-based work.' },
+  { group: 'community', name: 'Daniel Daylight', org: 'Mounty Yarns', role: 'Mount Isa partner', status: 'active partner', next: 'Youth / community pathway.' },
+  { group: 'community', name: 'Brodie Germaine', org: 'BG Fit', role: 'Mount Isa partner', status: 'active partner', next: 'Confirm payment path and justice pathway.' },
+  { group: 'buyer', name: 'Centrecorp Foundation', org: 'Centrecorp', role: 'regional buyer / board path', status: 'upcoming', next: 'Tennant Creek proof and purchase route.' },
+  { group: 'capital', name: 'SEFA', org: 'SEFA', role: 'impact loan / working capital', status: 'not ready', next: 'Needs unit economics, buyer pipeline, repayment logic.' },
+  { group: 'system', name: 'HighLevel', org: 'CRM', role: 'contacts and follow-up', status: 'confirm-first', next: 'Only named contact, owner, message angle, due date, source link.' },
+  { group: 'system', name: 'Supply Nation / IPP pathway', org: 'Procurement', role: 'Indigenous procurement readiness', status: 'possible', next: 'Needs entity and governance memo.' },
+  { group: 'capital', name: 'IBA', org: 'First Nations enterprise finance', role: 'enterprise pathway finance', status: 'possible', next: 'Needs governance, ownership, and financial model.' },
+  { group: 'buyer', name: 'Housing / hostels / ACCHOs', org: 'Buyer group', role: 'direct purchase / pre-purchase', status: 'possible', next: 'Package buyer offer.' },
+  { group: 'buyer', name: 'Mining foundations', org: 'Buyer / foundation group', role: 'place-based pre-purchases', status: 'possible', next: 'Match regions, communities, and purchase offer.' },
+  { group: 'buyer', name: 'ALPA / Outback Stores', org: 'Remote retail', role: 'remote distribution / buyer path', status: 'possible', next: 'Needs offer, pricing, logistics.' },
+  { group: 'buyer', name: 'SDA / community housing', org: 'Housing market', role: 'fitout / accessible housing buyer', status: 'possible', next: 'Needs product bundle and contracting party.' },
+];
+
+export const goodsTargetPileRows = [
+  { lane: 'grant', target: 'QBE / Catalysing Impact', money: '~$210K', status: 'live', firstMove: 'Finish cost sheet and entity memo.' },
+  { lane: 'foundation', target: 'Snow / VFFF / FRRR / AMP / TFN proof path', money: '$445,685 received proof', status: 'warm proof', firstMove: 'Build relationship-led approach brief.' },
+  { lane: 'capital', target: 'SEFA / IBA / PFI', money: 'working capital / $640K+', status: 'not ready', firstMove: 'Repayment, governance, buyer pipeline.' },
+  { lane: 'production', target: 'REAL / Oonchiumpa consortium', money: '$1.2M over 4 years', status: 'submitted', firstMove: 'Keep facility logic current.' },
+  { lane: 'buyer', target: 'Centrecorp / mining foundations', money: '~$150K+', status: 'upcoming', firstMove: 'Package Tennant Creek proof.' },
+  { lane: 'buyer', target: 'ACCHOs / hostels / housing / SDA', money: 'purchase orders', status: 'possible', firstMove: 'Package product, price, freight, support.' },
+  { lane: 'shared service', target: 'ACT / CivicGraph / HighLevel / wiki', money: 'retainer or support margin', status: 'needs pricing', firstMove: 'Set support menu and owner table.' },
+];
+
+export const goodsCoreWorkAreas = [
+  {
+    area: 'Delivered cost sheet',
+    status: 'blocking',
+    next: 'Calculate the last 50 beds delivered cost, margin band, freight, labour, and failure/repair assumptions.',
+    proof: 'Actual delivered cost report',
+  },
+  {
+    area: 'QBE pack',
+    status: 'live',
+    next: 'One clean pack: ask, budget, use of funds, deployment proof, risk, and next 90 days.',
+    proof: 'Catalysing Impact application draft',
+  },
+  {
+    area: 'Entity and governance',
+    status: 'blocking major asks',
+    next: 'Name applicant, contracting party, IP/licence logic, benefit share, and Supply Nation/IPP path.',
+    proof: 'Entity option memo',
+  },
+  {
+    area: 'Buyer offer',
+    status: 'needs packaging',
+    next: 'Define buyer product bundle, price, delivery shape, warranty/support, and reporting promise.',
+    proof: 'Goods market intelligence',
+  },
+  {
+    area: 'Evidence pack',
+    status: 'ready but needs hygiene',
+    next: 'Reconcile 389 canonical asset claim with 404 CSV rows and keep QR/source links clean.',
+    proof: 'Asset register + QR manifest',
+  },
+  {
+    area: 'CRM follow-up',
+    status: 'needs routing',
+    next: 'Move only qualified QBE, Snow, buyer, and foundation follow-ups into HighLevel with a named next touch.',
+    proof: 'GHL Goods buyer/demand pipelines',
+  },
+];
+
+export const goodsFocusedGrantRows = [
+  {
+    lane: 'QBE first',
+    target: 'QBE Catalysing Impact',
+    use: 'Catalytic capacity, proof, and operating support.',
+    action: 'Finish cost sheet and QBE pack before opening generic grant search.',
+    href: '/org/act/wiki/sources/catalysing-impact-application-draft-grant-application',
+  },
+  {
+    lane: 'Production facility',
+    target: 'REAL Innovation Fund / PFI',
+    use: 'Containerised on-country production capacity and governance pathway.',
+    action: 'Keep Oonchiumpa consortium route and repayment/governance logic current.',
+    href: '/opportunities/ecosystem?project=goods&lane=capital',
+  },
+  {
+    lane: 'Buyer money',
+    target: 'Housing, ACCHO, hostel, mining foundation pre-purchases',
+    use: 'Direct purchase or pre-purchase of beds, washing machines, fitouts, logistics, and support.',
+    action: 'Package buyer offer before treating these as grants.',
+    href: '/opportunities/ecosystem?project=goods&lane=procurement',
+  },
+  {
+    lane: 'Foundation options',
+    target: 'Health, dignity, housing, circular economy, First Nations enterprise',
+    use: 'Relationship-led asks that fund evidence, community deployment, and scale readiness.',
+    action: 'Use received-funder proof before cold foundation outreach.',
+    href: '/foundations?project=goods',
+  },
+  {
+    lane: 'Open grants',
+    target: 'Manufacturing, circular economy, Indigenous business, regional health',
+    use: 'Only grants that match Goods work areas, not broad community noise.',
+    action: 'Show a short list after QBE/cost/gov gaps are visible.',
+    href: '/grants?type=open_opportunity&sort=closing_asc&project=goods&quality=ready',
+  },
+];
+
 export const goodsOperatingOutputs = [
   {
     label: 'Strategic thesis',

--- a/scripts/migrations/cleanup-qld-kickstarter-round1-duplicates.sql
+++ b/scripts/migrations/cleanup-qld-kickstarter-round1-duplicates.sql
@@ -1,0 +1,57 @@
+begin;
+
+create temp table _qld_kickstarter_cleanup_aliases (
+  alias_name text primary key,
+  recipient_name text not null
+) on commit drop;
+
+insert into _qld_kickstarter_cleanup_aliases (alias_name, recipient_name) values
+('Adapt Mentorship Indigenous Corporation', 'Adapt Mentorship Indigenous Corporation'),
+('Desert Pea Association Inc', 'Desert Pea Association Inc'),
+('Downs Industry Schools Co-op', 'Downs Industry Schools Co-operation Incorporate'),
+('Dynamic Community Care', 'Dynamic Community Care Pty Ltd'),
+('Family and Children''s Emerging Support Services', 'Family and Childrens Emerging Support Services'),
+('Fight 4 Youth', 'Fight 4 Youth'),
+('Gunya Meta', 'Gunya Meta'),
+('Mudth-Niyleta ATSI Corporation', 'Mudth-Niyleta Aboriginal and Torres Strait Islander Corporation'),
+('V.I.T.A.L. Projex', 'V.I.T.A.L. Projex'),
+('Youth Retreat Centre', 'Youth Retreat Centre');
+
+with old_rows as (
+  select distinct on (a.recipient_name)
+    a.recipient_name,
+    jf.amount_dollars,
+    jf.recipient_abn,
+    jf.gs_entity_id
+  from justice_funding jf
+  join _qld_kickstarter_cleanup_aliases a
+    on lower(a.alias_name) = lower(jf.recipient_name)
+  where jf.source = 'qld_ministerial_statement'
+    and jf.program_name = 'Kickstarter Grants'
+    and coalesce(jf.is_aggregate, false) = false
+    and ('youth-justice' = any(coalesce(jf.topics, array[]::text[]))
+      or jf.sector in ('civic_intelligence', 'youth_justice'))
+  order by a.recipient_name, jf.amount_dollars desc nulls last, jf.recipient_abn nulls last, jf.updated_at desc nulls last
+)
+update justice_funding jf
+set
+  amount_dollars = coalesce(jf.amount_dollars, old_rows.amount_dollars),
+  recipient_abn = coalesce(jf.recipient_abn, old_rows.recipient_abn),
+  gs_entity_id = coalesce(jf.gs_entity_id, old_rows.gs_entity_id),
+  updated_at = now()
+from old_rows
+where jf.source = 'qld_youth_justice_kickstarter_round1'
+  and jf.program_name = 'Kickstarter Grants'
+  and jf.program_round = 'Round 1 2024-25'
+  and lower(jf.recipient_name) = lower(old_rows.recipient_name);
+
+delete from justice_funding jf
+using _qld_kickstarter_cleanup_aliases a
+where jf.source = 'qld_ministerial_statement'
+  and jf.program_name = 'Kickstarter Grants'
+  and coalesce(jf.is_aggregate, false) = false
+  and lower(jf.recipient_name) = lower(a.alias_name)
+  and ('youth-justice' = any(coalesce(jf.topics, array[]::text[]))
+    or jf.sector in ('civic_intelligence', 'youth_justice'));
+
+commit;

--- a/scripts/migrations/resolve-qld-kickstarter-round1-entities.sql
+++ b/scripts/migrations/resolve-qld-kickstarter-round1-entities.sql
@@ -1,0 +1,135 @@
+begin;
+
+create temp table _resolved_kickstarter_entities (
+  funded_name text primary key,
+  canonical_name text not null,
+  abn text not null,
+  entity_type text not null,
+  state text,
+  postcode text,
+  confidence text not null,
+  source_url text not null,
+  description text
+) on commit drop;
+
+insert into _resolved_kickstarter_entities (
+  funded_name,
+  canonical_name,
+  abn,
+  entity_type,
+  state,
+  postcode,
+  confidence,
+  source_url,
+  description
+) values
+('Accer Care Pty Ltd', 'ACCER CARE PTY LTD', '69679139381', 'company', 'QLD', '4035', 'registry', 'https://abr.business.gov.au/ABN/View?id=69679139381', 'Queensland private company resolved from ABN Lookup for the Kickstarter Round 1 YD Project.'),
+('ARC Parenting', 'ARC Parenting', '72159364473', 'unknown', 'QLD', null, 'reported', 'https://www.arcparenting.com.au/about', 'ARC Parenting publishes this ABN on its website and is listed as a Queensland Youth Justice Kickstarter Round 1 provider.'),
+('Legacy Connect (Cultural Wellbeing Services)', 'The Trustee for LC Trust', '76595226474', 'trust', 'QLD', '4300', 'registry', 'https://abr.business.gov.au/ABN/View?id=76595226474', 'ABN Lookup lists the current business name Legacy Connect for The Trustee for LC Trust.'),
+('Redcliffe Area Youth Space Incorporated', 'Your Space Australia Incorporated', '17724640741', 'charity', 'QLD', '4020', 'registry', 'https://abr.business.gov.au/ABN/View/17724640741', 'Current legal name for the historical Redcliffe Area Youth Space Incorporated ABN.'),
+('Thrive and Connect', 'THRIVE & CONNECT PTY LTD', '69677779029', 'company', 'QLD', '4870', 'registry', 'https://abr.business.gov.au/ABN/View?id=69677779029', 'Queensland private company resolved from ABN Lookup for the Kickstarter Round 1 Thrive Guiding project.');
+
+insert into gs_entities (
+  entity_type,
+  canonical_name,
+  abn,
+  gs_id,
+  description,
+  state,
+  postcode,
+  sector,
+  sub_sector,
+  tags,
+  source_datasets,
+  source_count,
+  confidence
+)
+select
+  r.entity_type,
+  r.canonical_name,
+  r.abn,
+  'AU-ABN-' || r.abn,
+  r.description,
+  r.state,
+  r.postcode,
+  'youth_justice',
+  'early_intervention',
+  array['youth-justice', 'kickstarter', 'early-intervention']::text[],
+  array['abr', 'qld_youth_justice_kickstarter_round1']::text[],
+  2,
+  r.confidence
+from _resolved_kickstarter_entities r
+where not exists (
+  select 1
+  from gs_entities e
+  where e.abn = r.abn
+);
+
+with entity_match as (
+  select distinct on (r.funded_name)
+    r.funded_name,
+    r.abn,
+    e.id as entity_id
+  from _resolved_kickstarter_entities r
+  join gs_entities e
+    on e.abn = r.abn
+  order by r.funded_name,
+    case when lower(e.canonical_name) = lower(r.canonical_name) then 0 else 1 end,
+    e.updated_at desc nulls last
+)
+update justice_funding jf
+set
+  recipient_abn = em.abn,
+  gs_entity_id = em.entity_id,
+  updated_at = now()
+from entity_match em
+where jf.source = 'qld_youth_justice_kickstarter_round1'
+  and jf.program_name = 'Kickstarter Grants'
+  and jf.program_round = 'Round 1 2024-25'
+  and lower(jf.recipient_name) = lower(em.funded_name);
+
+with entity_match as (
+  select distinct on (r.funded_name)
+    r.funded_name,
+    r.canonical_name,
+    r.abn,
+    e.id as entity_id
+  from _resolved_kickstarter_entities r
+  join gs_entities e
+    on e.abn = r.abn
+  order by r.funded_name,
+    case when lower(e.canonical_name) = lower(r.canonical_name) then 0 else 1 end,
+    e.updated_at desc nulls last
+),
+aliases(alias_type, alias_value, entity_id, source, is_primary) as (
+  select 'funded_name', funded_name, entity_id, 'qld_youth_justice_kickstarter_round1', false from entity_match
+  union all
+  select 'legal_name', canonical_name, entity_id, 'abr', true from entity_match
+  union all
+  select 'business_name', 'Legacy Connect', entity_id, 'abr', false from entity_match where abn = '76595226474'
+  union all
+  select 'historical_name', 'Redcliffe Area Youth Space Incorporated', entity_id, 'abr', false from entity_match where abn = '17724640741'
+)
+insert into gs_entity_aliases (
+  entity_id,
+  alias_type,
+  alias_value,
+  source,
+  is_primary
+)
+select
+  a.entity_id,
+  a.alias_type,
+  a.alias_value,
+  a.source,
+  a.is_primary
+from aliases a
+where not exists (
+  select 1
+  from gs_entity_aliases existing
+  where existing.entity_id = a.entity_id
+    and lower(existing.alias_value) = lower(a.alias_value)
+    and existing.alias_type = a.alias_type
+);
+
+commit;

--- a/scripts/migrations/seed-qld-kickstarter-round1-2024-25.sql
+++ b/scripts/migrations/seed-qld-kickstarter-round1-2024-25.sql
@@ -1,0 +1,281 @@
+begin;
+
+create temp table _qld_kickstarter_round1 (
+  recipient_name text primary key,
+  recipient_abn text,
+  region text not null,
+  project_name text not null,
+  location text not null,
+  project_description text not null
+) on commit drop;
+
+insert into _qld_kickstarter_round1 (
+  recipient_name,
+  recipient_abn,
+  region,
+  project_name,
+  location,
+  project_description
+) values
+('Accer Care Pty Ltd', null, 'Brisbane and Moreton Bay', 'YD Project', 'Brisbane', 'Project: YD Project
+
+A 12-week early intervention initiative aimed at empowering Indigenous youth aged 8-17 years through individualised case management, mentoring, and cultural activities aimed at fostering positive life choices.'),
+('ARC Parenting', '72159364473', 'Brisbane and Moreton Bay', 'Parenting on the ARC Workshop', 'Brisbane', 'Project: Parenting on the ARC Workshop
+
+This is a 12-month trauma-informed, psychoeducational initiative designed to support parents and caregivers of at-risk children and youth aged 8-17. It provides evidence-based tools to enhance emotional regulation, reduce family conflict, and strengthen relationships.'),
+('Indigenous Mana Limited', '82679578977', 'Brisbane and Moreton Bay', 'Indigenous Mana Academy', 'Moreton Bay', 'Project: Indigenous Mana Academy
+
+Indigenous Mana Academy is a 12-month program for youths aged 10-17 in the Moreton Bay Region using rugby league, mentorship, and cultural activities to re-engage at-risk youth back into education, reduce anti-social behaviour, and strengthen family and community connections. Delivered in partnership with First Nations businesses and Elders, the program will offer a range of supports including rugby training sessions, mentoring, cultural camps, and family engagement sessions.'),
+('Inspiring Brighter Futures Foundation', '67165142861', 'Brisbane and Moreton Bay', 'Onwards & Upwards Wellbeing Mentoring program', 'Brisbane', 'Project: Onwards & Upwards Wellbeing Mentoring program
+
+Supporting youths aged 12-17 years, this 12-month initiative focuses on Indigenous participants through personalised mentoring, run coaching, and education in well-being, leadership, and vocational skills.'),
+('Lutheran Church of Queensland', '37293060173', 'Brisbane and Moreton Bay', 'Compass - Moreton Bay', 'Moreton Bay', 'Project: Compass - Moreton Bay
+
+Compass provides support for 10-17-year-old youths and their families through tailored case coordination and community engagement over a 12-month period to address underlying needs, strengthen emotional regulation and social-emotional wellbeing.'),
+('Redcliffe Area Youth Space Incorporated', null, 'Brisbane and Moreton Bay', 'PIVOT (Prevention and InterVention for Offending Teens)', 'Moreton Bay', 'Project: PIVOT (Prevention and InterVention for Offending Teens)
+
+This program offers trauma-informed case management, mentoring, education support, pathways to employment, and pro-social activities to help reduce youth crime and antisocial behaviour.'),
+('Queensland Blue Light Association Incorporated', '67047589753', 'Brisbane and Moreton Bay', 'Blue Edge Brisbane and Moreton Bay', 'Brisbane', 'Project: Blue Edge Brisbane and Moreton Bay
+
+This eight-week program enhances mental and physical wellbeing, building leadership and resilience, and reducing low-level crime through positive behaviours and community connections.'),
+('Fight 4 Youth', '62672971162', 'South East', 'Positive Pathways Toolkit', 'Gold Coast', 'Project: Positive Pathways Toolkit
+
+An early intervention program for 8-17-year-old youths, teaching emotional regulation, decision-making skills and resilience, addressing peer pressure, substance use, and fostering positive community engagement.'),
+('Gunya Meta', '56389629420', 'South East', 'Strong Warriors, Strong Future', 'Logan', 'Project: Strong Warriors, Strong Future
+
+This culturally-led project provides an opportunity for 20 First Nations youths aged 10-17 to strengthen cultural identity, kinship, and family inclusion over an 18-month program.'),
+('Kirrawe Indigenous Corporation', '23983548310', 'South East', 'Walama Ngurra Bangaba: Returning home building futures', 'Brisbane, Logan, and Gold Coast', 'Project: Walama Ngurra Bangaba: Returning home building futures
+
+This is a 12-month trauma-informed program for First Nations youth aged 8-17, focusing on re-engaging them with education, training, or employment while strengthening cultural and community connections.'),
+('Royal Society for the Prevention of Cruelty to Animals (Queensland) Limited', '74851544037', 'South East', 'Tails of Change', 'Brisbane and Logan', 'Project: Tails of Change
+
+A two-year early intervention program using hands-on animal care to help disengaged youth aged 11-17 years to build empathy, emotional regulation, and pro-social behaviours, reducing the risk of offending.'),
+('Adapt Mentorship Indigenous Corporation', '76524714688', 'South West', 'Adapt Youth Mentorship Program', 'Toowoomba', 'Project: Adapt Youth Mentorship Program
+
+This 12-month program will deliver culturally responsive mentoring, creative activities, and tailored support to reduce crime and promote positive behaviour for First Nations youth aged 8-17.'),
+('Downs Industry Schools Co-operation Incorporate', '39841878209', 'South West', 'Step Up Now (SUN)', 'Toowoomba', 'Project: Step Up Now (SUN)
+
+SUN is a 5-month program that will support at-risk youth to develop life skills, resilience, and to transition into education, employment, or training.'),
+('Dynamic Community Care Pty Ltd', '29652088803', 'South West', 'The Durungal Program', 'Ipswich and Toowoomba', 'Project: The Durungal Program
+
+An eight-week intervention for youths aged 10-17 years, focusing on non-violent conflict resolution, aggression reduction, and social skills development through weekly or fortnightly face-to-face sessions delivered by a qualified facilitator in a confidential setting.'),
+('Legacy Connect (Cultural Wellbeing Services)', null, 'South West', 'Legacy Cultural Youth Program (Springfield Lakes)', 'Ipswich', 'Project: Legacy Cultural Youth Program (Springfield Lakes)
+
+This two-year, trauma-informed initiative supports at-risk Pasifika, culturally and linguistically diverse (CALD), and Indigenous youths aged 10-17 years in Ipswich and West Moreton through culturally grounded workshops and one-on-one mentoring.'),
+('Village Support Limited', '30682255643', 'South West', 'Where We All Belong', 'Toowoomba', 'Project: Where We All Belong
+
+This program will support youth and their families, working in partnership with schools to deliver tailored supports, combining sports, cultural programs, career workshops, and family forums to reduce offending behaviour.'),
+('V.I.T.A.L. Projex', '33156130648', 'South West', 'STRONG Futures (Strength, Trust, Respect, Opportunity, New Ground)', 'Ipswich', 'Project: STRONG Futures (Strength, Trust, Respect, Opportunity, New Ground)
+
+STRONG Futures is a 12-month, trauma-informed early intervention program delivered in four 10-week cohorts to provide youths aged 10-17 years the opportunity to improve anti-social behaviour and reduce reoffending.'),
+('Youth Retreat Centre', null, 'South West', 'Reconnect with Culture and Community', 'Ipswich', 'Project: Reconnect with Culture and Community
+
+An outreach program in Ipswich offering intensive case management over 12-months, including mentoring, and tailored referrals to support First Nations and general youth aged 14-17 years.'),
+('Central Queensland Indigenous Development', '60110812489', 'Sunshine Coast and Central Queensland', 'Deadly Futures - Ready for Work program', 'Bundaberg, Rockhampton, Woorabinda', 'Project: Deadly Futures - Ready for Work program
+
+Deadly Futures is a 12-week employment readiness initiative for First Nations youth aged 13-17 years, including cultural mentorship and skills development activities to promote positive behaviour and a pathway to education, training, or employment.'),
+('Lookout 07', '87666455661', 'Sunshine Coast and Central Queensland', 'The Youth Leadership Program', 'Sunshine Coast', 'Project: The Youth Leadership Program
+
+This program provides support for 12-17-year-olds through mentoring, mindset coaching, and job-readiness training over a period of 10 weeks.'),
+('South Burnett CTC Incorporated', '85399349965', 'Sunshine Coast and Central Queensland', 'Safer Pathways', 'South Burnett', 'Project: Safer Pathways
+
+This initiative provides support over 15 months for disengaged, homeless, or at-risk youth aged 8-17 years, offering individualised support plans, structured peer group activities, emotional regulation and community re-engagement sessions to help get them back on track.'),
+('Brodie Germaine Fitness Aboriginal Corporation', '57591914579', 'North Queensland', 'CAMPFIRE - Cultural Advancement and Mentoring Program', 'Bouila, Doomadgee, Mount Isa', 'Project: CAMPFIRE - Cultural Advancement and Mentoring Program
+
+This 18-month program is led by Elders, cultural leaders, and trained mentors to strengthen cultural identity, emotional regulation, and positive relationships while re-engaging youth with education and employment.'),
+('Family and Childrens Emerging Support Services', '47410115747', 'North Queensland', 'The Youth Leadership program', 'Mackay', 'Project: The Youth Leadership program
+
+The Youth Leadership program provides support for 12-17-year-olds through cultural mentoring, mental health and housing support, as well as life skills education, including literacy, hygiene, and budgeting.'),
+('NQ Ummah Care', '95636275075', 'North Queensland', 'Pathways to Engagement (PE) for Culturally Diverse Youth', 'Townsville', 'Project: Pathways to Engagement (PE) for Culturally Diverse Youth
+
+This program provides 16 months of support to youth from migrant backgrounds, empowering at-risk youth to make positive life choices through soccer-based activities, life skill workshops and mentorship, preventing youth offending, and improving education and employment outcomes.'),
+('Mudth-Niyleta Aboriginal and Torres Strait Islander Corporation', '75038997115', 'North Queensland', 'Youth Wellbeing', 'Mackay', 'Project: Youth Wellbeing
+
+This program offers support to disengaged, homeless, or at-risk youth aged 8-17 years to re-engage with education, employment, and the community through case management care plans, referrals to allied health services, mentorship and networking opportunities.'),
+('Silver Lining Foundation', '92625056108', 'North Queensland', 'Out of Hours Support program', 'Townsville', 'Project: Out of Hours Support program
+
+Delivered by First Nations mentors, the Out of Hours Support program provides activity-based mentoring for 8-17-year-olds over 16 months, offering structured support during weekends, afternoons, and school holidays to reduce criminal behaviour by engaging youth in positive, culturally appropriate activities and fostering pro-social connections.'),
+('Townsville Fire Limited', '77152027300', 'North Queensland', 'Pathways to Empowerment - Building Brighter Futures for at-risk youth', 'Townsville', 'Project: Pathways to Empowerment - Building Brighter Futures for at-risk youth
+
+Participants will undertake a 10-week program, including weekly basketball training and mentoring sessions with Townsville Fire athletes. This program offers a range of supports to young people aged 10-17 years in the Townsville region, combining sport-based activities, mentoring, life skills workshops, and cultural interventions to re-engage at-risk youth back into education, the community, and future pathways.'),
+('Aspire Cairns Community Limited', '15651164082', 'Far North Queensland', 'Learn, Lead, Play and Thrive - Where Sport Fuels Success', 'Cairns', 'Project: Learn, Lead, Play and Thrive - Where Sport Fuels Success
+
+A sport-for-development model that prioritises Aboriginal and Torres Strait Islander youth, girls, and underrepresented groups aged 8-17 years, focusing on physical activity, cultural connection, education support, and mentoring to build resilience, foster community connections, and improve outcomes.'),
+('Australian Training Works Group Pty Ltd', '14646861449', 'Far North Queensland', 'The Rebuild Project', 'Cairns', 'Project: The Rebuild Project
+
+The Rebuild project supports youth aged 15-17 years to build skills and contribute to community through a structured program including daily mechanical training and free repair services for residents in need, fostering positive pathways, community connection, and a sense of purpose for participants.'),
+('Bori Muy Limited', '43682387300', 'Far North Queensland', 'Connecting The Dots Youth Program', 'Cairns', 'Project: Connecting The Dots Youth Program
+
+This is a 12-week initiative supports Aboriginal and Torres Strait Islander youth aged 8-17 years through one-on-one mentoring, culturally safe health workshops, and pro-social community activities, including "On Country" cultural camps.'),
+('Desert Pea Association Inc', '38854047029', 'Far North Queensland', 'CROSSROADS - Kuranda', 'Mareeba', 'Project: CROSSROADS - Kuranda
+
+A 12-month program targeting at-risk Indigenous youth aged 12-17, using digital media and cultural frameworks to address anti-social behaviour and disconnection.'),
+('Jabalbina Yalanji Aboriginal Corporation', '79611886178', 'Far North Queensland', 'Jabalbina On Country Cultural Workshops', 'Cairns', 'Project: Jabalbina On Country Cultural Workshops
+
+This workshop provides a 12-week program of cultural activities for at-risk 10-17-year-olds, including storytelling, bush skills, and artifact making.'),
+('Prosocial Skills Development', '26635173635', 'Far North Queensland', 'Mastering Me', 'Cairns', 'Project: Mastering Me
+
+Master Me is a one year long early intervention program supporting youths aged 8-17 years with emerging antisocial behaviours by combining mentoring, activity-based learning, and prosocial skills development to foster emotional regulation, build relationships, and create a supportive therapeutic community.'),
+('Thrive and Connect', '69677779029', 'Far North Queensland', 'Thrive Guiding', 'Cairns', 'Project: Thrive Guiding
+
+Thrive Guiding will support youth aged 10-14 years in the Cairns region over 13 months. With four 10-week intensive sessions, the program provides one-on-one mentoring and team building exercises to build cultural identity, belonging, and pathways to education, training, and community.');
+
+create temp table _qld_kickstarter_aliases (
+  alias_name text primary key,
+  recipient_name text not null references _qld_kickstarter_round1(recipient_name)
+) on commit drop;
+
+insert into _qld_kickstarter_aliases (alias_name, recipient_name) values
+('Aspire Cairns Community Limited', 'Aspire Cairns Community Limited'),
+('Bori Muy LTD', 'Bori Muy Limited'),
+('Bori Muy Limited', 'Bori Muy Limited'),
+('Brodie Germaine Fitness Aboriginal Corporation', 'Brodie Germaine Fitness Aboriginal Corporation'),
+('Central Queensland Indigenous Development', 'Central Queensland Indigenous Development'),
+('Indigenous Mana Academy', 'Indigenous Mana Limited'),
+('Indigenous Mana Limited', 'Indigenous Mana Limited'),
+('Jabalbina Yalanji Aboriginal Corporation', 'Jabalbina Yalanji Aboriginal Corporation'),
+('Lookout 07', 'Lookout 07'),
+('NQ Ummah Care', 'NQ Ummah Care'),
+('Prosocial Skills Development', 'Prosocial Skills Development'),
+('The Silver Lining Foundation', 'Silver Lining Foundation'),
+('Silver Lining Foundation', 'Silver Lining Foundation'),
+('Thrive and Connect', 'Thrive and Connect');
+
+create temp table _qld_kickstarter_existing_amounts as
+select distinct on (a.recipient_name)
+  a.recipient_name,
+  jf.amount_dollars
+from justice_funding jf
+join _qld_kickstarter_aliases a
+  on lower(a.alias_name) = lower(jf.recipient_name)
+where jf.program_name = 'Kickstarter Grants'
+  and coalesce(jf.is_aggregate, false) = false
+  and ('youth-justice' = any(coalesce(jf.topics, array[]::text[]))
+    or jf.sector in ('civic_intelligence', 'youth_justice'))
+order by a.recipient_name, jf.amount_dollars desc nulls last, jf.updated_at desc nulls last;
+
+with entity_match as (
+  select distinct on (r.recipient_name)
+    r.recipient_name,
+    e.id as gs_entity_id
+  from _qld_kickstarter_round1 r
+  join gs_entities e
+    on e.abn = r.recipient_abn
+  order by r.recipient_name,
+    case when e.entity_type = 'program' then 1 else 0 end,
+    e.source_count desc nulls last,
+    e.updated_at desc nulls last
+),
+updated as (
+  update justice_funding jf
+  set
+    source = 'qld_youth_justice_kickstarter_round1',
+    source_url = 'https://www.youthjustice.qld.gov.au/partnerships/kickstarter-grants',
+    source_statement_id = 'kickstarter-round1-2024-25-' || lower(regexp_replace(r.recipient_name, '[^a-zA-Z0-9]+', '-', 'g')),
+    recipient_name = r.recipient_name,
+    recipient_abn = coalesce(r.recipient_abn, jf.recipient_abn),
+    program_name = 'Kickstarter Grants',
+    program_round = 'Round 1 2024-25',
+    state = 'QLD',
+    location = r.location,
+    funding_type = 'grant',
+    sector = 'youth_justice',
+    project_description = r.project_description,
+    announcement_date = '2026-03-11',
+    financial_year = '2024-25',
+    gs_entity_id = coalesce(em.gs_entity_id, jf.gs_entity_id),
+    topics = array(select distinct unnest(coalesce(jf.topics, array[]::text[]) || array['youth-justice', 'kickstarter', 'early-intervention']::text[])),
+    is_aggregate = false,
+    updated_at = now()
+  from _qld_kickstarter_aliases a
+  join _qld_kickstarter_round1 r
+    on r.recipient_name = a.recipient_name
+  left join entity_match em
+    on em.recipient_name = r.recipient_name
+  where lower(jf.recipient_name) = lower(a.alias_name)
+    and jf.program_name = 'Kickstarter Grants'
+    and coalesce(jf.is_aggregate, false) = false
+    and ('youth-justice' = any(coalesce(jf.topics, array[]::text[]))
+      or jf.sector in ('civic_intelligence', 'youth_justice'))
+  returning jf.id, r.recipient_name
+)
+insert into justice_funding (
+  source,
+  source_url,
+  source_statement_id,
+  recipient_name,
+  recipient_abn,
+  program_name,
+  program_round,
+  amount_dollars,
+  state,
+  location,
+  funding_type,
+  sector,
+  project_description,
+  announcement_date,
+  financial_year,
+  gs_entity_id,
+  topics,
+  is_aggregate
+)
+select
+  'qld_youth_justice_kickstarter_round1',
+  'https://www.youthjustice.qld.gov.au/partnerships/kickstarter-grants',
+  'kickstarter-round1-2024-25-' || lower(regexp_replace(r.recipient_name, '[^a-zA-Z0-9]+', '-', 'g')),
+  r.recipient_name,
+  r.recipient_abn,
+  'Kickstarter Grants',
+  'Round 1 2024-25',
+  ea.amount_dollars,
+  'QLD',
+  r.location,
+  'grant',
+  'youth_justice',
+  r.project_description,
+  '2026-03-11',
+  '2024-25',
+  em.gs_entity_id,
+  array['youth-justice', 'kickstarter', 'early-intervention']::text[],
+  false
+from _qld_kickstarter_round1 r
+left join _qld_kickstarter_existing_amounts ea
+  on ea.recipient_name = r.recipient_name
+left join entity_match em
+  on em.recipient_name = r.recipient_name
+where not exists (
+  select 1
+  from justice_funding jf
+  where lower(jf.recipient_name) = lower(r.recipient_name)
+    and jf.program_name = 'Kickstarter Grants'
+    and jf.program_round = 'Round 1 2024-25'
+    and coalesce(jf.is_aggregate, false) = false
+    and ('youth-justice' = any(coalesce(jf.topics, array[]::text[]))
+      or jf.sector = 'youth_justice')
+)
+and not exists (
+  select 1
+  from updated u
+  where u.recipient_name = r.recipient_name
+);
+
+with ranked as (
+  select
+    id,
+    row_number() over (
+      partition by lower(recipient_name), program_name, program_round
+      order by amount_dollars desc nulls last, updated_at desc nulls last, created_at desc nulls last, id
+    ) as rn
+  from justice_funding
+  where program_name = 'Kickstarter Grants'
+    and program_round = 'Round 1 2024-25'
+    and coalesce(is_aggregate, false) = false
+    and ('youth-justice' = any(coalesce(topics, array[]::text[]))
+      or sector = 'youth_justice')
+)
+delete from justice_funding jf
+using ranked r
+where jf.id = r.id
+  and r.rn > 1;
+
+commit;


### PR DESCRIPTION
## Summary
Two unrelated batches that piled up in the working tree, split into separate commits:

**1. \`chore(qld-yj):\` Kickstarter Round 1 2024-25 migrations** (already applied to prod via Supabase MCP)
- 34 grants seeded ($3.8M, FY2024-25)
- 5 new \`gs_entities\` resolved + aliased
- 10 superseded ministerial-statement rows cleaned

**2. \`feat(goods):\` Control-sheet project view + tracker stage parity**
- New short-circuit project dashboard at \`/org/[slug]/goods\`
- Tracker API: prefer user's own \`org_profile\`, expand \`stageMap\` so all pipeline rows render
- Trimmed ~900 lines from \`tracker-client\` (dead pre-pipeline state)

## Test plan
- [ ] \`npx tsc --noEmit\` clean (verified locally)
- [ ] Visit \`/org/<your-slug>/goods\` — control-sheet dashboard renders, "Full data view" escape hatch works
- [ ] Visit \`/tracker\` — all pipeline statuses (researching/pursuing/negotiating/approved/won/lost/expired) render in the kanban
- [ ] Verify \`/reports/youth-justice/qld/sector\` picks up the 34 new Kickstarter grants on next ISR revalidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)