### PR TITLE
Goods: buyer-pipeline activation + entity-graph data-quality

### DIFF
--- a/scripts/add-goods-anchor-buyers.mjs
+++ b/scripts/add-goods-anchor-buyers.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Task 1: add the 3 warm anchor buyers + dedupe ALPA. Approved by Ben 2026-05-27.
+ * (Centrecorp skipped — it's a funder, in Supporter Journey.)
+ *
+ *   node --env-file=.env scripts/add-goods-anchor-buyers.mjs            # dry-run
+ *   node --env-file=.env scripts/add-goods-anchor-buyers.mjs --apply
+ *
+ * - Inserts Outback Stores / Miwatj Health / Tangentyere Council with real ABNs +
+ *   contract evidence (austender) and a warmth fit_score floor of 85 (these known
+ *   relationships should rank near the top; the contract scorer under-rates buyers).
+ * - Dedupes ALPA: 256 rows (128 communities x 2 name-casings) -> 1 per community (128),
+ *   keeping the proper-cased name. Restore-first.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const sql = async (q) => { const { data, error } = await supabase.rpc('exec_sql', { query: q }); if (error) throw new Error(error.message); return data || []; };
+
+const WARMTH_FLOOR = 85;
+// contract evidence pulled 2026-05-27 from austender_contracts (goods_value=0 for all → no +50)
+const ANCHORS = [
+  { entity_name: 'Outback Stores Pty Ltd', abn: '63120661234', buyer_role: 'store', community_id: null, is_community_controlled: false, website: 'https://www.outbackstores.com.au', govt_contract_value: 92000, govt_contract_count: 1 },
+  { entity_name: 'Miwatj Health Aboriginal Corporation', abn: '96843428729', buyer_role: 'health_service', community_id: '9651e030-c893-40de-aee8-2df0d45a6706', is_community_controlled: true, website: 'https://www.miwatj.com.au', govt_contract_value: 48000, govt_contract_count: 1 },
+  { entity_name: 'Tangentyere Council Aboriginal Corporation', abn: '81688672692', buyer_role: 'council', community_id: '6cec2c4f-d390-4bff-95e1-5ad9db9b08da', is_community_controlled: true, website: 'https://www.tangentyere.org.au', govt_contract_value: 3113493.21, govt_contract_count: 14 },
+];
+// contract-evidence fit (hydrate formula): +20 if total>$1M, +15 if count>10, +50 goods, +15 grant.
+const contractFit = (a) => (a.govt_contract_value > 1e6 ? 20 : 0) + (a.govt_contract_count > 10 ? 15 : 0);
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n── Anchors ──`);
+  const existing = await sql(`SELECT abn FROM goods_procurement_entities WHERE abn IN ('63120661234','96843428729','81688672692')`);
+  const have = new Set(existing.map((r) => r.abn));
+  const toInsert = ANCHORS.filter((a) => !have.has(a.abn)).map((a) => ({
+    entity_name: a.entity_name, abn: a.abn, buyer_role: a.buyer_role, community_id: a.community_id,
+    is_community_controlled: a.is_community_controlled, relationship_status: 'prospect', website: a.website,
+    govt_contract_value: a.govt_contract_value, govt_contract_count: a.govt_contract_count,
+    fit_score: Math.max(WARMTH_FLOOR, contractFit(a)),
+  }));
+  toInsert.forEach((a) => console.log(`  + ${a.entity_name}  fit:${a.fit_score} (contract ${contractFit({ govt_contract_value: a.govt_contract_value, govt_contract_count: a.govt_contract_count })}, floor ${WARMTH_FLOOR})  abn:${a.abn} community:${a.community_id || 'multi/none'}`));
+  if (have.size) console.log(`  (skip ${have.size} already present)`);
+
+  // ALPA dedupe
+  console.log(`\n── ALPA dedupe ──`);
+  const alpa = await sql(`SELECT id, entity_name, community_id FROM goods_procurement_entities WHERE entity_name ILIKE '%arnhem land progress%'`);
+  const PROPER = 'The Arnhem Land Progress Aboriginal Corporation';
+  const byComm = new Map();
+  for (const r of alpa) { const k = r.community_id || 'null'; (byComm.get(k) || byComm.set(k, []).get(k)).push(r); }
+  const deleteIds = [];
+  for (const [, group] of byComm) {
+    group.sort((a, b) => (a.entity_name === PROPER ? -1 : 0) - (b.entity_name === PROPER ? -1 : 0));
+    deleteIds.push(...group.slice(1).map((r) => r.id));
+  }
+  console.log(`  ALPA rows: ${alpa.length} across ${byComm.size} communities → keep ${byComm.size}, delete ${deleteIds.length} dup-casing rows`);
+
+  if (!APPLY) { console.log('\n(Dry-run. Re-run with --apply.)'); return; }
+
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-goods-anchor-add-alpa-dedupe.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ at: new Date().toISOString(), inserted: toInsert, alpaDeletedIds: deleteIds, alpaAll: alpa }, null, 2));
+  console.log(`\nRestore snapshot: ${restorePath}`);
+
+  if (toInsert.length) {
+    const { data, error } = await supabase.from('goods_procurement_entities').insert(toInsert).select('id, entity_name');
+    if (error) throw new Error(`anchor insert: ${error.message}`);
+    console.log(`✓ inserted ${data.length} anchors`);
+  }
+  if (deleteIds.length) {
+    // delete in chunks to keep URLs short
+    for (let i = 0; i < deleteIds.length; i += 50) {
+      const { error } = await supabase.from('goods_procurement_entities').delete().in('id', deleteIds.slice(i, i + 50));
+      if (error) throw new Error(`ALPA dedupe delete: ${error.message}`);
+    }
+    console.log(`✓ deleted ${deleteIds.length} ALPA dup rows (ALPA now 1/community)`);
+  }
+  console.log('\n── Done ──');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs
+++ b/scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Anchor-gap backfill: add the marquee remote-NT councils + big ACCHOs that the operating
+ * model expects but goods_procurement_entities was MISSING. Flagged in
+ * thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/buyers-candidates.md (Table 3).
+ *
+ * Mirrors add-goods-anchor-buyers.mjs. Idempotent (skips ABNs already present). Restore snapshot.
+ *   node --env-file=.env scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs --apply
+ *
+ * Data provenance: every abn + govt_contract_value/count is REAL, aggregated by ABN from
+ * austender_contracts (queried 2026-05-27). No values invented. Sunrise Health + Mala'la Health
+ * are NOT austender suppliers (no verifiable ABN/contract) → deliberately EXCLUDED, listed below
+ * for manual add. fit_score = 70 ("high-fit anchor prospect, contract-evidenced, NOT yet warm")
+ * — deliberately below the 85 floor the original script used for genuinely-warm relationships.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const FIT = 70; // anchor-prospect floor (warm relationships are 85; cold default scoring under-rates these)
+
+// abn + contract evidence aggregated by ABN from austender_contracts (2026-05-27). community_id=null
+// (councils span many communities — same as Outback Stores in the original anchor script).
+const ANCHORS = [
+  { entity_name: 'MacDonnell Regional Council',                         abn: '21340804903', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 44125295, govt_contract_count: 32 },
+  { entity_name: 'Roper Gulf Regional Council',                         abn: '94746956090', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 22248695, govt_contract_count: 29 },
+  { entity_name: 'Victoria Daly Regional Council',                      abn: '66931675319', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 9824405,  govt_contract_count: 29 },
+  { entity_name: 'West Daly Regional Council',                          abn: '25966579574', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 4518868,  govt_contract_count: 17 },
+  { entity_name: 'Barkly Regional Council',                             abn: '32171281456', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 3591517,  govt_contract_count: 8 },
+  { entity_name: 'East Arnhem Regional Council',                        abn: '92334301078', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 2701282,  govt_contract_count: 9 },
+  { entity_name: 'Central Australian Aboriginal Congress',             abn: '76210591710', buyer_role: 'health_service', is_community_controlled: true,  govt_contract_value: 2039174,  govt_contract_count: 5 },
+  { entity_name: 'Laynhapuy Homelands Aboriginal Corporation',         abn: '86695642473', buyer_role: 'community_org',  is_community_controlled: true,  govt_contract_value: 1073818,  govt_contract_count: 11 },
+  { entity_name: 'Katherine West Health Board Aboriginal Corporation', abn: '23351866925', buyer_role: 'health_service', is_community_controlled: true,  govt_contract_value: 168217,   govt_contract_count: 1 },
+];
+// NOT added (no verifiable ABN/contract in austender — do NOT fabricate): Sunrise Health Service
+// Aboriginal Corporation, Mala'la Health Service Aboriginal Corporation (Mala'la already a GHL contact).
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}  (target: goods_procurement_entities)\n`);
+  const abns = ANCHORS.map((a) => a.abn);
+  const { data: existing, error: exErr } = await supabase.from('goods_procurement_entities').select('abn').in('abn', abns);
+  if (exErr) throw new Error(`existence check: ${exErr.message}`);
+  const have = new Set((existing || []).map((r) => r.abn));
+
+  const toInsert = ANCHORS.filter((a) => !have.has(a.abn)).map((a) => ({
+    entity_name: a.entity_name, abn: a.abn, buyer_role: a.buyer_role, community_id: null,
+    is_community_controlled: a.is_community_controlled, relationship_status: 'prospect',
+    govt_contract_value: a.govt_contract_value, govt_contract_count: a.govt_contract_count, fit_score: FIT,
+  }));
+
+  for (const a of toInsert) console.log(`  + ${a.entity_name.padEnd(52)} ${a.buyer_role.padEnd(14)} fit:${a.fit_score}  $${a.govt_contract_value.toLocaleString()} / ${a.govt_contract_count} contracts  abn:${a.abn}`);
+  if (have.size) console.log(`  (skip ${have.size} already present: ${[...have].join(', ')})`);
+  console.log(`\nWould insert: ${toInsert.length}`);
+
+  if (!APPLY) { console.log('\n(Dry-run. Re-run with --apply to write.)'); return; }
+  if (!toInsert.length) { console.log('Nothing to insert.'); return; }
+
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-goods-anchor-councils-acchos-backfill.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ at: new Date().toISOString(), inserted: toInsert }, null, 2));
+  console.log(`Restore snapshot: ${restorePath}`);
+
+  const { data, error } = await supabase.from('goods_procurement_entities').insert(toInsert).select('id, entity_name, fit_score');
+  if (error) throw new Error(`anchor backfill insert: ${error.message}`);
+  console.log(`✓ inserted ${data.length} anchor buyers`);
+  data.forEach((r) => console.log(`   ${r.id}  ${r.entity_name}  fit:${r.fit_score}`));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/drop-goods-noise-localities.mjs
+++ b/scripts/drop-goods-noise-localities.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Task 3: drop the 9 AGIL template-noise localities (all 52 beds/6 washers default).
+ * Approved by Ben 2026-05-27 ("Drop fully"). Restore-first; reversible.
+ *
+ *   node --env-file=.env scripts/drop-goods-noise-localities.mjs            # dry-run
+ *   node --env-file=.env scripts/drop-goods-noise-localities.mjs --apply    # writes
+ *
+ * Deletes: 9 GHL Demand-Register opps + their placeholder contacts;
+ *          9 goods_communities rows (CASCADE clears their entities/signals).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+// CASCADE-deleting the 9 communities also deletes 147 linked entities (incl. real ones
+// like NLC/AMSANT). --ghl-only does the GHL signal cleanup WITHOUT touching the DB.
+const GHL_ONLY = process.argv.includes('--ghl-only');
+const DB_ONLY = process.argv.includes('--db-only'); // GHL opps already deleted; do the DB cascade only
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+const GHL_BASE = 'https://services.leadconnectorhq.com';
+const GHL_KEY = process.env.GHL_API_KEY;
+
+const NAMES = ['THULKURR','NEW MERINEE','GUNUN WOONAM','SHIPTON FLATS','FORDY FARM','AAYKA','THAANGKUNH-NHIIN','BANNICK BURN','JILUNDARINA'];
+// GHL Demand-Register opp + placeholder contact ids (from audit 2026-05-27)
+const GHL_RECORDS = [
+  ['cj7CXxIDLzKMxIVHHpNm','7sp5Zwueh0OKblAKQirR','THULKURR'],
+  ['8CAq5cV6LBlozjP4fmbo','xBxaigCAdO1v8ARO1lo2','NEW MERINEE'],
+  ['7rqTX3XLuiwMz8cvLMw3','gPxPrnGkA01DbSigTaYM','GUNUN WOONAM'],
+  ['HTtygM4ogZ3gacHk3wwE','dYbBIH1H5deXDEerV5HE','SHIPTON FLATS'],
+  ['58uGnRzT5FdHuDAvjKia','fm0tdDRDfl3EFTOg1JS7','FORDY FARM'],
+  ['1HJOMb5vZMw0ulxm2tBS','jkXvzq4QJDPKCur8akIX','AAYKA'],
+  ['NVnUPdbDuJlKwlFT4Zx6','cAt1QstivkhGfT2ShFAc','THAANGKUNH-NHIIN'],
+  ['omkK7FwtMTormWvwpXcK','wu6SihnJXkEkKrUYtheG','BANNICK BURN'],
+  ['seEc4BT9h5csxlXAJVhO','Q0HsirXpDJJ3vLpNIKmj','JILUNDARINA'],
+];
+
+async function sql(query) {
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`SQL error: ${error.message}`);
+  return data || [];
+}
+async function ghlDelete(path) {
+  const r = await fetch(`${GHL_BASE}${path}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${GHL_KEY}`, Version: '2021-07-28' },
+  });
+  if (!r.ok) throw new Error(`GHL ${r.status}: ${await r.text()}`);
+}
+
+async function main() {
+  const inList = NAMES.map((n) => `'${n.replace(/'/g, "''")}'`).join(',');
+  const rows = await sql(`SELECT id, community_name, state, demand_beds, demand_washers FROM goods_communities WHERE upper(community_name) IN (${inList})`);
+  const ids = rows.map((r) => r.id);
+  const cascade = ids.length
+    ? await sql(`SELECT
+        (SELECT count(*) FROM goods_procurement_entities WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])) entities,
+        (SELECT count(*) FROM goods_procurement_signals WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])) signals`)
+    : [{ entities: 0, signals: 0 }];
+
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+  console.log(`goods_communities rows matched: ${rows.length}/${NAMES.length}`);
+  rows.forEach((r) => console.log(`  ${r.community_name} (${r.state}) beds:${r.demand_beds} id:${r.id}`));
+  console.log(`Will CASCADE: ${cascade[0].entities} entities + ${cascade[0].signals} signals`);
+  console.log(`GHL deletes: ${GHL_RECORDS.length} opps + ${GHL_RECORDS.length} placeholder contacts\n`);
+
+  if (!APPLY) { console.log('(Dry-run. Re-run with --apply.)'); return; }
+
+  // Capture the entities + signals to be deleted, for full reversibility.
+  const cascadeEntities = ids.length
+    ? await sql(`SELECT id, entity_name, abn, fit_score, buyer_role, community_id FROM goods_procurement_entities WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])`)
+    : [];
+  const cascadeSignals = ids.length
+    ? await sql(`SELECT * FROM goods_procurement_signals WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])`)
+    : [];
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-goods-9-noise-drop-restore.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ removedAt: new Date().toISOString(), communities: rows, ghl: GHL_RECORDS, cascade: cascade[0], cascadeEntities, cascadeSignals }, null, 2));
+  console.log(`Restore snapshot (incl. ${cascadeEntities.length} entities + ${cascadeSignals.length} signals): ${restorePath}\n`);
+
+  let ok = 0, fail = 0;
+  if (!DB_ONLY) {
+    for (const [opp, contact, name] of GHL_RECORDS) {
+      try { await ghlDelete(`/opportunities/${opp}`); console.log(`✓ GHL opp ${name}`); ok++; }
+      catch (e) { console.error(`✗ GHL opp ${name}: ${e.message}`); fail++; }
+      try { await ghlDelete(`/contacts/${contact}`); ok++; }
+      catch (e) { console.error(`✗ GHL contact ${name}: ${e.message}`); fail++; }
+    }
+  }
+  if (GHL_ONLY) {
+    console.log(`\n(--ghl-only: DB rows left intact — ${cascade[0].entities} entities NOT cascaded.)`);
+  } else if (ids.length) {
+    // exec_sql is SELECT-only → PostgREST writes. signals FK = RESTRICT (delete first);
+    // entities FK = CASCADE but delete explicitly too for determinism. Then communities.
+    let e;
+    ({ error: e } = await supabase.from('goods_procurement_signals').delete().in('community_id', ids));
+    if (e) throw new Error(`signals delete: ${e.message}`);
+    ({ error: e } = await supabase.from('goods_procurement_entities').delete().in('community_id', ids));
+    if (e) throw new Error(`entities delete: ${e.message}`);
+    ({ error: e } = await supabase.from('goods_communities').delete().in('id', ids));
+    if (e) throw new Error(`communities delete: ${e.message}`);
+    console.log(`✓ deleted ${ids.length} communities + ${cascadeEntities.length} entities + ${cascadeSignals.length} signals`);
+  }
+  console.log(`\n── Done ── GHL ok:${ok} fail:${fail}; DB rows deleted:${ids.length}`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/fix-alpa-overmatch.mjs
+++ b/scripts/fix-alpa-overmatch.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Data-quality fix: ALPA was proximity-fanned to 128 communities (one entity_id/gs_id,
+ * one bulk insert) — it is ONE remote-retail network operator, not 128 buyers. Collapse to
+ * a single network-level entity (community_id = null, like Outback Stores). The communities
+ * ALPA serves already have their own local store-corp entities as the per-community buyers.
+ * Approved by Ben 2026-05-27 ("fix this"). Restore-first; reversible.
+ *
+ *   node --env-file=.env scripts/fix-alpa-overmatch.mjs            # dry-run
+ *   node --env-file=.env scripts/fix-alpa-overmatch.mjs --apply
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const sql = async (q) => { const { data, error } = await supabase.rpc('exec_sql', { query: q }); if (error) throw new Error(error.message); return data || []; };
+const WARMTH_FLOOR = 85;
+
+async function main() {
+  const rows = await sql(`SELECT id, entity_name, community_id, fit_score, ghl_opportunity_id FROM goods_procurement_entities WHERE entity_name ILIKE '%arnhem land progress%' ORDER BY (ghl_opportunity_id IS NOT NULL) DESC, id`);
+  if (!rows.length) { console.log('No ALPA rows found.'); return; }
+
+  // Keep the row already linked to GHL if any, else the first; null its community, floor warmth.
+  const keep = rows[0];
+  const deleteIds = rows.slice(1).map((r) => r.id);
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+  console.log(`ALPA rows: ${rows.length} → keep 1 (id ${keep.id}), set community_id=NULL, fit_score=${Math.max(WARMTH_FLOOR, keep.fit_score || 0)}; delete ${deleteIds.length}`);
+
+  if (!APPLY) { console.log('\n(Dry-run. Re-run with --apply.)'); return; }
+
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-alpa-overmatch-fix.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ at: new Date().toISOString(), keptId: keep.id, deletedIds: deleteIds, allRows: rows }, null, 2));
+  console.log(`Restore snapshot: ${restorePath}`);
+
+  const { error: uErr } = await supabase.from('goods_procurement_entities')
+    .update({ community_id: null, fit_score: Math.max(WARMTH_FLOOR, keep.fit_score || 0), relationship_status: 'prospect', updated_at: new Date().toISOString() })
+    .eq('id', keep.id);
+  if (uErr) throw new Error(`update keeper: ${uErr.message}`);
+
+  // Re-point any demand signals that named a to-be-deleted ALPA row as buyer → the keeper.
+  for (let i = 0; i < deleteIds.length; i += 50) {
+    const chunk = deleteIds.slice(i, i + 50);
+    const { error } = await supabase.from('goods_procurement_signals').update({ buyer_entity_id: keep.id }).in('buyer_entity_id', chunk);
+    if (error) throw new Error(`repoint signals: ${error.message}`);
+  }
+
+  for (let i = 0; i < deleteIds.length; i += 50) {
+    const { error } = await supabase.from('goods_procurement_entities').delete().in('id', deleteIds.slice(i, i + 50));
+    if (error) throw new Error(`delete: ${error.message}`);
+  }
+  console.log(`✓ ALPA collapsed to 1 network entity (community-null, fit 85); deleted ${deleteIds.length} fan-out rows`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/push-goods-top25-to-demand-register.mjs
+++ b/scripts/push-goods-top25-to-demand-register.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Task 2: push the top-25 (by fit_score) scored buyers into the GHL "Goods — Demand Register"
+ * at the "Buyer Matched" stage. Approved by Ben 2026-05-27.
+ *
+ * Per the Goods CRM operating model: scored-but-uncontacted entities = Demand-Register signal
+ * (NOT the Buyer Pipeline, which is contacted commercial deals).
+ *
+ *   node --env-file=.env scripts/push-goods-top25-to-demand-register.mjs            # dry-run
+ *   node --env-file=.env scripts/push-goods-top25-to-demand-register.mjs --apply    # writes
+ *   ... --limit 25
+ *
+ * Idempotent: dedups distinct entities (table has dup rows), skips entities already pushed
+ * (ghl_opportunity_id set), upserts contacts by deterministic email, writes ghl_* link back.
+ * Mirrors apps/web/src/lib/services/goods-buyer-ghl.ts patterns.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+const li = process.argv.indexOf('--limit');
+const LIMIT = li >= 0 ? parseInt(process.argv[li + 1], 10) : 25;
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+const GHL = 'https://services.leadconnectorhq.com';
+const KEY = process.env.GHL_API_KEY;
+const LOC = process.env.GHL_LOCATION_ID;
+const DEMAND_PIPELINE = 'UQsrmuqzxMSdCTklxEcG';
+const BUYER_MATCHED_STAGE = '02502aa3-9a0d-4ddd-b1f0-c1e836838426';
+
+async function sql(query) {
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`SQL error: ${error.message}`);
+  return data || [];
+}
+const H = { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json', Version: '2021-07-28' };
+const slug = (s, n) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, n);
+// Deterministic email for idempotent contact upsert. Reproduces the original
+// slug(entity,60)-slug(community,40) EXACTLY for local parts <=64 (so run-1 contacts
+// match), and only truncates the long ones (which failed RFC 64-char limit first time).
+const buildEmail = (entity, community) => {
+  let local = `${slug(entity, 60)}-${slug(community, 40)}`;
+  if (local.length > 64) local = local.slice(0, 64).replace(/-+$/, '');
+  return `${local}@goods.civicgraph.io`;
+};
+
+async function main() {
+  if (!KEY || !LOC) throw new Error('Missing GHL_API_KEY / GHL_LOCATION_ID');
+
+  // Top-N distinct entities by fit_score (dedup the table's duplicate rows), with community.
+  const rows = await sql(`
+    SELECT * FROM (
+      SELECT DISTINCT ON (lower(e.entity_name))
+        e.id, e.entity_name, e.buyer_role, e.abn, e.website, e.fit_score,
+        e.is_community_controlled, COALESCE(e.relationship_status,'prospect') relationship_status,
+        e.govt_contract_value, e.ghl_opportunity_id,
+        c.community_name, c.state
+      FROM goods_procurement_entities e
+      LEFT JOIN goods_communities c ON c.id = e.community_id
+      ORDER BY lower(e.entity_name), e.fit_score DESC NULLS LAST
+    ) d
+    ORDER BY d.fit_score DESC NULLS LAST, d.govt_contract_value DESC NULLS LAST
+    LIMIT ${LIMIT}`);
+
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'} · target: Goods — Demand Register / Buyer Matched · ${rows.length} entities\n`);
+
+  let created = 0, skipped = 0, fail = 0;
+  for (const r of rows) {
+    const community = r.community_name || 'Unmatched';
+    const tag = (s) => s;
+    const tags = [
+      'CivicGraph', 'Goods', 'act-gd', 'project:act-gd',
+      `Goods-Community-${community.replace(/\s+/g, '-')}`,
+      r.state ? `Goods-State-${r.state}` : null,
+      r.buyer_role ? `Goods-Role-${r.buyer_role}` : null,
+      r.is_community_controlled ? 'Goods-CommunityControlled' : null,
+      `Goods-Stage-${r.relationship_status}`,
+    ].filter(Boolean).map(tag);
+    const oppName = `${r.entity_name} — ${community}`;
+    const label = `${oppName}  fit:${r.fit_score} role:${r.buyer_role}`;
+
+    if (r.ghl_opportunity_id) { console.log(`= SKIP (already pushed)  ${label}`); skipped++; continue; }
+    if (!APPLY) { console.log(`+ WOULD PUSH  ${label}`); continue; }
+
+    try {
+      const email = buildEmail(r.entity_name, community);
+      const up = await fetch(`${GHL}/contacts/upsert`, {
+        method: 'POST', headers: H,
+        body: JSON.stringify({ locationId: LOC, email, companyName: r.entity_name, firstName: r.entity_name.slice(0, 80), website: r.website || undefined, tags, source: `CivicGraph Goods top-25 (${community})` }),
+      });
+      if (!up.ok) throw new Error(`contact upsert ${up.status}: ${(await up.text()).slice(0, 150)}`);
+      const contactId = (await up.json())?.contact?.id;
+      if (!contactId) throw new Error('no contactId');
+
+      // Dedup: reuse an existing opp on this contact in the Demand Register (self-heals
+      // partial runs where the opp was created but writeback failed).
+      let oppId = null;
+      const srch = await fetch(`${GHL}/opportunities/search?location_id=${LOC}&pipeline_id=${DEMAND_PIPELINE}&contact_id=${contactId}&limit=5`, { headers: H });
+      if (srch.ok) {
+        const opps = (await srch.json()).opportunities || [];
+        oppId = (opps.find((o) => o.name === oppName) || opps[0])?.id || null;
+      }
+      let reused = !!oppId;
+      if (!oppId) {
+        const op = await fetch(`${GHL}/opportunities/`, {
+          method: 'POST', headers: H,
+          body: JSON.stringify({ locationId: LOC, name: oppName, pipelineId: DEMAND_PIPELINE, pipelineStageId: BUYER_MATCHED_STAGE, status: 'open', contactId, monetaryValue: 0, source: 'Goods top-25 activation' }),
+        });
+        if (!op.ok) throw new Error(`opp create ${op.status}: ${(await op.text()).slice(0, 150)}`);
+        oppId = (await op.json())?.opportunity?.id;
+      }
+
+      const { error: upErr } = await supabase.from('goods_procurement_entities').update({
+        ghl_contact_id: contactId, ghl_opportunity_id: oppId,
+        ghl_pipeline_id: DEMAND_PIPELINE, ghl_stage_id: BUYER_MATCHED_STAGE,
+        ghl_stage_name: 'Buyer Matched', ghl_last_pushed_at: new Date().toISOString(),
+      }).eq('id', r.id);
+      if (upErr) throw new Error(`writeback: ${upErr.message}`);
+
+      console.log(`+ ${reused ? 'LINKED (existing opp)' : 'PUSHED'}  ${label}  (opp ${oppId})`);
+      created++;
+    } catch (e) {
+      console.error(`✗ ${label}: ${e.message}`);
+      fail++;
+    }
+  }
+
+  console.log(`\n── ${APPLY ? 'Done' : 'Dry-run'} ── created:${created} skipped:${skipped} fail:${fail}`);
+  if (!APPLY) console.log('(Re-run with --apply to write.)');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/query-goods-buyers-readonly.mjs
+++ b/scripts/query-goods-buyers-readonly.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * READ-ONLY diagnostics for the Goods buyer activation plan. SELECTs only.
+ * Run: node --env-file=.env scripts/query-goods-buyers-readonly.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+async function sql(query) {
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`SQL error: ${error.message}`);
+  return data || [];
+}
+
+const j = (x) => JSON.stringify(x);
+
+async function main() {
+  console.log('── 1. ENTITY SUMMARY ──');
+  console.log(j(await sql(`
+    SELECT count(*) total,
+           count(*) FILTER (WHERE fit_score > 0) scored,
+           count(*) FILTER (WHERE ghl_opportunity_id IS NOT NULL) pushed,
+           count(*) FILTER (WHERE abn IS NOT NULL) with_abn
+    FROM goods_procurement_entities`)));
+
+  console.log('\n── 2. ANCHOR PRESENCE (grouped) ──');
+  const anchors = await sql(`
+    SELECT entity_name, count(*) dups, max(fit_score) fit, max(buyer_role) role,
+           bool_or(is_community_controlled) cc, bool_or(ghl_opportunity_id IS NOT NULL) pushed
+    FROM goods_procurement_entities
+    WHERE entity_name ILIKE ANY (ARRAY['%outback stores%','%centrecorp%','%miwatj%','%alpa%','%arnhem land progress%','%tangentyere%'])
+    GROUP BY entity_name ORDER BY entity_name`);
+  anchors.forEach((r) => console.log(`  ${r.entity_name}  dups:${r.dups} fit:${r.fit} role:${r.role} cc:${r.cc} pushed:${r.pushed}`));
+  console.log(`  (distinct names: ${anchors.length})`);
+
+  console.log('\n── 3. TOP 25 BY fit_score ──');
+  const top = await sql(`
+    SELECT entity_name, fit_score, buyer_role, govt_contract_value, govt_contract_count,
+           is_community_controlled,
+           (ghl_opportunity_id IS NOT NULL) AS pushed
+    FROM goods_procurement_entities
+    ORDER BY fit_score DESC NULLS LAST, govt_contract_value DESC NULLS LAST
+    LIMIT 25`);
+  top.forEach((r, i) => console.log(
+    `${String(i + 1).padStart(2)}. ${r.entity_name}  fit:${r.fit_score}  role:${r.buyer_role}  gov:$${r.govt_contract_value || 0}(${r.govt_contract_count || 0})  cc:${r.is_community_controlled}  pushed:${r.pushed}`));
+
+  console.log('\n── 4. THE 9 LEFTOVER COMMUNITIES (demand basis) ──');
+  const nine = await sql(`
+    SELECT community_name, state, demand_beds, demand_washers
+    FROM goods_communities
+    WHERE upper(community_name) = ANY (ARRAY['THULKURR','NEW MERINEE','GUNUN WOONAM','SHIPTON FLATS','FORDY FARM','AAYKA','THAANGKUNH-NHIIN','BANNICK BURN','JILUNDARINA'])
+    ORDER BY community_name`);
+  nine.forEach((r) => console.log(
+    `  ${r.community_name} (${r.state})  beds:${r.demand_beds}  washers:${r.demand_washers}`));
+  console.log(`  (rows found: ${nine.length})`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/thoughts/2026-05-27-alpa-overmatch-fix.json
+++ b/thoughts/2026-05-27-alpa-overmatch-fix.json
@@ -1,0 +1,1031 @@
+{
+  "at": "2026-05-27T06:26:18.277Z",
+  "keptId": "01bee3bd-e6d8-4485-bc81-58345aff8856",
+  "deletedIds": [
+    "020ca948-610e-48cb-9499-f5cd50d1eb24",
+    "09b20bcf-dfe0-4fd7-9f1f-9e28c7c3b7f4",
+    "0a927479-ba1c-4391-843f-436f574fbff9",
+    "0bc1fd36-9ffc-4b98-8977-0c2445072416",
+    "0d9bafde-0982-4443-92d7-283a3711ff5e",
+    "0de8a1da-640a-4bd6-983d-5e8a56368965",
+    "0f7060c8-8ced-46e7-b614-ad0a690b730c",
+    "102ad8a6-660b-4ae7-bdae-6cdcc8082e37",
+    "111e0f58-2bf6-481c-9f3c-fae0582ca405",
+    "1192a6eb-fd9b-4030-a973-dbd8cb9753ef",
+    "13dc2bb5-a297-4cde-a23c-8832e5cb418a",
+    "13f6a83f-38e0-4a79-b7e0-d03a8af8f536",
+    "156a4ad8-fda6-4e82-bd99-9541d456cfd4",
+    "15ff5c47-d23d-4faf-b1d3-3f46a08ddfc4",
+    "17ce28e5-9162-47f0-8048-b3c4e96ddabb",
+    "1a02eafe-945a-4afb-a2e6-e9da5b654a83",
+    "1d6f1de5-b639-4a74-a816-0a904a1bb75a",
+    "2270627e-2a2f-4a1c-a767-ca064b15bee0",
+    "268dc74c-c111-46ad-8376-840cd062d9ff",
+    "26cb7865-902e-4266-80db-e3d60cd461d4",
+    "2860219b-535a-4d86-a3bb-2f6649081c37",
+    "3202957c-b6c0-4072-ae21-828fbafd4663",
+    "334005aa-8631-436c-ac9a-f22389a2593f",
+    "3374b1a3-6a20-4db2-80ca-d2d3002a879d",
+    "363a0791-fce6-4b68-8c86-befec13d3b66",
+    "363ac789-43ee-4671-849f-703c0b6eb27f",
+    "3a0782ed-02f0-4b8b-856b-5a48020f038d",
+    "3a24ce42-fab7-40fd-8aa7-c238b339f33a",
+    "3d2784c3-ee5b-45c7-aa08-8b4ed74968aa",
+    "3d439055-60c0-49c3-b93e-c6cd4b6a3485",
+    "3efaceb2-5ab5-4217-8eb2-10e30c493d77",
+    "3f48ba47-cbe2-4288-baca-6910caf9d0de",
+    "42843ede-f708-454a-9426-2a4fbb45b04e",
+    "45898c8c-8a9e-4482-b43d-367332c75156",
+    "4794d62c-891f-4bb5-b4c1-2fd4118f9a8b",
+    "486d7194-626a-4086-86e0-50cc538de7d5",
+    "4ee3e6c1-531f-4bfa-bd6d-6cb392193e6a",
+    "4ee55304-6356-44a0-8143-c33a2085137b",
+    "5344bd32-37a4-4586-8016-393893b6c8c7",
+    "54d601e0-4cdd-4e64-b722-f634e1d67078",
+    "553be114-eb0e-420f-8551-5b7a630aaddd",
+    "581d19ad-3681-4a8f-bb68-d94a4a618ff8",
+    "58ad74f8-f12d-4c79-a42d-e54129b064fe",
+    "5bfc0b5b-817c-4deb-8ae2-794532951b00",
+    "5c3a366f-58e5-4d73-b38d-c7aed64bbbae",
+    "5c512b73-1a42-4e0c-b2b4-74746eea617a",
+    "5c58cf47-925c-42d0-ab44-f006a432e076",
+    "60806f0e-f422-4a0a-b875-96fb065bf712",
+    "61383236-242f-42f2-bb79-4d623f07abc2",
+    "617502d2-b62a-4a4e-9244-d2a035dd6eec",
+    "626dd13c-821d-4c9e-9065-64f114256707",
+    "64ca01d9-cc1c-450c-b3bb-a996965cc2e5",
+    "64f206d8-548d-4f8d-9ea6-26d92f5f8271",
+    "65c9d9b1-07b4-425b-9ea6-533a3c84e5be",
+    "682ed82e-7558-4d5d-85cf-4339b4b968f7",
+    "68a7664f-00f4-4215-aab2-8287472fc90d",
+    "68b4c0f3-20df-446f-8a72-0f9dbce3ab4d",
+    "6bc5444e-464e-4c7b-b207-fb5d6346d603",
+    "72b9a5be-1888-4eb6-b4e6-d1f155679aeb",
+    "72e06d99-44fb-418c-9c0c-72105e9d60c6",
+    "73370b86-66ce-4f6b-9f8b-2c0cea3aac13",
+    "752c2086-89f1-4fc2-90f8-014a26e04981",
+    "77c05c23-d4d0-4639-8550-2436bef18e10",
+    "8733e859-eeef-42c2-ba56-f66f9ca1f35f",
+    "87b344a3-45c6-4c3e-ab40-fc32d4a267cb",
+    "881450ae-8b26-4c79-a6b7-168289dbcd66",
+    "884da29f-9e97-4b03-980f-6b5d9ced3d67",
+    "88964032-4c08-45d1-b5a2-c4428241f395",
+    "8ac42dfb-044c-42bb-b866-5b8b03afa0df",
+    "8b5462d8-b430-44b8-aa1d-1c623de30756",
+    "8d52778c-0c4f-4acf-a0c6-ebeb0b06784f",
+    "8f8d358a-142e-4cff-be2e-c6e27b838244",
+    "91e61d0a-8ecf-4b65-b441-3036c2041f98",
+    "92dde1b1-e8fb-489c-9cbf-8404d6777cd4",
+    "9714c60c-364a-412b-8136-44eed1620d1c",
+    "989592ea-eb2f-4e57-9164-e07abe7d685f",
+    "98a3c0d6-d4af-4702-aa5d-8477c2667a99",
+    "98d55dc7-cc47-4460-bc79-8f0331664ce1",
+    "9ccce53e-6036-400e-ada2-861aa6a1b36c",
+    "9da7ae8b-984f-44a6-8916-5ab5265c3756",
+    "9e23b5d1-7544-4f2f-9bd6-dab4f4920c20",
+    "9e6a9491-c05e-4d00-946f-cd8400bdd361",
+    "9ea7aecc-6f36-4710-830f-5c9422288400",
+    "9fe7407a-b847-4f5d-840c-4c61e98ef739",
+    "9ff44c0f-5e76-4e84-829e-e5a9ba375d57",
+    "a505e381-1eb1-4a67-b409-995946a214d3",
+    "a8671a46-44c1-433c-84dc-bd057ec5bd9f",
+    "ada1d953-5e80-460d-bcbb-c94d3b61b5a9",
+    "aea9393a-52b3-4235-9c52-790cc9a97ce8",
+    "aee405cd-dae2-4a0e-bb1d-52ae05b74778",
+    "b017cbc0-5ef7-474e-9f47-51bef2d2cc2d",
+    "b04896d0-8f8c-4bc8-b6a3-cd95cda33967",
+    "b52e6d66-cd08-48ba-8957-dcc3ef013645",
+    "b6ae8b58-0b41-4737-a91b-b92960c03d51",
+    "b702ab5f-e5e4-43a3-a337-857b7454b29f",
+    "b7ca53b7-cff4-4370-8ca0-e3dfed0c3c88",
+    "b9d4fc15-04c9-4700-af4e-c93db471e0a5",
+    "babe7d35-cc47-4cac-b1c3-01c1e8a119a9",
+    "bb229140-aaa3-4e7a-9f3e-dac7b9309219",
+    "bbdde4ee-445c-4c04-bc14-ea75f2718c7c",
+    "bf449f88-04f1-4793-b569-2fe08798c181",
+    "bf67fdf8-dd32-4697-a465-0a9ce1221b27",
+    "c03ccd06-d689-4f73-8acc-31d98aa43323",
+    "c4cb139a-b678-4aab-90b6-b2c3d07678bb",
+    "c8e54b09-43db-4b92-82b9-93d96b5e4bd2",
+    "cab734ed-5fb4-4cbe-afa7-7978e566f108",
+    "cc9dcada-dbba-454c-a80b-a8e087f5b937",
+    "cf4f23ca-1c05-44e4-ac4f-1a09a47997b3",
+    "d037da74-eb05-439c-bed4-1177d85385eb",
+    "d0caeb07-3486-43f6-ab18-54466753e44c",
+    "d5107417-fedd-45f1-a430-73f852422479",
+    "d78cbb70-9758-4ad4-9bf4-9be1cd7befcb",
+    "da021f78-8c23-44d8-bfc3-64c6949a83ce",
+    "dbaf71d5-13f0-458b-88d6-af200731142b",
+    "def0f945-bd2f-46a0-bb1a-80a1087d7070",
+    "e04753fc-c798-47ff-ab5f-fe36e8f230b6",
+    "e44f6330-f4a9-4981-bec6-e1a004de39ec",
+    "e638ab86-f832-4eac-a76a-030e02de84a6",
+    "e6eb4cee-0930-4ce2-a122-1c08c98bf70a",
+    "e91062d7-4dcf-4f1c-8720-005dad187089",
+    "eb404cbf-1d0e-4cd8-a9a3-4e1e77dfaf3e",
+    "f0878825-26d1-46b7-965d-8ea697141ebb",
+    "f33088bd-5993-4f65-bef1-0a3abca24a97",
+    "f8421634-3478-4b16-8866-b3b97c54dcd6",
+    "fb19b92a-d71b-4675-8568-b38c7c629f6b",
+    "fe076bcf-cd72-4e84-9200-1ea57ff02e93",
+    "fee08649-fe02-41a8-9e7d-f3460d960775"
+  ],
+  "allRows": [
+    {
+      "id": "01bee3bd-e6d8-4485-bc81-58345aff8856",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": null,
+      "fit_score": 85,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "020ca948-610e-48cb-9499-f5cd50d1eb24",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "69cbd105-7d07-42e8-9e9e-ac7bbbe4a4e7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "09b20bcf-dfe0-4fd7-9f1f-9e28c7c3b7f4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1f033e9b-410e-49e3-8630-6281e4aff947",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0a927479-ba1c-4391-843f-436f574fbff9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9e1f554-5130-4595-bf31-2f40407abb08",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0bc1fd36-9ffc-4b98-8977-0c2445072416",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1333d5f7-8428-4575-bd43-d76fce8a04bb",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0d9bafde-0982-4443-92d7-283a3711ff5e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "326d979b-6d53-4466-bc58-99124a03c9ed",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0de8a1da-640a-4bd6-983d-5e8a56368965",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa8193a4-a289-48da-b18f-4ac9f66e4e9c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0f7060c8-8ced-46e7-b614-ad0a690b730c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fe5e105f-a264-4ea6-ab09-025ffaf1d149",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "102ad8a6-660b-4ae7-bdae-6cdcc8082e37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f64c5dc5-678f-42cf-af57-9dcb225ce479",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "111e0f58-2bf6-481c-9f3c-fae0582ca405",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "9025299a-46cb-4793-b1b8-5281e71eda4c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "1192a6eb-fd9b-4030-a973-dbd8cb9753ef",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "56bb9c94-9ef3-4755-800f-b86d2d15360a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "13dc2bb5-a297-4cde-a23c-8832e5cb418a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3ae1b29e-21bb-4d0f-ab4c-3468da66fc29",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "13f6a83f-38e0-4a79-b7e0-d03a8af8f536",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "dd10c923-3afd-4819-88c4-7d9556ce4278",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "156a4ad8-fda6-4e82-bd99-9541d456cfd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "10380ad3-cb06-4e7b-ae99-071693283c31",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "15ff5c47-d23d-4faf-b1d3-3f46a08ddfc4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "996df6f9-cf4c-4853-944d-d7db32984e7f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "17ce28e5-9162-47f0-8048-b3c4e96ddabb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "76eed511-6de0-4e23-bb3b-b61af3a8a449",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "1a02eafe-945a-4afb-a2e6-e9da5b654a83",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a360ee62-c030-41fc-abda-ec987b36d5e2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "1d6f1de5-b639-4a74-a816-0a904a1bb75a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33cb0161-b755-4881-8b56-a2c278717ef6",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "2270627e-2a2f-4a1c-a767-ca064b15bee0",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "75625293-fd9c-4bd1-a6b5-4aaad5d83b0a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "268dc74c-c111-46ad-8376-840cd062d9ff",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "587bee01-82d2-4388-b836-695aeaf3bb0c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "26cb7865-902e-4266-80db-e3d60cd461d4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "559aed4c-452c-42b4-a5c3-efde3496c5a3",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "2860219b-535a-4d86-a3bb-2f6649081c37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7295dc9b-ffe4-4de5-8004-1d2beb8159d2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3202957c-b6c0-4072-ae21-828fbafd4663",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "85f977f6-d92e-4e86-a696-68db873b3afd",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "334005aa-8631-436c-ac9a-f22389a2593f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "38b86b4f-b069-41de-9afc-9da31af5537e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3374b1a3-6a20-4db2-80ca-d2d3002a879d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fb62dbd4-5911-410e-8b14-814b5a6a3e81",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "363a0791-fce6-4b68-8c86-befec13d3b66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e6b6194-e946-4f73-ae4b-8c11d110a6fb",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "363ac789-43ee-4671-849f-703c0b6eb27f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a844ff90-3557-49c4-920f-6be929d4ddb8",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3a0782ed-02f0-4b8b-856b-5a48020f038d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "99c0a586-4046-4760-8bbf-ba32930282c7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3a24ce42-fab7-40fd-8aa7-c238b339f33a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1b03f6c1-71c0-4c3d-aeb6-bb17e01604ea",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3d2784c3-ee5b-45c7-aa08-8b4ed74968aa",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5189ad94-ca4f-4a75-b61b-fa38feb38947",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3d439055-60c0-49c3-b93e-c6cd4b6a3485",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5afc7867-6734-4ab7-bdae-c00a481e7123",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3efaceb2-5ab5-4217-8eb2-10e30c493d77",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f3774fe4-976c-4c61-b570-854d0cbd547f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3f48ba47-cbe2-4288-baca-6910caf9d0de",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "40e7112b-7292-4b08-bede-0c130c1303a9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "42843ede-f708-454a-9426-2a4fbb45b04e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "05059406-3078-43c4-85e3-3d74034c426b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "45898c8c-8a9e-4482-b43d-367332c75156",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0d772b5-4483-4d2a-b6c7-c7b4cdad0f79",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "4794d62c-891f-4bb5-b4c1-2fd4118f9a8b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "693e077d-cabc-4fa8-aa46-8a268d1e3fa4",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "486d7194-626a-4086-86e0-50cc538de7d5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "874ab15e-4b76-4cf2-902f-dc35e445c747",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "4ee3e6c1-531f-4bfa-bd6d-6cb392193e6a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ef44035-bfdb-46db-8862-44421f1ef906",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "4ee55304-6356-44a0-8143-c33a2085137b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83de3ac4-b57a-44c1-8c55-8b7752834231",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5344bd32-37a4-4586-8016-393893b6c8c7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "16e4e421-cd3b-4dce-bebd-777df456c4b6",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "54d601e0-4cdd-4e64-b722-f634e1d67078",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "30314bcc-8234-4817-9343-c80b8fdf0335",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "553be114-eb0e-420f-8551-5b7a630aaddd",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2f751ffe-361f-4acd-b830-e79496806422",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "581d19ad-3681-4a8f-bb68-d94a4a618ff8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b2b9da14-5e34-40be-a251-f8c43170c267",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "58ad74f8-f12d-4c79-a42d-e54129b064fe",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0cd2eca7-202f-4f88-9345-e3fb4acc4b4a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5bfc0b5b-817c-4deb-8ae2-794532951b00",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bab993ab-1242-44ed-bdfd-547ae3cde53d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5c3a366f-58e5-4d73-b38d-c7aed64bbbae",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f39425d7-a23c-48f8-bac0-1d8459ff9b04",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5c512b73-1a42-4e0c-b2b4-74746eea617a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3192ad9a-efe3-4bae-aa5d-365f47bb8b9d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5c58cf47-925c-42d0-ab44-f006a432e076",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7357848d-de00-448c-a0bd-c39d16cee26b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "60806f0e-f422-4a0a-b875-96fb065bf712",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c69d1467-bbb7-4c88-8994-ed3d9891ea61",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "61383236-242f-42f2-bb79-4d623f07abc2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4a434d3d-2f89-4aa5-949a-2aeea7efe874",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "617502d2-b62a-4a4e-9244-d2a035dd6eec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "665e4f90-3fc8-4543-a922-f9a8a37dd8ca",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "626dd13c-821d-4c9e-9065-64f114256707",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2eef2a86-c557-46c3-9d6a-e9ea5b3b16dc",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "64ca01d9-cc1c-450c-b3bb-a996965cc2e5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e19b261-4711-486a-92fa-46ccc30699be",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "64f206d8-548d-4f8d-9ea6-26d92f5f8271",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ef58ba70-9ea8-437f-bfb5-c21e992e5c95",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "65c9d9b1-07b4-425b-9ea6-533a3c84e5be",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eea22c27-3d7d-46a9-a69a-000cd24ce85e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "682ed82e-7558-4d5d-85cf-4339b4b968f7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e118b9e-6e66-4664-b3d4-e7d227f9fb61",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "68a7664f-00f4-4215-aab2-8287472fc90d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2bab2980-2cc6-4a0e-bdd2-26aebefb6a71",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "68b4c0f3-20df-446f-8a72-0f9dbce3ab4d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3fc6250b-e4b0-4237-935c-bfc5b6bd7798",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "6bc5444e-464e-4c7b-b207-fb5d6346d603",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "95d53b99-1597-4444-b993-527df1ccebf3",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "72b9a5be-1888-4eb6-b4e6-d1f155679aeb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5f28a435-d8a0-4eec-bcc0-fbe462ba39e8",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "72e06d99-44fb-418c-9c0c-72105e9d60c6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6638aa15-a453-418b-9770-1b6731ea4ce6",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "73370b86-66ce-4f6b-9f8b-2c0cea3aac13",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "97cbc411-879e-48e9-b869-8a55afa41090",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "752c2086-89f1-4fc2-90f8-014a26e04981",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ed0302db-26aa-4276-a9f0-78e9dc564aca",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "77c05c23-d4d0-4639-8550-2436bef18e10",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6dca668d-b579-4d2b-9c5b-0a9717dcb4ff",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8733e859-eeef-42c2-ba56-f66f9ca1f35f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a9e3fa98-9626-4848-a7cd-583be703b5f3",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "87b344a3-45c6-4c3e-ab40-fc32d4a267cb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e8f18266-8492-4ff2-8c88-962174b21da5",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "881450ae-8b26-4c79-a6b7-168289dbcd66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0360e22-b4e9-433f-bed8-90a80d7247ec",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "884da29f-9e97-4b03-980f-6b5d9ced3d67",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "181d2c92-c68e-4bf8-b97e-69702e2e8ebc",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "88964032-4c08-45d1-b5a2-c4428241f395",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d6bb573d-6f43-448e-b73e-b6db5ba9d850",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8ac42dfb-044c-42bb-b866-5b8b03afa0df",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9a7717d-d862-4ea6-b03f-8106779dda88",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8b5462d8-b430-44b8-aa1d-1c623de30756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bf34d173-c2c4-4fa4-b620-40990180ee04",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8d52778c-0c4f-4acf-a0c6-ebeb0b06784f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0ecee8e-7e6c-42a7-b132-e3dacb15af64",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8f8d358a-142e-4cff-be2e-c6e27b838244",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f2b5ef75-e846-4ac4-92b1-124c8720e14c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "91e61d0a-8ecf-4b65-b441-3036c2041f98",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7757ca13-adfb-44f6-9a53-091049bb0f96",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "92dde1b1-e8fb-489c-9cbf-8404d6777cd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "25115d57-334e-4681-83b6-672b65025d34",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9714c60c-364a-412b-8136-44eed1620d1c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7f2b9909-4473-4c34-94b5-e06e1995e8f1",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "989592ea-eb2f-4e57-9164-e07abe7d685f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ad3be288-5813-4403-ba03-8e54c29871c2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "98a3c0d6-d4af-4702-aa5d-8477c2667a99",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfbb2957-1f35-4bd3-867d-74c1c9a2b0ff",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "98d55dc7-cc47-4460-bc79-8f0331664ce1",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2d5440fd-c858-4530-b3ec-fa47892d0b1a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9ccce53e-6036-400e-ada2-861aa6a1b36c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0969aa07-3121-471e-b9be-14b71bb3ecad",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9da7ae8b-984f-44a6-8916-5ab5265c3756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7d5fb158-562f-4ec6-9c51-d5aebab64e18",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9e23b5d1-7544-4f2f-9bd6-dab4f4920c20",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ae2907cc-0787-4041-af52-277c5b7fa018",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9e6a9491-c05e-4d00-946f-cd8400bdd361",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a3ead96b-c524-496e-b4fd-a9b6ac24db50",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9ea7aecc-6f36-4710-830f-5c9422288400",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "92ce53e8-9ee5-4eca-ab12-c3bb6e23bc9f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9fe7407a-b847-4f5d-840c-4c61e98ef739",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5542092-d005-4b18-8625-96a5d5f7b2dc",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9ff44c0f-5e76-4e84-829e-e5a9ba375d57",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0c7a823e-7476-4c12-a965-d939af1fdfbb",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "a505e381-1eb1-4a67-b409-995946a214d3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "254622ed-a732-4468-966d-53d1a0631f4e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "a8671a46-44c1-433c-84dc-bd057ec5bd9f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1c07aa76-76f2-4b9f-b512-da4d8d85b3f0",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "ada1d953-5e80-460d-bcbb-c94d3b61b5a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "aac1d53e-ed49-48e4-8d30-eb978df0dc66",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "aea9393a-52b3-4235-9c52-790cc9a97ce8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "faf22799-7f6f-48fb-a58e-04a30b37e0c9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "aee405cd-dae2-4a0e-bb1d-52ae05b74778",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5453dada-25b6-4562-b39f-78307bda471b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b017cbc0-5ef7-474e-9f47-51bef2d2cc2d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa1534e6-2279-4567-9019-6af88a6c3689",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b04896d0-8f8c-4bc8-b6a3-cd95cda33967",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6a49b433-e539-495b-b897-a485d4ea393a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b52e6d66-cd08-48ba-8957-dcc3ef013645",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a687bbdd-949d-45c2-8b61-5af6c7f8ccbd",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b6ae8b58-0b41-4737-a91b-b92960c03d51",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ee1cf48-dbf8-41f3-8f26-02d6f480bd0b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b702ab5f-e5e4-43a3-a337-857b7454b29f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "20a4b122-c05d-47ad-86d3-ab3b21b0a857",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b7ca53b7-cff4-4370-8ca0-e3dfed0c3c88",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "887d6318-fc1b-44d2-ba58-5861d7337f88",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b9d4fc15-04c9-4700-af4e-c93db471e0a5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "db3667b2-7590-4b62-9b50-ed5529f92a08",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "babe7d35-cc47-4cac-b1c3-01c1e8a119a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "8bd07931-33f5-476c-8c1f-64762730fc60",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bb229140-aaa3-4e7a-9f3e-dac7b9309219",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "555545c2-5159-4ceb-b326-1d94e3200ab9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bbdde4ee-445c-4c04-bc14-ea75f2718c7c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfe42149-ff1c-432f-87ea-6e352e029c2d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bf449f88-04f1-4793-b569-2fe08798c181",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6fa6e58b-792f-4699-8724-152f2d28f3c1",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bf67fdf8-dd32-4697-a465-0a9ce1221b27",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33a622b9-dd03-4007-830e-a8ba6a7d403e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "c03ccd06-d689-4f73-8acc-31d98aa43323",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5febc193-3e36-4abe-be13-6cd3e3a61ec4",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "c4cb139a-b678-4aab-90b6-b2c3d07678bb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e9440683-ff23-4f80-94bb-bacb51cf3ea9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "c8e54b09-43db-4b92-82b9-93d96b5e4bd2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4f019b91-6f85-423b-948e-c804246f908e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "cab734ed-5fb4-4cbe-afa7-7978e566f108",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6d853c0a-3ae8-4d4e-bfe5-ce5cf389fdc7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "cc9dcada-dbba-454c-a80b-a8e087f5b937",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6ebaab14-7739-41c0-baea-edb8eb529690",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "cf4f23ca-1c05-44e4-ac4f-1a09a47997b3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0eca684a-cf6d-4c9c-8c6b-49562873221a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d037da74-eb05-439c-bed4-1177d85385eb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e14a07f2-c509-4f2b-accf-e2dfe9afb8bd",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d0caeb07-3486-43f6-ab18-54466753e44c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "327f04d7-1940-4959-a181-71a2afae932b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d5107417-fedd-45f1-a430-73f852422479",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "91188d0e-a532-4e63-8b14-ae60ab6f86b7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d78cbb70-9758-4ad4-9bf4-9be1cd7befcb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "815f1ccd-b780-4541-992e-06df8cae3a1e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "da021f78-8c23-44d8-bfc3-64c6949a83ce",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "26913bcb-3382-42d0-81f6-20c20cc0056a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "dbaf71d5-13f0-458b-88d6-af200731142b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "15660559-77d0-4a75-ac5a-04537f6c004c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "def0f945-bd2f-46a0-bb1a-80a1087d7070",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "41288e0c-ce52-4c35-9bbd-f60146bb738e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e04753fc-c798-47ff-ab5f-fe36e8f230b6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3176f7d0-f9f2-47d7-a8f6-c1bd16b2421d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e44f6330-f4a9-4981-bec6-e1a004de39ec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a2c90b29-884b-4c3f-8fe4-f4eb7815f8b0",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e638ab86-f832-4eac-a76a-030e02de84a6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "52320561-2f0a-4ee1-8077-0ea959ee8a41",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e6eb4cee-0930-4ce2-a122-1c08c98bf70a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "72b41997-ad23-4091-9fa3-a8dc174e0b17",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e91062d7-4dcf-4f1c-8720-005dad187089",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83cdb339-d105-4bcf-b545-3efd80a10d6b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "eb404cbf-1d0e-4cd8-a9a3-4e1e77dfaf3e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eed61bbb-a742-4b2f-a740-94c05f6f4f24",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "f0878825-26d1-46b7-965d-8ea697141ebb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "57f8f423-3f80-4d12-9872-9c169c848ed2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "f33088bd-5993-4f65-bef1-0a3abca24a97",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0dceb21-b206-4239-a7e7-5c87019d503e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "f8421634-3478-4b16-8866-b3b97c54dcd6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d07ce626-a755-4248-97c7-b39bbab5a96f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "fb19b92a-d71b-4675-8568-b38c7c629f6b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5f0b932-f200-46c6-948f-62b82ecb1e12",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "fe076bcf-cd72-4e84-9200-1ea57ff02e93",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c79b6112-d0c8-4759-8111-9dc41a4f2eb7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "fee08649-fe02-41a8-9e7d-f3460d960775",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6e87e403-72cf-4382-8183-4844ceeb4023",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    }
+  ]
+}

--- a/thoughts/2026-05-27-goods-9-noise-drop-restore.json
+++ b/thoughts/2026-05-27-goods-9-noise-drop-restore.json
@@ -1,0 +1,1641 @@
+{
+  "removedAt": "2026-05-27T06:17:39.481Z",
+  "communities": [
+    {
+      "id": "d8f51cc1-00cf-454f-9b1b-803873e23113",
+      "community_name": "BANNICK BURN",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60",
+      "community_name": "JILUNDARINA",
+      "state": "NT",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77",
+      "community_name": "AAYKA",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc",
+      "community_name": "SHIPTON FLATS",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "25b7684b-5105-4daa-88b7-3c9a726340f8",
+      "community_name": "GUNUN WOONAM",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "b48620f5-0cb3-4419-9674-b8bab41f22c7",
+      "community_name": "NEW MERINEE",
+      "state": "NSW",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "c03eea29-af8b-4e6c-848c-45305dac1ba7",
+      "community_name": "THULKURR",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d",
+      "community_name": "FORDY FARM",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "ca8b8df1-1438-4ae4-9376-bb2726a78759",
+      "community_name": "THAANGKUNH-NHIIN",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    }
+  ],
+  "ghl": [
+    [
+      "cj7CXxIDLzKMxIVHHpNm",
+      "7sp5Zwueh0OKblAKQirR",
+      "THULKURR"
+    ],
+    [
+      "8CAq5cV6LBlozjP4fmbo",
+      "xBxaigCAdO1v8ARO1lo2",
+      "NEW MERINEE"
+    ],
+    [
+      "7rqTX3XLuiwMz8cvLMw3",
+      "gPxPrnGkA01DbSigTaYM",
+      "GUNUN WOONAM"
+    ],
+    [
+      "HTtygM4ogZ3gacHk3wwE",
+      "dYbBIH1H5deXDEerV5HE",
+      "SHIPTON FLATS"
+    ],
+    [
+      "58uGnRzT5FdHuDAvjKia",
+      "fm0tdDRDfl3EFTOg1JS7",
+      "FORDY FARM"
+    ],
+    [
+      "1HJOMb5vZMw0ulxm2tBS",
+      "jkXvzq4QJDPKCur8akIX",
+      "AAYKA"
+    ],
+    [
+      "NVnUPdbDuJlKwlFT4Zx6",
+      "cAt1QstivkhGfT2ShFAc",
+      "THAANGKUNH-NHIIN"
+    ],
+    [
+      "omkK7FwtMTormWvwpXcK",
+      "wu6SihnJXkEkKrUYtheG",
+      "BANNICK BURN"
+    ],
+    [
+      "seEc4BT9h5csxlXAJVhO",
+      "Q0HsirXpDJJ3vLpNIKmj",
+      "JILUNDARINA"
+    ]
+  ],
+  "cascade": {
+    "entities": 147,
+    "signals": 9
+  },
+  "cascadeEntities": [
+    {
+      "id": "c28719c1-0c5a-4b23-8609-6d20dc4b2d86",
+      "entity_name": "Volunteer Marine Rescue Karumba Inc",
+      "abn": "39394393984",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "25b7684b-5105-4daa-88b7-3c9a726340f8"
+    },
+    {
+      "id": "76ff1ecc-99e5-4793-8575-a48e012b2a75",
+      "entity_name": "Karumba Childrens Centre",
+      "abn": "52202439178",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "25b7684b-5105-4daa-88b7-3c9a726340f8"
+    },
+    {
+      "id": "5e811ff1-d573-4c1c-9ed0-aa98889f54b9",
+      "entity_name": "METRO MINING LIMITED (45 117 763 443)",
+      "abn": "25101655298",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "73a9e205-2517-438b-8755-b1465e8c58f1",
+      "entity_name": "RIBSHIRE PTY LTD T/A GOODLINE",
+      "abn": "40085847892",
+      "fit_score": 15,
+      "buyer_role": "government",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "6c373606-7ee5-400e-9d8e-86c81ddc10b0",
+      "entity_name": "Weipa Early Childhood Education Association Inc",
+      "abn": "73435425114",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "93c398b7-a1f8-4a0e-892b-eea8c3196d6d",
+      "entity_name": "Apostolic Jesus Name Fellowship",
+      "abn": "72932643944",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "185d0b9d-16ad-44fa-a064-3b6f5b1d99cb",
+      "entity_name": "ALNGITH CORPORATION LIMITED",
+      "abn": "98098199832",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "045199d7-e88e-474d-9163-bd84a9aeab4d",
+      "entity_name": "MOKWIRI NUNG LTD",
+      "abn": "54650651522",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "7f071a37-39e7-4276-bebb-fb3d4747eb1d",
+      "entity_name": "Napranum Pal Group Limited",
+      "abn": "42110700500",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "047d9c8b-86a9-4c4b-b011-bb9e46520c70",
+      "entity_name": "Weipa Community Care Assn Inc",
+      "abn": "72964419283",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "edf33f94-493c-4373-b349-82ee46b37348",
+      "entity_name": "Uca-Napranum Uniting Church",
+      "abn": "36388612170",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "858a13cb-0e70-469c-8d05-766be0a48695",
+      "entity_name": "Weipa Wildlife Care Inc.",
+      "abn": "60756762974",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "26f509a2-1a18-44e1-97a8-b47e6f61848b",
+      "entity_name": "HOWARD CHRISTIAN COLLEGE AUSTRALIA LTD",
+      "abn": "50689692877",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "b089707a-a3e9-4286-bba9-e03944343964",
+      "entity_name": "KLUTHUTHU CHRISTIAN COLLEGE LTD",
+      "abn": "19634798520",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "1accfcc0-7218-4a91-9bee-caacce4216e1",
+      "entity_name": "Rsl Queensland Branch Weipa Sub Branch",
+      "abn": "89640595313",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "e596d9c2-8bac-4a3f-aabc-78cd12034d4b",
+      "entity_name": "COOKTOWN FISHERMANS WHARF",
+      "abn": "93582956627",
+      "fit_score": 30,
+      "buyer_role": "other",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "7b158551-5772-44a8-9848-387e03f4d874",
+      "entity_name": "Health, Opportunity, Purpose and Empowerment Incorporated",
+      "abn": "40484799563",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "47e9d00c-4e03-4837-b701-eeee8d7dc0df",
+      "entity_name": "Juunjuwarra Aboriginal Corporation",
+      "abn": "20733551348",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "3434f836-d308-4663-9753-a3d10c5cefeb",
+      "entity_name": "Cape York Folk Club Inc.",
+      "abn": "75628689675",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "ec23faec-7b54-4d75-9567-65a1f7a098b0",
+      "entity_name": "Cooktown District Community Centre Ltd",
+      "abn": "63361686724",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "2037ce36-217a-42e5-aca3-0e767a5e578b",
+      "entity_name": "COOKTOWN CREATIVE ARTS ASSOCIATION INCORPORATED",
+      "abn": "84233971672",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "09907f58-1cde-4e86-af27-41ff97ab593d",
+      "entity_name": "Cooktown Baptist Fellowship",
+      "abn": "11127864935",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "85b996f0-89d6-471b-9ca7-bb76964bf25e",
+      "entity_name": "Cape York Weeds & Feral Animals Inc",
+      "abn": "31169159829",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "0c6318dc-2ec5-48ac-a1f0-cf53956f6fbe",
+      "entity_name": "Cooktown Congregation of Jehovah's Witnesses",
+      "abn": "75569784947",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "31333472-6809-4cae-a689-519ca657813e",
+      "entity_name": "Cooktown Kindergarten Association Inc",
+      "abn": "65007825127",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "a73115e4-3a65-4282-be55-0a95218c2544",
+      "entity_name": "PANDANUS PARK INC",
+      "abn": "83396148426",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "b9869a7b-2616-4293-b8a9-df597496c2ac",
+      "entity_name": "COOKTOWN RE-ENACTMENT ASSOCIATION INCORPORATED",
+      "abn": "34843064496",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "8760fbef-8b62-4051-b28d-aae9c71469e4",
+      "entity_name": "CUC CAPE YORK LTD",
+      "abn": "36661204995",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "6cdab7ff-d26c-4d2a-90a0-7358e6319a18",
+      "entity_name": "Yuku-Baja-Muliku Landowner and Reserves Ltd",
+      "abn": "68124429009",
+      "fit_score": 35,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "fd235b38-5770-4473-9236-8c9d993cbff7",
+      "entity_name": "Vera Scarth-Johnson Gallery Association Inc",
+      "abn": "67189793230",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "f4854147-70f4-45b8-8544-2d2822d51436",
+      "entity_name": "The Cooktown And District Historical Society Inc",
+      "abn": "86671012646",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "f80671a1-1437-4c75-bbb6-d81dfe73bfd8",
+      "entity_name": "South Cape York Catchments Inc.",
+      "abn": "77532434684",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "d7fbbd00-68a2-4f93-8033-1c04d06938e9",
+      "entity_name": "BRIGHT FOOD ASIA PACIFIC PTY LTD",
+      "abn": "57354565744",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f6124d34-0b18-44bd-aa42-2c6fe434a180",
+      "entity_name": "COUNTRY CARE GROUP HOME MODIFICATIONS PTY LTD (81 619 350 435)",
+      "abn": "81619350435",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7025a17d-1b8c-4a2a-82bd-03a61d9ab168",
+      "entity_name": "C.M.V. FARMS PTY. LTD. (98 005 880 848)",
+      "abn": "98005880848",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3e520d52-65aa-40b5-9805-707bef5a14b6",
+      "entity_name": "Fruitvale Pty Ltd",
+      "abn": "63059307881",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "88d4d2e4-318b-44c5-93a6-c7323d735f4b",
+      "entity_name": "COUNTRY CARE MANAGEMENT SERVICES PTY LTD (23 606 437 101)",
+      "abn": "23606437101",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "1cd4fe1a-6d5c-45dc-a496-f9877d48711e",
+      "entity_name": "GTS FREIGHT MANAGEMENT PTY LTD",
+      "abn": "58007997604",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "25beff5e-6705-45a8-abaa-f1a6b4b8febd",
+      "entity_name": "SMYBB PTY LTD (45 096 514 788)",
+      "abn": "45096514788",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "78037cd8-504d-4b89-bfaa-ee576ddf9cf7",
+      "entity_name": "HAEUSLERS GROUP PTY LTD",
+      "abn": "72004735700",
+      "fit_score": 15,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "42773991-0425-4b91-9b5a-db3622e10765",
+      "entity_name": "Tandou Ltd",
+      "abn": "81001014562",
+      "fit_score": 50,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "73f00bca-7211-4133-825b-86b32ac86d04",
+      "entity_name": "THE COUNTRY CARE GROUP PTY LTD (26 088 222 226)",
+      "abn": "26088222226",
+      "fit_score": 35,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "db7b3cf1-1a2d-451d-9315-b5264cca8270",
+      "entity_name": "TASCO CARRIERS PTY LTD (39 162 327 175)",
+      "abn": "39162327175",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "ba172ce3-326b-4d32-b2b9-30c4354b6fd4",
+      "entity_name": "UCCELLO MARKETING PTY LTD (50 602 569 595)",
+      "abn": "50602569595",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7ad74f75-a82f-4297-b8b9-f2f416b23bc5",
+      "entity_name": "Mallee Accommodation and Support Program Limited",
+      "abn": "51726968790",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "487bcac6-2b3f-496d-b39b-4c4bc5d29153",
+      "entity_name": "K CARE HEALTHCARE SOLUTIONS PTY LTD (47 159 431 099)",
+      "abn": "47159431099",
+      "fit_score": 15,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "34c743cc-ef04-4ad4-8cec-879863bbf1fd",
+      "entity_name": "Pasadena Pre School Association Inc",
+      "abn": "76417827585",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "469be806-1a67-4dd1-b003-749185d680c8",
+      "entity_name": "MALLEE HOUSING LTD",
+      "abn": "50690640469",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "248bbc3c-c889-4885-9f11-dd3562a771ad",
+      "entity_name": "Mildura Base Public Hospital (73 543 496 421)",
+      "abn": "73543496421",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "2f3d0a11-a287-4a2d-b143-84c596fe41e2",
+      "entity_name": "Sunraysia Community Health Services Limited",
+      "abn": "56957121036",
+      "fit_score": 35,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "a805f172-e053-483a-a538-b43677be0661",
+      "entity_name": "Sunraysia Mallee Ethnic Communities Council Inc",
+      "abn": "37282486762",
+      "fit_score": 0,
+      "buyer_role": "government",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7f9cb0ff-4732-4964-b865-0206e51af3d4",
+      "entity_name": "University Of The Third Age Sunraysia Inc.",
+      "abn": "49791479741",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "007a6958-d30e-4b4d-8ec8-ce8b531eb2e6",
+      "entity_name": "Oasis-City Common Equity Rental Housing Co-Operative Limited Registered Co-Operative No. G3002N",
+      "abn": "34352726093",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "c11d8870-d0ba-4bd4-ba31-278800a1b7e6",
+      "entity_name": "Aljor Constructions",
+      "abn": "59079489099",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "2e99df8a-d978-44dd-9699-9d3806a884aa",
+      "entity_name": "Agape Orphanage Network (Australia) Inc.",
+      "abn": "97361098908",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bd953daa-4a44-491c-a3df-a3ccd8f9082f",
+      "entity_name": "MADEC Australia Limited",
+      "abn": "48086804015",
+      "fit_score": 50,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "db4e3e8a-075e-467a-bd3e-a95d9b629478",
+      "entity_name": "MALLEE FAMILY CARE LTD",
+      "abn": "32085588656",
+      "fit_score": 30,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bd1e23ad-446b-4012-bc52-54a1fcf63699",
+      "entity_name": "ANABELLE BITS PTY LTD (40 068 649 972)",
+      "abn": "72091751656",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "0b76a8db-dfe5-49f4-9368-71199af5bf06",
+      "entity_name": "Cambodian-Australian Buddhist Temple Association incorporated",
+      "abn": "25940163249",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7befe938-b10a-4d35-859c-14308a65527b",
+      "entity_name": "Food Next Door Co-op Ltd",
+      "abn": "63220050847",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "13d54f6e-bc1a-4702-a795-d5157fb08e7d",
+      "entity_name": "Rural Business and Community Limited",
+      "abn": "70870481312",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "282ffe82-badf-46ee-8713-b5debeb15087",
+      "entity_name": "OneVine Community Church Inc",
+      "abn": "40168383140",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3abd1bae-fef2-46ab-a032-6d61ef370c66",
+      "entity_name": "INSTITUTE FOR FUTURE COOPERATION LTD",
+      "abn": "62673241211",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3c035234-b291-4d90-9789-7d7abda64724",
+      "entity_name": "SKY TEMPLE LTD",
+      "abn": "28677234892",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "881dcf39-cb4f-440e-bc34-1b0c598ac2ec",
+      "entity_name": "PMF-SUNRAYSIA INC",
+      "abn": "43492856387",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "c91d4625-9ca6-4a0c-9246-3503341e5506",
+      "entity_name": "River Edge Church Inc.",
+      "abn": "82148212870",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "0c8fb595-fb61-44b1-a934-3bd2b3fad667",
+      "entity_name": "MATES INCORPORATED MILDURA INC",
+      "abn": "91991750993",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "8a09db0f-8f9e-4668-b919-ba1b9708887b",
+      "entity_name": "Sunraysia Animal Rehousing Group Inc.",
+      "abn": "57383474239",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "cb5291c4-5cc4-4d23-baa1-41d56e465d21",
+      "entity_name": "Mildura Legacy Club Incorporated",
+      "abn": "26450652465",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "e17a9841-5839-44f6-8547-170afd43ef5a",
+      "entity_name": "MDAS Limited",
+      "abn": "53602202139",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f0336aab-8478-4684-a200-34afef3a7d1b",
+      "entity_name": "Mallee Sexual Assault Unit Ltd",
+      "abn": "57685819813",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f0d39a0b-4da3-43cc-87cf-0e41d57a9910",
+      "entity_name": "Mildura East Congregation of Jehovah's Witnesses",
+      "abn": "83756145361",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f33a4742-4710-4496-a0b2-6e66bba7058e",
+      "entity_name": "MILDURA CHURCH OF CHRIST INCORPORATED",
+      "abn": "29525047085",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f3710263-9bb9-4157-804e-7d82b3c9fc9c",
+      "entity_name": "Mildura Baptist Church Incorporated",
+      "abn": "21133229270",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "4e921f80-f48e-4e5e-beb6-0440bc959277",
+      "entity_name": "Srs Creative Futures Inc",
+      "abn": "37716221458",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "ffffc794-2453-4d56-9ad6-ee405f06f0b3",
+      "entity_name": "Mildura Rsl Sub Branch Inc",
+      "abn": "94275221734",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "1679128c-a137-40de-b9db-79e642f6ba8a",
+      "entity_name": "Mildura West Congregation of Jehovah's Witnesses",
+      "abn": "84193768898",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "41f25754-52b7-4ae4-86f9-3abd1a8e4450",
+      "entity_name": "Northern Mallee Leaders Inc.",
+      "abn": "48317418213",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5182760f-0d97-409f-aed5-95eef9a67ef3",
+      "entity_name": "NORTHERN MALLEE LOCAL LEARNING AND EMPLOYMENT NETWORK",
+      "abn": "78430405938",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "6c99aa5e-58a4-41f5-8c7f-f3b10c85e8e9",
+      "entity_name": "MILDURA WRITERS FESTIVAL LTD",
+      "abn": "51692962771",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "8eabf918-69b4-44b4-9f20-6485dc2f047c",
+      "entity_name": "New Life Christian Church Inc",
+      "abn": "41389926061",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "a5f77b2b-1b19-4586-a625-e8bf4d18ebee",
+      "entity_name": "The Mildura Life Saving Club Incorporated",
+      "abn": "13401094420",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "b01c85af-e554-4712-9e1e-c880cf46f301",
+      "entity_name": "Mildura West Kindergarten Inc.",
+      "abn": "52364764437",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "b05abf62-70ee-41a1-aadb-291a5da02b1a",
+      "entity_name": "No Borders Creative Inc",
+      "abn": "37306164261",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "fc7348b5-78d0-44d8-a271-556be14677e5",
+      "entity_name": "Mildura Show Society Inc",
+      "abn": "44590145044",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "8a32858d-e0a8-4bbc-8726-ed2a864daa95",
+      "entity_name": "St Andrews Uniting Church Mildura",
+      "abn": "52702492922",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "d181c46c-edc4-41aa-8f18-896beb39faf2",
+      "entity_name": "Strata Owners Alliance Inc",
+      "abn": "16614304016",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "d1e6efe5-9caa-4dc1-991d-aae6c0080ed7",
+      "entity_name": "Sunraysia Carers Support Group Incorporated",
+      "abn": "35962018482",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "e709957b-fc77-4fcf-9c34-e66534226c98",
+      "entity_name": "Sunraysia Cancer Resources Incorporated",
+      "abn": "50681685892",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "91909276-07e0-437a-be4c-bb58c4eb6824",
+      "entity_name": "Sunraysia Early Settlers Museum Inc",
+      "abn": "91900692898",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3d47b967-73e9-40a9-ac32-f72728607776",
+      "entity_name": "WAT KHMER BUDDHIST TEMPLE OF MILDURA VICTORIA IN AUSTRALIA LTD",
+      "abn": "63689135564",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "4220995b-2a67-481c-8979-be846cf8d633",
+      "entity_name": "THE TRUSTEE FOR TASCO INLAND AUSTRALIA UNIT TRUST (64 676 389 090)",
+      "abn": "64676389090",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5bd92af4-936d-4e8d-a3ba-a19ca116f533",
+      "entity_name": "UCA Presbytery Of Western Victoria",
+      "abn": "28901597834",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "601c2202-418a-4e3f-8c0f-efa7c47751cf",
+      "entity_name": "The Turkish Islamic Society Mildura Inc.",
+      "abn": "12417895581",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "9add201e-8d27-4231-8c20-4af573e6cfc3",
+      "entity_name": "THE SUNRAYSIA SUSTAINABILITY NETWORK INC",
+      "abn": "37092573714",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "13be74b2-47e2-42cb-a7f6-a65e9a900392",
+      "entity_name": "Zoe Support Australia",
+      "abn": "76161029705",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "09120d84-75e3-4374-baa2-90495b91e75a",
+      "entity_name": "Uniting Church In Australia Parish Of Sunraysia",
+      "abn": "79396267732",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "0355724d-7f08-4f43-8588-1193491637e2",
+      "entity_name": "The Trustee for BAYSIDE BWE UNIT TRUST (69 809 123 175)",
+      "abn": "52006531817",
+      "fit_score": 15,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "fbfb463d-9462-4bf5-b2ad-ef4fd4a069ab",
+      "entity_name": "MILDURA DISTRICT HOSPITAL FUND LTD. (13 078 202 089)",
+      "abn": "13078202089",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "094402ae-7668-4ca4-b3f3-83baafd42327",
+      "entity_name": "Sunraysia & Murray Group Training Limited",
+      "abn": "19006114076",
+      "fit_score": 35,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "40b4141d-1751-42a2-a474-f485989c41d2",
+      "entity_name": "Trinity Lutheran College",
+      "abn": "43974264930",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bc5d8bf7-750a-437d-b517-ba455303f432",
+      "entity_name": "TRINITY LUTHERAN COLLEGE MILDURA LTD",
+      "abn": "22650100119",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5ab2c130-1cd8-4591-8db1-c3a30486ad3d",
+      "entity_name": "All Nations Christian Fellowship Mildura Incorporated",
+      "abn": "83249205656",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "b3fda541-3586-41dd-8ba1-6787c6f97adb",
+      "entity_name": "Living Waters Christian Community",
+      "abn": "45184860981",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bced9b7f-ed1b-4529-bafb-d281d76da29f",
+      "entity_name": "Sunraysia Regional Consulting Limited",
+      "abn": "70624280413",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "abbce57b-29ae-46db-a7ef-e69c9b1cdae1",
+      "entity_name": "Christie Centre Inc",
+      "abn": "68554592464",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "01a30eb0-259c-42db-974d-9e111d433471",
+      "entity_name": "Sunassist Volunteer Helpers Inc",
+      "abn": "51565565026",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "1fe67c44-2089-4100-9a28-8e85658815ef",
+      "entity_name": "Sunraysia Residential Services Inc",
+      "abn": "88441353792",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5013f1e4-f58a-4421-8c34-c6c68fc22586",
+      "entity_name": "Sunraysia Community Radio Association Inc.",
+      "abn": "19305406312",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "a55d4426-f29d-4260-b02b-633fbf9a6e83",
+      "entity_name": "K CARE HOLDINGS PTY LTD (80 626 058 035)",
+      "abn": "80626058035",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "74614ec2-5764-4228-be9b-1cc14f8e73bb",
+      "entity_name": "SPECIALISED MOBILITY PTY LTD (59 159 633 664)",
+      "abn": "59159633664",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "35893580-3e8f-4c95-828f-60ea177642ac",
+      "entity_name": "Karumba Childrens Centre",
+      "abn": "52202439178",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "c03eea29-af8b-4e6c-848c-45305dac1ba7"
+    },
+    {
+      "id": "ef6a32a2-f160-4c64-a16a-f3670c4e6759",
+      "entity_name": "Volunteer Marine Rescue Karumba Inc",
+      "abn": "39394393984",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "c03eea29-af8b-4e6c-848c-45305dac1ba7"
+    },
+    {
+      "id": "68465b86-6107-443e-8e1d-b49ceb3b2ebc",
+      "entity_name": "METRO MINING LIMITED (45 117 763 443)",
+      "abn": "25101655298",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "4fdf0b6c-09b6-42c5-acdf-e488ad31a8ca",
+      "entity_name": "RIBSHIRE PTY LTD T/A GOODLINE",
+      "abn": "40085847892",
+      "fit_score": 15,
+      "buyer_role": "government",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "18e754c5-1f86-480a-984a-42560c3fd390",
+      "entity_name": "Weipa Early Childhood Education Association Inc",
+      "abn": "73435425114",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "c46fd095-db93-4cd4-979f-0134a4cd6fc3",
+      "entity_name": "Apostolic Jesus Name Fellowship",
+      "abn": "72932643944",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "5325b921-e06d-4986-bc0f-1db2ece8cfa8",
+      "entity_name": "ALNGITH CORPORATION LIMITED",
+      "abn": "98098199832",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "68da334e-fad8-42a3-9b2d-65471b9fba1a",
+      "entity_name": "Napranum Pal Group Limited",
+      "abn": "42110700500",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "b244bac0-f16b-41bd-9cc1-4070d4db8ed4",
+      "entity_name": "MOKWIRI NUNG LTD",
+      "abn": "54650651522",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "d113b411-cc7a-43e8-a4a6-f27be08aa455",
+      "entity_name": "Uca-Napranum Uniting Church",
+      "abn": "36388612170",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "287b8974-9484-4dc9-b638-7fd2426bed20",
+      "entity_name": "Rsl Queensland Branch Weipa Sub Branch",
+      "abn": "89640595313",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "a5b6e42c-0f37-4a61-948c-b51a078cdc80",
+      "entity_name": "Weipa Wildlife Care Inc.",
+      "abn": "60756762974",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "57ebe00c-2f84-4492-a6e9-ff08c4b36ae5",
+      "entity_name": "HOWARD CHRISTIAN COLLEGE AUSTRALIA LTD",
+      "abn": "50689692877",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "850de022-c11b-4816-aa8e-ad31ae94b3df",
+      "entity_name": "KLUTHUTHU CHRISTIAN COLLEGE LTD",
+      "abn": "19634798520",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "4fa59e70-dd4e-49e1-b865-d437d2d784e5",
+      "entity_name": "Weipa Community Care Assn Inc",
+      "abn": "72964419283",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "4eacf5d0-fbca-4c9d-b900-4495a1e07479",
+      "entity_name": "Northern Land Council",
+      "abn": "56327515336",
+      "fit_score": 74,
+      "buyer_role": "council",
+      "community_id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60"
+    },
+    {
+      "id": "6a7e4c9a-1bbb-45a7-b496-17d78ffbf1d4",
+      "entity_name": "Aboriginal Medical Services Alliance Northern Territory Aboriginal Corporation",
+      "abn": "26263401676",
+      "fit_score": 74,
+      "buyer_role": "health_service",
+      "community_id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60"
+    },
+    {
+      "id": "f217c2aa-141d-4a2e-8601-208e3f91655a",
+      "entity_name": "Karumba Childrens Centre",
+      "abn": "52202439178",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "d8f51cc1-00cf-454f-9b1b-803873e23113"
+    },
+    {
+      "id": "592f00cc-e004-4cec-9dda-d7c43954e126",
+      "entity_name": "Volunteer Marine Rescue Karumba Inc",
+      "abn": "39394393984",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "d8f51cc1-00cf-454f-9b1b-803873e23113"
+    },
+    {
+      "id": "6067cbc2-06be-40a3-a877-73dcd100ef8b",
+      "entity_name": "Health, Opportunity, Purpose and Empowerment Incorporated",
+      "abn": "40484799563",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "ab4f7ee7-9b7d-41e1-be0e-fbeab5edd3c6",
+      "entity_name": "Juunjuwarra Aboriginal Corporation",
+      "abn": "20733551348",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "daf46569-decf-46ab-b5d7-571b511c14e8",
+      "entity_name": "COOKTOWN FISHERMANS WHARF",
+      "abn": "93582956627",
+      "fit_score": 30,
+      "buyer_role": "other",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "626e3776-bdf2-4fe8-8a9c-9f4ff12c5828",
+      "entity_name": "Cape York Weeds & Feral Animals Inc",
+      "abn": "31169159829",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "92c2d4c3-da1b-43ee-80ab-f7ddd519a02a",
+      "entity_name": "Cape York Folk Club Inc.",
+      "abn": "75628689675",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "9a76b03b-a455-47d1-bf8c-9060cfea1e8f",
+      "entity_name": "Cooktown District Community Centre Ltd",
+      "abn": "63361686724",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "1d302148-261e-4270-a07e-9f5ecba0c9d7",
+      "entity_name": "Cooktown Baptist Fellowship",
+      "abn": "11127864935",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "4c96c8fb-131b-42c8-81b1-8a8363ac71b9",
+      "entity_name": "COOKTOWN CREATIVE ARTS ASSOCIATION INCORPORATED",
+      "abn": "84233971672",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "e98eb5fe-f154-440d-90a2-3783c1a522a6",
+      "entity_name": "Cooktown Kindergarten Association Inc",
+      "abn": "65007825127",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "977c0a0f-dbd5-4328-857d-bf2c36780baa",
+      "entity_name": "COOKTOWN RE-ENACTMENT ASSOCIATION INCORPORATED",
+      "abn": "34843064496",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "cac5963a-cafa-42bf-94e8-cc697a382dc8",
+      "entity_name": "PANDANUS PARK INC",
+      "abn": "83396148426",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "e170dae5-1165-4a15-a389-274acffc066d",
+      "entity_name": "CUC CAPE YORK LTD",
+      "abn": "36661204995",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "9fd894d1-011d-47a2-be2e-91482428889a",
+      "entity_name": "South Cape York Catchments Inc.",
+      "abn": "77532434684",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "a4b11119-42e7-4360-8462-441f5967cef0",
+      "entity_name": "The Cooktown And District Historical Society Inc",
+      "abn": "86671012646",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "d3e02220-9822-427f-b553-2fca3b5c5116",
+      "entity_name": "Vera Scarth-Johnson Gallery Association Inc",
+      "abn": "67189793230",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "77b037eb-b74d-4e87-9def-f944eb3dab0d",
+      "entity_name": "Cooktown Congregation of Jehovah's Witnesses",
+      "abn": "75569784947",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "4dea6ecc-4d4c-43f2-85b5-22137d8da0d5",
+      "entity_name": "Yuku-Baja-Muliku Landowner and Reserves Ltd",
+      "abn": "68124429009",
+      "fit_score": 35,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    }
+  ],
+  "cascadeSignals": [
+    {
+      "id": "29df0073-eca2-4e3d-b63b-ef105060dc77",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "25b7684b-5105-4daa-88b7-3c9a726340f8",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "c28719c1-0c5a-4b23-8609-6d20dc4b2d86",
+      "title": "Unmet demand: GUNUN WOONAM (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: GUNUN WOONAM (QLD) — 52 beds, 6 washers\n\nBest buyer match: Volunteer Marine Rescue Karumba Inc (community_org) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "gPxPrnGkA01DbSigTaYM",
+      "ghl_synced_at": "2026-04-26T23:52:41.599+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:31.820743+00:00"
+    },
+    {
+      "id": "8f2c22fa-ca3c-4f4e-abf0-52a35b280fc2",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "73a9e205-2517-438b-8755-b1465e8c58f1",
+      "title": "Unmet demand: AAYKA (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: AAYKA (QLD) — 52 beds, 6 washers\n\nBest buyer match: RIBSHIRE PTY LTD T/A GOODLINE (government) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "jkXvzq4QJDPKCur8akIX",
+      "ghl_synced_at": "2026-04-26T23:52:35.591+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:43.956012+00:00"
+    },
+    {
+      "id": "d18789de-c4f0-42ee-b46f-f157ad80c231",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "6cdab7ff-d26c-4d2a-90a0-7358e6319a18",
+      "title": "Unmet demand: SHIPTON FLATS (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: SHIPTON FLATS (QLD) — 52 beds, 6 washers\n\nBest buyer match: Yuku-Baja-Muliku Landowner and Reserves Ltd (community_org) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "dYbBIH1H5deXDEerV5HE",
+      "ghl_synced_at": "2026-04-26T23:52:39.705+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:29.482734+00:00"
+    },
+    {
+      "id": "df63964b-ee24-4626-9ee3-3a6f3b802f11",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "73f00bca-7211-4133-825b-86b32ac86d04",
+      "title": "Unmet demand: NEW MERINEE (NSW) — 52 beds, 6 washers",
+      "description": "Unmet demand: NEW MERINEE (NSW) — 52 beds, 6 washers\n\nBest buyer match: THE COUNTRY CARE GROUP PTY LTD (26 088 222 226) (other) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "ed3cb3a0-52a1-4a30-8805-f8d968664734",
+        "c91e3e47-e0a6-4c89-a67d-3f8b62deca28",
+        "f6865bfc-e4b6-464e-b3d5-1a10071672b6"
+      ],
+      "matched_foundation_ids": [
+        "7ef21e92-51c5-450d-82b3-6ffbc1237372",
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "6a6a4405-d780-472b-a95a-ab93182e641d"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "xBxaigCAdO1v8ARO1lo2",
+      "ghl_synced_at": "2026-04-26T23:52:43.047+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:30.776773+00:00"
+    },
+    {
+      "id": "f6c726f2-86d1-499a-88aa-e1622ac05429",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "c03eea29-af8b-4e6c-848c-45305dac1ba7",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "35893580-3e8f-4c95-828f-60ea177642ac",
+      "title": "Unmet demand: THULKURR (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: THULKURR (QLD) — 52 beds, 6 washers\n\nBest buyer match: Karumba Childrens Centre (community_org) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "7sp5Zwueh0OKblAKQirR",
+      "ghl_synced_at": "2026-04-26T23:52:44.847+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:29.400089+00:00"
+    },
+    {
+      "id": "3ebc9597-9f37-4a24-b5cf-6c81ab0a7e66",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "4fdf0b6c-09b6-42c5-acdf-e488ad31a8ca",
+      "title": "Unmet demand: THAANGKUNH-NHIIN (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: THAANGKUNH-NHIIN (QLD) — 52 beds, 6 washers\n\nBest buyer match: RIBSHIRE PTY LTD T/A GOODLINE (government) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "cAt1QstivkhGfT2ShFAc",
+      "ghl_synced_at": "2026-04-26T23:52:32.134+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:44.990509+00:00"
+    },
+    {
+      "id": "d27d1f72-dac8-4505-af65-d1d57a855500",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "4eacf5d0-fbca-4c9d-b900-4495a1e07479",
+      "title": "Unmet demand: JILUNDARINA (NT) — 52 beds, 6 washers",
+      "description": "Unmet demand: JILUNDARINA (NT) — 52 beds, 6 washers\n\nBest buyer match: Northern Land Council (council) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "767692f2-b796-49e2-bfc5-e128041666e5",
+        "0e970592-0f2e-49e7-a287-02b66bdc6450",
+        "3f9b4d83-4468-40e7-afe1-222b7b7f8920"
+      ],
+      "matched_foundation_ids": [
+        "6e67e605-9cea-4ae8-8416-2745c71d51bb",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "Q0HsirXpDJJ3vLpNIKmj",
+      "ghl_synced_at": "2026-04-26T23:52:28.701+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:46.110555+00:00"
+    },
+    {
+      "id": "fd81643a-aa6a-477e-a773-f80477314b30",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "d8f51cc1-00cf-454f-9b1b-803873e23113",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "f217c2aa-141d-4a2e-8601-208e3f91655a",
+      "title": "Unmet demand: BANNICK BURN (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: BANNICK BURN (QLD) — 52 beds, 6 washers\n\nBest buyer match: Karumba Childrens Centre (community_org) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "wu6SihnJXkEkKrUYtheG",
+      "ghl_synced_at": "2026-04-26T23:52:30.357+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:43.448041+00:00"
+    },
+    {
+      "id": "87d65b0a-b040-4388-bf77-d27e6abf0ce5",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "4dea6ecc-4d4c-43f2-85b5-22137d8da0d5",
+      "title": "Unmet demand: FORDY FARM (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: FORDY FARM (QLD) — 52 beds, 6 washers\n\nBest buyer match: Yuku-Baja-Muliku Landowner and Reserves Ltd (community_org) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "fm0tdDRDfl3EFTOg1JS7",
+      "ghl_synced_at": "2026-04-26T23:52:37.381+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:43.880864+00:00"
+    }
+  ]
+}

--- a/thoughts/2026-05-27-goods-anchor-add-alpa-dedupe.json
+++ b/thoughts/2026-05-27-goods-anchor-add-alpa-dedupe.json
@@ -1,0 +1,1453 @@
+{
+  "at": "2026-05-27T06:20:10.649Z",
+  "inserted": [
+    {
+      "entity_name": "Outback Stores Pty Ltd",
+      "abn": "63120661234",
+      "buyer_role": "store",
+      "community_id": null,
+      "is_community_controlled": false,
+      "relationship_status": "prospect",
+      "website": "https://www.outbackstores.com.au",
+      "govt_contract_value": 92000,
+      "govt_contract_count": 1,
+      "fit_score": 85
+    },
+    {
+      "entity_name": "Miwatj Health Aboriginal Corporation",
+      "abn": "96843428729",
+      "buyer_role": "health_service",
+      "community_id": "9651e030-c893-40de-aee8-2df0d45a6706",
+      "is_community_controlled": true,
+      "relationship_status": "prospect",
+      "website": "https://www.miwatj.com.au",
+      "govt_contract_value": 48000,
+      "govt_contract_count": 1,
+      "fit_score": 85
+    },
+    {
+      "entity_name": "Tangentyere Council Aboriginal Corporation",
+      "abn": "81688672692",
+      "buyer_role": "council",
+      "community_id": "6cec2c4f-d390-4bff-95e1-5ad9db9b08da",
+      "is_community_controlled": true,
+      "relationship_status": "prospect",
+      "website": "https://www.tangentyere.org.au",
+      "govt_contract_value": 3113493.21,
+      "govt_contract_count": 14,
+      "fit_score": 85
+    }
+  ],
+  "alpaDeletedIds": [
+    "1ea92e85-c7d2-4a4c-8be2-26f30b84732e",
+    "7e215c7c-19ad-4128-b255-f9e74f8244f7",
+    "b8adb481-2057-422b-971b-608990c3ac40",
+    "9766a537-52c2-4858-86d9-07f223d6bc4c",
+    "5f859f10-89e8-4b46-9a2a-289fd66ce9c4",
+    "d9f2d3fb-fc65-46f7-bdc4-e460926c95bb",
+    "1c65d8cc-bde1-4ba8-b997-402f2e7386df",
+    "697bea33-7e38-451c-9e24-3ce771a2123c",
+    "623b5cfe-7326-4d28-8429-d145de601f83",
+    "f0814898-bb93-4016-a815-f41b4690fffc",
+    "5a69405d-745b-42ef-9931-924cf8d5907a",
+    "b2d70b03-b69a-4fb0-99e1-1c5c34c8a160",
+    "57cea0c9-c945-492a-bc6f-68f7b4e70c4b",
+    "fca8091f-9554-4824-a892-5f2054e1b0ed",
+    "eed5b2e4-8c77-42e5-8b98-2a30ec36c32f",
+    "d907d705-fea0-40c8-88ca-5ec6aa7ef132",
+    "21810a9c-edf4-496a-859c-4ac0bc538b33",
+    "700494e4-3f39-4708-bfba-ec77815f2005",
+    "587c1f8c-0fb4-4386-94e2-754268d21cc6",
+    "70d1d648-ef19-4803-b087-c83737cbd817",
+    "fd79bed3-8250-46f2-a7f1-063737563038",
+    "c160708f-430a-4c1a-8733-bc7048c23ce4",
+    "ef28089f-8bea-437a-a519-0331280e3932",
+    "081402a3-7090-4f58-8cfe-24490381eaf7",
+    "687ec918-a734-42fb-953d-f1b82b2ccb38",
+    "b2ca0cb7-c20f-44c1-b58c-a90de9dd5309",
+    "1fbb31c6-9346-496a-9bc7-14cfd2938b58",
+    "2fb93376-37a2-408d-96c0-b75879be87ba",
+    "2908a674-dfb3-4b20-83d6-a17980f74d07",
+    "e27e32f7-bfa3-44c1-bba0-bee11407e0e5",
+    "2c62a1f6-646a-4efd-90a5-233bb89303d7",
+    "fd0da4fa-1164-4e60-a9ea-2c0fbc822b4c",
+    "4cae9ea0-2862-4d47-a2f4-08c193086180",
+    "70b2a1c7-9a47-4999-9d50-eec51fb286f2",
+    "54f620d1-5241-4c34-8bb4-c9db373fa0e4",
+    "cb2cd656-e5e1-41fb-a93f-c034b01c4c05",
+    "9f4f7ef1-946a-479f-aaaa-f778a20371df",
+    "216d2895-f8fb-4b8d-aff0-8ca850aeff94",
+    "f51d0d4f-cd32-4d91-b8b2-8b4c5167490c",
+    "603e149e-f3e0-460f-b267-723a18f6d4c6",
+    "23d9dbc4-c2e1-4dac-b463-b8d51eeb3844",
+    "dd0bb1bc-63e0-4599-a5d0-37882ad6898e",
+    "6e603da2-62a1-48e5-8153-2e121f81cd44",
+    "4610425f-42ce-47d7-a6cd-cdebb25e1c2e",
+    "39a277df-75cd-454c-9d1d-0a38108fe286",
+    "b1c5fd0d-7487-4086-b3d7-f6bace799829",
+    "1b3963f1-6f0b-456b-9b3d-238c10b8b6a5",
+    "7c8d8d44-58dc-400a-8799-6976a5d998f4",
+    "afa27860-2fdc-4f9d-a7f1-3288257decbc",
+    "83d32724-c8e4-4efe-b7e6-62d56b5c875f",
+    "519242f8-da1c-4abb-8aed-d2b42f3c0268",
+    "f0630186-cdf8-46e1-ae74-5d4bd3f12e0b",
+    "122d1623-3d05-4a4a-9d89-97ff3aac316d",
+    "54a7c82d-92d0-4f19-a435-105d716901a9",
+    "119369c1-fe0e-47be-bae8-84de7a3fbf7f",
+    "d5918f35-249c-430b-97a4-519e6a227d99",
+    "83c25dd9-6ce8-43fa-b7a5-48353acc0ce3",
+    "6a972a95-07ac-4f16-8c90-366c46e348ca",
+    "c4b7f53d-db2a-4f36-b047-a5c75e7791bb",
+    "7e2f23b5-50e7-4d30-9927-4ab884d7bcdc",
+    "2b3f981d-5349-47d4-be2b-ff538fdd5125",
+    "bdca435b-8084-41ae-ab9c-53b0cf28afb8",
+    "7fa338c3-435b-4e6a-8fca-18192b8637ba",
+    "e1720335-ed90-46d9-9b08-8ece6ab4a77f",
+    "b2f7b058-3376-4785-bc50-0d40085c46be",
+    "a49ea232-88cd-4da1-a516-5d232bac61e4",
+    "bd770ea8-3e6f-4d69-8601-f56202f6a42f",
+    "54844cfc-d08e-4e70-ba32-2a66730e9044",
+    "d1ee7cf8-735c-4fb8-b681-0980bfda0842",
+    "aa4468da-a0f1-44e2-90c7-a7fc17197b6b",
+    "939927d0-b746-4a52-abaa-296880e3ad12",
+    "e33c3ce2-25ff-4177-bef2-94dc9bee3fa0",
+    "8fa143c3-0227-4fe7-84a8-f16518390386",
+    "632da83a-5ccb-4eac-ba63-7636098d6473",
+    "33ee6f13-31e8-49c0-9b96-6b436dc17b21",
+    "576b31ce-5bc0-4304-8cd3-22069e4506f9",
+    "6c351f6a-1984-4735-b9f1-05fdccbc998e",
+    "1bd1b21b-a29f-498b-860f-ef7aee923ee8",
+    "7c957e7a-dbf7-49f7-85ec-50505ce22297",
+    "1e11a6a5-2244-4cf0-9485-ba7d89e1abed",
+    "4493eb52-53a3-43bd-9311-b11b4bf9d3c2",
+    "f5e914d4-fc6f-4a3e-86e5-9d895a0c1b54",
+    "28b560e5-a95f-49b8-8e23-23092238494c",
+    "07a42019-3591-4284-bd1e-0c615f9ccd43",
+    "f526a726-8ec1-4172-bb29-598ec97d51b6",
+    "cd31cf6a-810e-40b7-ad28-a79ee88f5a8f",
+    "cd6e7db7-7115-418b-abf8-ed8f97d8d674",
+    "2a88a25d-2fa9-4fbd-86fe-3178c852bb1e",
+    "f5b03ee4-6619-43f1-aa52-3d16591c0af0",
+    "fe1a3d14-9c66-44f9-8ce5-006a67b94abd",
+    "ee3624bc-fd09-4252-b539-8649e608c0ef",
+    "0baba5a1-11c7-459b-b46d-f91fdc933879",
+    "7cbf8f1f-c43d-4298-ab5b-76ba31c4e56a",
+    "13085b52-6862-48e9-b20b-1df16a2e9479",
+    "4a29d804-f067-43d1-80bc-468651d2844c",
+    "c5d7e8da-1a30-48a5-a75d-94f361d7f0d1",
+    "9081a1ca-4136-4575-bffa-fcb582f84bc7",
+    "fbc17957-b298-413b-977a-7a146b72c6fa",
+    "68b75679-2d49-4501-b66e-b278b524c63d",
+    "5114b30b-12d3-44c5-8a77-31d0cb5e08ce",
+    "247448a1-d53d-4cde-a93c-aa00e06bcc1e",
+    "deca13c9-7b85-4dba-abc2-e45a0e42b9b2",
+    "b91f5948-80b8-4bc6-9f36-b44f2b96f45d",
+    "67bbc246-9ea7-4dc9-9c8a-1772fa780530",
+    "ceb6b125-0cbe-4fd9-9306-69a23c9c9611",
+    "f948744a-be92-48b2-82a0-a7e0cd97f30f",
+    "9a7f2cda-fb08-4d81-b292-7c3c3367f51e",
+    "38213c76-3dfc-451d-846c-b47fc72831ed",
+    "3ab59d2d-9e36-48f9-9672-3370e321b113",
+    "00e5047e-d704-4b19-8c2d-595ab54ab01b",
+    "0d902dc2-fdd8-499e-85af-0e3e116265b1",
+    "b849a589-fd79-4129-a68b-fcd53a2f0589",
+    "da744bfe-4691-4b5a-b61a-dcd9365805de",
+    "b39d2a42-b834-403e-9863-f0486e9c15de",
+    "fc2f09ce-e513-42f0-bf1b-48071dfc7019",
+    "66ce0d88-2bc6-4255-bc7b-6e81394703fa",
+    "162e0e2b-ca3a-4a7f-a976-c87df7b22590",
+    "470a40af-95dc-4026-84dc-19dcb385a4e3",
+    "e39ee05e-070c-442d-9f8d-d782b9878936",
+    "e0d6c895-2311-4f22-aef5-fc3b3094d2e0",
+    "185209fc-7526-44e2-b6c4-da720a21a993",
+    "d0af3542-8d4b-405e-996b-b5afbd6ece2a",
+    "e20aaf9e-88d0-4344-9b2f-5e540ec3791c",
+    "5aa1db08-733d-4d63-b5ad-37caf3dc6bbf",
+    "3f6b44e4-0af1-48ff-b326-61b16eff6ea7",
+    "7e23af80-df68-43bc-8afb-f02615786938",
+    "6a5660a4-a535-4e33-bbe3-eb7eaf07ac89",
+    "fb4d2db8-3417-4e25-8121-f62e95cbe33a"
+  ],
+  "alpaAll": [
+    {
+      "id": "42843ede-f708-454a-9426-2a4fbb45b04e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "05059406-3078-43c4-85e3-3d74034c426b"
+    },
+    {
+      "id": "1ea92e85-c7d2-4a4c-8be2-26f30b84732e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "05059406-3078-43c4-85e3-3d74034c426b"
+    },
+    {
+      "id": "9ccce53e-6036-400e-ada2-861aa6a1b36c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0969aa07-3121-471e-b9be-14b71bb3ecad"
+    },
+    {
+      "id": "7e215c7c-19ad-4128-b255-f9e74f8244f7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0969aa07-3121-471e-b9be-14b71bb3ecad"
+    },
+    {
+      "id": "9ff44c0f-5e76-4e84-829e-e5a9ba375d57",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0c7a823e-7476-4c12-a965-d939af1fdfbb"
+    },
+    {
+      "id": "b8adb481-2057-422b-971b-608990c3ac40",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0c7a823e-7476-4c12-a965-d939af1fdfbb"
+    },
+    {
+      "id": "58ad74f8-f12d-4c79-a42d-e54129b064fe",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0cd2eca7-202f-4f88-9345-e3fb4acc4b4a"
+    },
+    {
+      "id": "9766a537-52c2-4858-86d9-07f223d6bc4c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0cd2eca7-202f-4f88-9345-e3fb4acc4b4a"
+    },
+    {
+      "id": "cf4f23ca-1c05-44e4-ac4f-1a09a47997b3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0eca684a-cf6d-4c9c-8c6b-49562873221a"
+    },
+    {
+      "id": "5f859f10-89e8-4b46-9a2a-289fd66ce9c4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0eca684a-cf6d-4c9c-8c6b-49562873221a"
+    },
+    {
+      "id": "b6ae8b58-0b41-4737-a91b-b92960c03d51",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ee1cf48-dbf8-41f3-8f26-02d6f480bd0b"
+    },
+    {
+      "id": "d9f2d3fb-fc65-46f7-bdc4-e460926c95bb",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0ee1cf48-dbf8-41f3-8f26-02d6f480bd0b"
+    },
+    {
+      "id": "4ee3e6c1-531f-4bfa-bd6d-6cb392193e6a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ef44035-bfdb-46db-8862-44421f1ef906"
+    },
+    {
+      "id": "1c65d8cc-bde1-4ba8-b997-402f2e7386df",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0ef44035-bfdb-46db-8862-44421f1ef906"
+    },
+    {
+      "id": "156a4ad8-fda6-4e82-bd99-9541d456cfd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "10380ad3-cb06-4e7b-ae99-071693283c31"
+    },
+    {
+      "id": "697bea33-7e38-451c-9e24-3ce771a2123c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "10380ad3-cb06-4e7b-ae99-071693283c31"
+    },
+    {
+      "id": "0bc1fd36-9ffc-4b98-8977-0c2445072416",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1333d5f7-8428-4575-bd43-d76fce8a04bb"
+    },
+    {
+      "id": "623b5cfe-7326-4d28-8429-d145de601f83",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1333d5f7-8428-4575-bd43-d76fce8a04bb"
+    },
+    {
+      "id": "dbaf71d5-13f0-458b-88d6-af200731142b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "15660559-77d0-4a75-ac5a-04537f6c004c"
+    },
+    {
+      "id": "f0814898-bb93-4016-a815-f41b4690fffc",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "15660559-77d0-4a75-ac5a-04537f6c004c"
+    },
+    {
+      "id": "5344bd32-37a4-4586-8016-393893b6c8c7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "16e4e421-cd3b-4dce-bebd-777df456c4b6"
+    },
+    {
+      "id": "5a69405d-745b-42ef-9931-924cf8d5907a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "16e4e421-cd3b-4dce-bebd-777df456c4b6"
+    },
+    {
+      "id": "884da29f-9e97-4b03-980f-6b5d9ced3d67",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "181d2c92-c68e-4bf8-b97e-69702e2e8ebc"
+    },
+    {
+      "id": "b2d70b03-b69a-4fb0-99e1-1c5c34c8a160",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "181d2c92-c68e-4bf8-b97e-69702e2e8ebc"
+    },
+    {
+      "id": "3a24ce42-fab7-40fd-8aa7-c238b339f33a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1b03f6c1-71c0-4c3d-aeb6-bb17e01604ea"
+    },
+    {
+      "id": "57cea0c9-c945-492a-bc6f-68f7b4e70c4b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1b03f6c1-71c0-4c3d-aeb6-bb17e01604ea"
+    },
+    {
+      "id": "a8671a46-44c1-433c-84dc-bd057ec5bd9f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1c07aa76-76f2-4b9f-b512-da4d8d85b3f0"
+    },
+    {
+      "id": "fca8091f-9554-4824-a892-5f2054e1b0ed",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1c07aa76-76f2-4b9f-b512-da4d8d85b3f0"
+    },
+    {
+      "id": "09b20bcf-dfe0-4fd7-9f1f-9e28c7c3b7f4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1f033e9b-410e-49e3-8630-6281e4aff947"
+    },
+    {
+      "id": "eed5b2e4-8c77-42e5-8b98-2a30ec36c32f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1f033e9b-410e-49e3-8630-6281e4aff947"
+    },
+    {
+      "id": "b702ab5f-e5e4-43a3-a337-857b7454b29f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "20a4b122-c05d-47ad-86d3-ab3b21b0a857"
+    },
+    {
+      "id": "d907d705-fea0-40c8-88ca-5ec6aa7ef132",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "20a4b122-c05d-47ad-86d3-ab3b21b0a857"
+    },
+    {
+      "id": "92dde1b1-e8fb-489c-9cbf-8404d6777cd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "25115d57-334e-4681-83b6-672b65025d34"
+    },
+    {
+      "id": "21810a9c-edf4-496a-859c-4ac0bc538b33",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "25115d57-334e-4681-83b6-672b65025d34"
+    },
+    {
+      "id": "a505e381-1eb1-4a67-b409-995946a214d3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "254622ed-a732-4468-966d-53d1a0631f4e"
+    },
+    {
+      "id": "700494e4-3f39-4708-bfba-ec77815f2005",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "254622ed-a732-4468-966d-53d1a0631f4e"
+    },
+    {
+      "id": "da021f78-8c23-44d8-bfc3-64c6949a83ce",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "26913bcb-3382-42d0-81f6-20c20cc0056a"
+    },
+    {
+      "id": "587c1f8c-0fb4-4386-94e2-754268d21cc6",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "26913bcb-3382-42d0-81f6-20c20cc0056a"
+    },
+    {
+      "id": "68a7664f-00f4-4215-aab2-8287472fc90d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2bab2980-2cc6-4a0e-bdd2-26aebefb6a71"
+    },
+    {
+      "id": "70d1d648-ef19-4803-b087-c83737cbd817",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2bab2980-2cc6-4a0e-bdd2-26aebefb6a71"
+    },
+    {
+      "id": "98d55dc7-cc47-4460-bc79-8f0331664ce1",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2d5440fd-c858-4530-b3ec-fa47892d0b1a"
+    },
+    {
+      "id": "fd79bed3-8250-46f2-a7f1-063737563038",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2d5440fd-c858-4530-b3ec-fa47892d0b1a"
+    },
+    {
+      "id": "626dd13c-821d-4c9e-9065-64f114256707",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2eef2a86-c557-46c3-9d6a-e9ea5b3b16dc"
+    },
+    {
+      "id": "c160708f-430a-4c1a-8733-bc7048c23ce4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2eef2a86-c557-46c3-9d6a-e9ea5b3b16dc"
+    },
+    {
+      "id": "553be114-eb0e-420f-8551-5b7a630aaddd",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2f751ffe-361f-4acd-b830-e79496806422"
+    },
+    {
+      "id": "ef28089f-8bea-437a-a519-0331280e3932",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2f751ffe-361f-4acd-b830-e79496806422"
+    },
+    {
+      "id": "54d601e0-4cdd-4e64-b722-f634e1d67078",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "30314bcc-8234-4817-9343-c80b8fdf0335"
+    },
+    {
+      "id": "081402a3-7090-4f58-8cfe-24490381eaf7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "30314bcc-8234-4817-9343-c80b8fdf0335"
+    },
+    {
+      "id": "e04753fc-c798-47ff-ab5f-fe36e8f230b6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3176f7d0-f9f2-47d7-a8f6-c1bd16b2421d"
+    },
+    {
+      "id": "687ec918-a734-42fb-953d-f1b82b2ccb38",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3176f7d0-f9f2-47d7-a8f6-c1bd16b2421d"
+    },
+    {
+      "id": "5c512b73-1a42-4e0c-b2b4-74746eea617a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3192ad9a-efe3-4bae-aa5d-365f47bb8b9d"
+    },
+    {
+      "id": "b2ca0cb7-c20f-44c1-b58c-a90de9dd5309",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3192ad9a-efe3-4bae-aa5d-365f47bb8b9d"
+    },
+    {
+      "id": "0d9bafde-0982-4443-92d7-283a3711ff5e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "326d979b-6d53-4466-bc58-99124a03c9ed"
+    },
+    {
+      "id": "1fbb31c6-9346-496a-9bc7-14cfd2938b58",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "326d979b-6d53-4466-bc58-99124a03c9ed"
+    },
+    {
+      "id": "d0caeb07-3486-43f6-ab18-54466753e44c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "327f04d7-1940-4959-a181-71a2afae932b"
+    },
+    {
+      "id": "2fb93376-37a2-408d-96c0-b75879be87ba",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "327f04d7-1940-4959-a181-71a2afae932b"
+    },
+    {
+      "id": "bf67fdf8-dd32-4697-a465-0a9ce1221b27",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33a622b9-dd03-4007-830e-a8ba6a7d403e"
+    },
+    {
+      "id": "2908a674-dfb3-4b20-83d6-a17980f74d07",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "33a622b9-dd03-4007-830e-a8ba6a7d403e"
+    },
+    {
+      "id": "1d6f1de5-b639-4a74-a816-0a904a1bb75a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33cb0161-b755-4881-8b56-a2c278717ef6"
+    },
+    {
+      "id": "e27e32f7-bfa3-44c1-bba0-bee11407e0e5",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "33cb0161-b755-4881-8b56-a2c278717ef6"
+    },
+    {
+      "id": "334005aa-8631-436c-ac9a-f22389a2593f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "38b86b4f-b069-41de-9afc-9da31af5537e"
+    },
+    {
+      "id": "2c62a1f6-646a-4efd-90a5-233bb89303d7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "38b86b4f-b069-41de-9afc-9da31af5537e"
+    },
+    {
+      "id": "13dc2bb5-a297-4cde-a23c-8832e5cb418a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3ae1b29e-21bb-4d0f-ab4c-3468da66fc29"
+    },
+    {
+      "id": "fd0da4fa-1164-4e60-a9ea-2c0fbc822b4c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3ae1b29e-21bb-4d0f-ab4c-3468da66fc29"
+    },
+    {
+      "id": "68b4c0f3-20df-446f-8a72-0f9dbce3ab4d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3fc6250b-e4b0-4237-935c-bfc5b6bd7798"
+    },
+    {
+      "id": "4cae9ea0-2862-4d47-a2f4-08c193086180",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3fc6250b-e4b0-4237-935c-bfc5b6bd7798"
+    },
+    {
+      "id": "3f48ba47-cbe2-4288-baca-6910caf9d0de",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "40e7112b-7292-4b08-bede-0c130c1303a9"
+    },
+    {
+      "id": "70b2a1c7-9a47-4999-9d50-eec51fb286f2",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "40e7112b-7292-4b08-bede-0c130c1303a9"
+    },
+    {
+      "id": "def0f945-bd2f-46a0-bb1a-80a1087d7070",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "41288e0c-ce52-4c35-9bbd-f60146bb738e"
+    },
+    {
+      "id": "54f620d1-5241-4c34-8bb4-c9db373fa0e4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "41288e0c-ce52-4c35-9bbd-f60146bb738e"
+    },
+    {
+      "id": "61383236-242f-42f2-bb79-4d623f07abc2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4a434d3d-2f89-4aa5-949a-2aeea7efe874"
+    },
+    {
+      "id": "cb2cd656-e5e1-41fb-a93f-c034b01c4c05",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4a434d3d-2f89-4aa5-949a-2aeea7efe874"
+    },
+    {
+      "id": "682ed82e-7558-4d5d-85cf-4339b4b968f7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e118b9e-6e66-4664-b3d4-e7d227f9fb61"
+    },
+    {
+      "id": "9f4f7ef1-946a-479f-aaaa-f778a20371df",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4e118b9e-6e66-4664-b3d4-e7d227f9fb61"
+    },
+    {
+      "id": "64ca01d9-cc1c-450c-b3bb-a996965cc2e5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e19b261-4711-486a-92fa-46ccc30699be"
+    },
+    {
+      "id": "216d2895-f8fb-4b8d-aff0-8ca850aeff94",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4e19b261-4711-486a-92fa-46ccc30699be"
+    },
+    {
+      "id": "363a0791-fce6-4b68-8c86-befec13d3b66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e6b6194-e946-4f73-ae4b-8c11d110a6fb"
+    },
+    {
+      "id": "f51d0d4f-cd32-4d91-b8b2-8b4c5167490c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4e6b6194-e946-4f73-ae4b-8c11d110a6fb"
+    },
+    {
+      "id": "c8e54b09-43db-4b92-82b9-93d96b5e4bd2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4f019b91-6f85-423b-948e-c804246f908e"
+    },
+    {
+      "id": "603e149e-f3e0-460f-b267-723a18f6d4c6",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4f019b91-6f85-423b-948e-c804246f908e"
+    },
+    {
+      "id": "3d2784c3-ee5b-45c7-aa08-8b4ed74968aa",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5189ad94-ca4f-4a75-b61b-fa38feb38947"
+    },
+    {
+      "id": "23d9dbc4-c2e1-4dac-b463-b8d51eeb3844",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5189ad94-ca4f-4a75-b61b-fa38feb38947"
+    },
+    {
+      "id": "e638ab86-f832-4eac-a76a-030e02de84a6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "52320561-2f0a-4ee1-8077-0ea959ee8a41"
+    },
+    {
+      "id": "dd0bb1bc-63e0-4599-a5d0-37882ad6898e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "52320561-2f0a-4ee1-8077-0ea959ee8a41"
+    },
+    {
+      "id": "aee405cd-dae2-4a0e-bb1d-52ae05b74778",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5453dada-25b6-4562-b39f-78307bda471b"
+    },
+    {
+      "id": "6e603da2-62a1-48e5-8153-2e121f81cd44",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5453dada-25b6-4562-b39f-78307bda471b"
+    },
+    {
+      "id": "bb229140-aaa3-4e7a-9f3e-dac7b9309219",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "555545c2-5159-4ceb-b326-1d94e3200ab9"
+    },
+    {
+      "id": "4610425f-42ce-47d7-a6cd-cdebb25e1c2e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "555545c2-5159-4ceb-b326-1d94e3200ab9"
+    },
+    {
+      "id": "26cb7865-902e-4266-80db-e3d60cd461d4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "559aed4c-452c-42b4-a5c3-efde3496c5a3"
+    },
+    {
+      "id": "39a277df-75cd-454c-9d1d-0a38108fe286",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "559aed4c-452c-42b4-a5c3-efde3496c5a3"
+    },
+    {
+      "id": "1192a6eb-fd9b-4030-a973-dbd8cb9753ef",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "56bb9c94-9ef3-4755-800f-b86d2d15360a"
+    },
+    {
+      "id": "b1c5fd0d-7487-4086-b3d7-f6bace799829",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "56bb9c94-9ef3-4755-800f-b86d2d15360a"
+    },
+    {
+      "id": "f0878825-26d1-46b7-965d-8ea697141ebb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "57f8f423-3f80-4d12-9872-9c169c848ed2"
+    },
+    {
+      "id": "1b3963f1-6f0b-456b-9b3d-238c10b8b6a5",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "57f8f423-3f80-4d12-9872-9c169c848ed2"
+    },
+    {
+      "id": "268dc74c-c111-46ad-8376-840cd062d9ff",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "587bee01-82d2-4388-b836-695aeaf3bb0c"
+    },
+    {
+      "id": "7c8d8d44-58dc-400a-8799-6976a5d998f4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "587bee01-82d2-4388-b836-695aeaf3bb0c"
+    },
+    {
+      "id": "3d439055-60c0-49c3-b93e-c6cd4b6a3485",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5afc7867-6734-4ab7-bdae-c00a481e7123"
+    },
+    {
+      "id": "afa27860-2fdc-4f9d-a7f1-3288257decbc",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5afc7867-6734-4ab7-bdae-c00a481e7123"
+    },
+    {
+      "id": "72b9a5be-1888-4eb6-b4e6-d1f155679aeb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5f28a435-d8a0-4eec-bcc0-fbe462ba39e8"
+    },
+    {
+      "id": "83d32724-c8e4-4efe-b7e6-62d56b5c875f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5f28a435-d8a0-4eec-bcc0-fbe462ba39e8"
+    },
+    {
+      "id": "c03ccd06-d689-4f73-8acc-31d98aa43323",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5febc193-3e36-4abe-be13-6cd3e3a61ec4"
+    },
+    {
+      "id": "519242f8-da1c-4abb-8aed-d2b42f3c0268",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5febc193-3e36-4abe-be13-6cd3e3a61ec4"
+    },
+    {
+      "id": "72e06d99-44fb-418c-9c0c-72105e9d60c6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6638aa15-a453-418b-9770-1b6731ea4ce6"
+    },
+    {
+      "id": "f0630186-cdf8-46e1-ae74-5d4bd3f12e0b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6638aa15-a453-418b-9770-1b6731ea4ce6"
+    },
+    {
+      "id": "617502d2-b62a-4a4e-9244-d2a035dd6eec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "665e4f90-3fc8-4543-a922-f9a8a37dd8ca"
+    },
+    {
+      "id": "122d1623-3d05-4a4a-9d89-97ff3aac316d",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "665e4f90-3fc8-4543-a922-f9a8a37dd8ca"
+    },
+    {
+      "id": "4794d62c-891f-4bb5-b4c1-2fd4118f9a8b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "693e077d-cabc-4fa8-aa46-8a268d1e3fa4"
+    },
+    {
+      "id": "54a7c82d-92d0-4f19-a435-105d716901a9",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "693e077d-cabc-4fa8-aa46-8a268d1e3fa4"
+    },
+    {
+      "id": "020ca948-610e-48cb-9499-f5cd50d1eb24",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "69cbd105-7d07-42e8-9e9e-ac7bbbe4a4e7"
+    },
+    {
+      "id": "119369c1-fe0e-47be-bae8-84de7a3fbf7f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "69cbd105-7d07-42e8-9e9e-ac7bbbe4a4e7"
+    },
+    {
+      "id": "b04896d0-8f8c-4bc8-b6a3-cd95cda33967",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6a49b433-e539-495b-b897-a485d4ea393a"
+    },
+    {
+      "id": "d5918f35-249c-430b-97a4-519e6a227d99",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6a49b433-e539-495b-b897-a485d4ea393a"
+    },
+    {
+      "id": "cab734ed-5fb4-4cbe-afa7-7978e566f108",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6d853c0a-3ae8-4d4e-bfe5-ce5cf389fdc7"
+    },
+    {
+      "id": "83c25dd9-6ce8-43fa-b7a5-48353acc0ce3",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6d853c0a-3ae8-4d4e-bfe5-ce5cf389fdc7"
+    },
+    {
+      "id": "77c05c23-d4d0-4639-8550-2436bef18e10",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6dca668d-b579-4d2b-9c5b-0a9717dcb4ff"
+    },
+    {
+      "id": "6a972a95-07ac-4f16-8c90-366c46e348ca",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6dca668d-b579-4d2b-9c5b-0a9717dcb4ff"
+    },
+    {
+      "id": "fee08649-fe02-41a8-9e7d-f3460d960775",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6e87e403-72cf-4382-8183-4844ceeb4023"
+    },
+    {
+      "id": "c4b7f53d-db2a-4f36-b047-a5c75e7791bb",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6e87e403-72cf-4382-8183-4844ceeb4023"
+    },
+    {
+      "id": "cc9dcada-dbba-454c-a80b-a8e087f5b937",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6ebaab14-7739-41c0-baea-edb8eb529690"
+    },
+    {
+      "id": "7e2f23b5-50e7-4d30-9927-4ab884d7bcdc",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6ebaab14-7739-41c0-baea-edb8eb529690"
+    },
+    {
+      "id": "bf449f88-04f1-4793-b569-2fe08798c181",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6fa6e58b-792f-4699-8724-152f2d28f3c1"
+    },
+    {
+      "id": "2b3f981d-5349-47d4-be2b-ff538fdd5125",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6fa6e58b-792f-4699-8724-152f2d28f3c1"
+    },
+    {
+      "id": "2860219b-535a-4d86-a3bb-2f6649081c37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7295dc9b-ffe4-4de5-8004-1d2beb8159d2"
+    },
+    {
+      "id": "bdca435b-8084-41ae-ab9c-53b0cf28afb8",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7295dc9b-ffe4-4de5-8004-1d2beb8159d2"
+    },
+    {
+      "id": "e6eb4cee-0930-4ce2-a122-1c08c98bf70a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "72b41997-ad23-4091-9fa3-a8dc174e0b17"
+    },
+    {
+      "id": "7fa338c3-435b-4e6a-8fca-18192b8637ba",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "72b41997-ad23-4091-9fa3-a8dc174e0b17"
+    },
+    {
+      "id": "5c58cf47-925c-42d0-ab44-f006a432e076",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7357848d-de00-448c-a0bd-c39d16cee26b"
+    },
+    {
+      "id": "e1720335-ed90-46d9-9b08-8ece6ab4a77f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7357848d-de00-448c-a0bd-c39d16cee26b"
+    },
+    {
+      "id": "2270627e-2a2f-4a1c-a767-ca064b15bee0",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "75625293-fd9c-4bd1-a6b5-4aaad5d83b0a"
+    },
+    {
+      "id": "b2f7b058-3376-4785-bc50-0d40085c46be",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "75625293-fd9c-4bd1-a6b5-4aaad5d83b0a"
+    },
+    {
+      "id": "17ce28e5-9162-47f0-8048-b3c4e96ddabb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "76eed511-6de0-4e23-bb3b-b61af3a8a449"
+    },
+    {
+      "id": "a49ea232-88cd-4da1-a516-5d232bac61e4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "76eed511-6de0-4e23-bb3b-b61af3a8a449"
+    },
+    {
+      "id": "91e61d0a-8ecf-4b65-b441-3036c2041f98",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7757ca13-adfb-44f6-9a53-091049bb0f96"
+    },
+    {
+      "id": "bd770ea8-3e6f-4d69-8601-f56202f6a42f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7757ca13-adfb-44f6-9a53-091049bb0f96"
+    },
+    {
+      "id": "9da7ae8b-984f-44a6-8916-5ab5265c3756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7d5fb158-562f-4ec6-9c51-d5aebab64e18"
+    },
+    {
+      "id": "54844cfc-d08e-4e70-ba32-2a66730e9044",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7d5fb158-562f-4ec6-9c51-d5aebab64e18"
+    },
+    {
+      "id": "9714c60c-364a-412b-8136-44eed1620d1c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7f2b9909-4473-4c34-94b5-e06e1995e8f1"
+    },
+    {
+      "id": "d1ee7cf8-735c-4fb8-b681-0980bfda0842",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7f2b9909-4473-4c34-94b5-e06e1995e8f1"
+    },
+    {
+      "id": "d78cbb70-9758-4ad4-9bf4-9be1cd7befcb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "815f1ccd-b780-4541-992e-06df8cae3a1e"
+    },
+    {
+      "id": "aa4468da-a0f1-44e2-90c7-a7fc17197b6b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "815f1ccd-b780-4541-992e-06df8cae3a1e"
+    },
+    {
+      "id": "e91062d7-4dcf-4f1c-8720-005dad187089",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83cdb339-d105-4bcf-b545-3efd80a10d6b"
+    },
+    {
+      "id": "939927d0-b746-4a52-abaa-296880e3ad12",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "83cdb339-d105-4bcf-b545-3efd80a10d6b"
+    },
+    {
+      "id": "4ee55304-6356-44a0-8143-c33a2085137b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83de3ac4-b57a-44c1-8c55-8b7752834231"
+    },
+    {
+      "id": "e33c3ce2-25ff-4177-bef2-94dc9bee3fa0",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "83de3ac4-b57a-44c1-8c55-8b7752834231"
+    },
+    {
+      "id": "3202957c-b6c0-4072-ae21-828fbafd4663",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "85f977f6-d92e-4e86-a696-68db873b3afd"
+    },
+    {
+      "id": "8fa143c3-0227-4fe7-84a8-f16518390386",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "85f977f6-d92e-4e86-a696-68db873b3afd"
+    },
+    {
+      "id": "486d7194-626a-4086-86e0-50cc538de7d5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "874ab15e-4b76-4cf2-902f-dc35e445c747"
+    },
+    {
+      "id": "632da83a-5ccb-4eac-ba63-7636098d6473",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "874ab15e-4b76-4cf2-902f-dc35e445c747"
+    },
+    {
+      "id": "b7ca53b7-cff4-4370-8ca0-e3dfed0c3c88",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "887d6318-fc1b-44d2-ba58-5861d7337f88"
+    },
+    {
+      "id": "33ee6f13-31e8-49c0-9b96-6b436dc17b21",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "887d6318-fc1b-44d2-ba58-5861d7337f88"
+    },
+    {
+      "id": "babe7d35-cc47-4cac-b1c3-01c1e8a119a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "8bd07931-33f5-476c-8c1f-64762730fc60"
+    },
+    {
+      "id": "576b31ce-5bc0-4304-8cd3-22069e4506f9",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "8bd07931-33f5-476c-8c1f-64762730fc60"
+    },
+    {
+      "id": "111e0f58-2bf6-481c-9f3c-fae0582ca405",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "9025299a-46cb-4793-b1b8-5281e71eda4c"
+    },
+    {
+      "id": "6c351f6a-1984-4735-b9f1-05fdccbc998e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "9025299a-46cb-4793-b1b8-5281e71eda4c"
+    },
+    {
+      "id": "d5107417-fedd-45f1-a430-73f852422479",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "91188d0e-a532-4e63-8b14-ae60ab6f86b7"
+    },
+    {
+      "id": "1bd1b21b-a29f-498b-860f-ef7aee923ee8",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "91188d0e-a532-4e63-8b14-ae60ab6f86b7"
+    },
+    {
+      "id": "9ea7aecc-6f36-4710-830f-5c9422288400",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "92ce53e8-9ee5-4eca-ab12-c3bb6e23bc9f"
+    },
+    {
+      "id": "7c957e7a-dbf7-49f7-85ec-50505ce22297",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "92ce53e8-9ee5-4eca-ab12-c3bb6e23bc9f"
+    },
+    {
+      "id": "6bc5444e-464e-4c7b-b207-fb5d6346d603",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "95d53b99-1597-4444-b993-527df1ccebf3"
+    },
+    {
+      "id": "1e11a6a5-2244-4cf0-9485-ba7d89e1abed",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "95d53b99-1597-4444-b993-527df1ccebf3"
+    },
+    {
+      "id": "73370b86-66ce-4f6b-9f8b-2c0cea3aac13",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "97cbc411-879e-48e9-b869-8a55afa41090"
+    },
+    {
+      "id": "4493eb52-53a3-43bd-9311-b11b4bf9d3c2",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "97cbc411-879e-48e9-b869-8a55afa41090"
+    },
+    {
+      "id": "15ff5c47-d23d-4faf-b1d3-3f46a08ddfc4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "996df6f9-cf4c-4853-944d-d7db32984e7f"
+    },
+    {
+      "id": "f5e914d4-fc6f-4a3e-86e5-9d895a0c1b54",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "996df6f9-cf4c-4853-944d-d7db32984e7f"
+    },
+    {
+      "id": "3a0782ed-02f0-4b8b-856b-5a48020f038d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "99c0a586-4046-4760-8bbf-ba32930282c7"
+    },
+    {
+      "id": "28b560e5-a95f-49b8-8e23-23092238494c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "99c0a586-4046-4760-8bbf-ba32930282c7"
+    },
+    {
+      "id": "01bee3bd-e6d8-4485-bc81-58345aff8856",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "9c032753-98bb-4f12-b83e-14fc9021ecd8"
+    },
+    {
+      "id": "07a42019-3591-4284-bd1e-0c615f9ccd43",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "9c032753-98bb-4f12-b83e-14fc9021ecd8"
+    },
+    {
+      "id": "e44f6330-f4a9-4981-bec6-e1a004de39ec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a2c90b29-884b-4c3f-8fe4-f4eb7815f8b0"
+    },
+    {
+      "id": "f526a726-8ec1-4172-bb29-598ec97d51b6",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a2c90b29-884b-4c3f-8fe4-f4eb7815f8b0"
+    },
+    {
+      "id": "1a02eafe-945a-4afb-a2e6-e9da5b654a83",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a360ee62-c030-41fc-abda-ec987b36d5e2"
+    },
+    {
+      "id": "cd31cf6a-810e-40b7-ad28-a79ee88f5a8f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a360ee62-c030-41fc-abda-ec987b36d5e2"
+    },
+    {
+      "id": "9e6a9491-c05e-4d00-946f-cd8400bdd361",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a3ead96b-c524-496e-b4fd-a9b6ac24db50"
+    },
+    {
+      "id": "cd6e7db7-7115-418b-abf8-ed8f97d8d674",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a3ead96b-c524-496e-b4fd-a9b6ac24db50"
+    },
+    {
+      "id": "b52e6d66-cd08-48ba-8957-dcc3ef013645",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a687bbdd-949d-45c2-8b61-5af6c7f8ccbd"
+    },
+    {
+      "id": "2a88a25d-2fa9-4fbd-86fe-3178c852bb1e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a687bbdd-949d-45c2-8b61-5af6c7f8ccbd"
+    },
+    {
+      "id": "363ac789-43ee-4671-849f-703c0b6eb27f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a844ff90-3557-49c4-920f-6be929d4ddb8"
+    },
+    {
+      "id": "f5b03ee4-6619-43f1-aa52-3d16591c0af0",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a844ff90-3557-49c4-920f-6be929d4ddb8"
+    },
+    {
+      "id": "8733e859-eeef-42c2-ba56-f66f9ca1f35f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a9e3fa98-9626-4848-a7cd-583be703b5f3"
+    },
+    {
+      "id": "fe1a3d14-9c66-44f9-8ce5-006a67b94abd",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a9e3fa98-9626-4848-a7cd-583be703b5f3"
+    },
+    {
+      "id": "ada1d953-5e80-460d-bcbb-c94d3b61b5a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "aac1d53e-ed49-48e4-8d30-eb978df0dc66"
+    },
+    {
+      "id": "ee3624bc-fd09-4252-b539-8649e608c0ef",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "aac1d53e-ed49-48e4-8d30-eb978df0dc66"
+    },
+    {
+      "id": "989592ea-eb2f-4e57-9164-e07abe7d685f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ad3be288-5813-4403-ba03-8e54c29871c2"
+    },
+    {
+      "id": "0baba5a1-11c7-459b-b46d-f91fdc933879",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ad3be288-5813-4403-ba03-8e54c29871c2"
+    },
+    {
+      "id": "9e23b5d1-7544-4f2f-9bd6-dab4f4920c20",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ae2907cc-0787-4041-af52-277c5b7fa018"
+    },
+    {
+      "id": "7cbf8f1f-c43d-4298-ab5b-76ba31c4e56a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ae2907cc-0787-4041-af52-277c5b7fa018"
+    },
+    {
+      "id": "881450ae-8b26-4c79-a6b7-168289dbcd66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0360e22-b4e9-433f-bed8-90a80d7247ec"
+    },
+    {
+      "id": "13085b52-6862-48e9-b20b-1df16a2e9479",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "b0360e22-b4e9-433f-bed8-90a80d7247ec"
+    },
+    {
+      "id": "45898c8c-8a9e-4482-b43d-367332c75156",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0d772b5-4483-4d2a-b6c7-c7b4cdad0f79"
+    },
+    {
+      "id": "4a29d804-f067-43d1-80bc-468651d2844c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "b0d772b5-4483-4d2a-b6c7-c7b4cdad0f79"
+    },
+    {
+      "id": "581d19ad-3681-4a8f-bb68-d94a4a618ff8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b2b9da14-5e34-40be-a251-f8c43170c267"
+    },
+    {
+      "id": "c5d7e8da-1a30-48a5-a75d-94f361d7f0d1",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "b2b9da14-5e34-40be-a251-f8c43170c267"
+    },
+    {
+      "id": "5bfc0b5b-817c-4deb-8ae2-794532951b00",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bab993ab-1242-44ed-bdfd-547ae3cde53d"
+    },
+    {
+      "id": "9081a1ca-4136-4575-bffa-fcb582f84bc7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bab993ab-1242-44ed-bdfd-547ae3cde53d"
+    },
+    {
+      "id": "8b5462d8-b430-44b8-aa1d-1c623de30756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bf34d173-c2c4-4fa4-b620-40990180ee04"
+    },
+    {
+      "id": "fbc17957-b298-413b-977a-7a146b72c6fa",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bf34d173-c2c4-4fa4-b620-40990180ee04"
+    },
+    {
+      "id": "98a3c0d6-d4af-4702-aa5d-8477c2667a99",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfbb2957-1f35-4bd3-867d-74c1c9a2b0ff"
+    },
+    {
+      "id": "68b75679-2d49-4501-b66e-b278b524c63d",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bfbb2957-1f35-4bd3-867d-74c1c9a2b0ff"
+    },
+    {
+      "id": "bbdde4ee-445c-4c04-bc14-ea75f2718c7c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfe42149-ff1c-432f-87ea-6e352e029c2d"
+    },
+    {
+      "id": "5114b30b-12d3-44c5-8a77-31d0cb5e08ce",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bfe42149-ff1c-432f-87ea-6e352e029c2d"
+    },
+    {
+      "id": "f33088bd-5993-4f65-bef1-0a3abca24a97",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0dceb21-b206-4239-a7e7-5c87019d503e"
+    },
+    {
+      "id": "247448a1-d53d-4cde-a93c-aa00e06bcc1e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c0dceb21-b206-4239-a7e7-5c87019d503e"
+    },
+    {
+      "id": "8d52778c-0c4f-4acf-a0c6-ebeb0b06784f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0ecee8e-7e6c-42a7-b132-e3dacb15af64"
+    },
+    {
+      "id": "deca13c9-7b85-4dba-abc2-e45a0e42b9b2",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c0ecee8e-7e6c-42a7-b132-e3dacb15af64"
+    },
+    {
+      "id": "9fe7407a-b847-4f5d-840c-4c61e98ef739",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5542092-d005-4b18-8625-96a5d5f7b2dc"
+    },
+    {
+      "id": "b91f5948-80b8-4bc6-9f36-b44f2b96f45d",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c5542092-d005-4b18-8625-96a5d5f7b2dc"
+    },
+    {
+      "id": "fb19b92a-d71b-4675-8568-b38c7c629f6b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5f0b932-f200-46c6-948f-62b82ecb1e12"
+    },
+    {
+      "id": "67bbc246-9ea7-4dc9-9c8a-1772fa780530",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c5f0b932-f200-46c6-948f-62b82ecb1e12"
+    },
+    {
+      "id": "60806f0e-f422-4a0a-b875-96fb065bf712",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c69d1467-bbb7-4c88-8994-ed3d9891ea61"
+    },
+    {
+      "id": "ceb6b125-0cbe-4fd9-9306-69a23c9c9611",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c69d1467-bbb7-4c88-8994-ed3d9891ea61"
+    },
+    {
+      "id": "fe076bcf-cd72-4e84-9200-1ea57ff02e93",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c79b6112-d0c8-4759-8111-9dc41a4f2eb7"
+    },
+    {
+      "id": "f948744a-be92-48b2-82a0-a7e0cd97f30f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c79b6112-d0c8-4759-8111-9dc41a4f2eb7"
+    },
+    {
+      "id": "f8421634-3478-4b16-8866-b3b97c54dcd6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d07ce626-a755-4248-97c7-b39bbab5a96f"
+    },
+    {
+      "id": "9a7f2cda-fb08-4d81-b292-7c3c3367f51e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d07ce626-a755-4248-97c7-b39bbab5a96f"
+    },
+    {
+      "id": "88964032-4c08-45d1-b5a2-c4428241f395",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d6bb573d-6f43-448e-b73e-b6db5ba9d850"
+    },
+    {
+      "id": "38213c76-3dfc-451d-846c-b47fc72831ed",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d6bb573d-6f43-448e-b73e-b6db5ba9d850"
+    },
+    {
+      "id": "8ac42dfb-044c-42bb-b866-5b8b03afa0df",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9a7717d-d862-4ea6-b03f-8106779dda88"
+    },
+    {
+      "id": "3ab59d2d-9e36-48f9-9672-3370e321b113",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d9a7717d-d862-4ea6-b03f-8106779dda88"
+    },
+    {
+      "id": "0a927479-ba1c-4391-843f-436f574fbff9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9e1f554-5130-4595-bf31-2f40407abb08"
+    },
+    {
+      "id": "00e5047e-d704-4b19-8c2d-595ab54ab01b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d9e1f554-5130-4595-bf31-2f40407abb08"
+    },
+    {
+      "id": "b9d4fc15-04c9-4700-af4e-c93db471e0a5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "db3667b2-7590-4b62-9b50-ed5529f92a08"
+    },
+    {
+      "id": "0d902dc2-fdd8-499e-85af-0e3e116265b1",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "db3667b2-7590-4b62-9b50-ed5529f92a08"
+    },
+    {
+      "id": "13f6a83f-38e0-4a79-b7e0-d03a8af8f536",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "dd10c923-3afd-4819-88c4-7d9556ce4278"
+    },
+    {
+      "id": "b849a589-fd79-4129-a68b-fcd53a2f0589",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "dd10c923-3afd-4819-88c4-7d9556ce4278"
+    },
+    {
+      "id": "d037da74-eb05-439c-bed4-1177d85385eb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e14a07f2-c509-4f2b-accf-e2dfe9afb8bd"
+    },
+    {
+      "id": "da744bfe-4691-4b5a-b61a-dcd9365805de",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "e14a07f2-c509-4f2b-accf-e2dfe9afb8bd"
+    },
+    {
+      "id": "87b344a3-45c6-4c3e-ab40-fc32d4a267cb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e8f18266-8492-4ff2-8c88-962174b21da5"
+    },
+    {
+      "id": "b39d2a42-b834-403e-9863-f0486e9c15de",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "e8f18266-8492-4ff2-8c88-962174b21da5"
+    },
+    {
+      "id": "c4cb139a-b678-4aab-90b6-b2c3d07678bb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e9440683-ff23-4f80-94bb-bacb51cf3ea9"
+    },
+    {
+      "id": "fc2f09ce-e513-42f0-bf1b-48071dfc7019",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "e9440683-ff23-4f80-94bb-bacb51cf3ea9"
+    },
+    {
+      "id": "752c2086-89f1-4fc2-90f8-014a26e04981",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ed0302db-26aa-4276-a9f0-78e9dc564aca"
+    },
+    {
+      "id": "66ce0d88-2bc6-4255-bc7b-6e81394703fa",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ed0302db-26aa-4276-a9f0-78e9dc564aca"
+    },
+    {
+      "id": "65c9d9b1-07b4-425b-9ea6-533a3c84e5be",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eea22c27-3d7d-46a9-a69a-000cd24ce85e"
+    },
+    {
+      "id": "162e0e2b-ca3a-4a7f-a976-c87df7b22590",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "eea22c27-3d7d-46a9-a69a-000cd24ce85e"
+    },
+    {
+      "id": "eb404cbf-1d0e-4cd8-a9a3-4e1e77dfaf3e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eed61bbb-a742-4b2f-a740-94c05f6f4f24"
+    },
+    {
+      "id": "470a40af-95dc-4026-84dc-19dcb385a4e3",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "eed61bbb-a742-4b2f-a740-94c05f6f4f24"
+    },
+    {
+      "id": "64f206d8-548d-4f8d-9ea6-26d92f5f8271",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ef58ba70-9ea8-437f-bfb5-c21e992e5c95"
+    },
+    {
+      "id": "e39ee05e-070c-442d-9f8d-d782b9878936",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ef58ba70-9ea8-437f-bfb5-c21e992e5c95"
+    },
+    {
+      "id": "8f8d358a-142e-4cff-be2e-c6e27b838244",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f2b5ef75-e846-4ac4-92b1-124c8720e14c"
+    },
+    {
+      "id": "e0d6c895-2311-4f22-aef5-fc3b3094d2e0",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f2b5ef75-e846-4ac4-92b1-124c8720e14c"
+    },
+    {
+      "id": "3efaceb2-5ab5-4217-8eb2-10e30c493d77",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f3774fe4-976c-4c61-b570-854d0cbd547f"
+    },
+    {
+      "id": "185209fc-7526-44e2-b6c4-da720a21a993",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f3774fe4-976c-4c61-b570-854d0cbd547f"
+    },
+    {
+      "id": "5c3a366f-58e5-4d73-b38d-c7aed64bbbae",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f39425d7-a23c-48f8-bac0-1d8459ff9b04"
+    },
+    {
+      "id": "d0af3542-8d4b-405e-996b-b5afbd6ece2a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f39425d7-a23c-48f8-bac0-1d8459ff9b04"
+    },
+    {
+      "id": "102ad8a6-660b-4ae7-bdae-6cdcc8082e37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f64c5dc5-678f-42cf-af57-9dcb225ce479"
+    },
+    {
+      "id": "e20aaf9e-88d0-4344-9b2f-5e540ec3791c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f64c5dc5-678f-42cf-af57-9dcb225ce479"
+    },
+    {
+      "id": "b017cbc0-5ef7-474e-9f47-51bef2d2cc2d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa1534e6-2279-4567-9019-6af88a6c3689"
+    },
+    {
+      "id": "5aa1db08-733d-4d63-b5ad-37caf3dc6bbf",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fa1534e6-2279-4567-9019-6af88a6c3689"
+    },
+    {
+      "id": "0de8a1da-640a-4bd6-983d-5e8a56368965",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa8193a4-a289-48da-b18f-4ac9f66e4e9c"
+    },
+    {
+      "id": "3f6b44e4-0af1-48ff-b326-61b16eff6ea7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fa8193a4-a289-48da-b18f-4ac9f66e4e9c"
+    },
+    {
+      "id": "aea9393a-52b3-4235-9c52-790cc9a97ce8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "faf22799-7f6f-48fb-a58e-04a30b37e0c9"
+    },
+    {
+      "id": "7e23af80-df68-43bc-8afb-f02615786938",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "faf22799-7f6f-48fb-a58e-04a30b37e0c9"
+    },
+    {
+      "id": "3374b1a3-6a20-4db2-80ca-d2d3002a879d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fb62dbd4-5911-410e-8b14-814b5a6a3e81"
+    },
+    {
+      "id": "6a5660a4-a535-4e33-bbe3-eb7eaf07ac89",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fb62dbd4-5911-410e-8b14-814b5a6a3e81"
+    },
+    {
+      "id": "0f7060c8-8ced-46e7-b614-ad0a690b730c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fe5e105f-a264-4ea6-ab09-025ffaf1d149"
+    },
+    {
+      "id": "fb4d2db8-3417-4e25-8121-f62e95cbe33a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fe5e105f-a264-4ea6-ab09-025ffaf1d149"
+    }
+  ]
+}


### PR DESCRIPTION
Activates the Goods buyer engine into GHL and cleans up the entity graph. Writes were applied to the shared Supabase + GHL during the session; this PR is the reusable tooling + audit/restore record.

## What's here
- **push-goods-top25-to-demand-register.mjs** — push top-25 by `fit_score` (deduped) into GHL "Goods — Demand Register" / Buyer Matched, with `ghl_*` writeback. Idempotent.
- **add-goods-anchor-buyers.mjs** — add 3 warm anchor buyers (Outback Stores, Miwatj Health, Tangentyere) with real ABNs + a warmth `fit_score` floor (the scorer measures contract evidence, not warmth). Dedupes ALPA casing 256→128.
- **fix-alpa-overmatch.mjs** — collapse ALPA proximity over-match (one org fanned to 128 communities) to a single network entity; re-points dependent signals.
- **drop-goods-noise-localities.mjs** — remove 9 AGIL gazetteer noise localities (GHL + DB, FK-ordered).
- **query-goods-buyers-readonly.mjs** — read-only diagnostics.
- **thoughts/2026-05-27-*.json** — restore snapshots for every destructive op (reversible).

All scripts default to dry-run; `--apply` writes. `exec_sql` is SELECT-only here, so writes use PostgREST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)