### PR TITLE
fix(test): unblock CI by repairing entity-service search test

### DIFF
--- a/apps/web/tests/unit/lib/services/entity-service.test.ts
+++ b/apps/web/tests/unit/lib/services/entity-service.test.ts
@@ -16,9 +16,14 @@ function createMockDb() {
   chain.range = vi.fn().mockReturnValue(chain);
   chain.single = vi.fn().mockResolvedValue({ data: null, error: null });
 
+  const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+
   // Terminal: resolve the chain
   const resolveWith = (data: unknown, error: unknown = null, count?: number) => {
     chain.single.mockResolvedValue({ data, error });
+    // EntityService.search now prefers an exec_sql RPC; mirror the chain payload
+    // there so a single _resolveWith call covers both code paths.
+    rpc.mockResolvedValue({ data: Array.isArray(data) ? data : data == null ? [] : [data], error });
     // For non-single queries, make the chain itself thenable
     (chain as Record<string, unknown>).then = (fn: (v: unknown) => void) => {
       return Promise.resolve({ data, error, count }).then(fn);
@@ -35,7 +40,7 @@ function createMockDb() {
 
   const db = {
     from: vi.fn().mockReturnValue(chain),
-    rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    rpc,
     _chain: chain,
     _resolveWith: resolveWith,
   };


### PR DESCRIPTION
## Summary
\`EntityService.search\` now prefers an indexed \`exec_sql\` RPC and only falls back to chained \`ilike()\` when the RPC errors. The unit-test mock only primed the chain branch, so the test's results array was unreachable and \`search()\` returned \`[]\` — failing CI on every PR for weeks.

Wire the chain payload into \`rpc\` from inside \`_resolveWith\` so one call covers both code paths.

## Test plan
- [x] \`npx vitest run\` clean: 221/221 green (was 220/221, with \`tests/unit/lib/services/entity-service.test.ts:108\` failing)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)