### PR TITLE
feat(goods): Phase 3 — AusTender open-tender (ATM) ingestion (stacks 2026-05-27 grants/procurement work)

### DIFF
--- a/scripts/add-goods-anchor-buyers.mjs
+++ b/scripts/add-goods-anchor-buyers.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Task 1: add the 3 warm anchor buyers + dedupe ALPA. Approved by Ben 2026-05-27.
+ * (Centrecorp skipped — it's a funder, in Supporter Journey.)
+ *
+ *   node --env-file=.env scripts/add-goods-anchor-buyers.mjs            # dry-run
+ *   node --env-file=.env scripts/add-goods-anchor-buyers.mjs --apply
+ *
+ * - Inserts Outback Stores / Miwatj Health / Tangentyere Council with real ABNs +
+ *   contract evidence (austender) and a warmth fit_score floor of 85 (these known
+ *   relationships should rank near the top; the contract scorer under-rates buyers).
+ * - Dedupes ALPA: 256 rows (128 communities x 2 name-casings) -> 1 per community (128),
+ *   keeping the proper-cased name. Restore-first.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const sql = async (q) => { const { data, error } = await supabase.rpc('exec_sql', { query: q }); if (error) throw new Error(error.message); return data || []; };
+
+const WARMTH_FLOOR = 85;
+// contract evidence pulled 2026-05-27 from austender_contracts (goods_value=0 for all → no +50)
+const ANCHORS = [
+  { entity_name: 'Outback Stores Pty Ltd', abn: '63120661234', buyer_role: 'store', community_id: null, is_community_controlled: false, website: 'https://www.outbackstores.com.au', govt_contract_value: 92000, govt_contract_count: 1 },
+  { entity_name: 'Miwatj Health Aboriginal Corporation', abn: '96843428729', buyer_role: 'health_service', community_id: '9651e030-c893-40de-aee8-2df0d45a6706', is_community_controlled: true, website: 'https://www.miwatj.com.au', govt_contract_value: 48000, govt_contract_count: 1 },
+  { entity_name: 'Tangentyere Council Aboriginal Corporation', abn: '81688672692', buyer_role: 'council', community_id: '6cec2c4f-d390-4bff-95e1-5ad9db9b08da', is_community_controlled: true, website: 'https://www.tangentyere.org.au', govt_contract_value: 3113493.21, govt_contract_count: 14 },
+];
+// contract-evidence fit (hydrate formula): +20 if total>$1M, +15 if count>10, +50 goods, +15 grant.
+const contractFit = (a) => (a.govt_contract_value > 1e6 ? 20 : 0) + (a.govt_contract_count > 10 ? 15 : 0);
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n── Anchors ──`);
+  const existing = await sql(`SELECT abn FROM goods_procurement_entities WHERE abn IN ('63120661234','96843428729','81688672692')`);
+  const have = new Set(existing.map((r) => r.abn));
+  const toInsert = ANCHORS.filter((a) => !have.has(a.abn)).map((a) => ({
+    entity_name: a.entity_name, abn: a.abn, buyer_role: a.buyer_role, community_id: a.community_id,
+    is_community_controlled: a.is_community_controlled, relationship_status: 'prospect', website: a.website,
+    govt_contract_value: a.govt_contract_value, govt_contract_count: a.govt_contract_count,
+    fit_score: Math.max(WARMTH_FLOOR, contractFit(a)),
+  }));
+  toInsert.forEach((a) => console.log(`  + ${a.entity_name}  fit:${a.fit_score} (contract ${contractFit({ govt_contract_value: a.govt_contract_value, govt_contract_count: a.govt_contract_count })}, floor ${WARMTH_FLOOR})  abn:${a.abn} community:${a.community_id || 'multi/none'}`));
+  if (have.size) console.log(`  (skip ${have.size} already present)`);
+
+  // ALPA dedupe
+  console.log(`\n── ALPA dedupe ──`);
+  const alpa = await sql(`SELECT id, entity_name, community_id FROM goods_procurement_entities WHERE entity_name ILIKE '%arnhem land progress%'`);
+  const PROPER = 'The Arnhem Land Progress Aboriginal Corporation';
+  const byComm = new Map();
+  for (const r of alpa) { const k = r.community_id || 'null'; (byComm.get(k) || byComm.set(k, []).get(k)).push(r); }
+  const deleteIds = [];
+  for (const [, group] of byComm) {
+    group.sort((a, b) => (a.entity_name === PROPER ? -1 : 0) - (b.entity_name === PROPER ? -1 : 0));
+    deleteIds.push(...group.slice(1).map((r) => r.id));
+  }
+  console.log(`  ALPA rows: ${alpa.length} across ${byComm.size} communities → keep ${byComm.size}, delete ${deleteIds.length} dup-casing rows`);
+
+  if (!APPLY) { console.log('\n(Dry-run. Re-run with --apply.)'); return; }
+
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-goods-anchor-add-alpa-dedupe.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ at: new Date().toISOString(), inserted: toInsert, alpaDeletedIds: deleteIds, alpaAll: alpa }, null, 2));
+  console.log(`\nRestore snapshot: ${restorePath}`);
+
+  if (toInsert.length) {
+    const { data, error } = await supabase.from('goods_procurement_entities').insert(toInsert).select('id, entity_name');
+    if (error) throw new Error(`anchor insert: ${error.message}`);
+    console.log(`✓ inserted ${data.length} anchors`);
+  }
+  if (deleteIds.length) {
+    // delete in chunks to keep URLs short
+    for (let i = 0; i < deleteIds.length; i += 50) {
+      const { error } = await supabase.from('goods_procurement_entities').delete().in('id', deleteIds.slice(i, i + 50));
+      if (error) throw new Error(`ALPA dedupe delete: ${error.message}`);
+    }
+    console.log(`✓ deleted ${deleteIds.length} ALPA dup rows (ALPA now 1/community)`);
+  }
+  console.log('\n── Done ──');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs
+++ b/scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Anchor-gap backfill: add the marquee remote-NT councils + big ACCHOs that the operating
+ * model expects but goods_procurement_entities was MISSING. Flagged in
+ * thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/buyers-candidates.md (Table 3).
+ *
+ * Mirrors add-goods-anchor-buyers.mjs. Idempotent (skips ABNs already present). Restore snapshot.
+ *   node --env-file=.env scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs --apply
+ *
+ * Data provenance: every abn + govt_contract_value/count is REAL, aggregated by ABN from
+ * austender_contracts (queried 2026-05-27). No values invented. Sunrise Health + Mala'la Health
+ * are NOT austender suppliers (no verifiable ABN/contract) → deliberately EXCLUDED, listed below
+ * for manual add. fit_score = 70 ("high-fit anchor prospect, contract-evidenced, NOT yet warm")
+ * — deliberately below the 85 floor the original script used for genuinely-warm relationships.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const FIT = 70; // anchor-prospect floor (warm relationships are 85; cold default scoring under-rates these)
+
+// abn + contract evidence aggregated by ABN from austender_contracts (2026-05-27). community_id=null
+// (councils span many communities — same as Outback Stores in the original anchor script).
+const ANCHORS = [
+  { entity_name: 'MacDonnell Regional Council',                         abn: '21340804903', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 44125295, govt_contract_count: 32 },
+  { entity_name: 'Roper Gulf Regional Council',                         abn: '94746956090', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 22248695, govt_contract_count: 29 },
+  { entity_name: 'Victoria Daly Regional Council',                      abn: '66931675319', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 9824405,  govt_contract_count: 29 },
+  { entity_name: 'West Daly Regional Council',                          abn: '25966579574', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 4518868,  govt_contract_count: 17 },
+  { entity_name: 'Barkly Regional Council',                             abn: '32171281456', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 3591517,  govt_contract_count: 8 },
+  { entity_name: 'East Arnhem Regional Council',                        abn: '92334301078', buyer_role: 'council',        is_community_controlled: false, govt_contract_value: 2701282,  govt_contract_count: 9 },
+  { entity_name: 'Central Australian Aboriginal Congress',             abn: '76210591710', buyer_role: 'health_service', is_community_controlled: true,  govt_contract_value: 2039174,  govt_contract_count: 5 },
+  { entity_name: 'Laynhapuy Homelands Aboriginal Corporation',         abn: '86695642473', buyer_role: 'community_org',  is_community_controlled: true,  govt_contract_value: 1073818,  govt_contract_count: 11 },
+  { entity_name: 'Katherine West Health Board Aboriginal Corporation', abn: '23351866925', buyer_role: 'health_service', is_community_controlled: true,  govt_contract_value: 168217,   govt_contract_count: 1 },
+];
+// NOT added (no verifiable ABN/contract in austender — do NOT fabricate): Sunrise Health Service
+// Aboriginal Corporation, Mala'la Health Service Aboriginal Corporation (Mala'la already a GHL contact).
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}  (target: goods_procurement_entities)\n`);
+  const abns = ANCHORS.map((a) => a.abn);
+  const { data: existing, error: exErr } = await supabase.from('goods_procurement_entities').select('abn').in('abn', abns);
+  if (exErr) throw new Error(`existence check: ${exErr.message}`);
+  const have = new Set((existing || []).map((r) => r.abn));
+
+  const toInsert = ANCHORS.filter((a) => !have.has(a.abn)).map((a) => ({
+    entity_name: a.entity_name, abn: a.abn, buyer_role: a.buyer_role, community_id: null,
+    is_community_controlled: a.is_community_controlled, relationship_status: 'prospect',
+    govt_contract_value: a.govt_contract_value, govt_contract_count: a.govt_contract_count, fit_score: FIT,
+  }));
+
+  for (const a of toInsert) console.log(`  + ${a.entity_name.padEnd(52)} ${a.buyer_role.padEnd(14)} fit:${a.fit_score}  $${a.govt_contract_value.toLocaleString()} / ${a.govt_contract_count} contracts  abn:${a.abn}`);
+  if (have.size) console.log(`  (skip ${have.size} already present: ${[...have].join(', ')})`);
+  console.log(`\nWould insert: ${toInsert.length}`);
+
+  if (!APPLY) { console.log('\n(Dry-run. Re-run with --apply to write.)'); return; }
+  if (!toInsert.length) { console.log('Nothing to insert.'); return; }
+
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-goods-anchor-councils-acchos-backfill.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ at: new Date().toISOString(), inserted: toInsert }, null, 2));
+  console.log(`Restore snapshot: ${restorePath}`);
+
+  const { data, error } = await supabase.from('goods_procurement_entities').insert(toInsert).select('id, entity_name, fit_score');
+  if (error) throw new Error(`anchor backfill insert: ${error.message}`);
+  console.log(`✓ inserted ${data.length} anchor buyers`);
+  data.forEach((r) => console.log(`   ${r.id}  ${r.entity_name}  fit:${r.fit_score}`));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/drop-goods-noise-localities.mjs
+++ b/scripts/drop-goods-noise-localities.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Task 3: drop the 9 AGIL template-noise localities (all 52 beds/6 washers default).
+ * Approved by Ben 2026-05-27 ("Drop fully"). Restore-first; reversible.
+ *
+ *   node --env-file=.env scripts/drop-goods-noise-localities.mjs            # dry-run
+ *   node --env-file=.env scripts/drop-goods-noise-localities.mjs --apply    # writes
+ *
+ * Deletes: 9 GHL Demand-Register opps + their placeholder contacts;
+ *          9 goods_communities rows (CASCADE clears their entities/signals).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+// CASCADE-deleting the 9 communities also deletes 147 linked entities (incl. real ones
+// like NLC/AMSANT). --ghl-only does the GHL signal cleanup WITHOUT touching the DB.
+const GHL_ONLY = process.argv.includes('--ghl-only');
+const DB_ONLY = process.argv.includes('--db-only'); // GHL opps already deleted; do the DB cascade only
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+const GHL_BASE = 'https://services.leadconnectorhq.com';
+const GHL_KEY = process.env.GHL_API_KEY;
+
+const NAMES = ['THULKURR','NEW MERINEE','GUNUN WOONAM','SHIPTON FLATS','FORDY FARM','AAYKA','THAANGKUNH-NHIIN','BANNICK BURN','JILUNDARINA'];
+// GHL Demand-Register opp + placeholder contact ids (from audit 2026-05-27)
+const GHL_RECORDS = [
+  ['cj7CXxIDLzKMxIVHHpNm','7sp5Zwueh0OKblAKQirR','THULKURR'],
+  ['8CAq5cV6LBlozjP4fmbo','xBxaigCAdO1v8ARO1lo2','NEW MERINEE'],
+  ['7rqTX3XLuiwMz8cvLMw3','gPxPrnGkA01DbSigTaYM','GUNUN WOONAM'],
+  ['HTtygM4ogZ3gacHk3wwE','dYbBIH1H5deXDEerV5HE','SHIPTON FLATS'],
+  ['58uGnRzT5FdHuDAvjKia','fm0tdDRDfl3EFTOg1JS7','FORDY FARM'],
+  ['1HJOMb5vZMw0ulxm2tBS','jkXvzq4QJDPKCur8akIX','AAYKA'],
+  ['NVnUPdbDuJlKwlFT4Zx6','cAt1QstivkhGfT2ShFAc','THAANGKUNH-NHIIN'],
+  ['omkK7FwtMTormWvwpXcK','wu6SihnJXkEkKrUYtheG','BANNICK BURN'],
+  ['seEc4BT9h5csxlXAJVhO','Q0HsirXpDJJ3vLpNIKmj','JILUNDARINA'],
+];
+
+async function sql(query) {
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`SQL error: ${error.message}`);
+  return data || [];
+}
+async function ghlDelete(path) {
+  const r = await fetch(`${GHL_BASE}${path}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${GHL_KEY}`, Version: '2021-07-28' },
+  });
+  if (!r.ok) throw new Error(`GHL ${r.status}: ${await r.text()}`);
+}
+
+async function main() {
+  const inList = NAMES.map((n) => `'${n.replace(/'/g, "''")}'`).join(',');
+  const rows = await sql(`SELECT id, community_name, state, demand_beds, demand_washers FROM goods_communities WHERE upper(community_name) IN (${inList})`);
+  const ids = rows.map((r) => r.id);
+  const cascade = ids.length
+    ? await sql(`SELECT
+        (SELECT count(*) FROM goods_procurement_entities WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])) entities,
+        (SELECT count(*) FROM goods_procurement_signals WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])) signals`)
+    : [{ entities: 0, signals: 0 }];
+
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+  console.log(`goods_communities rows matched: ${rows.length}/${NAMES.length}`);
+  rows.forEach((r) => console.log(`  ${r.community_name} (${r.state}) beds:${r.demand_beds} id:${r.id}`));
+  console.log(`Will CASCADE: ${cascade[0].entities} entities + ${cascade[0].signals} signals`);
+  console.log(`GHL deletes: ${GHL_RECORDS.length} opps + ${GHL_RECORDS.length} placeholder contacts\n`);
+
+  if (!APPLY) { console.log('(Dry-run. Re-run with --apply.)'); return; }
+
+  // Capture the entities + signals to be deleted, for full reversibility.
+  const cascadeEntities = ids.length
+    ? await sql(`SELECT id, entity_name, abn, fit_score, buyer_role, community_id FROM goods_procurement_entities WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])`)
+    : [];
+  const cascadeSignals = ids.length
+    ? await sql(`SELECT * FROM goods_procurement_signals WHERE community_id = ANY(ARRAY['${ids.join("','")}']::uuid[])`)
+    : [];
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-goods-9-noise-drop-restore.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ removedAt: new Date().toISOString(), communities: rows, ghl: GHL_RECORDS, cascade: cascade[0], cascadeEntities, cascadeSignals }, null, 2));
+  console.log(`Restore snapshot (incl. ${cascadeEntities.length} entities + ${cascadeSignals.length} signals): ${restorePath}\n`);
+
+  let ok = 0, fail = 0;
+  if (!DB_ONLY) {
+    for (const [opp, contact, name] of GHL_RECORDS) {
+      try { await ghlDelete(`/opportunities/${opp}`); console.log(`✓ GHL opp ${name}`); ok++; }
+      catch (e) { console.error(`✗ GHL opp ${name}: ${e.message}`); fail++; }
+      try { await ghlDelete(`/contacts/${contact}`); ok++; }
+      catch (e) { console.error(`✗ GHL contact ${name}: ${e.message}`); fail++; }
+    }
+  }
+  if (GHL_ONLY) {
+    console.log(`\n(--ghl-only: DB rows left intact — ${cascade[0].entities} entities NOT cascaded.)`);
+  } else if (ids.length) {
+    // exec_sql is SELECT-only → PostgREST writes. signals FK = RESTRICT (delete first);
+    // entities FK = CASCADE but delete explicitly too for determinism. Then communities.
+    let e;
+    ({ error: e } = await supabase.from('goods_procurement_signals').delete().in('community_id', ids));
+    if (e) throw new Error(`signals delete: ${e.message}`);
+    ({ error: e } = await supabase.from('goods_procurement_entities').delete().in('community_id', ids));
+    if (e) throw new Error(`entities delete: ${e.message}`);
+    ({ error: e } = await supabase.from('goods_communities').delete().in('id', ids));
+    if (e) throw new Error(`communities delete: ${e.message}`);
+    console.log(`✓ deleted ${ids.length} communities + ${cascadeEntities.length} entities + ${cascadeSignals.length} signals`);
+  }
+  console.log(`\n── Done ── GHL ok:${ok} fail:${fail}; DB rows deleted:${ids.length}`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/fix-alpa-overmatch.mjs
+++ b/scripts/fix-alpa-overmatch.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Data-quality fix: ALPA was proximity-fanned to 128 communities (one entity_id/gs_id,
+ * one bulk insert) — it is ONE remote-retail network operator, not 128 buyers. Collapse to
+ * a single network-level entity (community_id = null, like Outback Stores). The communities
+ * ALPA serves already have their own local store-corp entities as the per-community buyers.
+ * Approved by Ben 2026-05-27 ("fix this"). Restore-first; reversible.
+ *
+ *   node --env-file=.env scripts/fix-alpa-overmatch.mjs            # dry-run
+ *   node --env-file=.env scripts/fix-alpa-overmatch.mjs --apply
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const sql = async (q) => { const { data, error } = await supabase.rpc('exec_sql', { query: q }); if (error) throw new Error(error.message); return data || []; };
+const WARMTH_FLOOR = 85;
+
+async function main() {
+  const rows = await sql(`SELECT id, entity_name, community_id, fit_score, ghl_opportunity_id FROM goods_procurement_entities WHERE entity_name ILIKE '%arnhem land progress%' ORDER BY (ghl_opportunity_id IS NOT NULL) DESC, id`);
+  if (!rows.length) { console.log('No ALPA rows found.'); return; }
+
+  // Keep the row already linked to GHL if any, else the first; null its community, floor warmth.
+  const keep = rows[0];
+  const deleteIds = rows.slice(1).map((r) => r.id);
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+  console.log(`ALPA rows: ${rows.length} → keep 1 (id ${keep.id}), set community_id=NULL, fit_score=${Math.max(WARMTH_FLOOR, keep.fit_score || 0)}; delete ${deleteIds.length}`);
+
+  if (!APPLY) { console.log('\n(Dry-run. Re-run with --apply.)'); return; }
+
+  const restorePath = '/Users/benknight/Code/grantscope/thoughts/2026-05-27-alpa-overmatch-fix.json';
+  fs.writeFileSync(restorePath, JSON.stringify({ at: new Date().toISOString(), keptId: keep.id, deletedIds: deleteIds, allRows: rows }, null, 2));
+  console.log(`Restore snapshot: ${restorePath}`);
+
+  const { error: uErr } = await supabase.from('goods_procurement_entities')
+    .update({ community_id: null, fit_score: Math.max(WARMTH_FLOOR, keep.fit_score || 0), relationship_status: 'prospect', updated_at: new Date().toISOString() })
+    .eq('id', keep.id);
+  if (uErr) throw new Error(`update keeper: ${uErr.message}`);
+
+  // Re-point any demand signals that named a to-be-deleted ALPA row as buyer → the keeper.
+  for (let i = 0; i < deleteIds.length; i += 50) {
+    const chunk = deleteIds.slice(i, i + 50);
+    const { error } = await supabase.from('goods_procurement_signals').update({ buyer_entity_id: keep.id }).in('buyer_entity_id', chunk);
+    if (error) throw new Error(`repoint signals: ${error.message}`);
+  }
+
+  for (let i = 0; i < deleteIds.length; i += 50) {
+    const { error } = await supabase.from('goods_procurement_entities').delete().in('id', deleteIds.slice(i, i + 50));
+    if (error) throw new Error(`delete: ${error.message}`);
+  }
+  console.log(`✓ ALPA collapsed to 1 network entity (community-null, fit 85); deleted ${deleteIds.length} fan-out rows`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -40,6 +40,17 @@ export const AGENTS = {
     timeoutMs: 600_000,
     dependencies: [],
   },
+  // Open ATMs (Approach To Market) — what Goods can BID on now, vs the awarded
+  // contracts above. RSS feed + per-ATM UNSPSC gate → grant_opportunities
+  // (discovery_method='procurement'). Phase 3 of the Goods procurement pipeline.
+  'sync-austender-open-tenders': {
+    command: ['node', '--env-file=.env', 'scripts/sync-austender-open-tenders.mjs', '--apply'],
+    displayName: 'Sync AusTender Open Tenders (Goods)',
+    category: 'sync',
+    defaultPriority: 3,
+    timeoutMs: 600_000,
+    dependencies: [],
+  },
   'sync-ato-tax-transparency': {
     command: ['node', '--env-file=.env', 'scripts/sync-ato-tax-transparency.mjs'],
     displayName: 'Sync ATO Tax Transparency',

--- a/scripts/lib/goods-relevance.mjs
+++ b/scripts/lib/goods-relevance.mjs
@@ -50,6 +50,23 @@ const DISQUALIFIERS = [
   'travel grant', 'conference', 'symposium',
 ];
 
+// Hard structural disqualifiers — Goods (a Pty Ltd / community-controlled social
+// enterprise) cannot apply to these, regardless of how Goods-shaped the text reads.
+// These produce ~71% of the score>=60 noise:
+//   - arc-grants:    ARC university research (DP/LP/DE/LE/FT). The high-scoring
+//                    rows are *real* First Nations research projects (score 100 on
+//                    Indigenous keywords) — eligible-looking, structurally barred.
+//   - qld-arts-data: arts-development grants; Goods is not an arts producer.
+const SOURCE_DISQUALIFIERS = new Set(['arc-grants', 'qld-arts-data']);
+// University / research-council providers are research bodies, not Goods funders
+// or buyers. Matches "X University" and "University of X".
+const UNIVERSITY_PROVIDER = /\buniversit(?:y|ies)\b/;
+
+// discovery_method tags for the parallel money-types GrantScope's grant scorer
+// under-weights (capital + procurement). Boost so they aren't squashed for not
+// reading like a "grant". Forward-looking hook — no such rows exist yet.
+const BOOSTED_DISCOVERY_METHODS = new Set(['indigenous-finance', 'procurement']);
+
 /**
  * Score a single grant. Returns { score, signals } where signals explains the math.
  * @param {object} grant Row from grant_opportunities (any subset of columns is fine)
@@ -59,6 +76,22 @@ export function scoreGrantForGoods(grant) {
   const provider = String(grant.provider || '').toLowerCase();
   const description = String(grant.description || '').toLowerCase();
   const haystack = [name, provider, description].join(' ');
+  const source = String(grant.source || '').toLowerCase();
+  const discoveryMethod = String(grant.discovery_method || '').toLowerCase();
+
+  // Hard structural disqualifier — short-circuit to 0 before any scoring. A
+  // First-Nations-themed ARC research grant still scores 0 here: Goods cannot
+  // apply to it. This is the single highest-leverage de-noiser.
+  if (SOURCE_DISQUALIFIERS.has(source) || UNIVERSITY_PROVIDER.test(provider)) {
+    return {
+      score: 0,
+      signals: {
+        hard_disqualified: SOURCE_DISQUALIFIERS.has(source) ? `source:${source}` : 'provider:university',
+        tier1_hits: [], tier2_hits: [], tier3_hits: [],
+        category_hits: [], geography: null, amount_band: null, disqualifier_hits: [],
+      },
+    };
+  }
 
   const categories = Array.isArray(grant.categories) ? grant.categories.map(c => String(c).toLowerCase()) : [];
   const focusAreas = Array.isArray(grant.focus_areas) ? grant.focus_areas.map(c => String(c).toLowerCase()) : [];
@@ -110,6 +143,24 @@ export function scoreGrantForGoods(grant) {
       score += 12;
       break;
     }
+  }
+
+  // SEDI (Social Enterprise Development Initiative) — DSS/IIA capability program,
+  // the strongest open capability fit for Goods. The acronym match is
+  // word-boundary, so it scores "SEDI Capability Building Grant" high while NEVER
+  // matching "sediment". (No DSS/IIA hint exists in goodsProviderHints, so without
+  // this the program scores ~6 despite being a top fit.)
+  if (/\bsedi\b/.test(haystack) || haystack.includes('social enterprise development initiative')) {
+    signals.sedi_hit = true;
+    score += 30;
+  }
+
+  // Capital + procurement opportunities (IBA loans, Supply Nation, remote-housing
+  // supply) don't read like grants and would otherwise score low. Tag-based boost
+  // keyed on discovery_method so they surface alongside grants.
+  if (BOOSTED_DISCOVERY_METHODS.has(discoveryMethod)) {
+    signals.discovery_boost = discoveryMethod;
+    score += 25;
   }
 
   const goodsCategorySet = new Set([

--- a/scripts/lib/goods-relevance.mjs
+++ b/scripts/lib/goods-relevance.mjs
@@ -45,10 +45,19 @@ const GOODS_GEOGRAPHIES = new Set(['AU-NT', 'AU-WA', 'AU-QLD', 'AU-SA']);
 
 // Disqualifiers — strong indicators this is NOT Goods-shaped
 const DISQUALIFIERS = [
-  'scholarship', 'phd', 'research grant', 'fellowship', 'sabbatical',
+  'scholarship', 'phd', 'research grant',
   'individual artist', 'individual researcher', 'student bursary',
   'travel grant', 'conference', 'symposium',
 ];
+
+// Soft disqualifiers that ONLY fire in a research/academic context. A
+// "fellowship" from Westpac or Barayamal is founder capability for Goods; a
+// research fellowship is not. (University-provider grants are already hard-zeroed
+// above, so this only governs fellowships from non-university funders.)
+const CONDITIONAL_DISQUALIFIERS = ['fellowship', 'sabbatical'];
+// NB: deliberately excludes 'scholar' — it false-matches philanthropic funders
+// like "Westpac Scholars Trust". 'scholarship' stays a hard DISQUALIFIER above.
+const ACADEMIC_CONTEXT = ['research', 'phd', 'postdoctoral', 'postdoc', 'academic', 'university'];
 
 // Hard structural disqualifiers — Goods (a Pty Ltd / community-controlled social
 // enterprise) cannot apply to these, regardless of how Goods-shaped the text reads.
@@ -214,6 +223,19 @@ export function scoreGrantForGoods(grant) {
     if (name.includes(dq) || description.includes(dq)) {
       signals.disqualifier_hits.push(dq);
       score -= 15;
+    }
+  }
+
+  // Fellowship/sabbatical only disqualify alongside a research/academic marker —
+  // founder-development fellowships (Westpac Social Change, Barayamal) are a
+  // legitimate Goods capability signal and should not be zeroed.
+  const hasAcademicContext = ACADEMIC_CONTEXT.some(m => haystack.includes(m));
+  if (hasAcademicContext) {
+    for (const dq of CONDITIONAL_DISQUALIFIERS) {
+      if (name.includes(dq) || description.includes(dq)) {
+        signals.disqualifier_hits.push(`${dq}(academic)`);
+        score -= 15;
+      }
     }
   }
 

--- a/scripts/lib/goods-relevance.test.mjs
+++ b/scripts/lib/goods-relevance.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Tests for the Goods relevance scorer.
+ * Run: node --test scripts/lib/goods-relevance.test.mjs
+ *
+ * Locks the 2026-05-27 scoring-noise fix so it can't silently regress:
+ *   - arc-grants / qld-arts-data / university providers hard-zero
+ *   - "sediment" never gets a SEDI boost; real SEDI scores high
+ *   - real Goods-shaped grants still score high
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scoreGrantForGoods, GOODS_TAG_THRESHOLD } from './goods-relevance.mjs';
+
+test('arc-grants source hard-zeros even a First-Nations-themed research grant', () => {
+  const { score, signals } = scoreGrantForGoods({
+    name: 'Policy for self-determination: the case study of ATSIC',
+    provider: 'The University of Queensland',
+    description: 'Indigenous Aboriginal Torres Strait self-determination community research.',
+    amount_max: 1_200_000,
+    source: 'arc-grants',
+  });
+  assert.equal(score, 0);
+  assert.equal(signals.hard_disqualified, 'source:arc-grants');
+});
+
+test('qld-arts-data source hard-zeros an Indigenous arts grant', () => {
+  const { score } = scoreGrantForGoods({
+    name: 'Indigenous Regional Arts Development Fund (IRADF) — Yarrabah',
+    provider: 'Queensland Government',
+    description: 'Aboriginal community arts development.',
+    source: 'qld-arts-data',
+  });
+  assert.equal(score, 0);
+});
+
+test('university provider hard-zeros regardless of source', () => {
+  const { score, signals } = scoreGrantForGoods({
+    name: 'Remote Indigenous housing study',
+    provider: 'University of New South Wales',
+    description: 'Aboriginal remote housing community infrastructure.',
+    source: 'grantconnect',
+  });
+  assert.equal(score, 0);
+  assert.equal(signals.hard_disqualified, 'provider:university');
+});
+
+test('"sediment" never receives a SEDI boost and scores low', () => {
+  const { score, signals } = scoreGrantForGoods({
+    name: 'Shallow water carbonate sediment dissolution dynamics',
+    provider: 'Geoscience Australia',
+    description: 'Sedimentary basin drilling and dissolution modelling.',
+    amount_max: 500_000,
+    source: 'grantconnect',
+  });
+  assert.equal(signals.sedi_hit, undefined);
+  assert.ok(score < GOODS_TAG_THRESHOLD, `expected < ${GOODS_TAG_THRESHOLD}, got ${score}`);
+});
+
+test('real SEDI Capability grant scores at/above the tag threshold', () => {
+  const { score, signals } = scoreGrantForGoods({
+    name: 'SEDI Capability Building Grant',
+    provider: 'Impact Investing Australia (admin) — Dept of Social Services (funder)',
+    description: 'Capability-building grants up to $120K for trading social enterprises (Indigenous-owned/controlled eligible, typically >$50K revenue).',
+    amount_max: 120_000,
+    geography: 'AU',
+    source: 'dss',
+  });
+  assert.equal(signals.sedi_hit, true);
+  assert.ok(score >= GOODS_TAG_THRESHOLD, `expected >= ${GOODS_TAG_THRESHOLD}, got ${score}`);
+});
+
+test('a real Goods-shaped Indigenous housing grant still scores high', () => {
+  const { score } = scoreGrantForGoods({
+    name: 'Remote Aboriginal Housing Essential Goods Program',
+    provider: 'NSW Government — Aboriginal Housing Office',
+    description: 'Funding for whitegoods, beds and furniture for remote Aboriginal community housing.',
+    amount_max: 250_000,
+    geography: 'AU-NT',
+    source: 'nsw-grants',
+  });
+  assert.ok(score >= GOODS_TAG_THRESHOLD, `expected >= ${GOODS_TAG_THRESHOLD}, got ${score}`);
+});
+
+test('discovery_method=indigenous-finance boosts a capital opportunity', () => {
+  const withBoost = scoreGrantForGoods({
+    name: 'IBA Start-Up Finance Package',
+    provider: 'Indigenous Business Australia',
+    description: 'Loan with up to 30% grant component to buy business assets.',
+    amount_max: 150_000,
+    source: 'indigenous-finance-crawler',
+    discovery_method: 'indigenous-finance',
+  });
+  assert.equal(withBoost.signals.discovery_boost, 'indigenous-finance');
+  assert.ok(withBoost.score >= GOODS_TAG_THRESHOLD, `expected >= ${GOODS_TAG_THRESHOLD}, got ${withBoost.score}`);
+});

--- a/scripts/lib/goods-relevance.test.mjs
+++ b/scripts/lib/goods-relevance.test.mjs
@@ -81,6 +81,30 @@ test('a real Goods-shaped Indigenous housing grant still scores high', () => {
   assert.ok(score >= GOODS_TAG_THRESHOLD, `expected >= ${GOODS_TAG_THRESHOLD}, got ${score}`);
 });
 
+test('founder-development fellowship (no academic context) is NOT zeroed', () => {
+  const { score, signals } = scoreGrantForGoods({
+    name: 'Westpac Social Change Fellowship',
+    provider: 'Westpac Scholars Trust',
+    description: 'Development program for social entrepreneurs creating community change. Indigenous social enterprise founders eligible.',
+    amount_max: 50_000,
+    geography: 'AU',
+    source: 'foundation_program',
+  });
+  assert.ok(!signals.disqualifier_hits.includes('fellowship(academic)'), 'should not penalise a non-academic fellowship');
+  assert.ok(score > 0, `expected > 0, got ${score}`);
+});
+
+test('research fellowship (academic context) is still penalised', () => {
+  const { signals } = scoreGrantForGoods({
+    name: 'Indigenous Health Research Fellowship',
+    provider: 'NHMRC',
+    description: 'Postdoctoral research fellowship for academic study of Aboriginal community health.',
+    amount_max: 500_000,
+    source: 'grantconnect',
+  });
+  assert.ok(signals.disqualifier_hits.includes('fellowship(academic)'), 'academic fellowship should still be penalised');
+});
+
 test('discovery_method=indigenous-finance boosts a capital opportunity', () => {
   const withBoost = scoreGrantForGoods({
     name: 'IBA Start-Up Finance Package',

--- a/scripts/push-goods-top25-to-demand-register.mjs
+++ b/scripts/push-goods-top25-to-demand-register.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Task 2: push the top-25 (by fit_score) scored buyers into the GHL "Goods — Demand Register"
+ * at the "Buyer Matched" stage. Approved by Ben 2026-05-27.
+ *
+ * Per the Goods CRM operating model: scored-but-uncontacted entities = Demand-Register signal
+ * (NOT the Buyer Pipeline, which is contacted commercial deals).
+ *
+ *   node --env-file=.env scripts/push-goods-top25-to-demand-register.mjs            # dry-run
+ *   node --env-file=.env scripts/push-goods-top25-to-demand-register.mjs --apply    # writes
+ *   ... --limit 25
+ *
+ * Idempotent: dedups distinct entities (table has dup rows), skips entities already pushed
+ * (ghl_opportunity_id set), upserts contacts by deterministic email, writes ghl_* link back.
+ * Mirrors apps/web/src/lib/services/goods-buyer-ghl.ts patterns.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+const li = process.argv.indexOf('--limit');
+const LIMIT = li >= 0 ? parseInt(process.argv[li + 1], 10) : 25;
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+const GHL = 'https://services.leadconnectorhq.com';
+const KEY = process.env.GHL_API_KEY;
+const LOC = process.env.GHL_LOCATION_ID;
+const DEMAND_PIPELINE = 'UQsrmuqzxMSdCTklxEcG';
+const BUYER_MATCHED_STAGE = '02502aa3-9a0d-4ddd-b1f0-c1e836838426';
+
+async function sql(query) {
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`SQL error: ${error.message}`);
+  return data || [];
+}
+const H = { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json', Version: '2021-07-28' };
+const slug = (s, n) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, n);
+// Deterministic email for idempotent contact upsert. Reproduces the original
+// slug(entity,60)-slug(community,40) EXACTLY for local parts <=64 (so run-1 contacts
+// match), and only truncates the long ones (which failed RFC 64-char limit first time).
+const buildEmail = (entity, community) => {
+  let local = `${slug(entity, 60)}-${slug(community, 40)}`;
+  if (local.length > 64) local = local.slice(0, 64).replace(/-+$/, '');
+  return `${local}@goods.civicgraph.io`;
+};
+
+async function main() {
+  if (!KEY || !LOC) throw new Error('Missing GHL_API_KEY / GHL_LOCATION_ID');
+
+  // Top-N distinct entities by fit_score (dedup the table's duplicate rows), with community.
+  const rows = await sql(`
+    SELECT * FROM (
+      SELECT DISTINCT ON (lower(e.entity_name))
+        e.id, e.entity_name, e.buyer_role, e.abn, e.website, e.fit_score,
+        e.is_community_controlled, COALESCE(e.relationship_status,'prospect') relationship_status,
+        e.govt_contract_value, e.ghl_opportunity_id,
+        c.community_name, c.state
+      FROM goods_procurement_entities e
+      LEFT JOIN goods_communities c ON c.id = e.community_id
+      ORDER BY lower(e.entity_name), e.fit_score DESC NULLS LAST
+    ) d
+    ORDER BY d.fit_score DESC NULLS LAST, d.govt_contract_value DESC NULLS LAST
+    LIMIT ${LIMIT}`);
+
+  console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'} · target: Goods — Demand Register / Buyer Matched · ${rows.length} entities\n`);
+
+  let created = 0, skipped = 0, fail = 0;
+  for (const r of rows) {
+    const community = r.community_name || 'Unmatched';
+    const tag = (s) => s;
+    const tags = [
+      'CivicGraph', 'Goods', 'act-gd', 'project:act-gd',
+      `Goods-Community-${community.replace(/\s+/g, '-')}`,
+      r.state ? `Goods-State-${r.state}` : null,
+      r.buyer_role ? `Goods-Role-${r.buyer_role}` : null,
+      r.is_community_controlled ? 'Goods-CommunityControlled' : null,
+      `Goods-Stage-${r.relationship_status}`,
+    ].filter(Boolean).map(tag);
+    const oppName = `${r.entity_name} — ${community}`;
+    const label = `${oppName}  fit:${r.fit_score} role:${r.buyer_role}`;
+
+    if (r.ghl_opportunity_id) { console.log(`= SKIP (already pushed)  ${label}`); skipped++; continue; }
+    if (!APPLY) { console.log(`+ WOULD PUSH  ${label}`); continue; }
+
+    try {
+      const email = buildEmail(r.entity_name, community);
+      const up = await fetch(`${GHL}/contacts/upsert`, {
+        method: 'POST', headers: H,
+        body: JSON.stringify({ locationId: LOC, email, companyName: r.entity_name, firstName: r.entity_name.slice(0, 80), website: r.website || undefined, tags, source: `CivicGraph Goods top-25 (${community})` }),
+      });
+      if (!up.ok) throw new Error(`contact upsert ${up.status}: ${(await up.text()).slice(0, 150)}`);
+      const contactId = (await up.json())?.contact?.id;
+      if (!contactId) throw new Error('no contactId');
+
+      // Dedup: reuse an existing opp on this contact in the Demand Register (self-heals
+      // partial runs where the opp was created but writeback failed).
+      let oppId = null;
+      const srch = await fetch(`${GHL}/opportunities/search?location_id=${LOC}&pipeline_id=${DEMAND_PIPELINE}&contact_id=${contactId}&limit=5`, { headers: H });
+      if (srch.ok) {
+        const opps = (await srch.json()).opportunities || [];
+        oppId = (opps.find((o) => o.name === oppName) || opps[0])?.id || null;
+      }
+      let reused = !!oppId;
+      if (!oppId) {
+        const op = await fetch(`${GHL}/opportunities/`, {
+          method: 'POST', headers: H,
+          body: JSON.stringify({ locationId: LOC, name: oppName, pipelineId: DEMAND_PIPELINE, pipelineStageId: BUYER_MATCHED_STAGE, status: 'open', contactId, monetaryValue: 0, source: 'Goods top-25 activation' }),
+        });
+        if (!op.ok) throw new Error(`opp create ${op.status}: ${(await op.text()).slice(0, 150)}`);
+        oppId = (await op.json())?.opportunity?.id;
+      }
+
+      const { error: upErr } = await supabase.from('goods_procurement_entities').update({
+        ghl_contact_id: contactId, ghl_opportunity_id: oppId,
+        ghl_pipeline_id: DEMAND_PIPELINE, ghl_stage_id: BUYER_MATCHED_STAGE,
+        ghl_stage_name: 'Buyer Matched', ghl_last_pushed_at: new Date().toISOString(),
+      }).eq('id', r.id);
+      if (upErr) throw new Error(`writeback: ${upErr.message}`);
+
+      console.log(`+ ${reused ? 'LINKED (existing opp)' : 'PUSHED'}  ${label}  (opp ${oppId})`);
+      created++;
+    } catch (e) {
+      console.error(`✗ ${label}: ${e.message}`);
+      fail++;
+    }
+  }
+
+  console.log(`\n── ${APPLY ? 'Done' : 'Dry-run'} ── created:${created} skipped:${skipped} fail:${fail}`);
+  if (!APPLY) console.log('(Re-run with --apply to write.)');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/query-goods-buyers-readonly.mjs
+++ b/scripts/query-goods-buyers-readonly.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * READ-ONLY diagnostics for the Goods buyer activation plan. SELECTs only.
+ * Run: node --env-file=.env scripts/query-goods-buyers-readonly.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+async function sql(query) {
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`SQL error: ${error.message}`);
+  return data || [];
+}
+
+const j = (x) => JSON.stringify(x);
+
+async function main() {
+  console.log('── 1. ENTITY SUMMARY ──');
+  console.log(j(await sql(`
+    SELECT count(*) total,
+           count(*) FILTER (WHERE fit_score > 0) scored,
+           count(*) FILTER (WHERE ghl_opportunity_id IS NOT NULL) pushed,
+           count(*) FILTER (WHERE abn IS NOT NULL) with_abn
+    FROM goods_procurement_entities`)));
+
+  console.log('\n── 2. ANCHOR PRESENCE (grouped) ──');
+  const anchors = await sql(`
+    SELECT entity_name, count(*) dups, max(fit_score) fit, max(buyer_role) role,
+           bool_or(is_community_controlled) cc, bool_or(ghl_opportunity_id IS NOT NULL) pushed
+    FROM goods_procurement_entities
+    WHERE entity_name ILIKE ANY (ARRAY['%outback stores%','%centrecorp%','%miwatj%','%alpa%','%arnhem land progress%','%tangentyere%'])
+    GROUP BY entity_name ORDER BY entity_name`);
+  anchors.forEach((r) => console.log(`  ${r.entity_name}  dups:${r.dups} fit:${r.fit} role:${r.role} cc:${r.cc} pushed:${r.pushed}`));
+  console.log(`  (distinct names: ${anchors.length})`);
+
+  console.log('\n── 3. TOP 25 BY fit_score ──');
+  const top = await sql(`
+    SELECT entity_name, fit_score, buyer_role, govt_contract_value, govt_contract_count,
+           is_community_controlled,
+           (ghl_opportunity_id IS NOT NULL) AS pushed
+    FROM goods_procurement_entities
+    ORDER BY fit_score DESC NULLS LAST, govt_contract_value DESC NULLS LAST
+    LIMIT 25`);
+  top.forEach((r, i) => console.log(
+    `${String(i + 1).padStart(2)}. ${r.entity_name}  fit:${r.fit_score}  role:${r.buyer_role}  gov:$${r.govt_contract_value || 0}(${r.govt_contract_count || 0})  cc:${r.is_community_controlled}  pushed:${r.pushed}`));
+
+  console.log('\n── 4. THE 9 LEFTOVER COMMUNITIES (demand basis) ──');
+  const nine = await sql(`
+    SELECT community_name, state, demand_beds, demand_washers
+    FROM goods_communities
+    WHERE upper(community_name) = ANY (ARRAY['THULKURR','NEW MERINEE','GUNUN WOONAM','SHIPTON FLATS','FORDY FARM','AAYKA','THAANGKUNH-NHIIN','BANNICK BURN','JILUNDARINA'])
+    ORDER BY community_name`);
+  nine.forEach((r) => console.log(
+    `  ${r.community_name} (${r.state})  beds:${r.demand_beds}  washers:${r.demand_washers}`));
+  console.log(`  (rows found: ${nine.length})`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/score-goods-relevance.mjs
+++ b/scripts/score-goods-relevance.mjs
@@ -49,13 +49,15 @@ function pickColumns(row) {
     closes_at: row.closes_at,
     aligned_projects: row.aligned_projects || [],
     goods_relevance_score: row.goods_relevance_score,
+    source: row.source,
+    discovery_method: row.discovery_method,
   };
 }
 
 async function fetchBatch(offset) {
   let q = supabase
     .from('grant_opportunities')
-    .select('id,name,provider,description,geography,amount_max,categories,focus_areas,closes_at,aligned_projects,goods_relevance_score,goods_relevance_scored_at,updated_at')
+    .select('id,name,provider,description,geography,amount_max,categories,focus_areas,closes_at,aligned_projects,goods_relevance_score,goods_relevance_scored_at,updated_at,source,discovery_method')
     .order('id', { ascending: true })
     .range(offset, offset + BATCH - 1);
 
@@ -186,16 +188,36 @@ async function main() {
   let totalScored = 0;
   let totalTagged = 0;
   let totalHighFit = 0;
+  let totalSkippedManual = 0;
   // When incremental (filter on IS NULL), the pool shrinks each batch so we keep
   // offset=0. For rescore-all the offset must advance to walk the whole table.
   let offset = 0;
   const histogram = { '0-19': 0, '20-39': 0, '40-49': 0, '50-69': 0, '70-100': 0 };
 
+  // Curated rows (source LIKE 'manual%') carry hand-set scores — e.g. SEDI First
+  // Nations (88). The scorer must NOT clobber them. We preserve their score and
+  // only stamp scored_at so the incremental IS-NULL pool still drains.
+  const isManual = (row) => /^manual/i.test(String(row.source || ''));
+
   while (totalScored < LIMIT) {
     const batch = await fetchBatch(offset);
     if (batch.length === 0) break;
 
-    const scored = batch.map(row => {
+    const manualRows = batch.filter(isManual);
+    const scorable = batch.filter(row => !isManual(row));
+
+    if (manualRows.length) {
+      totalSkippedManual += manualRows.length;
+      if (!DRY_RUN) {
+        const { error } = await supabase
+          .from('grant_opportunities')
+          .update({ goods_relevance_scored_at: new Date().toISOString() })
+          .in('id', manualRows.map(r => r.id));
+        if (error) console.error(`  preserve manual: ${error.message.slice(0, 80)}`);
+      }
+    }
+
+    const scored = scorable.map(row => {
       const result = scoreGrantForGoods(pickColumns(row));
       if (result.score >= GOODS_TAG_THRESHOLD) totalTagged++;
       if (result.score >= GOODS_HIGH_FIT_THRESHOLD) totalHighFit++;
@@ -220,7 +242,8 @@ async function main() {
   }
 
   console.log('\n=== SUMMARY ===');
-  console.log(`Total scored:    ${totalScored}`);
+  console.log(`Rows processed:  ${totalScored}`);
+  console.log(`Manual preserved:${totalSkippedManual} (source LIKE 'manual%' — score untouched)`);
   console.log(`ACT-GD tagged:   ${totalTagged} (score >= ${GOODS_TAG_THRESHOLD})`);
   console.log(`High-fit:        ${totalHighFit} (score >= ${GOODS_HIGH_FIT_THRESHOLD})`);
   console.log('Distribution:');

--- a/scripts/seed-goods-source-vector-programs-2026-05-27.mjs
+++ b/scripts/seed-goods-source-vector-programs-2026-05-27.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Seed the Goods "source-vector" programs identified in the 2026-05-27 grants
+ * sweep (§3/§4) — the capital / capability / procurement / grant opportunities
+ * GrantScope's nightly crawlers don't cover.
+ *
+ * REVIEW-FIRST. Default is --dry-run (prints, writes nothing). Use --apply to write.
+ *
+ *   node --env-file=.env scripts/seed-goods-source-vector-programs-2026-05-27.mjs            # dry-run
+ *   node --env-file=.env scripts/seed-goods-source-vector-programs-2026-05-27.mjs --apply
+ *
+ * Net-new rows are source='manual-research-2026-05-27' so the score-goods-relevance
+ * manual-guard preserves their curated scores. discovery_method routes capital/
+ * procurement rows through the scorer's +25 boost. After --apply, run the rescorer
+ * so the enriched existing rows pick up new scores:
+ *   node --env-file=.env scripts/score-goods-relevance.mjs --rescore-all
+ *
+ * NOTE: sweep amounts/dates are mostly "Inferred" — verify against the funder page
+ * before relying on any value here.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+const MANUAL_SOURCE = 'manual-research-2026-05-27';
+const TAGS = ['ACT-GD', 'goods'];
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+// ── Net-new programs (INSERT/upsert on (source,name)) ───────────────────────
+// score is curated per the sweep; >=50 rows get the ACT-GD/goods tags.
+const NET_NEW = [
+  {
+    name: 'IBA Start-Up Finance Package', provider: 'Indigenous Business Australia',
+    program: 'Start-Up Finance', discovery_method: 'indigenous-finance',
+    amount_min: null, amount_max: 150000, status: 'open', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: false, score: 82,
+    url: 'https://iba.gov.au/business/business-finance/',
+    description: 'Loan with up to 30% as a grant component to buy business assets (machinery, inventory) — buys beds/washers/plant. ≥50% Indigenous-owned, ABN, viable business. Year-round. CAPITAL, not a grant portal listing.',
+  },
+  {
+    name: 'Supply Nation Certification + Buyer Access', provider: 'Supply Nation',
+    program: 'Indigenous Business Certification', discovery_method: 'procurement',
+    amount_min: null, amount_max: null, status: 'open', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: false, score: 80,
+    url: 'https://supplynation.org.au/',
+    description: 'Certification + access to corporate/govt RAP buyers ($5.83B FY24-25 member spend). ≥50% Indigenous-owned/controlled. DEMAND SIDE — register to sell beds/washers; a purchase order beats a grant and repeats.',
+  },
+  {
+    name: 'Aboriginals Benefit Account (ABA) Grants', provider: 'NIAA / Aboriginal Investment NT',
+    program: 'Aboriginals Benefit Account', discovery_method: 'grant',
+    amount_min: null, amount_max: null, status: 'open', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: true, score: 75,
+    url: 'https://aboriginalinvestment.org.au/grants',
+    description: 'Beneficial projects for Aboriginal Territorians; multi-year, admin costs OK. Remote-NT — Goods’ core delivery geography. Year-round open funding.',
+  },
+  {
+    name: 'NAIF Small Loans Program', provider: 'Northern Australia Infrastructure Facility',
+    program: 'Small Loans', discovery_method: 'indigenous-finance',
+    amount_min: null, amount_max: null, status: 'ongoing', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: true, score: 62,
+    url: 'https://naif.gov.au/',
+    description: 'Concessional finance (loans/equity, not grants) for First Nations community projects in Northern Australia. Capital for scale infrastructure.',
+  },
+  {
+    name: 'Many Rivers Microfinance', provider: 'Many Rivers',
+    program: 'Microenterprise Loans + Coaching', discovery_method: 'indigenous-finance',
+    amount_min: null, amount_max: null, status: 'ongoing', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: true, score: 60,
+    url: 'https://manyrivers.org.au/',
+    description: 'Microenterprise loans + coaching for First Nations businesses. Early capital + capability.',
+  },
+  {
+    name: 'Barayamal Accelerator', provider: 'Barayamal',
+    program: 'Indigenous Startup Accelerator', discovery_method: 'grant',
+    amount_min: null, amount_max: 10000, status: 'open', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: false, score: 55,
+    url: 'https://barayamal.com.au/',
+    description: 'Indigenous startup accelerator — grants + coworking + mentoring for First Nations founders, early-stage. ~$10K/startup. Capability + small grant + network.',
+  },
+  {
+    name: 'ILSC Future Industries Grant Program', provider: 'Indigenous Land and Sea Corporation (ILSC)',
+    program: 'Future Industries', discovery_method: 'grant',
+    amount_min: null, amount_max: null, status: 'open', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: true, score: 55,
+    url: 'https://www.ilsc.gov.au/grants/future-industries-grant-program/',
+    description: 'Independent specialist advice on economic opportunities on Country for Indigenous Corporations. Feasibility/advice for scale-up.',
+  },
+  {
+    name: 'FRRR / ANZ Seeds of Renewal', provider: 'FRRR + ANZ',
+    program: 'Seeds of Renewal', discovery_method: 'grant',
+    amount_min: null, amount_max: null, status: 'upcoming', closes_at: null,
+    accepts_pty_ltd: false, accepts_charity: true, score: 45,
+    url: 'https://frrr.org.au/funding/place/anz-seeds-of-renewal/',
+    description: 'Rural community + economic projects. Annual round. Rural NFP/community (Goods may need an auspice).',
+  },
+  {
+    name: 'Lowitja Institute Seeding / GLOWS', provider: 'Lowitja Institute',
+    program: 'Aboriginal & TSI Community Grants', discovery_method: 'grant',
+    amount_min: null, amount_max: null, status: 'open', closes_at: '2026-06-10',
+    accepts_pty_ltd: false, accepts_charity: true, score: 40,
+    url: 'https://lowitja.smartygrants.com.au/',
+    description: 'Aboriginal & TSI community grant stream (research-leaning; community stream only if Goods has a health-evidence angle). GLOWS closes 10 Jun 2026.',
+  },
+  {
+    name: 'Macquarie Group Foundation Grant', provider: 'Macquarie Group Foundation',
+    program: 'Global Grant-Making', discovery_method: 'grant',
+    amount_min: null, amount_max: null, status: 'pending', closes_at: null,
+    accepts_pty_ltd: true, accepts_charity: true, score: 40,
+    url: 'https://www.macquarie.com/au/en/about/community/macquarie-group-foundation.html',
+    description: 'Work-integrated social enterprises; Indigenous economic development. Relationship-led / by nomination, not open application.',
+  },
+];
+
+// ── Existing rows to ENRICH (UPDATE by id; score left to the rescorer) ──────
+const ENRICH = [
+  { id: 'b8a98813-1927-40a4-ad68-bad7d115b01d', label: 'ILSC Our Country Our Future (keep)',
+    patch: { provider: 'Indigenous Land and Sea Corporation (ILSC)', discovery_method: 'grant',
+      status: 'ongoing', accepts_pty_ltd: true, accepts_charity: true,
+      description: 'Land/water ownership + enterprise on Country; partnership brokering + funding for Indigenous groups. On-Country enterprise infrastructure.' } },
+  { id: 'a22e6b40-30c2-445e-916d-5e0b2902f5f6', label: 'Westpac Inclusive Employment Grant',
+    patch: { provider: 'Westpac Foundation', discovery_method: 'grant', amount_max: 50000,
+      status: 'upcoming', accepts_pty_ltd: false, accepts_charity: true,
+      description: 'Jobs/training for people facing barriers; social enterprises eligible. $50K over 2 years. Goods = employment social enterprise. Round opens 2026 (date TBC).' } },
+  { id: '8859f780-8fdd-49e7-8d31-7c1be4fa11f9', label: 'Westpac Social Change Fellowship',
+    patch: { provider: 'Westpac Scholars Trust', discovery_method: 'grant', amount_max: 50000,
+      status: 'open', closes_at: '2026-06-16', accepts_pty_ltd: true, accepts_charity: true,
+      description: 'Development program for social entrepreneurs creating community change; Indigenous social enterprise founders eligible. Founder capability. 2027 round closes 16 Jun 2026.' } },
+  { id: 'f270bdf5-77d7-4fdb-91d7-601f6bade95f', label: 'FRRR Strengthening Rural Communities (keep)',
+    patch: { provider: 'Foundation for Rural & Regional Renewal (FRRR)', discovery_method: 'grant',
+      amount_max: 50000, status: 'upcoming', closes_at: '2026-09-17', accepts_pty_ltd: false, accepts_charity: true,
+      description: 'Remote/rural community projects; explicit First Nations + economic-participation priority; non-DGR eligible. Round 30 opens 25 Jun 2026, closes 17 Sep. Remote + First Nations priority.' } },
+  { id: 'f8ddbf67-de8d-40cc-9098-54aa06ad2f9c', label: 'Telstra Connected Communities (mark closed)',
+    patch: { provider: 'Telstra Foundation', discovery_method: 'grant', status: 'closed',
+      description: 'Digital tech for remote communities; First Nations-led eligible. Annual; this cycle CLOSED 26 Mar 2026, next ~Feb 2027.' } },
+];
+
+// ── Duplicate rows to RETIRE (status='duplicate') ───────────────────────────
+const DEDUP = [
+  { id: 'db62e090-e391-44c6-9a7f-62b9e2491970', label: 'ILSC Our Country (ghl_sync dup of b8a98813)' },
+  { id: 'e525f89b-38c3-452d-83ae-b1ef2f087c10', label: 'Social Change Fellowship (dup of Westpac 8859f780)' },
+  { id: 'd4d6ce7d-ac6a-45de-ae03-c6e26d3a5be1', label: 'Strengthening Rural Communities (dup of SRC f270bdf5)' },
+  { id: 'ec05578d-e09b-4216-86c9-d7990ae86e78', label: 'Connected Communities Grant (dup of Telstra f8ddbf67)' },
+];
+
+function fmtMoney(v) { return v == null ? '—' : `$${v.toLocaleString()}`; }
+
+async function main() {
+  console.log(`\n=== Seed Goods source-vector programs === ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  console.log(`── NET-NEW (${NET_NEW.length}) → upsert on (source,name), source='${MANUAL_SOURCE}' ──`);
+  for (const r of NET_NEW) {
+    console.log(`  [${String(r.score).padStart(2)}] ${r.discovery_method.padEnd(18)} ${r.name}  (${fmtMoney(r.amount_max)}, ${r.status})`);
+  }
+  console.log(`\n── ENRICH existing (${ENRICH.length}) → UPDATE by id; score recomputed by rescorer ──`);
+  for (const e of ENRICH) console.log(`  ${e.id.slice(0, 8)}  ${e.label}`);
+  console.log(`\n── DEDUP (${DEDUP.length}) → status='duplicate' ──`);
+  for (const d of DEDUP) console.log(`  ${d.id.slice(0, 8)}  ${d.label}`);
+
+  if (!APPLY) {
+    console.log('\nDry-run only. Re-run with --apply to write, then rescore.');
+    return;
+  }
+
+  let ins = 0, enr = 0, ded = 0;
+  for (const r of NET_NEW) {
+    const row = {
+      name: r.name, provider: r.provider, program: r.program, source: MANUAL_SOURCE,
+      discovery_method: r.discovery_method, amount_min: r.amount_min, amount_max: r.amount_max,
+      status: r.status, closes_at: r.closes_at, deadline: r.closes_at,
+      accepts_pty_ltd: r.accepts_pty_ltd, accepts_charity: r.accepts_charity,
+      url: r.url, description: r.description,
+      goods_relevance_score: r.score, goods_relevance_scored_at: new Date().toISOString(),
+      aligned_projects: r.score >= 50 ? TAGS : [],
+    };
+    const { error } = await supabase.from('grant_opportunities').upsert(row, { onConflict: 'source,name' });
+    if (error) console.error(`  upsert "${r.name}": ${error.message.slice(0, 100)}`); else ins++;
+  }
+  for (const e of ENRICH) {
+    const { error } = await supabase.from('grant_opportunities').update({ ...e.patch, updated_at: new Date().toISOString() }).eq('id', e.id);
+    if (error) console.error(`  enrich ${e.id.slice(0, 8)}: ${error.message.slice(0, 100)}`); else enr++;
+  }
+  for (const d of DEDUP) {
+    const { error } = await supabase.from('grant_opportunities').update({ status: 'duplicate', goods_relevance_score: 0, aligned_projects: [], updated_at: new Date().toISOString() }).eq('id', d.id);
+    if (error) console.error(`  dedup ${d.id.slice(0, 8)}: ${error.message.slice(0, 100)}`); else ded++;
+  }
+  console.log(`\n✓ upserted ${ins}/${NET_NEW.length} net-new · enriched ${enr}/${ENRICH.length} · retired ${ded}/${DEDUP.length} dups`);
+  console.log('Next: node --env-file=.env scripts/score-goods-relevance.mjs --rescore-all');
+}
+
+main().catch(err => { console.error('FATAL:', err); process.exit(1); });

--- a/scripts/seed-goods-source-vector-programs-2026-05-27.mjs
+++ b/scripts/seed-goods-source-vector-programs-2026-05-27.mjs
@@ -165,7 +165,10 @@ async function main() {
     return;
   }
 
-  let ins = 0, enr = 0, ded = 0;
+  let ins = 0, skip = 0, enr = 0, ded = 0;
+  // The (source,name) unique index is PARTIAL, so ON CONFLICT can't infer it.
+  // These rows are net-new; plain INSERT, and a 23505 (unique violation) on a
+  // re-run is a benign "already there" skip — keeps the seeder idempotent.
   for (const r of NET_NEW) {
     const row = {
       name: r.name, provider: r.provider, program: r.program, source: MANUAL_SOURCE,
@@ -176,8 +179,11 @@ async function main() {
       goods_relevance_score: r.score, goods_relevance_scored_at: new Date().toISOString(),
       aligned_projects: r.score >= 50 ? TAGS : [],
     };
-    const { error } = await supabase.from('grant_opportunities').upsert(row, { onConflict: 'source,name' });
-    if (error) console.error(`  upsert "${r.name}": ${error.message.slice(0, 100)}`); else ins++;
+    const { error } = await supabase.from('grant_opportunities').insert(row);
+    if (error) {
+      if (error.code === '23505') { console.log(`  skip (exists): ${r.name}`); skip++; }
+      else console.error(`  insert "${r.name}": ${error.message.slice(0, 100)}`);
+    } else ins++;
   }
   for (const e of ENRICH) {
     const { error } = await supabase.from('grant_opportunities').update({ ...e.patch, updated_at: new Date().toISOString() }).eq('id', e.id);
@@ -187,7 +193,7 @@ async function main() {
     const { error } = await supabase.from('grant_opportunities').update({ status: 'duplicate', goods_relevance_score: 0, aligned_projects: [], updated_at: new Date().toISOString() }).eq('id', d.id);
     if (error) console.error(`  dedup ${d.id.slice(0, 8)}: ${error.message.slice(0, 100)}`); else ded++;
   }
-  console.log(`\n✓ upserted ${ins}/${NET_NEW.length} net-new · enriched ${enr}/${ENRICH.length} · retired ${ded}/${DEDUP.length} dups`);
+  console.log(`\n✓ inserted ${ins}/${NET_NEW.length} net-new (${skip} skipped as existing) · enriched ${enr}/${ENRICH.length} · retired ${ded}/${DEDUP.length} dups`);
   console.log('Next: node --env-file=.env scripts/score-goods-relevance.mjs --rescore-all');
 }
 

--- a/scripts/sync-austender-open-tenders.mjs
+++ b/scripts/sync-austender-open-tenders.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+/**
+ * Sync OPEN AusTender ATMs (Approach To Market) → grant_opportunities
+ *
+ * Phase 3 of the Goods capital/procurement pipelines
+ * (thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md).
+ *
+ * WHY a separate source from sync-austender-contracts.mjs:
+ *   The OCDS API (api.tenders.gov.au/ocds/findByDates) only exposes AWARDED
+ *   contracts — its DateType is restricted to
+ *   ['contractPublished','contractLastModified','contractStart','contractEnd'].
+ *   There is no tender/ATM/planning release type. "What open tenders can Goods
+ *   bid on right now?" is therefore unanswerable from OCDS. The live answer is
+ *   AusTender's Current ATM RSS feed (all government business opportunities
+ *   currently out to market), enriched per-ATM from the public detail page which
+ *   carries the UNSPSC category code, agency, ATM type and close date.
+ *
+ * FLOW:
+ *   1. Fetch the Current ATM RSS feed (~90 latest open ATMs).
+ *   2. Keyword pre-filter on title+description (Goods product words) — cheap,
+ *      narrows ~90 → a handful before any detail fetches. (--all skips this and
+ *      fetches every ATM, gating purely on UNSPSC; slower but no keyword misses.)
+ *   3. Fetch each candidate's /Atm/Show/{guid} page → extract UNSPSC code,
+ *      category title, agency, ATM type, close date, location.
+ *   4. PRECISION GATE on UNSPSC: a present-but-non-Goods code REJECTS the row
+ *      (this is what kills the keyword false-positives — "seabed" dredging,
+ *      "road bed" asphalt, Defence-Housing-Australia civil works all carry
+ *      construction/marine UNSPSC, not furniture/appliance). No code → fall back
+ *      to the keyword match.
+ *   5. Upsert survivors as grant_opportunities rows:
+ *        source='austender-open-tenders', discovery_method='procurement',
+ *        status='open', dedup on the unique `url` index (stable per ATM GUID).
+ *      NOT marked manual — they score through the scorer's +25 procurement boost
+ *      (goods-relevance.mjs BOOSTED_DISCOVERY_METHODS). Scored inline at ingest
+ *      so rows are immediately useful; the nightly rescorer reconfirms.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/sync-austender-open-tenders.mjs            # dry-run (no writes)
+ *   node --env-file=.env scripts/sync-austender-open-tenders.mjs --apply
+ *   node --env-file=.env scripts/sync-austender-open-tenders.mjs --all      # fetch every ATM (UNSPSC-only gate)
+ *   node --env-file=.env scripts/sync-austender-open-tenders.mjs --limit=5  # cap detail fetches (debug)
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { scoreGrantForGoods } from './lib/goods-relevance.mjs';
+
+const RSS_URL = 'https://www.tenders.gov.au/public_data/rss/rss.xml';
+const DETAIL_BASE = 'https://www.tenders.gov.au/Atm/Show/';
+const SOURCE = 'austender-open-tenders';
+// Browser-like UA: tenders.gov.au 403s bare/unknown agents.
+const UA = 'Mozilla/5.0 (compatible; GrantScope/1.0; +https://grantscope.au)';
+const TAGS = ['ACT-GD', 'goods']; // applied to aligned_projects when score >= 50
+
+const APPLY = process.argv.includes('--apply');
+const FETCH_ALL = process.argv.includes('--all');
+const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '0', 10);
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Goods product words — mirrors GOODS_KEYWORDS in hydrate-goods-procurement.mjs.
+// Used as the cheap RSS pre-filter and as the fallback gate when an ATM carries
+// no UNSPSC code.
+const GOODS_KEYWORDS = [
+  'furniture', 'bed', 'mattress', 'housing', 'accommodation',
+  'white goods', 'whitegood', 'appliance', 'washing', 'refrigerat', 'linen',
+  'fitout', 'fit-out', 'furnish', 'kitchen', 'laundry',
+  'fridge', 'freezer', 'dryer',
+];
+
+// UNSPSC families that ARE Goods product. The agency assigns these, so they are
+// the authoritative category gate.
+//   56xx  — Furniture and Furnishings (56101500 = Furniture, beds/mattresses etc.)
+//   5210  — Floor coverings
+//   5212  — Domestic bedclothes and linens (mattresses, bed linen)
+//   5213  — Domestic kitchenware and tableware
+//   5214  — Domestic appliances (whitegoods: refrigerators, washers, dryers)
+// Deliberately EXCLUDES 5216/5217 (consumer/AV electronics) — not Goods.
+const GOODS_UNSPSC_PREFIXES = ['5210', '5212', '5213', '5214'];
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+function log(msg) { console.log(`[atm] ${msg}`); }
+
+function decodeEntities(s) {
+  return String(s || '')
+    .replace(/<!\[CDATA\[|\]\]>/g, '')
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function stripHtml(s) {
+  return decodeEntities(s).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/** Parse the RSS feed into [{ title, link, guid, description, pubDate }]. */
+function parseRss(xml) {
+  const items = [];
+  const get = (block, tag) => {
+    const m = block.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`));
+    return m ? decodeEntities(m[1]).trim() : '';
+  };
+  for (const m of xml.matchAll(/<item>([\s\S]*?)<\/item>/g)) {
+    const block = m[1];
+    items.push({
+      title: get(block, 'title'),
+      link: get(block, 'link'),
+      guid: get(block, 'guid'),
+      description: stripHtml(get(block, 'description')),
+      pubDate: get(block, 'pubDate'),
+    });
+  }
+  return items;
+}
+
+async function fetchText(url, attempt = 1) {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'text/html,application/xml', 'User-Agent': UA },
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } catch (err) {
+    if (attempt < 2) {
+      await new Promise(r => setTimeout(r, 1500));
+      return fetchText(url, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+/** Pull a single-quoted value out of the page's embedded analytics object. */
+function pickAtmField(html, key) {
+  const m = html.match(new RegExp(`'${key}':\\s*'([^']*)'`));
+  return m ? m[1].trim() : null;
+}
+
+/** Close date sits in the TimeZone modal link as MM/DD/YYYY HH:MM:SS (URL-encoded). */
+function extractCloseDate(html) {
+  const m = html.match(/CloseDateTime=([^"'&]+)/);
+  if (!m) return { date: null, datetime: null };
+  const raw = decodeURIComponent(m[1]).trim(); // "05/29/2026 15:00:00"
+  const dm = raw.match(/^(\d{2})\/(\d{2})\/(\d{4})\s+([\d:]+)?/);
+  if (!dm) return { date: null, datetime: raw };
+  const [, mm, dd, yyyy, time] = dm;
+  return { date: `${yyyy}-${mm}-${dd}`, datetime: `${yyyy}-${mm}-${dd}${time ? ' ' + time : ''}` };
+}
+
+// AusTender uses bare state codes; map the Goods-relevant ones to the scorer's
+// geography format (AU-NT/AU-WA/AU-QLD/AU-SA get a +10 boost). Anything else (or
+// multi-jurisdiction) lands as 'AU' (national, +4).
+const STATE_TO_GEO = { NT: 'AU-NT', WA: 'AU-WA', QLD: 'AU-QLD', SA: 'AU-SA' };
+
+/** Fetch + parse one ATM detail page. */
+async function fetchAtmDetail(link) {
+  const html = await fetchText(link);
+  const close = extractCloseDate(html);
+  return {
+    atmId: pickAtmField(html, 'atmID'),
+    agency: pickAtmField(html, 'atmAgencyName'),
+    unspscCode: pickAtmField(html, 'atmCategoryCode'),
+    unspscTitle: pickAtmField(html, 'atmCategoryTitle'),
+    atmType: pickAtmField(html, 'atmType'),
+    locationState: pickAtmField(html, 'atmLocationState'),
+    locationCity: pickAtmField(html, 'atmLocationCity'),
+    closeDate: close.date,
+    closeDateTime: close.datetime,
+  };
+}
+
+/**
+ * Decide whether an ATM is Goods-relevant.
+ * @returns {{ accept: boolean, reason: string }}
+ */
+function gate(detail, rssText) {
+  const code = (detail.unspscCode || '').replace(/\D/g, '');
+  if (code) {
+    const isGoods = code.startsWith('56') || GOODS_UNSPSC_PREFIXES.some(p => code.startsWith(p));
+    // A present-but-non-Goods UNSPSC is authoritative → reject (kills the
+    // keyword false-positives). Only the category title is allowed to rescue it,
+    // for the rare case the agency coded it generically but titled it clearly.
+    if (isGoods) return { accept: true, reason: `unspsc:${code}` };
+    const titleHit = GOODS_KEYWORDS.find(k => (detail.unspscTitle || '').toLowerCase().includes(k));
+    if (titleHit) return { accept: true, reason: `category-title:${titleHit}` };
+    return { accept: false, reason: `unspsc-non-goods:${code}` };
+  }
+  // No UNSPSC on the page → fall back to the keyword match on free text.
+  const hay = `${rssText} ${detail.unspscTitle || ''}`.toLowerCase();
+  const kw = GOODS_KEYWORDS.find(k => hay.includes(k));
+  return kw ? { accept: true, reason: `keyword:${kw}` } : { accept: false, reason: 'no-unspsc-no-keyword' };
+}
+
+function buildRow(item, detail, gateReason) {
+  const geography = STATE_TO_GEO[detail.locationState] || 'AU';
+  const categories = ['procurement'];
+  if (detail.unspscTitle) categories.push(detail.unspscTitle.toLowerCase());
+
+  const descParts = [item.description];
+  if (detail.agency) descParts.push(`Agency: ${detail.agency}.`);
+  if (detail.atmType) descParts.push(`ATM type: ${detail.atmType}.`);
+  if (detail.unspscTitle) descParts.push(`Category: ${detail.unspscTitle} (UNSPSC ${detail.unspscCode}).`);
+  if (detail.closeDate) descParts.push(`Closes ${detail.closeDate}.`);
+  const description = descParts.filter(Boolean).join(' ').slice(0, 2000);
+
+  const row = {
+    name: item.title,
+    provider: detail.agency || 'AusTender',
+    program: detail.atmType || 'Approach to Market',
+    source: SOURCE,
+    source_id: detail.atmId || item.guid || item.link,
+    discovery_method: 'procurement',
+    status: 'open',
+    closes_at: detail.closeDate,
+    deadline: detail.closeDate,
+    url: item.link,
+    description,
+    categories,
+    geography,
+    accepts_pty_ltd: true,   // open tenders accept Pty Ltd suppliers (Goods' entity)
+    accepts_charity: true,
+    metadata: {
+      atm_id: detail.atmId,
+      unspsc_code: detail.unspscCode,
+      unspsc_title: detail.unspscTitle,
+      atm_type: detail.atmType,
+      location_state: detail.locationState,
+      location_city: detail.locationCity,
+      close_datetime: detail.closeDateTime,
+      gate_reason: gateReason,
+      rss_pub_date: item.pubDate,
+      ingested_at: new Date().toISOString(),
+    },
+    updated_at: new Date().toISOString(),
+  };
+
+  // Score inline through the shared scorer (discovery_method='procurement' → +25).
+  const { score, signals } = scoreGrantForGoods(row);
+  row.goods_relevance_score = score;
+  row.goods_relevance_scored_at = new Date().toISOString();
+  row.goods_relevance_signals = signals;
+  row.aligned_projects = score >= 50 ? TAGS : [];
+  return row;
+}
+
+async function main() {
+  console.log(`\n=== Sync AusTender open ATMs → grant_opportunities === ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  log('Fetching Current ATM RSS feed...');
+  const xml = await fetchText(RSS_URL);
+  const items = parseRss(xml);
+  log(`RSS carries ${items.length} open ATMs.`);
+
+  // Pre-filter unless --all.
+  let candidates = items;
+  if (!FETCH_ALL) {
+    candidates = items.filter(it => {
+      const hay = `${it.title} ${it.description}`.toLowerCase();
+      return GOODS_KEYWORDS.some(k => hay.includes(k));
+    });
+    log(`Keyword pre-filter: ${items.length} → ${candidates.length} candidates (use --all to fetch every ATM).`);
+  }
+  if (LIMIT > 0) candidates = candidates.slice(0, LIMIT);
+
+  const accepted = [];
+  let rejected = 0, errored = 0;
+  for (const item of candidates) {
+    const guid = item.link?.startsWith('http') ? item.link : `${DETAIL_BASE}${item.guid}`;
+    try {
+      const detail = await fetchAtmDetail(item.link || guid);
+      const g = gate(detail, `${item.title} ${item.description}`);
+      if (!g.accept) {
+        rejected++;
+        console.log(`  ✗ ${g.reason.padEnd(26)} ${item.title.slice(0, 70)}`);
+      } else {
+        const row = buildRow(item, detail, g.reason);
+        accepted.push(row);
+        console.log(`  ✓ [${String(row.goods_relevance_score).padStart(3)}] ${g.reason.padEnd(26)} ${item.title.slice(0, 60)}  (${detail.closeDate || 'no close'}, ${detail.agency || '?'})`);
+      }
+    } catch (err) {
+      errored++;
+      console.error(`  ! fetch failed: ${item.title.slice(0, 60)} — ${err.message}`);
+    }
+    await new Promise(r => setTimeout(r, 600)); // polite delay between detail fetches
+  }
+
+  console.log(`\nGate: ${accepted.length} accepted · ${rejected} rejected · ${errored} fetch errors`);
+  const scoring = accepted.filter(r => r.goods_relevance_score >= 50).length;
+  console.log(`Scoring: ${scoring}/${accepted.length} clear the ACT-GD threshold (>=50) and get tagged.`);
+
+  if (!APPLY) {
+    console.log('\nDry-run only. Re-run with --apply to upsert.');
+    if (accepted[0]) console.log('\nSample row:\n', JSON.stringify({ ...accepted[0], description: accepted[0].description.slice(0, 120) + '…' }, null, 2));
+    return;
+  }
+
+  let up = 0, err = 0;
+  for (const row of accepted) {
+    const { error } = await supabase.from('grant_opportunities').upsert(row, { onConflict: 'url' });
+    if (error) { console.error(`  upsert "${row.name.slice(0, 50)}": ${error.message.slice(0, 120)}`); err++; }
+    else up++;
+  }
+  console.log(`\n✓ Upserted ${up}/${accepted.length} open ATMs (${err} errors).`);
+  console.log('Rows are scored inline; nightly score-goods-relevance.mjs --rescore-all reconfirms.');
+}
+
+main().catch(err => { console.error('FATAL:', err); process.exit(1); });

--- a/thoughts/2026-05-27-alpa-overmatch-fix.json
+++ b/thoughts/2026-05-27-alpa-overmatch-fix.json
@@ -1,0 +1,1031 @@
+{
+  "at": "2026-05-27T06:26:18.277Z",
+  "keptId": "01bee3bd-e6d8-4485-bc81-58345aff8856",
+  "deletedIds": [
+    "020ca948-610e-48cb-9499-f5cd50d1eb24",
+    "09b20bcf-dfe0-4fd7-9f1f-9e28c7c3b7f4",
+    "0a927479-ba1c-4391-843f-436f574fbff9",
+    "0bc1fd36-9ffc-4b98-8977-0c2445072416",
+    "0d9bafde-0982-4443-92d7-283a3711ff5e",
+    "0de8a1da-640a-4bd6-983d-5e8a56368965",
+    "0f7060c8-8ced-46e7-b614-ad0a690b730c",
+    "102ad8a6-660b-4ae7-bdae-6cdcc8082e37",
+    "111e0f58-2bf6-481c-9f3c-fae0582ca405",
+    "1192a6eb-fd9b-4030-a973-dbd8cb9753ef",
+    "13dc2bb5-a297-4cde-a23c-8832e5cb418a",
+    "13f6a83f-38e0-4a79-b7e0-d03a8af8f536",
+    "156a4ad8-fda6-4e82-bd99-9541d456cfd4",
+    "15ff5c47-d23d-4faf-b1d3-3f46a08ddfc4",
+    "17ce28e5-9162-47f0-8048-b3c4e96ddabb",
+    "1a02eafe-945a-4afb-a2e6-e9da5b654a83",
+    "1d6f1de5-b639-4a74-a816-0a904a1bb75a",
+    "2270627e-2a2f-4a1c-a767-ca064b15bee0",
+    "268dc74c-c111-46ad-8376-840cd062d9ff",
+    "26cb7865-902e-4266-80db-e3d60cd461d4",
+    "2860219b-535a-4d86-a3bb-2f6649081c37",
+    "3202957c-b6c0-4072-ae21-828fbafd4663",
+    "334005aa-8631-436c-ac9a-f22389a2593f",
+    "3374b1a3-6a20-4db2-80ca-d2d3002a879d",
+    "363a0791-fce6-4b68-8c86-befec13d3b66",
+    "363ac789-43ee-4671-849f-703c0b6eb27f",
+    "3a0782ed-02f0-4b8b-856b-5a48020f038d",
+    "3a24ce42-fab7-40fd-8aa7-c238b339f33a",
+    "3d2784c3-ee5b-45c7-aa08-8b4ed74968aa",
+    "3d439055-60c0-49c3-b93e-c6cd4b6a3485",
+    "3efaceb2-5ab5-4217-8eb2-10e30c493d77",
+    "3f48ba47-cbe2-4288-baca-6910caf9d0de",
+    "42843ede-f708-454a-9426-2a4fbb45b04e",
+    "45898c8c-8a9e-4482-b43d-367332c75156",
+    "4794d62c-891f-4bb5-b4c1-2fd4118f9a8b",
+    "486d7194-626a-4086-86e0-50cc538de7d5",
+    "4ee3e6c1-531f-4bfa-bd6d-6cb392193e6a",
+    "4ee55304-6356-44a0-8143-c33a2085137b",
+    "5344bd32-37a4-4586-8016-393893b6c8c7",
+    "54d601e0-4cdd-4e64-b722-f634e1d67078",
+    "553be114-eb0e-420f-8551-5b7a630aaddd",
+    "581d19ad-3681-4a8f-bb68-d94a4a618ff8",
+    "58ad74f8-f12d-4c79-a42d-e54129b064fe",
+    "5bfc0b5b-817c-4deb-8ae2-794532951b00",
+    "5c3a366f-58e5-4d73-b38d-c7aed64bbbae",
+    "5c512b73-1a42-4e0c-b2b4-74746eea617a",
+    "5c58cf47-925c-42d0-ab44-f006a432e076",
+    "60806f0e-f422-4a0a-b875-96fb065bf712",
+    "61383236-242f-42f2-bb79-4d623f07abc2",
+    "617502d2-b62a-4a4e-9244-d2a035dd6eec",
+    "626dd13c-821d-4c9e-9065-64f114256707",
+    "64ca01d9-cc1c-450c-b3bb-a996965cc2e5",
+    "64f206d8-548d-4f8d-9ea6-26d92f5f8271",
+    "65c9d9b1-07b4-425b-9ea6-533a3c84e5be",
+    "682ed82e-7558-4d5d-85cf-4339b4b968f7",
+    "68a7664f-00f4-4215-aab2-8287472fc90d",
+    "68b4c0f3-20df-446f-8a72-0f9dbce3ab4d",
+    "6bc5444e-464e-4c7b-b207-fb5d6346d603",
+    "72b9a5be-1888-4eb6-b4e6-d1f155679aeb",
+    "72e06d99-44fb-418c-9c0c-72105e9d60c6",
+    "73370b86-66ce-4f6b-9f8b-2c0cea3aac13",
+    "752c2086-89f1-4fc2-90f8-014a26e04981",
+    "77c05c23-d4d0-4639-8550-2436bef18e10",
+    "8733e859-eeef-42c2-ba56-f66f9ca1f35f",
+    "87b344a3-45c6-4c3e-ab40-fc32d4a267cb",
+    "881450ae-8b26-4c79-a6b7-168289dbcd66",
+    "884da29f-9e97-4b03-980f-6b5d9ced3d67",
+    "88964032-4c08-45d1-b5a2-c4428241f395",
+    "8ac42dfb-044c-42bb-b866-5b8b03afa0df",
+    "8b5462d8-b430-44b8-aa1d-1c623de30756",
+    "8d52778c-0c4f-4acf-a0c6-ebeb0b06784f",
+    "8f8d358a-142e-4cff-be2e-c6e27b838244",
+    "91e61d0a-8ecf-4b65-b441-3036c2041f98",
+    "92dde1b1-e8fb-489c-9cbf-8404d6777cd4",
+    "9714c60c-364a-412b-8136-44eed1620d1c",
+    "989592ea-eb2f-4e57-9164-e07abe7d685f",
+    "98a3c0d6-d4af-4702-aa5d-8477c2667a99",
+    "98d55dc7-cc47-4460-bc79-8f0331664ce1",
+    "9ccce53e-6036-400e-ada2-861aa6a1b36c",
+    "9da7ae8b-984f-44a6-8916-5ab5265c3756",
+    "9e23b5d1-7544-4f2f-9bd6-dab4f4920c20",
+    "9e6a9491-c05e-4d00-946f-cd8400bdd361",
+    "9ea7aecc-6f36-4710-830f-5c9422288400",
+    "9fe7407a-b847-4f5d-840c-4c61e98ef739",
+    "9ff44c0f-5e76-4e84-829e-e5a9ba375d57",
+    "a505e381-1eb1-4a67-b409-995946a214d3",
+    "a8671a46-44c1-433c-84dc-bd057ec5bd9f",
+    "ada1d953-5e80-460d-bcbb-c94d3b61b5a9",
+    "aea9393a-52b3-4235-9c52-790cc9a97ce8",
+    "aee405cd-dae2-4a0e-bb1d-52ae05b74778",
+    "b017cbc0-5ef7-474e-9f47-51bef2d2cc2d",
+    "b04896d0-8f8c-4bc8-b6a3-cd95cda33967",
+    "b52e6d66-cd08-48ba-8957-dcc3ef013645",
+    "b6ae8b58-0b41-4737-a91b-b92960c03d51",
+    "b702ab5f-e5e4-43a3-a337-857b7454b29f",
+    "b7ca53b7-cff4-4370-8ca0-e3dfed0c3c88",
+    "b9d4fc15-04c9-4700-af4e-c93db471e0a5",
+    "babe7d35-cc47-4cac-b1c3-01c1e8a119a9",
+    "bb229140-aaa3-4e7a-9f3e-dac7b9309219",
+    "bbdde4ee-445c-4c04-bc14-ea75f2718c7c",
+    "bf449f88-04f1-4793-b569-2fe08798c181",
+    "bf67fdf8-dd32-4697-a465-0a9ce1221b27",
+    "c03ccd06-d689-4f73-8acc-31d98aa43323",
+    "c4cb139a-b678-4aab-90b6-b2c3d07678bb",
+    "c8e54b09-43db-4b92-82b9-93d96b5e4bd2",
+    "cab734ed-5fb4-4cbe-afa7-7978e566f108",
+    "cc9dcada-dbba-454c-a80b-a8e087f5b937",
+    "cf4f23ca-1c05-44e4-ac4f-1a09a47997b3",
+    "d037da74-eb05-439c-bed4-1177d85385eb",
+    "d0caeb07-3486-43f6-ab18-54466753e44c",
+    "d5107417-fedd-45f1-a430-73f852422479",
+    "d78cbb70-9758-4ad4-9bf4-9be1cd7befcb",
+    "da021f78-8c23-44d8-bfc3-64c6949a83ce",
+    "dbaf71d5-13f0-458b-88d6-af200731142b",
+    "def0f945-bd2f-46a0-bb1a-80a1087d7070",
+    "e04753fc-c798-47ff-ab5f-fe36e8f230b6",
+    "e44f6330-f4a9-4981-bec6-e1a004de39ec",
+    "e638ab86-f832-4eac-a76a-030e02de84a6",
+    "e6eb4cee-0930-4ce2-a122-1c08c98bf70a",
+    "e91062d7-4dcf-4f1c-8720-005dad187089",
+    "eb404cbf-1d0e-4cd8-a9a3-4e1e77dfaf3e",
+    "f0878825-26d1-46b7-965d-8ea697141ebb",
+    "f33088bd-5993-4f65-bef1-0a3abca24a97",
+    "f8421634-3478-4b16-8866-b3b97c54dcd6",
+    "fb19b92a-d71b-4675-8568-b38c7c629f6b",
+    "fe076bcf-cd72-4e84-9200-1ea57ff02e93",
+    "fee08649-fe02-41a8-9e7d-f3460d960775"
+  ],
+  "allRows": [
+    {
+      "id": "01bee3bd-e6d8-4485-bc81-58345aff8856",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": null,
+      "fit_score": 85,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "020ca948-610e-48cb-9499-f5cd50d1eb24",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "69cbd105-7d07-42e8-9e9e-ac7bbbe4a4e7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "09b20bcf-dfe0-4fd7-9f1f-9e28c7c3b7f4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1f033e9b-410e-49e3-8630-6281e4aff947",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0a927479-ba1c-4391-843f-436f574fbff9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9e1f554-5130-4595-bf31-2f40407abb08",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0bc1fd36-9ffc-4b98-8977-0c2445072416",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1333d5f7-8428-4575-bd43-d76fce8a04bb",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0d9bafde-0982-4443-92d7-283a3711ff5e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "326d979b-6d53-4466-bc58-99124a03c9ed",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0de8a1da-640a-4bd6-983d-5e8a56368965",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa8193a4-a289-48da-b18f-4ac9f66e4e9c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "0f7060c8-8ced-46e7-b614-ad0a690b730c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fe5e105f-a264-4ea6-ab09-025ffaf1d149",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "102ad8a6-660b-4ae7-bdae-6cdcc8082e37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f64c5dc5-678f-42cf-af57-9dcb225ce479",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "111e0f58-2bf6-481c-9f3c-fae0582ca405",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "9025299a-46cb-4793-b1b8-5281e71eda4c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "1192a6eb-fd9b-4030-a973-dbd8cb9753ef",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "56bb9c94-9ef3-4755-800f-b86d2d15360a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "13dc2bb5-a297-4cde-a23c-8832e5cb418a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3ae1b29e-21bb-4d0f-ab4c-3468da66fc29",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "13f6a83f-38e0-4a79-b7e0-d03a8af8f536",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "dd10c923-3afd-4819-88c4-7d9556ce4278",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "156a4ad8-fda6-4e82-bd99-9541d456cfd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "10380ad3-cb06-4e7b-ae99-071693283c31",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "15ff5c47-d23d-4faf-b1d3-3f46a08ddfc4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "996df6f9-cf4c-4853-944d-d7db32984e7f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "17ce28e5-9162-47f0-8048-b3c4e96ddabb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "76eed511-6de0-4e23-bb3b-b61af3a8a449",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "1a02eafe-945a-4afb-a2e6-e9da5b654a83",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a360ee62-c030-41fc-abda-ec987b36d5e2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "1d6f1de5-b639-4a74-a816-0a904a1bb75a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33cb0161-b755-4881-8b56-a2c278717ef6",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "2270627e-2a2f-4a1c-a767-ca064b15bee0",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "75625293-fd9c-4bd1-a6b5-4aaad5d83b0a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "268dc74c-c111-46ad-8376-840cd062d9ff",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "587bee01-82d2-4388-b836-695aeaf3bb0c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "26cb7865-902e-4266-80db-e3d60cd461d4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "559aed4c-452c-42b4-a5c3-efde3496c5a3",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "2860219b-535a-4d86-a3bb-2f6649081c37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7295dc9b-ffe4-4de5-8004-1d2beb8159d2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3202957c-b6c0-4072-ae21-828fbafd4663",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "85f977f6-d92e-4e86-a696-68db873b3afd",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "334005aa-8631-436c-ac9a-f22389a2593f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "38b86b4f-b069-41de-9afc-9da31af5537e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3374b1a3-6a20-4db2-80ca-d2d3002a879d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fb62dbd4-5911-410e-8b14-814b5a6a3e81",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "363a0791-fce6-4b68-8c86-befec13d3b66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e6b6194-e946-4f73-ae4b-8c11d110a6fb",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "363ac789-43ee-4671-849f-703c0b6eb27f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a844ff90-3557-49c4-920f-6be929d4ddb8",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3a0782ed-02f0-4b8b-856b-5a48020f038d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "99c0a586-4046-4760-8bbf-ba32930282c7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3a24ce42-fab7-40fd-8aa7-c238b339f33a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1b03f6c1-71c0-4c3d-aeb6-bb17e01604ea",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3d2784c3-ee5b-45c7-aa08-8b4ed74968aa",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5189ad94-ca4f-4a75-b61b-fa38feb38947",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3d439055-60c0-49c3-b93e-c6cd4b6a3485",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5afc7867-6734-4ab7-bdae-c00a481e7123",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3efaceb2-5ab5-4217-8eb2-10e30c493d77",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f3774fe4-976c-4c61-b570-854d0cbd547f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "3f48ba47-cbe2-4288-baca-6910caf9d0de",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "40e7112b-7292-4b08-bede-0c130c1303a9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "42843ede-f708-454a-9426-2a4fbb45b04e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "05059406-3078-43c4-85e3-3d74034c426b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "45898c8c-8a9e-4482-b43d-367332c75156",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0d772b5-4483-4d2a-b6c7-c7b4cdad0f79",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "4794d62c-891f-4bb5-b4c1-2fd4118f9a8b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "693e077d-cabc-4fa8-aa46-8a268d1e3fa4",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "486d7194-626a-4086-86e0-50cc538de7d5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "874ab15e-4b76-4cf2-902f-dc35e445c747",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "4ee3e6c1-531f-4bfa-bd6d-6cb392193e6a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ef44035-bfdb-46db-8862-44421f1ef906",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "4ee55304-6356-44a0-8143-c33a2085137b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83de3ac4-b57a-44c1-8c55-8b7752834231",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5344bd32-37a4-4586-8016-393893b6c8c7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "16e4e421-cd3b-4dce-bebd-777df456c4b6",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "54d601e0-4cdd-4e64-b722-f634e1d67078",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "30314bcc-8234-4817-9343-c80b8fdf0335",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "553be114-eb0e-420f-8551-5b7a630aaddd",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2f751ffe-361f-4acd-b830-e79496806422",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "581d19ad-3681-4a8f-bb68-d94a4a618ff8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b2b9da14-5e34-40be-a251-f8c43170c267",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "58ad74f8-f12d-4c79-a42d-e54129b064fe",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0cd2eca7-202f-4f88-9345-e3fb4acc4b4a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5bfc0b5b-817c-4deb-8ae2-794532951b00",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bab993ab-1242-44ed-bdfd-547ae3cde53d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5c3a366f-58e5-4d73-b38d-c7aed64bbbae",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f39425d7-a23c-48f8-bac0-1d8459ff9b04",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5c512b73-1a42-4e0c-b2b4-74746eea617a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3192ad9a-efe3-4bae-aa5d-365f47bb8b9d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "5c58cf47-925c-42d0-ab44-f006a432e076",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7357848d-de00-448c-a0bd-c39d16cee26b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "60806f0e-f422-4a0a-b875-96fb065bf712",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c69d1467-bbb7-4c88-8994-ed3d9891ea61",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "61383236-242f-42f2-bb79-4d623f07abc2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4a434d3d-2f89-4aa5-949a-2aeea7efe874",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "617502d2-b62a-4a4e-9244-d2a035dd6eec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "665e4f90-3fc8-4543-a922-f9a8a37dd8ca",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "626dd13c-821d-4c9e-9065-64f114256707",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2eef2a86-c557-46c3-9d6a-e9ea5b3b16dc",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "64ca01d9-cc1c-450c-b3bb-a996965cc2e5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e19b261-4711-486a-92fa-46ccc30699be",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "64f206d8-548d-4f8d-9ea6-26d92f5f8271",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ef58ba70-9ea8-437f-bfb5-c21e992e5c95",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "65c9d9b1-07b4-425b-9ea6-533a3c84e5be",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eea22c27-3d7d-46a9-a69a-000cd24ce85e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "682ed82e-7558-4d5d-85cf-4339b4b968f7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e118b9e-6e66-4664-b3d4-e7d227f9fb61",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "68a7664f-00f4-4215-aab2-8287472fc90d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2bab2980-2cc6-4a0e-bdd2-26aebefb6a71",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "68b4c0f3-20df-446f-8a72-0f9dbce3ab4d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3fc6250b-e4b0-4237-935c-bfc5b6bd7798",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "6bc5444e-464e-4c7b-b207-fb5d6346d603",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "95d53b99-1597-4444-b993-527df1ccebf3",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "72b9a5be-1888-4eb6-b4e6-d1f155679aeb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5f28a435-d8a0-4eec-bcc0-fbe462ba39e8",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "72e06d99-44fb-418c-9c0c-72105e9d60c6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6638aa15-a453-418b-9770-1b6731ea4ce6",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "73370b86-66ce-4f6b-9f8b-2c0cea3aac13",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "97cbc411-879e-48e9-b869-8a55afa41090",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "752c2086-89f1-4fc2-90f8-014a26e04981",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ed0302db-26aa-4276-a9f0-78e9dc564aca",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "77c05c23-d4d0-4639-8550-2436bef18e10",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6dca668d-b579-4d2b-9c5b-0a9717dcb4ff",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8733e859-eeef-42c2-ba56-f66f9ca1f35f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a9e3fa98-9626-4848-a7cd-583be703b5f3",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "87b344a3-45c6-4c3e-ab40-fc32d4a267cb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e8f18266-8492-4ff2-8c88-962174b21da5",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "881450ae-8b26-4c79-a6b7-168289dbcd66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0360e22-b4e9-433f-bed8-90a80d7247ec",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "884da29f-9e97-4b03-980f-6b5d9ced3d67",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "181d2c92-c68e-4bf8-b97e-69702e2e8ebc",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "88964032-4c08-45d1-b5a2-c4428241f395",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d6bb573d-6f43-448e-b73e-b6db5ba9d850",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8ac42dfb-044c-42bb-b866-5b8b03afa0df",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9a7717d-d862-4ea6-b03f-8106779dda88",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8b5462d8-b430-44b8-aa1d-1c623de30756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bf34d173-c2c4-4fa4-b620-40990180ee04",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8d52778c-0c4f-4acf-a0c6-ebeb0b06784f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0ecee8e-7e6c-42a7-b132-e3dacb15af64",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "8f8d358a-142e-4cff-be2e-c6e27b838244",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f2b5ef75-e846-4ac4-92b1-124c8720e14c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "91e61d0a-8ecf-4b65-b441-3036c2041f98",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7757ca13-adfb-44f6-9a53-091049bb0f96",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "92dde1b1-e8fb-489c-9cbf-8404d6777cd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "25115d57-334e-4681-83b6-672b65025d34",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9714c60c-364a-412b-8136-44eed1620d1c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7f2b9909-4473-4c34-94b5-e06e1995e8f1",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "989592ea-eb2f-4e57-9164-e07abe7d685f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ad3be288-5813-4403-ba03-8e54c29871c2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "98a3c0d6-d4af-4702-aa5d-8477c2667a99",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfbb2957-1f35-4bd3-867d-74c1c9a2b0ff",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "98d55dc7-cc47-4460-bc79-8f0331664ce1",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2d5440fd-c858-4530-b3ec-fa47892d0b1a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9ccce53e-6036-400e-ada2-861aa6a1b36c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0969aa07-3121-471e-b9be-14b71bb3ecad",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9da7ae8b-984f-44a6-8916-5ab5265c3756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7d5fb158-562f-4ec6-9c51-d5aebab64e18",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9e23b5d1-7544-4f2f-9bd6-dab4f4920c20",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ae2907cc-0787-4041-af52-277c5b7fa018",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9e6a9491-c05e-4d00-946f-cd8400bdd361",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a3ead96b-c524-496e-b4fd-a9b6ac24db50",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9ea7aecc-6f36-4710-830f-5c9422288400",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "92ce53e8-9ee5-4eca-ab12-c3bb6e23bc9f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9fe7407a-b847-4f5d-840c-4c61e98ef739",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5542092-d005-4b18-8625-96a5d5f7b2dc",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "9ff44c0f-5e76-4e84-829e-e5a9ba375d57",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0c7a823e-7476-4c12-a965-d939af1fdfbb",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "a505e381-1eb1-4a67-b409-995946a214d3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "254622ed-a732-4468-966d-53d1a0631f4e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "a8671a46-44c1-433c-84dc-bd057ec5bd9f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1c07aa76-76f2-4b9f-b512-da4d8d85b3f0",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "ada1d953-5e80-460d-bcbb-c94d3b61b5a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "aac1d53e-ed49-48e4-8d30-eb978df0dc66",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "aea9393a-52b3-4235-9c52-790cc9a97ce8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "faf22799-7f6f-48fb-a58e-04a30b37e0c9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "aee405cd-dae2-4a0e-bb1d-52ae05b74778",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5453dada-25b6-4562-b39f-78307bda471b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b017cbc0-5ef7-474e-9f47-51bef2d2cc2d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa1534e6-2279-4567-9019-6af88a6c3689",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b04896d0-8f8c-4bc8-b6a3-cd95cda33967",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6a49b433-e539-495b-b897-a485d4ea393a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b52e6d66-cd08-48ba-8957-dcc3ef013645",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a687bbdd-949d-45c2-8b61-5af6c7f8ccbd",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b6ae8b58-0b41-4737-a91b-b92960c03d51",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ee1cf48-dbf8-41f3-8f26-02d6f480bd0b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b702ab5f-e5e4-43a3-a337-857b7454b29f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "20a4b122-c05d-47ad-86d3-ab3b21b0a857",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b7ca53b7-cff4-4370-8ca0-e3dfed0c3c88",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "887d6318-fc1b-44d2-ba58-5861d7337f88",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "b9d4fc15-04c9-4700-af4e-c93db471e0a5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "db3667b2-7590-4b62-9b50-ed5529f92a08",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "babe7d35-cc47-4cac-b1c3-01c1e8a119a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "8bd07931-33f5-476c-8c1f-64762730fc60",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bb229140-aaa3-4e7a-9f3e-dac7b9309219",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "555545c2-5159-4ceb-b326-1d94e3200ab9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bbdde4ee-445c-4c04-bc14-ea75f2718c7c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfe42149-ff1c-432f-87ea-6e352e029c2d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bf449f88-04f1-4793-b569-2fe08798c181",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6fa6e58b-792f-4699-8724-152f2d28f3c1",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "bf67fdf8-dd32-4697-a465-0a9ce1221b27",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33a622b9-dd03-4007-830e-a8ba6a7d403e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "c03ccd06-d689-4f73-8acc-31d98aa43323",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5febc193-3e36-4abe-be13-6cd3e3a61ec4",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "c4cb139a-b678-4aab-90b6-b2c3d07678bb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e9440683-ff23-4f80-94bb-bacb51cf3ea9",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "c8e54b09-43db-4b92-82b9-93d96b5e4bd2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4f019b91-6f85-423b-948e-c804246f908e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "cab734ed-5fb4-4cbe-afa7-7978e566f108",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6d853c0a-3ae8-4d4e-bfe5-ce5cf389fdc7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "cc9dcada-dbba-454c-a80b-a8e087f5b937",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6ebaab14-7739-41c0-baea-edb8eb529690",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "cf4f23ca-1c05-44e4-ac4f-1a09a47997b3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0eca684a-cf6d-4c9c-8c6b-49562873221a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d037da74-eb05-439c-bed4-1177d85385eb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e14a07f2-c509-4f2b-accf-e2dfe9afb8bd",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d0caeb07-3486-43f6-ab18-54466753e44c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "327f04d7-1940-4959-a181-71a2afae932b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d5107417-fedd-45f1-a430-73f852422479",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "91188d0e-a532-4e63-8b14-ae60ab6f86b7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "d78cbb70-9758-4ad4-9bf4-9be1cd7befcb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "815f1ccd-b780-4541-992e-06df8cae3a1e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "da021f78-8c23-44d8-bfc3-64c6949a83ce",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "26913bcb-3382-42d0-81f6-20c20cc0056a",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "dbaf71d5-13f0-458b-88d6-af200731142b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "15660559-77d0-4a75-ac5a-04537f6c004c",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "def0f945-bd2f-46a0-bb1a-80a1087d7070",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "41288e0c-ce52-4c35-9bbd-f60146bb738e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e04753fc-c798-47ff-ab5f-fe36e8f230b6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3176f7d0-f9f2-47d7-a8f6-c1bd16b2421d",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e44f6330-f4a9-4981-bec6-e1a004de39ec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a2c90b29-884b-4c3f-8fe4-f4eb7815f8b0",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e638ab86-f832-4eac-a76a-030e02de84a6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "52320561-2f0a-4ee1-8077-0ea959ee8a41",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e6eb4cee-0930-4ce2-a122-1c08c98bf70a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "72b41997-ad23-4091-9fa3-a8dc174e0b17",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "e91062d7-4dcf-4f1c-8720-005dad187089",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83cdb339-d105-4bcf-b545-3efd80a10d6b",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "eb404cbf-1d0e-4cd8-a9a3-4e1e77dfaf3e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eed61bbb-a742-4b2f-a740-94c05f6f4f24",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "f0878825-26d1-46b7-965d-8ea697141ebb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "57f8f423-3f80-4d12-9872-9c169c848ed2",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "f33088bd-5993-4f65-bef1-0a3abca24a97",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0dceb21-b206-4239-a7e7-5c87019d503e",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "f8421634-3478-4b16-8866-b3b97c54dcd6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d07ce626-a755-4248-97c7-b39bbab5a96f",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "fb19b92a-d71b-4675-8568-b38c7c629f6b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5f0b932-f200-46c6-948f-62b82ecb1e12",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "fe076bcf-cd72-4e84-9200-1ea57ff02e93",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c79b6112-d0c8-4759-8111-9dc41a4f2eb7",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    },
+    {
+      "id": "fee08649-fe02-41a8-9e7d-f3460d960775",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6e87e403-72cf-4382-8183-4844ceeb4023",
+      "fit_score": 56,
+      "ghl_opportunity_id": null
+    }
+  ]
+}

--- a/thoughts/2026-05-27-goods-9-noise-drop-restore.json
+++ b/thoughts/2026-05-27-goods-9-noise-drop-restore.json
@@ -1,0 +1,1641 @@
+{
+  "removedAt": "2026-05-27T06:17:39.481Z",
+  "communities": [
+    {
+      "id": "d8f51cc1-00cf-454f-9b1b-803873e23113",
+      "community_name": "BANNICK BURN",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60",
+      "community_name": "JILUNDARINA",
+      "state": "NT",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77",
+      "community_name": "AAYKA",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc",
+      "community_name": "SHIPTON FLATS",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "25b7684b-5105-4daa-88b7-3c9a726340f8",
+      "community_name": "GUNUN WOONAM",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "b48620f5-0cb3-4419-9674-b8bab41f22c7",
+      "community_name": "NEW MERINEE",
+      "state": "NSW",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "c03eea29-af8b-4e6c-848c-45305dac1ba7",
+      "community_name": "THULKURR",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d",
+      "community_name": "FORDY FARM",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    },
+    {
+      "id": "ca8b8df1-1438-4ae4-9376-bb2726a78759",
+      "community_name": "THAANGKUNH-NHIIN",
+      "state": "QLD",
+      "demand_beds": 52,
+      "demand_washers": 6
+    }
+  ],
+  "ghl": [
+    [
+      "cj7CXxIDLzKMxIVHHpNm",
+      "7sp5Zwueh0OKblAKQirR",
+      "THULKURR"
+    ],
+    [
+      "8CAq5cV6LBlozjP4fmbo",
+      "xBxaigCAdO1v8ARO1lo2",
+      "NEW MERINEE"
+    ],
+    [
+      "7rqTX3XLuiwMz8cvLMw3",
+      "gPxPrnGkA01DbSigTaYM",
+      "GUNUN WOONAM"
+    ],
+    [
+      "HTtygM4ogZ3gacHk3wwE",
+      "dYbBIH1H5deXDEerV5HE",
+      "SHIPTON FLATS"
+    ],
+    [
+      "58uGnRzT5FdHuDAvjKia",
+      "fm0tdDRDfl3EFTOg1JS7",
+      "FORDY FARM"
+    ],
+    [
+      "1HJOMb5vZMw0ulxm2tBS",
+      "jkXvzq4QJDPKCur8akIX",
+      "AAYKA"
+    ],
+    [
+      "NVnUPdbDuJlKwlFT4Zx6",
+      "cAt1QstivkhGfT2ShFAc",
+      "THAANGKUNH-NHIIN"
+    ],
+    [
+      "omkK7FwtMTormWvwpXcK",
+      "wu6SihnJXkEkKrUYtheG",
+      "BANNICK BURN"
+    ],
+    [
+      "seEc4BT9h5csxlXAJVhO",
+      "Q0HsirXpDJJ3vLpNIKmj",
+      "JILUNDARINA"
+    ]
+  ],
+  "cascade": {
+    "entities": 147,
+    "signals": 9
+  },
+  "cascadeEntities": [
+    {
+      "id": "c28719c1-0c5a-4b23-8609-6d20dc4b2d86",
+      "entity_name": "Volunteer Marine Rescue Karumba Inc",
+      "abn": "39394393984",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "25b7684b-5105-4daa-88b7-3c9a726340f8"
+    },
+    {
+      "id": "76ff1ecc-99e5-4793-8575-a48e012b2a75",
+      "entity_name": "Karumba Childrens Centre",
+      "abn": "52202439178",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "25b7684b-5105-4daa-88b7-3c9a726340f8"
+    },
+    {
+      "id": "5e811ff1-d573-4c1c-9ed0-aa98889f54b9",
+      "entity_name": "METRO MINING LIMITED (45 117 763 443)",
+      "abn": "25101655298",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "73a9e205-2517-438b-8755-b1465e8c58f1",
+      "entity_name": "RIBSHIRE PTY LTD T/A GOODLINE",
+      "abn": "40085847892",
+      "fit_score": 15,
+      "buyer_role": "government",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "6c373606-7ee5-400e-9d8e-86c81ddc10b0",
+      "entity_name": "Weipa Early Childhood Education Association Inc",
+      "abn": "73435425114",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "93c398b7-a1f8-4a0e-892b-eea8c3196d6d",
+      "entity_name": "Apostolic Jesus Name Fellowship",
+      "abn": "72932643944",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "185d0b9d-16ad-44fa-a064-3b6f5b1d99cb",
+      "entity_name": "ALNGITH CORPORATION LIMITED",
+      "abn": "98098199832",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "045199d7-e88e-474d-9163-bd84a9aeab4d",
+      "entity_name": "MOKWIRI NUNG LTD",
+      "abn": "54650651522",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "7f071a37-39e7-4276-bebb-fb3d4747eb1d",
+      "entity_name": "Napranum Pal Group Limited",
+      "abn": "42110700500",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "047d9c8b-86a9-4c4b-b011-bb9e46520c70",
+      "entity_name": "Weipa Community Care Assn Inc",
+      "abn": "72964419283",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "edf33f94-493c-4373-b349-82ee46b37348",
+      "entity_name": "Uca-Napranum Uniting Church",
+      "abn": "36388612170",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "858a13cb-0e70-469c-8d05-766be0a48695",
+      "entity_name": "Weipa Wildlife Care Inc.",
+      "abn": "60756762974",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "26f509a2-1a18-44e1-97a8-b47e6f61848b",
+      "entity_name": "HOWARD CHRISTIAN COLLEGE AUSTRALIA LTD",
+      "abn": "50689692877",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "b089707a-a3e9-4286-bba9-e03944343964",
+      "entity_name": "KLUTHUTHU CHRISTIAN COLLEGE LTD",
+      "abn": "19634798520",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "1accfcc0-7218-4a91-9bee-caacce4216e1",
+      "entity_name": "Rsl Queensland Branch Weipa Sub Branch",
+      "abn": "89640595313",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77"
+    },
+    {
+      "id": "e596d9c2-8bac-4a3f-aabc-78cd12034d4b",
+      "entity_name": "COOKTOWN FISHERMANS WHARF",
+      "abn": "93582956627",
+      "fit_score": 30,
+      "buyer_role": "other",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "7b158551-5772-44a8-9848-387e03f4d874",
+      "entity_name": "Health, Opportunity, Purpose and Empowerment Incorporated",
+      "abn": "40484799563",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "47e9d00c-4e03-4837-b701-eeee8d7dc0df",
+      "entity_name": "Juunjuwarra Aboriginal Corporation",
+      "abn": "20733551348",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "3434f836-d308-4663-9753-a3d10c5cefeb",
+      "entity_name": "Cape York Folk Club Inc.",
+      "abn": "75628689675",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "ec23faec-7b54-4d75-9567-65a1f7a098b0",
+      "entity_name": "Cooktown District Community Centre Ltd",
+      "abn": "63361686724",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "2037ce36-217a-42e5-aca3-0e767a5e578b",
+      "entity_name": "COOKTOWN CREATIVE ARTS ASSOCIATION INCORPORATED",
+      "abn": "84233971672",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "09907f58-1cde-4e86-af27-41ff97ab593d",
+      "entity_name": "Cooktown Baptist Fellowship",
+      "abn": "11127864935",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "85b996f0-89d6-471b-9ca7-bb76964bf25e",
+      "entity_name": "Cape York Weeds & Feral Animals Inc",
+      "abn": "31169159829",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "0c6318dc-2ec5-48ac-a1f0-cf53956f6fbe",
+      "entity_name": "Cooktown Congregation of Jehovah's Witnesses",
+      "abn": "75569784947",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "31333472-6809-4cae-a689-519ca657813e",
+      "entity_name": "Cooktown Kindergarten Association Inc",
+      "abn": "65007825127",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "a73115e4-3a65-4282-be55-0a95218c2544",
+      "entity_name": "PANDANUS PARK INC",
+      "abn": "83396148426",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "b9869a7b-2616-4293-b8a9-df597496c2ac",
+      "entity_name": "COOKTOWN RE-ENACTMENT ASSOCIATION INCORPORATED",
+      "abn": "34843064496",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "8760fbef-8b62-4051-b28d-aae9c71469e4",
+      "entity_name": "CUC CAPE YORK LTD",
+      "abn": "36661204995",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "6cdab7ff-d26c-4d2a-90a0-7358e6319a18",
+      "entity_name": "Yuku-Baja-Muliku Landowner and Reserves Ltd",
+      "abn": "68124429009",
+      "fit_score": 35,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "fd235b38-5770-4473-9236-8c9d993cbff7",
+      "entity_name": "Vera Scarth-Johnson Gallery Association Inc",
+      "abn": "67189793230",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "f4854147-70f4-45b8-8544-2d2822d51436",
+      "entity_name": "The Cooktown And District Historical Society Inc",
+      "abn": "86671012646",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "f80671a1-1437-4c75-bbb6-d81dfe73bfd8",
+      "entity_name": "South Cape York Catchments Inc.",
+      "abn": "77532434684",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc"
+    },
+    {
+      "id": "d7fbbd00-68a2-4f93-8033-1c04d06938e9",
+      "entity_name": "BRIGHT FOOD ASIA PACIFIC PTY LTD",
+      "abn": "57354565744",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f6124d34-0b18-44bd-aa42-2c6fe434a180",
+      "entity_name": "COUNTRY CARE GROUP HOME MODIFICATIONS PTY LTD (81 619 350 435)",
+      "abn": "81619350435",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7025a17d-1b8c-4a2a-82bd-03a61d9ab168",
+      "entity_name": "C.M.V. FARMS PTY. LTD. (98 005 880 848)",
+      "abn": "98005880848",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3e520d52-65aa-40b5-9805-707bef5a14b6",
+      "entity_name": "Fruitvale Pty Ltd",
+      "abn": "63059307881",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "88d4d2e4-318b-44c5-93a6-c7323d735f4b",
+      "entity_name": "COUNTRY CARE MANAGEMENT SERVICES PTY LTD (23 606 437 101)",
+      "abn": "23606437101",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "1cd4fe1a-6d5c-45dc-a496-f9877d48711e",
+      "entity_name": "GTS FREIGHT MANAGEMENT PTY LTD",
+      "abn": "58007997604",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "25beff5e-6705-45a8-abaa-f1a6b4b8febd",
+      "entity_name": "SMYBB PTY LTD (45 096 514 788)",
+      "abn": "45096514788",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "78037cd8-504d-4b89-bfaa-ee576ddf9cf7",
+      "entity_name": "HAEUSLERS GROUP PTY LTD",
+      "abn": "72004735700",
+      "fit_score": 15,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "42773991-0425-4b91-9b5a-db3622e10765",
+      "entity_name": "Tandou Ltd",
+      "abn": "81001014562",
+      "fit_score": 50,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "73f00bca-7211-4133-825b-86b32ac86d04",
+      "entity_name": "THE COUNTRY CARE GROUP PTY LTD (26 088 222 226)",
+      "abn": "26088222226",
+      "fit_score": 35,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "db7b3cf1-1a2d-451d-9315-b5264cca8270",
+      "entity_name": "TASCO CARRIERS PTY LTD (39 162 327 175)",
+      "abn": "39162327175",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "ba172ce3-326b-4d32-b2b9-30c4354b6fd4",
+      "entity_name": "UCCELLO MARKETING PTY LTD (50 602 569 595)",
+      "abn": "50602569595",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7ad74f75-a82f-4297-b8b9-f2f416b23bc5",
+      "entity_name": "Mallee Accommodation and Support Program Limited",
+      "abn": "51726968790",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "487bcac6-2b3f-496d-b39b-4c4bc5d29153",
+      "entity_name": "K CARE HEALTHCARE SOLUTIONS PTY LTD (47 159 431 099)",
+      "abn": "47159431099",
+      "fit_score": 15,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "34c743cc-ef04-4ad4-8cec-879863bbf1fd",
+      "entity_name": "Pasadena Pre School Association Inc",
+      "abn": "76417827585",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "469be806-1a67-4dd1-b003-749185d680c8",
+      "entity_name": "MALLEE HOUSING LTD",
+      "abn": "50690640469",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "248bbc3c-c889-4885-9f11-dd3562a771ad",
+      "entity_name": "Mildura Base Public Hospital (73 543 496 421)",
+      "abn": "73543496421",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "2f3d0a11-a287-4a2d-b143-84c596fe41e2",
+      "entity_name": "Sunraysia Community Health Services Limited",
+      "abn": "56957121036",
+      "fit_score": 35,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "a805f172-e053-483a-a538-b43677be0661",
+      "entity_name": "Sunraysia Mallee Ethnic Communities Council Inc",
+      "abn": "37282486762",
+      "fit_score": 0,
+      "buyer_role": "government",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7f9cb0ff-4732-4964-b865-0206e51af3d4",
+      "entity_name": "University Of The Third Age Sunraysia Inc.",
+      "abn": "49791479741",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "007a6958-d30e-4b4d-8ec8-ce8b531eb2e6",
+      "entity_name": "Oasis-City Common Equity Rental Housing Co-Operative Limited Registered Co-Operative No. G3002N",
+      "abn": "34352726093",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "c11d8870-d0ba-4bd4-ba31-278800a1b7e6",
+      "entity_name": "Aljor Constructions",
+      "abn": "59079489099",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "2e99df8a-d978-44dd-9699-9d3806a884aa",
+      "entity_name": "Agape Orphanage Network (Australia) Inc.",
+      "abn": "97361098908",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bd953daa-4a44-491c-a3df-a3ccd8f9082f",
+      "entity_name": "MADEC Australia Limited",
+      "abn": "48086804015",
+      "fit_score": 50,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "db4e3e8a-075e-467a-bd3e-a95d9b629478",
+      "entity_name": "MALLEE FAMILY CARE LTD",
+      "abn": "32085588656",
+      "fit_score": 30,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bd1e23ad-446b-4012-bc52-54a1fcf63699",
+      "entity_name": "ANABELLE BITS PTY LTD (40 068 649 972)",
+      "abn": "72091751656",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "0b76a8db-dfe5-49f4-9368-71199af5bf06",
+      "entity_name": "Cambodian-Australian Buddhist Temple Association incorporated",
+      "abn": "25940163249",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "7befe938-b10a-4d35-859c-14308a65527b",
+      "entity_name": "Food Next Door Co-op Ltd",
+      "abn": "63220050847",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "13d54f6e-bc1a-4702-a795-d5157fb08e7d",
+      "entity_name": "Rural Business and Community Limited",
+      "abn": "70870481312",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "282ffe82-badf-46ee-8713-b5debeb15087",
+      "entity_name": "OneVine Community Church Inc",
+      "abn": "40168383140",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3abd1bae-fef2-46ab-a032-6d61ef370c66",
+      "entity_name": "INSTITUTE FOR FUTURE COOPERATION LTD",
+      "abn": "62673241211",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3c035234-b291-4d90-9789-7d7abda64724",
+      "entity_name": "SKY TEMPLE LTD",
+      "abn": "28677234892",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "881dcf39-cb4f-440e-bc34-1b0c598ac2ec",
+      "entity_name": "PMF-SUNRAYSIA INC",
+      "abn": "43492856387",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "c91d4625-9ca6-4a0c-9246-3503341e5506",
+      "entity_name": "River Edge Church Inc.",
+      "abn": "82148212870",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "0c8fb595-fb61-44b1-a934-3bd2b3fad667",
+      "entity_name": "MATES INCORPORATED MILDURA INC",
+      "abn": "91991750993",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "8a09db0f-8f9e-4668-b919-ba1b9708887b",
+      "entity_name": "Sunraysia Animal Rehousing Group Inc.",
+      "abn": "57383474239",
+      "fit_score": 0,
+      "buyer_role": "housing_provider",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "cb5291c4-5cc4-4d23-baa1-41d56e465d21",
+      "entity_name": "Mildura Legacy Club Incorporated",
+      "abn": "26450652465",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "e17a9841-5839-44f6-8547-170afd43ef5a",
+      "entity_name": "MDAS Limited",
+      "abn": "53602202139",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f0336aab-8478-4684-a200-34afef3a7d1b",
+      "entity_name": "Mallee Sexual Assault Unit Ltd",
+      "abn": "57685819813",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f0d39a0b-4da3-43cc-87cf-0e41d57a9910",
+      "entity_name": "Mildura East Congregation of Jehovah's Witnesses",
+      "abn": "83756145361",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f33a4742-4710-4496-a0b2-6e66bba7058e",
+      "entity_name": "MILDURA CHURCH OF CHRIST INCORPORATED",
+      "abn": "29525047085",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "f3710263-9bb9-4157-804e-7d82b3c9fc9c",
+      "entity_name": "Mildura Baptist Church Incorporated",
+      "abn": "21133229270",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "4e921f80-f48e-4e5e-beb6-0440bc959277",
+      "entity_name": "Srs Creative Futures Inc",
+      "abn": "37716221458",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "ffffc794-2453-4d56-9ad6-ee405f06f0b3",
+      "entity_name": "Mildura Rsl Sub Branch Inc",
+      "abn": "94275221734",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "1679128c-a137-40de-b9db-79e642f6ba8a",
+      "entity_name": "Mildura West Congregation of Jehovah's Witnesses",
+      "abn": "84193768898",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "41f25754-52b7-4ae4-86f9-3abd1a8e4450",
+      "entity_name": "Northern Mallee Leaders Inc.",
+      "abn": "48317418213",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5182760f-0d97-409f-aed5-95eef9a67ef3",
+      "entity_name": "NORTHERN MALLEE LOCAL LEARNING AND EMPLOYMENT NETWORK",
+      "abn": "78430405938",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "6c99aa5e-58a4-41f5-8c7f-f3b10c85e8e9",
+      "entity_name": "MILDURA WRITERS FESTIVAL LTD",
+      "abn": "51692962771",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "8eabf918-69b4-44b4-9f20-6485dc2f047c",
+      "entity_name": "New Life Christian Church Inc",
+      "abn": "41389926061",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "a5f77b2b-1b19-4586-a625-e8bf4d18ebee",
+      "entity_name": "The Mildura Life Saving Club Incorporated",
+      "abn": "13401094420",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "b01c85af-e554-4712-9e1e-c880cf46f301",
+      "entity_name": "Mildura West Kindergarten Inc.",
+      "abn": "52364764437",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "b05abf62-70ee-41a1-aadb-291a5da02b1a",
+      "entity_name": "No Borders Creative Inc",
+      "abn": "37306164261",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "fc7348b5-78d0-44d8-a271-556be14677e5",
+      "entity_name": "Mildura Show Society Inc",
+      "abn": "44590145044",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "8a32858d-e0a8-4bbc-8726-ed2a864daa95",
+      "entity_name": "St Andrews Uniting Church Mildura",
+      "abn": "52702492922",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "d181c46c-edc4-41aa-8f18-896beb39faf2",
+      "entity_name": "Strata Owners Alliance Inc",
+      "abn": "16614304016",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "d1e6efe5-9caa-4dc1-991d-aae6c0080ed7",
+      "entity_name": "Sunraysia Carers Support Group Incorporated",
+      "abn": "35962018482",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "e709957b-fc77-4fcf-9c34-e66534226c98",
+      "entity_name": "Sunraysia Cancer Resources Incorporated",
+      "abn": "50681685892",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "91909276-07e0-437a-be4c-bb58c4eb6824",
+      "entity_name": "Sunraysia Early Settlers Museum Inc",
+      "abn": "91900692898",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "3d47b967-73e9-40a9-ac32-f72728607776",
+      "entity_name": "WAT KHMER BUDDHIST TEMPLE OF MILDURA VICTORIA IN AUSTRALIA LTD",
+      "abn": "63689135564",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "4220995b-2a67-481c-8979-be846cf8d633",
+      "entity_name": "THE TRUSTEE FOR TASCO INLAND AUSTRALIA UNIT TRUST (64 676 389 090)",
+      "abn": "64676389090",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5bd92af4-936d-4e8d-a3ba-a19ca116f533",
+      "entity_name": "UCA Presbytery Of Western Victoria",
+      "abn": "28901597834",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "601c2202-418a-4e3f-8c0f-efa7c47751cf",
+      "entity_name": "The Turkish Islamic Society Mildura Inc.",
+      "abn": "12417895581",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "9add201e-8d27-4231-8c20-4af573e6cfc3",
+      "entity_name": "THE SUNRAYSIA SUSTAINABILITY NETWORK INC",
+      "abn": "37092573714",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "13be74b2-47e2-42cb-a7f6-a65e9a900392",
+      "entity_name": "Zoe Support Australia",
+      "abn": "76161029705",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "09120d84-75e3-4374-baa2-90495b91e75a",
+      "entity_name": "Uniting Church In Australia Parish Of Sunraysia",
+      "abn": "79396267732",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "0355724d-7f08-4f43-8588-1193491637e2",
+      "entity_name": "The Trustee for BAYSIDE BWE UNIT TRUST (69 809 123 175)",
+      "abn": "52006531817",
+      "fit_score": 15,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "fbfb463d-9462-4bf5-b2ad-ef4fd4a069ab",
+      "entity_name": "MILDURA DISTRICT HOSPITAL FUND LTD. (13 078 202 089)",
+      "abn": "13078202089",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "094402ae-7668-4ca4-b3f3-83baafd42327",
+      "entity_name": "Sunraysia & Murray Group Training Limited",
+      "abn": "19006114076",
+      "fit_score": 35,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "40b4141d-1751-42a2-a474-f485989c41d2",
+      "entity_name": "Trinity Lutheran College",
+      "abn": "43974264930",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bc5d8bf7-750a-437d-b517-ba455303f432",
+      "entity_name": "TRINITY LUTHERAN COLLEGE MILDURA LTD",
+      "abn": "22650100119",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5ab2c130-1cd8-4591-8db1-c3a30486ad3d",
+      "entity_name": "All Nations Christian Fellowship Mildura Incorporated",
+      "abn": "83249205656",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "b3fda541-3586-41dd-8ba1-6787c6f97adb",
+      "entity_name": "Living Waters Christian Community",
+      "abn": "45184860981",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "bced9b7f-ed1b-4529-bafb-d281d76da29f",
+      "entity_name": "Sunraysia Regional Consulting Limited",
+      "abn": "70624280413",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "abbce57b-29ae-46db-a7ef-e69c9b1cdae1",
+      "entity_name": "Christie Centre Inc",
+      "abn": "68554592464",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "01a30eb0-259c-42db-974d-9e111d433471",
+      "entity_name": "Sunassist Volunteer Helpers Inc",
+      "abn": "51565565026",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "1fe67c44-2089-4100-9a28-8e85658815ef",
+      "entity_name": "Sunraysia Residential Services Inc",
+      "abn": "88441353792",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "5013f1e4-f58a-4421-8c34-c6c68fc22586",
+      "entity_name": "Sunraysia Community Radio Association Inc.",
+      "abn": "19305406312",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "a55d4426-f29d-4260-b02b-633fbf9a6e83",
+      "entity_name": "K CARE HOLDINGS PTY LTD (80 626 058 035)",
+      "abn": "80626058035",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "74614ec2-5764-4228-be9b-1cc14f8e73bb",
+      "entity_name": "SPECIALISED MOBILITY PTY LTD (59 159 633 664)",
+      "abn": "59159633664",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7"
+    },
+    {
+      "id": "35893580-3e8f-4c95-828f-60ea177642ac",
+      "entity_name": "Karumba Childrens Centre",
+      "abn": "52202439178",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "c03eea29-af8b-4e6c-848c-45305dac1ba7"
+    },
+    {
+      "id": "ef6a32a2-f160-4c64-a16a-f3670c4e6759",
+      "entity_name": "Volunteer Marine Rescue Karumba Inc",
+      "abn": "39394393984",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "c03eea29-af8b-4e6c-848c-45305dac1ba7"
+    },
+    {
+      "id": "68465b86-6107-443e-8e1d-b49ceb3b2ebc",
+      "entity_name": "METRO MINING LIMITED (45 117 763 443)",
+      "abn": "25101655298",
+      "fit_score": 0,
+      "buyer_role": "other",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "4fdf0b6c-09b6-42c5-acdf-e488ad31a8ca",
+      "entity_name": "RIBSHIRE PTY LTD T/A GOODLINE",
+      "abn": "40085847892",
+      "fit_score": 15,
+      "buyer_role": "government",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "18e754c5-1f86-480a-984a-42560c3fd390",
+      "entity_name": "Weipa Early Childhood Education Association Inc",
+      "abn": "73435425114",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "c46fd095-db93-4cd4-979f-0134a4cd6fc3",
+      "entity_name": "Apostolic Jesus Name Fellowship",
+      "abn": "72932643944",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "5325b921-e06d-4986-bc0f-1db2ece8cfa8",
+      "entity_name": "ALNGITH CORPORATION LIMITED",
+      "abn": "98098199832",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "68da334e-fad8-42a3-9b2d-65471b9fba1a",
+      "entity_name": "Napranum Pal Group Limited",
+      "abn": "42110700500",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "b244bac0-f16b-41bd-9cc1-4070d4db8ed4",
+      "entity_name": "MOKWIRI NUNG LTD",
+      "abn": "54650651522",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "d113b411-cc7a-43e8-a4a6-f27be08aa455",
+      "entity_name": "Uca-Napranum Uniting Church",
+      "abn": "36388612170",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "287b8974-9484-4dc9-b638-7fd2426bed20",
+      "entity_name": "Rsl Queensland Branch Weipa Sub Branch",
+      "abn": "89640595313",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "a5b6e42c-0f37-4a61-948c-b51a078cdc80",
+      "entity_name": "Weipa Wildlife Care Inc.",
+      "abn": "60756762974",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "57ebe00c-2f84-4492-a6e9-ff08c4b36ae5",
+      "entity_name": "HOWARD CHRISTIAN COLLEGE AUSTRALIA LTD",
+      "abn": "50689692877",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "850de022-c11b-4816-aa8e-ad31ae94b3df",
+      "entity_name": "KLUTHUTHU CHRISTIAN COLLEGE LTD",
+      "abn": "19634798520",
+      "fit_score": 0,
+      "buyer_role": "education",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "4fa59e70-dd4e-49e1-b865-d437d2d784e5",
+      "entity_name": "Weipa Community Care Assn Inc",
+      "abn": "72964419283",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759"
+    },
+    {
+      "id": "4eacf5d0-fbca-4c9d-b900-4495a1e07479",
+      "entity_name": "Northern Land Council",
+      "abn": "56327515336",
+      "fit_score": 74,
+      "buyer_role": "council",
+      "community_id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60"
+    },
+    {
+      "id": "6a7e4c9a-1bbb-45a7-b496-17d78ffbf1d4",
+      "entity_name": "Aboriginal Medical Services Alliance Northern Territory Aboriginal Corporation",
+      "abn": "26263401676",
+      "fit_score": 74,
+      "buyer_role": "health_service",
+      "community_id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60"
+    },
+    {
+      "id": "f217c2aa-141d-4a2e-8601-208e3f91655a",
+      "entity_name": "Karumba Childrens Centre",
+      "abn": "52202439178",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "d8f51cc1-00cf-454f-9b1b-803873e23113"
+    },
+    {
+      "id": "592f00cc-e004-4cec-9dda-d7c43954e126",
+      "entity_name": "Volunteer Marine Rescue Karumba Inc",
+      "abn": "39394393984",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "d8f51cc1-00cf-454f-9b1b-803873e23113"
+    },
+    {
+      "id": "6067cbc2-06be-40a3-a877-73dcd100ef8b",
+      "entity_name": "Health, Opportunity, Purpose and Empowerment Incorporated",
+      "abn": "40484799563",
+      "fit_score": 0,
+      "buyer_role": "health_service",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "ab4f7ee7-9b7d-41e1-be0e-fbeab5edd3c6",
+      "entity_name": "Juunjuwarra Aboriginal Corporation",
+      "abn": "20733551348",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "daf46569-decf-46ab-b5d7-571b511c14e8",
+      "entity_name": "COOKTOWN FISHERMANS WHARF",
+      "abn": "93582956627",
+      "fit_score": 30,
+      "buyer_role": "other",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "626e3776-bdf2-4fe8-8a9c-9f4ff12c5828",
+      "entity_name": "Cape York Weeds & Feral Animals Inc",
+      "abn": "31169159829",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "92c2d4c3-da1b-43ee-80ab-f7ddd519a02a",
+      "entity_name": "Cape York Folk Club Inc.",
+      "abn": "75628689675",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "9a76b03b-a455-47d1-bf8c-9060cfea1e8f",
+      "entity_name": "Cooktown District Community Centre Ltd",
+      "abn": "63361686724",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "1d302148-261e-4270-a07e-9f5ecba0c9d7",
+      "entity_name": "Cooktown Baptist Fellowship",
+      "abn": "11127864935",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "4c96c8fb-131b-42c8-81b1-8a8363ac71b9",
+      "entity_name": "COOKTOWN CREATIVE ARTS ASSOCIATION INCORPORATED",
+      "abn": "84233971672",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "e98eb5fe-f154-440d-90a2-3783c1a522a6",
+      "entity_name": "Cooktown Kindergarten Association Inc",
+      "abn": "65007825127",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "977c0a0f-dbd5-4328-857d-bf2c36780baa",
+      "entity_name": "COOKTOWN RE-ENACTMENT ASSOCIATION INCORPORATED",
+      "abn": "34843064496",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "cac5963a-cafa-42bf-94e8-cc697a382dc8",
+      "entity_name": "PANDANUS PARK INC",
+      "abn": "83396148426",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "e170dae5-1165-4a15-a389-274acffc066d",
+      "entity_name": "CUC CAPE YORK LTD",
+      "abn": "36661204995",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "9fd894d1-011d-47a2-be2e-91482428889a",
+      "entity_name": "South Cape York Catchments Inc.",
+      "abn": "77532434684",
+      "fit_score": 15,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "a4b11119-42e7-4360-8462-441f5967cef0",
+      "entity_name": "The Cooktown And District Historical Society Inc",
+      "abn": "86671012646",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "d3e02220-9822-427f-b553-2fca3b5c5116",
+      "entity_name": "Vera Scarth-Johnson Gallery Association Inc",
+      "abn": "67189793230",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "77b037eb-b74d-4e87-9def-f944eb3dab0d",
+      "entity_name": "Cooktown Congregation of Jehovah's Witnesses",
+      "abn": "75569784947",
+      "fit_score": 0,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    },
+    {
+      "id": "4dea6ecc-4d4c-43f2-85b5-22137d8da0d5",
+      "entity_name": "Yuku-Baja-Muliku Landowner and Reserves Ltd",
+      "abn": "68124429009",
+      "fit_score": 35,
+      "buyer_role": "community_org",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d"
+    }
+  ],
+  "cascadeSignals": [
+    {
+      "id": "29df0073-eca2-4e3d-b63b-ef105060dc77",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "25b7684b-5105-4daa-88b7-3c9a726340f8",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "c28719c1-0c5a-4b23-8609-6d20dc4b2d86",
+      "title": "Unmet demand: GUNUN WOONAM (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: GUNUN WOONAM (QLD) — 52 beds, 6 washers\n\nBest buyer match: Volunteer Marine Rescue Karumba Inc (community_org) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "gPxPrnGkA01DbSigTaYM",
+      "ghl_synced_at": "2026-04-26T23:52:41.599+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:31.820743+00:00"
+    },
+    {
+      "id": "8f2c22fa-ca3c-4f4e-abf0-52a35b280fc2",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "8497108e-5599-43f0-bc4a-d47d4a4a1d77",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "73a9e205-2517-438b-8755-b1465e8c58f1",
+      "title": "Unmet demand: AAYKA (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: AAYKA (QLD) — 52 beds, 6 washers\n\nBest buyer match: RIBSHIRE PTY LTD T/A GOODLINE (government) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "jkXvzq4QJDPKCur8akIX",
+      "ghl_synced_at": "2026-04-26T23:52:35.591+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:43.956012+00:00"
+    },
+    {
+      "id": "d18789de-c4f0-42ee-b46f-f157ad80c231",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "9eb2c64a-99ed-422a-9c97-2bde0b1281bc",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "6cdab7ff-d26c-4d2a-90a0-7358e6319a18",
+      "title": "Unmet demand: SHIPTON FLATS (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: SHIPTON FLATS (QLD) — 52 beds, 6 washers\n\nBest buyer match: Yuku-Baja-Muliku Landowner and Reserves Ltd (community_org) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "dYbBIH1H5deXDEerV5HE",
+      "ghl_synced_at": "2026-04-26T23:52:39.705+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:29.482734+00:00"
+    },
+    {
+      "id": "df63964b-ee24-4626-9ee3-3a6f3b802f11",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "b48620f5-0cb3-4419-9674-b8bab41f22c7",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "73f00bca-7211-4133-825b-86b32ac86d04",
+      "title": "Unmet demand: NEW MERINEE (NSW) — 52 beds, 6 washers",
+      "description": "Unmet demand: NEW MERINEE (NSW) — 52 beds, 6 washers\n\nBest buyer match: THE COUNTRY CARE GROUP PTY LTD (26 088 222 226) (other) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "ed3cb3a0-52a1-4a30-8805-f8d968664734",
+        "c91e3e47-e0a6-4c89-a67d-3f8b62deca28",
+        "f6865bfc-e4b6-464e-b3d5-1a10071672b6"
+      ],
+      "matched_foundation_ids": [
+        "7ef21e92-51c5-450d-82b3-6ffbc1237372",
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "6a6a4405-d780-472b-a95a-ab93182e641d"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "xBxaigCAdO1v8ARO1lo2",
+      "ghl_synced_at": "2026-04-26T23:52:43.047+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:30.776773+00:00"
+    },
+    {
+      "id": "f6c726f2-86d1-499a-88aa-e1622ac05429",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "c03eea29-af8b-4e6c-848c-45305dac1ba7",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "35893580-3e8f-4c95-828f-60ea177642ac",
+      "title": "Unmet demand: THULKURR (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: THULKURR (QLD) — 52 beds, 6 washers\n\nBest buyer match: Karumba Childrens Centre (community_org) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "7sp5Zwueh0OKblAKQirR",
+      "ghl_synced_at": "2026-04-26T23:52:44.847+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-21T02:01:26.48085+00:00",
+      "updated_at": "2026-05-13T19:41:29.400089+00:00"
+    },
+    {
+      "id": "3ebc9597-9f37-4a24-b5cf-6c81ab0a7e66",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "ca8b8df1-1438-4ae4-9376-bb2726a78759",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "4fdf0b6c-09b6-42c5-acdf-e488ad31a8ca",
+      "title": "Unmet demand: THAANGKUNH-NHIIN (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: THAANGKUNH-NHIIN (QLD) — 52 beds, 6 washers\n\nBest buyer match: RIBSHIRE PTY LTD T/A GOODLINE (government) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "cAt1QstivkhGfT2ShFAc",
+      "ghl_synced_at": "2026-04-26T23:52:32.134+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:44.990509+00:00"
+    },
+    {
+      "id": "d27d1f72-dac8-4505-af65-d1d57a855500",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "cf1c1dab-2b62-4da8-9cd0-3e2313d0ab60",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "4eacf5d0-fbca-4c9d-b900-4495a1e07479",
+      "title": "Unmet demand: JILUNDARINA (NT) — 52 beds, 6 washers",
+      "description": "Unmet demand: JILUNDARINA (NT) — 52 beds, 6 washers\n\nBest buyer match: Northern Land Council (council) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "767692f2-b796-49e2-bfc5-e128041666e5",
+        "0e970592-0f2e-49e7-a287-02b66bdc6450",
+        "3f9b4d83-4468-40e7-afe1-222b7b7f8920"
+      ],
+      "matched_foundation_ids": [
+        "6e67e605-9cea-4ae8-8416-2745c71d51bb",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "Q0HsirXpDJJ3vLpNIKmj",
+      "ghl_synced_at": "2026-04-26T23:52:28.701+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:46.110555+00:00"
+    },
+    {
+      "id": "fd81643a-aa6a-477e-a773-f80477314b30",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "d8f51cc1-00cf-454f-9b1b-803873e23113",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "f217c2aa-141d-4a2e-8601-208e3f91655a",
+      "title": "Unmet demand: BANNICK BURN (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: BANNICK BURN (QLD) — 52 beds, 6 washers\n\nBest buyer match: Karumba Childrens Centre (community_org) · 1 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "wu6SihnJXkEkKrUYtheG",
+      "ghl_synced_at": "2026-04-26T23:52:30.357+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:43.448041+00:00"
+    },
+    {
+      "id": "87d65b0a-b040-4388-bf77-d27e6abf0ce5",
+      "signal_type": "demand_unmet",
+      "priority": "medium",
+      "community_id": "f0680ba5-b744-4b03-bf68-3e3b14d6397d",
+      "asset_id": null,
+      "product_id": null,
+      "buyer_entity_id": "4dea6ecc-4d4c-43f2-85b5-22137d8da0d5",
+      "title": "Unmet demand: FORDY FARM (QLD) — 52 beds, 6 washers",
+      "description": "Unmet demand: FORDY FARM (QLD) — 52 beds, 6 washers\n\nBest buyer match: Yuku-Baja-Muliku Landowner and Reserves Ltd (community_org) · 9 more in area.",
+      "estimated_value": null,
+      "estimated_units": 58,
+      "products_needed": [
+        "bed",
+        "washer"
+      ],
+      "matched_grant_ids": [
+        "819d73cc-68e5-4e3e-9e2a-2c7b0f29f02f",
+        "0ab650db-ab1a-416b-9f45-ca27998314d6",
+        "233f3978-6700-4f76-a3b4-ce3a86866785"
+      ],
+      "matched_foundation_ids": [
+        "f7bcab78-8268-45d9-a165-052a0d87a509",
+        "b90cb1d5-af9e-4603-834c-e934ab2043ba",
+        "ea18b7a8-8b1a-49ec-a3f5-bce6345f66c8"
+      ],
+      "funding_confidence": "possible",
+      "status": "new",
+      "assigned_to": null,
+      "action_notes": null,
+      "actioned_at": null,
+      "ghl_contact_id": "fm0tdDRDfl3EFTOg1JS7",
+      "ghl_synced_at": "2026-04-26T23:52:37.381+00:00",
+      "source_agent": "goods-procurement-matcher",
+      "expires_at": null,
+      "created_at": "2026-04-14T08:03:23.780625+00:00",
+      "updated_at": "2026-05-13T19:41:43.880864+00:00"
+    }
+  ]
+}

--- a/thoughts/2026-05-27-goods-anchor-add-alpa-dedupe.json
+++ b/thoughts/2026-05-27-goods-anchor-add-alpa-dedupe.json
@@ -1,0 +1,1453 @@
+{
+  "at": "2026-05-27T06:20:10.649Z",
+  "inserted": [
+    {
+      "entity_name": "Outback Stores Pty Ltd",
+      "abn": "63120661234",
+      "buyer_role": "store",
+      "community_id": null,
+      "is_community_controlled": false,
+      "relationship_status": "prospect",
+      "website": "https://www.outbackstores.com.au",
+      "govt_contract_value": 92000,
+      "govt_contract_count": 1,
+      "fit_score": 85
+    },
+    {
+      "entity_name": "Miwatj Health Aboriginal Corporation",
+      "abn": "96843428729",
+      "buyer_role": "health_service",
+      "community_id": "9651e030-c893-40de-aee8-2df0d45a6706",
+      "is_community_controlled": true,
+      "relationship_status": "prospect",
+      "website": "https://www.miwatj.com.au",
+      "govt_contract_value": 48000,
+      "govt_contract_count": 1,
+      "fit_score": 85
+    },
+    {
+      "entity_name": "Tangentyere Council Aboriginal Corporation",
+      "abn": "81688672692",
+      "buyer_role": "council",
+      "community_id": "6cec2c4f-d390-4bff-95e1-5ad9db9b08da",
+      "is_community_controlled": true,
+      "relationship_status": "prospect",
+      "website": "https://www.tangentyere.org.au",
+      "govt_contract_value": 3113493.21,
+      "govt_contract_count": 14,
+      "fit_score": 85
+    }
+  ],
+  "alpaDeletedIds": [
+    "1ea92e85-c7d2-4a4c-8be2-26f30b84732e",
+    "7e215c7c-19ad-4128-b255-f9e74f8244f7",
+    "b8adb481-2057-422b-971b-608990c3ac40",
+    "9766a537-52c2-4858-86d9-07f223d6bc4c",
+    "5f859f10-89e8-4b46-9a2a-289fd66ce9c4",
+    "d9f2d3fb-fc65-46f7-bdc4-e460926c95bb",
+    "1c65d8cc-bde1-4ba8-b997-402f2e7386df",
+    "697bea33-7e38-451c-9e24-3ce771a2123c",
+    "623b5cfe-7326-4d28-8429-d145de601f83",
+    "f0814898-bb93-4016-a815-f41b4690fffc",
+    "5a69405d-745b-42ef-9931-924cf8d5907a",
+    "b2d70b03-b69a-4fb0-99e1-1c5c34c8a160",
+    "57cea0c9-c945-492a-bc6f-68f7b4e70c4b",
+    "fca8091f-9554-4824-a892-5f2054e1b0ed",
+    "eed5b2e4-8c77-42e5-8b98-2a30ec36c32f",
+    "d907d705-fea0-40c8-88ca-5ec6aa7ef132",
+    "21810a9c-edf4-496a-859c-4ac0bc538b33",
+    "700494e4-3f39-4708-bfba-ec77815f2005",
+    "587c1f8c-0fb4-4386-94e2-754268d21cc6",
+    "70d1d648-ef19-4803-b087-c83737cbd817",
+    "fd79bed3-8250-46f2-a7f1-063737563038",
+    "c160708f-430a-4c1a-8733-bc7048c23ce4",
+    "ef28089f-8bea-437a-a519-0331280e3932",
+    "081402a3-7090-4f58-8cfe-24490381eaf7",
+    "687ec918-a734-42fb-953d-f1b82b2ccb38",
+    "b2ca0cb7-c20f-44c1-b58c-a90de9dd5309",
+    "1fbb31c6-9346-496a-9bc7-14cfd2938b58",
+    "2fb93376-37a2-408d-96c0-b75879be87ba",
+    "2908a674-dfb3-4b20-83d6-a17980f74d07",
+    "e27e32f7-bfa3-44c1-bba0-bee11407e0e5",
+    "2c62a1f6-646a-4efd-90a5-233bb89303d7",
+    "fd0da4fa-1164-4e60-a9ea-2c0fbc822b4c",
+    "4cae9ea0-2862-4d47-a2f4-08c193086180",
+    "70b2a1c7-9a47-4999-9d50-eec51fb286f2",
+    "54f620d1-5241-4c34-8bb4-c9db373fa0e4",
+    "cb2cd656-e5e1-41fb-a93f-c034b01c4c05",
+    "9f4f7ef1-946a-479f-aaaa-f778a20371df",
+    "216d2895-f8fb-4b8d-aff0-8ca850aeff94",
+    "f51d0d4f-cd32-4d91-b8b2-8b4c5167490c",
+    "603e149e-f3e0-460f-b267-723a18f6d4c6",
+    "23d9dbc4-c2e1-4dac-b463-b8d51eeb3844",
+    "dd0bb1bc-63e0-4599-a5d0-37882ad6898e",
+    "6e603da2-62a1-48e5-8153-2e121f81cd44",
+    "4610425f-42ce-47d7-a6cd-cdebb25e1c2e",
+    "39a277df-75cd-454c-9d1d-0a38108fe286",
+    "b1c5fd0d-7487-4086-b3d7-f6bace799829",
+    "1b3963f1-6f0b-456b-9b3d-238c10b8b6a5",
+    "7c8d8d44-58dc-400a-8799-6976a5d998f4",
+    "afa27860-2fdc-4f9d-a7f1-3288257decbc",
+    "83d32724-c8e4-4efe-b7e6-62d56b5c875f",
+    "519242f8-da1c-4abb-8aed-d2b42f3c0268",
+    "f0630186-cdf8-46e1-ae74-5d4bd3f12e0b",
+    "122d1623-3d05-4a4a-9d89-97ff3aac316d",
+    "54a7c82d-92d0-4f19-a435-105d716901a9",
+    "119369c1-fe0e-47be-bae8-84de7a3fbf7f",
+    "d5918f35-249c-430b-97a4-519e6a227d99",
+    "83c25dd9-6ce8-43fa-b7a5-48353acc0ce3",
+    "6a972a95-07ac-4f16-8c90-366c46e348ca",
+    "c4b7f53d-db2a-4f36-b047-a5c75e7791bb",
+    "7e2f23b5-50e7-4d30-9927-4ab884d7bcdc",
+    "2b3f981d-5349-47d4-be2b-ff538fdd5125",
+    "bdca435b-8084-41ae-ab9c-53b0cf28afb8",
+    "7fa338c3-435b-4e6a-8fca-18192b8637ba",
+    "e1720335-ed90-46d9-9b08-8ece6ab4a77f",
+    "b2f7b058-3376-4785-bc50-0d40085c46be",
+    "a49ea232-88cd-4da1-a516-5d232bac61e4",
+    "bd770ea8-3e6f-4d69-8601-f56202f6a42f",
+    "54844cfc-d08e-4e70-ba32-2a66730e9044",
+    "d1ee7cf8-735c-4fb8-b681-0980bfda0842",
+    "aa4468da-a0f1-44e2-90c7-a7fc17197b6b",
+    "939927d0-b746-4a52-abaa-296880e3ad12",
+    "e33c3ce2-25ff-4177-bef2-94dc9bee3fa0",
+    "8fa143c3-0227-4fe7-84a8-f16518390386",
+    "632da83a-5ccb-4eac-ba63-7636098d6473",
+    "33ee6f13-31e8-49c0-9b96-6b436dc17b21",
+    "576b31ce-5bc0-4304-8cd3-22069e4506f9",
+    "6c351f6a-1984-4735-b9f1-05fdccbc998e",
+    "1bd1b21b-a29f-498b-860f-ef7aee923ee8",
+    "7c957e7a-dbf7-49f7-85ec-50505ce22297",
+    "1e11a6a5-2244-4cf0-9485-ba7d89e1abed",
+    "4493eb52-53a3-43bd-9311-b11b4bf9d3c2",
+    "f5e914d4-fc6f-4a3e-86e5-9d895a0c1b54",
+    "28b560e5-a95f-49b8-8e23-23092238494c",
+    "07a42019-3591-4284-bd1e-0c615f9ccd43",
+    "f526a726-8ec1-4172-bb29-598ec97d51b6",
+    "cd31cf6a-810e-40b7-ad28-a79ee88f5a8f",
+    "cd6e7db7-7115-418b-abf8-ed8f97d8d674",
+    "2a88a25d-2fa9-4fbd-86fe-3178c852bb1e",
+    "f5b03ee4-6619-43f1-aa52-3d16591c0af0",
+    "fe1a3d14-9c66-44f9-8ce5-006a67b94abd",
+    "ee3624bc-fd09-4252-b539-8649e608c0ef",
+    "0baba5a1-11c7-459b-b46d-f91fdc933879",
+    "7cbf8f1f-c43d-4298-ab5b-76ba31c4e56a",
+    "13085b52-6862-48e9-b20b-1df16a2e9479",
+    "4a29d804-f067-43d1-80bc-468651d2844c",
+    "c5d7e8da-1a30-48a5-a75d-94f361d7f0d1",
+    "9081a1ca-4136-4575-bffa-fcb582f84bc7",
+    "fbc17957-b298-413b-977a-7a146b72c6fa",
+    "68b75679-2d49-4501-b66e-b278b524c63d",
+    "5114b30b-12d3-44c5-8a77-31d0cb5e08ce",
+    "247448a1-d53d-4cde-a93c-aa00e06bcc1e",
+    "deca13c9-7b85-4dba-abc2-e45a0e42b9b2",
+    "b91f5948-80b8-4bc6-9f36-b44f2b96f45d",
+    "67bbc246-9ea7-4dc9-9c8a-1772fa780530",
+    "ceb6b125-0cbe-4fd9-9306-69a23c9c9611",
+    "f948744a-be92-48b2-82a0-a7e0cd97f30f",
+    "9a7f2cda-fb08-4d81-b292-7c3c3367f51e",
+    "38213c76-3dfc-451d-846c-b47fc72831ed",
+    "3ab59d2d-9e36-48f9-9672-3370e321b113",
+    "00e5047e-d704-4b19-8c2d-595ab54ab01b",
+    "0d902dc2-fdd8-499e-85af-0e3e116265b1",
+    "b849a589-fd79-4129-a68b-fcd53a2f0589",
+    "da744bfe-4691-4b5a-b61a-dcd9365805de",
+    "b39d2a42-b834-403e-9863-f0486e9c15de",
+    "fc2f09ce-e513-42f0-bf1b-48071dfc7019",
+    "66ce0d88-2bc6-4255-bc7b-6e81394703fa",
+    "162e0e2b-ca3a-4a7f-a976-c87df7b22590",
+    "470a40af-95dc-4026-84dc-19dcb385a4e3",
+    "e39ee05e-070c-442d-9f8d-d782b9878936",
+    "e0d6c895-2311-4f22-aef5-fc3b3094d2e0",
+    "185209fc-7526-44e2-b6c4-da720a21a993",
+    "d0af3542-8d4b-405e-996b-b5afbd6ece2a",
+    "e20aaf9e-88d0-4344-9b2f-5e540ec3791c",
+    "5aa1db08-733d-4d63-b5ad-37caf3dc6bbf",
+    "3f6b44e4-0af1-48ff-b326-61b16eff6ea7",
+    "7e23af80-df68-43bc-8afb-f02615786938",
+    "6a5660a4-a535-4e33-bbe3-eb7eaf07ac89",
+    "fb4d2db8-3417-4e25-8121-f62e95cbe33a"
+  ],
+  "alpaAll": [
+    {
+      "id": "42843ede-f708-454a-9426-2a4fbb45b04e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "05059406-3078-43c4-85e3-3d74034c426b"
+    },
+    {
+      "id": "1ea92e85-c7d2-4a4c-8be2-26f30b84732e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "05059406-3078-43c4-85e3-3d74034c426b"
+    },
+    {
+      "id": "9ccce53e-6036-400e-ada2-861aa6a1b36c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0969aa07-3121-471e-b9be-14b71bb3ecad"
+    },
+    {
+      "id": "7e215c7c-19ad-4128-b255-f9e74f8244f7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0969aa07-3121-471e-b9be-14b71bb3ecad"
+    },
+    {
+      "id": "9ff44c0f-5e76-4e84-829e-e5a9ba375d57",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0c7a823e-7476-4c12-a965-d939af1fdfbb"
+    },
+    {
+      "id": "b8adb481-2057-422b-971b-608990c3ac40",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0c7a823e-7476-4c12-a965-d939af1fdfbb"
+    },
+    {
+      "id": "58ad74f8-f12d-4c79-a42d-e54129b064fe",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0cd2eca7-202f-4f88-9345-e3fb4acc4b4a"
+    },
+    {
+      "id": "9766a537-52c2-4858-86d9-07f223d6bc4c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0cd2eca7-202f-4f88-9345-e3fb4acc4b4a"
+    },
+    {
+      "id": "cf4f23ca-1c05-44e4-ac4f-1a09a47997b3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0eca684a-cf6d-4c9c-8c6b-49562873221a"
+    },
+    {
+      "id": "5f859f10-89e8-4b46-9a2a-289fd66ce9c4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0eca684a-cf6d-4c9c-8c6b-49562873221a"
+    },
+    {
+      "id": "b6ae8b58-0b41-4737-a91b-b92960c03d51",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ee1cf48-dbf8-41f3-8f26-02d6f480bd0b"
+    },
+    {
+      "id": "d9f2d3fb-fc65-46f7-bdc4-e460926c95bb",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0ee1cf48-dbf8-41f3-8f26-02d6f480bd0b"
+    },
+    {
+      "id": "4ee3e6c1-531f-4bfa-bd6d-6cb392193e6a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "0ef44035-bfdb-46db-8862-44421f1ef906"
+    },
+    {
+      "id": "1c65d8cc-bde1-4ba8-b997-402f2e7386df",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "0ef44035-bfdb-46db-8862-44421f1ef906"
+    },
+    {
+      "id": "156a4ad8-fda6-4e82-bd99-9541d456cfd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "10380ad3-cb06-4e7b-ae99-071693283c31"
+    },
+    {
+      "id": "697bea33-7e38-451c-9e24-3ce771a2123c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "10380ad3-cb06-4e7b-ae99-071693283c31"
+    },
+    {
+      "id": "0bc1fd36-9ffc-4b98-8977-0c2445072416",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1333d5f7-8428-4575-bd43-d76fce8a04bb"
+    },
+    {
+      "id": "623b5cfe-7326-4d28-8429-d145de601f83",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1333d5f7-8428-4575-bd43-d76fce8a04bb"
+    },
+    {
+      "id": "dbaf71d5-13f0-458b-88d6-af200731142b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "15660559-77d0-4a75-ac5a-04537f6c004c"
+    },
+    {
+      "id": "f0814898-bb93-4016-a815-f41b4690fffc",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "15660559-77d0-4a75-ac5a-04537f6c004c"
+    },
+    {
+      "id": "5344bd32-37a4-4586-8016-393893b6c8c7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "16e4e421-cd3b-4dce-bebd-777df456c4b6"
+    },
+    {
+      "id": "5a69405d-745b-42ef-9931-924cf8d5907a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "16e4e421-cd3b-4dce-bebd-777df456c4b6"
+    },
+    {
+      "id": "884da29f-9e97-4b03-980f-6b5d9ced3d67",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "181d2c92-c68e-4bf8-b97e-69702e2e8ebc"
+    },
+    {
+      "id": "b2d70b03-b69a-4fb0-99e1-1c5c34c8a160",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "181d2c92-c68e-4bf8-b97e-69702e2e8ebc"
+    },
+    {
+      "id": "3a24ce42-fab7-40fd-8aa7-c238b339f33a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1b03f6c1-71c0-4c3d-aeb6-bb17e01604ea"
+    },
+    {
+      "id": "57cea0c9-c945-492a-bc6f-68f7b4e70c4b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1b03f6c1-71c0-4c3d-aeb6-bb17e01604ea"
+    },
+    {
+      "id": "a8671a46-44c1-433c-84dc-bd057ec5bd9f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1c07aa76-76f2-4b9f-b512-da4d8d85b3f0"
+    },
+    {
+      "id": "fca8091f-9554-4824-a892-5f2054e1b0ed",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1c07aa76-76f2-4b9f-b512-da4d8d85b3f0"
+    },
+    {
+      "id": "09b20bcf-dfe0-4fd7-9f1f-9e28c7c3b7f4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "1f033e9b-410e-49e3-8630-6281e4aff947"
+    },
+    {
+      "id": "eed5b2e4-8c77-42e5-8b98-2a30ec36c32f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "1f033e9b-410e-49e3-8630-6281e4aff947"
+    },
+    {
+      "id": "b702ab5f-e5e4-43a3-a337-857b7454b29f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "20a4b122-c05d-47ad-86d3-ab3b21b0a857"
+    },
+    {
+      "id": "d907d705-fea0-40c8-88ca-5ec6aa7ef132",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "20a4b122-c05d-47ad-86d3-ab3b21b0a857"
+    },
+    {
+      "id": "92dde1b1-e8fb-489c-9cbf-8404d6777cd4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "25115d57-334e-4681-83b6-672b65025d34"
+    },
+    {
+      "id": "21810a9c-edf4-496a-859c-4ac0bc538b33",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "25115d57-334e-4681-83b6-672b65025d34"
+    },
+    {
+      "id": "a505e381-1eb1-4a67-b409-995946a214d3",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "254622ed-a732-4468-966d-53d1a0631f4e"
+    },
+    {
+      "id": "700494e4-3f39-4708-bfba-ec77815f2005",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "254622ed-a732-4468-966d-53d1a0631f4e"
+    },
+    {
+      "id": "da021f78-8c23-44d8-bfc3-64c6949a83ce",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "26913bcb-3382-42d0-81f6-20c20cc0056a"
+    },
+    {
+      "id": "587c1f8c-0fb4-4386-94e2-754268d21cc6",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "26913bcb-3382-42d0-81f6-20c20cc0056a"
+    },
+    {
+      "id": "68a7664f-00f4-4215-aab2-8287472fc90d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2bab2980-2cc6-4a0e-bdd2-26aebefb6a71"
+    },
+    {
+      "id": "70d1d648-ef19-4803-b087-c83737cbd817",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2bab2980-2cc6-4a0e-bdd2-26aebefb6a71"
+    },
+    {
+      "id": "98d55dc7-cc47-4460-bc79-8f0331664ce1",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2d5440fd-c858-4530-b3ec-fa47892d0b1a"
+    },
+    {
+      "id": "fd79bed3-8250-46f2-a7f1-063737563038",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2d5440fd-c858-4530-b3ec-fa47892d0b1a"
+    },
+    {
+      "id": "626dd13c-821d-4c9e-9065-64f114256707",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2eef2a86-c557-46c3-9d6a-e9ea5b3b16dc"
+    },
+    {
+      "id": "c160708f-430a-4c1a-8733-bc7048c23ce4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2eef2a86-c557-46c3-9d6a-e9ea5b3b16dc"
+    },
+    {
+      "id": "553be114-eb0e-420f-8551-5b7a630aaddd",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "2f751ffe-361f-4acd-b830-e79496806422"
+    },
+    {
+      "id": "ef28089f-8bea-437a-a519-0331280e3932",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "2f751ffe-361f-4acd-b830-e79496806422"
+    },
+    {
+      "id": "54d601e0-4cdd-4e64-b722-f634e1d67078",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "30314bcc-8234-4817-9343-c80b8fdf0335"
+    },
+    {
+      "id": "081402a3-7090-4f58-8cfe-24490381eaf7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "30314bcc-8234-4817-9343-c80b8fdf0335"
+    },
+    {
+      "id": "e04753fc-c798-47ff-ab5f-fe36e8f230b6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3176f7d0-f9f2-47d7-a8f6-c1bd16b2421d"
+    },
+    {
+      "id": "687ec918-a734-42fb-953d-f1b82b2ccb38",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3176f7d0-f9f2-47d7-a8f6-c1bd16b2421d"
+    },
+    {
+      "id": "5c512b73-1a42-4e0c-b2b4-74746eea617a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3192ad9a-efe3-4bae-aa5d-365f47bb8b9d"
+    },
+    {
+      "id": "b2ca0cb7-c20f-44c1-b58c-a90de9dd5309",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3192ad9a-efe3-4bae-aa5d-365f47bb8b9d"
+    },
+    {
+      "id": "0d9bafde-0982-4443-92d7-283a3711ff5e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "326d979b-6d53-4466-bc58-99124a03c9ed"
+    },
+    {
+      "id": "1fbb31c6-9346-496a-9bc7-14cfd2938b58",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "326d979b-6d53-4466-bc58-99124a03c9ed"
+    },
+    {
+      "id": "d0caeb07-3486-43f6-ab18-54466753e44c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "327f04d7-1940-4959-a181-71a2afae932b"
+    },
+    {
+      "id": "2fb93376-37a2-408d-96c0-b75879be87ba",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "327f04d7-1940-4959-a181-71a2afae932b"
+    },
+    {
+      "id": "bf67fdf8-dd32-4697-a465-0a9ce1221b27",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33a622b9-dd03-4007-830e-a8ba6a7d403e"
+    },
+    {
+      "id": "2908a674-dfb3-4b20-83d6-a17980f74d07",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "33a622b9-dd03-4007-830e-a8ba6a7d403e"
+    },
+    {
+      "id": "1d6f1de5-b639-4a74-a816-0a904a1bb75a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "33cb0161-b755-4881-8b56-a2c278717ef6"
+    },
+    {
+      "id": "e27e32f7-bfa3-44c1-bba0-bee11407e0e5",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "33cb0161-b755-4881-8b56-a2c278717ef6"
+    },
+    {
+      "id": "334005aa-8631-436c-ac9a-f22389a2593f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "38b86b4f-b069-41de-9afc-9da31af5537e"
+    },
+    {
+      "id": "2c62a1f6-646a-4efd-90a5-233bb89303d7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "38b86b4f-b069-41de-9afc-9da31af5537e"
+    },
+    {
+      "id": "13dc2bb5-a297-4cde-a23c-8832e5cb418a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3ae1b29e-21bb-4d0f-ab4c-3468da66fc29"
+    },
+    {
+      "id": "fd0da4fa-1164-4e60-a9ea-2c0fbc822b4c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3ae1b29e-21bb-4d0f-ab4c-3468da66fc29"
+    },
+    {
+      "id": "68b4c0f3-20df-446f-8a72-0f9dbce3ab4d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "3fc6250b-e4b0-4237-935c-bfc5b6bd7798"
+    },
+    {
+      "id": "4cae9ea0-2862-4d47-a2f4-08c193086180",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "3fc6250b-e4b0-4237-935c-bfc5b6bd7798"
+    },
+    {
+      "id": "3f48ba47-cbe2-4288-baca-6910caf9d0de",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "40e7112b-7292-4b08-bede-0c130c1303a9"
+    },
+    {
+      "id": "70b2a1c7-9a47-4999-9d50-eec51fb286f2",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "40e7112b-7292-4b08-bede-0c130c1303a9"
+    },
+    {
+      "id": "def0f945-bd2f-46a0-bb1a-80a1087d7070",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "41288e0c-ce52-4c35-9bbd-f60146bb738e"
+    },
+    {
+      "id": "54f620d1-5241-4c34-8bb4-c9db373fa0e4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "41288e0c-ce52-4c35-9bbd-f60146bb738e"
+    },
+    {
+      "id": "61383236-242f-42f2-bb79-4d623f07abc2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4a434d3d-2f89-4aa5-949a-2aeea7efe874"
+    },
+    {
+      "id": "cb2cd656-e5e1-41fb-a93f-c034b01c4c05",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4a434d3d-2f89-4aa5-949a-2aeea7efe874"
+    },
+    {
+      "id": "682ed82e-7558-4d5d-85cf-4339b4b968f7",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e118b9e-6e66-4664-b3d4-e7d227f9fb61"
+    },
+    {
+      "id": "9f4f7ef1-946a-479f-aaaa-f778a20371df",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4e118b9e-6e66-4664-b3d4-e7d227f9fb61"
+    },
+    {
+      "id": "64ca01d9-cc1c-450c-b3bb-a996965cc2e5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e19b261-4711-486a-92fa-46ccc30699be"
+    },
+    {
+      "id": "216d2895-f8fb-4b8d-aff0-8ca850aeff94",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4e19b261-4711-486a-92fa-46ccc30699be"
+    },
+    {
+      "id": "363a0791-fce6-4b68-8c86-befec13d3b66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4e6b6194-e946-4f73-ae4b-8c11d110a6fb"
+    },
+    {
+      "id": "f51d0d4f-cd32-4d91-b8b2-8b4c5167490c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4e6b6194-e946-4f73-ae4b-8c11d110a6fb"
+    },
+    {
+      "id": "c8e54b09-43db-4b92-82b9-93d96b5e4bd2",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "4f019b91-6f85-423b-948e-c804246f908e"
+    },
+    {
+      "id": "603e149e-f3e0-460f-b267-723a18f6d4c6",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "4f019b91-6f85-423b-948e-c804246f908e"
+    },
+    {
+      "id": "3d2784c3-ee5b-45c7-aa08-8b4ed74968aa",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5189ad94-ca4f-4a75-b61b-fa38feb38947"
+    },
+    {
+      "id": "23d9dbc4-c2e1-4dac-b463-b8d51eeb3844",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5189ad94-ca4f-4a75-b61b-fa38feb38947"
+    },
+    {
+      "id": "e638ab86-f832-4eac-a76a-030e02de84a6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "52320561-2f0a-4ee1-8077-0ea959ee8a41"
+    },
+    {
+      "id": "dd0bb1bc-63e0-4599-a5d0-37882ad6898e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "52320561-2f0a-4ee1-8077-0ea959ee8a41"
+    },
+    {
+      "id": "aee405cd-dae2-4a0e-bb1d-52ae05b74778",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5453dada-25b6-4562-b39f-78307bda471b"
+    },
+    {
+      "id": "6e603da2-62a1-48e5-8153-2e121f81cd44",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5453dada-25b6-4562-b39f-78307bda471b"
+    },
+    {
+      "id": "bb229140-aaa3-4e7a-9f3e-dac7b9309219",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "555545c2-5159-4ceb-b326-1d94e3200ab9"
+    },
+    {
+      "id": "4610425f-42ce-47d7-a6cd-cdebb25e1c2e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "555545c2-5159-4ceb-b326-1d94e3200ab9"
+    },
+    {
+      "id": "26cb7865-902e-4266-80db-e3d60cd461d4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "559aed4c-452c-42b4-a5c3-efde3496c5a3"
+    },
+    {
+      "id": "39a277df-75cd-454c-9d1d-0a38108fe286",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "559aed4c-452c-42b4-a5c3-efde3496c5a3"
+    },
+    {
+      "id": "1192a6eb-fd9b-4030-a973-dbd8cb9753ef",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "56bb9c94-9ef3-4755-800f-b86d2d15360a"
+    },
+    {
+      "id": "b1c5fd0d-7487-4086-b3d7-f6bace799829",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "56bb9c94-9ef3-4755-800f-b86d2d15360a"
+    },
+    {
+      "id": "f0878825-26d1-46b7-965d-8ea697141ebb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "57f8f423-3f80-4d12-9872-9c169c848ed2"
+    },
+    {
+      "id": "1b3963f1-6f0b-456b-9b3d-238c10b8b6a5",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "57f8f423-3f80-4d12-9872-9c169c848ed2"
+    },
+    {
+      "id": "268dc74c-c111-46ad-8376-840cd062d9ff",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "587bee01-82d2-4388-b836-695aeaf3bb0c"
+    },
+    {
+      "id": "7c8d8d44-58dc-400a-8799-6976a5d998f4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "587bee01-82d2-4388-b836-695aeaf3bb0c"
+    },
+    {
+      "id": "3d439055-60c0-49c3-b93e-c6cd4b6a3485",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5afc7867-6734-4ab7-bdae-c00a481e7123"
+    },
+    {
+      "id": "afa27860-2fdc-4f9d-a7f1-3288257decbc",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5afc7867-6734-4ab7-bdae-c00a481e7123"
+    },
+    {
+      "id": "72b9a5be-1888-4eb6-b4e6-d1f155679aeb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5f28a435-d8a0-4eec-bcc0-fbe462ba39e8"
+    },
+    {
+      "id": "83d32724-c8e4-4efe-b7e6-62d56b5c875f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5f28a435-d8a0-4eec-bcc0-fbe462ba39e8"
+    },
+    {
+      "id": "c03ccd06-d689-4f73-8acc-31d98aa43323",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "5febc193-3e36-4abe-be13-6cd3e3a61ec4"
+    },
+    {
+      "id": "519242f8-da1c-4abb-8aed-d2b42f3c0268",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "5febc193-3e36-4abe-be13-6cd3e3a61ec4"
+    },
+    {
+      "id": "72e06d99-44fb-418c-9c0c-72105e9d60c6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6638aa15-a453-418b-9770-1b6731ea4ce6"
+    },
+    {
+      "id": "f0630186-cdf8-46e1-ae74-5d4bd3f12e0b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6638aa15-a453-418b-9770-1b6731ea4ce6"
+    },
+    {
+      "id": "617502d2-b62a-4a4e-9244-d2a035dd6eec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "665e4f90-3fc8-4543-a922-f9a8a37dd8ca"
+    },
+    {
+      "id": "122d1623-3d05-4a4a-9d89-97ff3aac316d",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "665e4f90-3fc8-4543-a922-f9a8a37dd8ca"
+    },
+    {
+      "id": "4794d62c-891f-4bb5-b4c1-2fd4118f9a8b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "693e077d-cabc-4fa8-aa46-8a268d1e3fa4"
+    },
+    {
+      "id": "54a7c82d-92d0-4f19-a435-105d716901a9",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "693e077d-cabc-4fa8-aa46-8a268d1e3fa4"
+    },
+    {
+      "id": "020ca948-610e-48cb-9499-f5cd50d1eb24",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "69cbd105-7d07-42e8-9e9e-ac7bbbe4a4e7"
+    },
+    {
+      "id": "119369c1-fe0e-47be-bae8-84de7a3fbf7f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "69cbd105-7d07-42e8-9e9e-ac7bbbe4a4e7"
+    },
+    {
+      "id": "b04896d0-8f8c-4bc8-b6a3-cd95cda33967",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6a49b433-e539-495b-b897-a485d4ea393a"
+    },
+    {
+      "id": "d5918f35-249c-430b-97a4-519e6a227d99",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6a49b433-e539-495b-b897-a485d4ea393a"
+    },
+    {
+      "id": "cab734ed-5fb4-4cbe-afa7-7978e566f108",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6d853c0a-3ae8-4d4e-bfe5-ce5cf389fdc7"
+    },
+    {
+      "id": "83c25dd9-6ce8-43fa-b7a5-48353acc0ce3",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6d853c0a-3ae8-4d4e-bfe5-ce5cf389fdc7"
+    },
+    {
+      "id": "77c05c23-d4d0-4639-8550-2436bef18e10",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6dca668d-b579-4d2b-9c5b-0a9717dcb4ff"
+    },
+    {
+      "id": "6a972a95-07ac-4f16-8c90-366c46e348ca",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6dca668d-b579-4d2b-9c5b-0a9717dcb4ff"
+    },
+    {
+      "id": "fee08649-fe02-41a8-9e7d-f3460d960775",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6e87e403-72cf-4382-8183-4844ceeb4023"
+    },
+    {
+      "id": "c4b7f53d-db2a-4f36-b047-a5c75e7791bb",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6e87e403-72cf-4382-8183-4844ceeb4023"
+    },
+    {
+      "id": "cc9dcada-dbba-454c-a80b-a8e087f5b937",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6ebaab14-7739-41c0-baea-edb8eb529690"
+    },
+    {
+      "id": "7e2f23b5-50e7-4d30-9927-4ab884d7bcdc",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6ebaab14-7739-41c0-baea-edb8eb529690"
+    },
+    {
+      "id": "bf449f88-04f1-4793-b569-2fe08798c181",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "6fa6e58b-792f-4699-8724-152f2d28f3c1"
+    },
+    {
+      "id": "2b3f981d-5349-47d4-be2b-ff538fdd5125",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "6fa6e58b-792f-4699-8724-152f2d28f3c1"
+    },
+    {
+      "id": "2860219b-535a-4d86-a3bb-2f6649081c37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7295dc9b-ffe4-4de5-8004-1d2beb8159d2"
+    },
+    {
+      "id": "bdca435b-8084-41ae-ab9c-53b0cf28afb8",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7295dc9b-ffe4-4de5-8004-1d2beb8159d2"
+    },
+    {
+      "id": "e6eb4cee-0930-4ce2-a122-1c08c98bf70a",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "72b41997-ad23-4091-9fa3-a8dc174e0b17"
+    },
+    {
+      "id": "7fa338c3-435b-4e6a-8fca-18192b8637ba",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "72b41997-ad23-4091-9fa3-a8dc174e0b17"
+    },
+    {
+      "id": "5c58cf47-925c-42d0-ab44-f006a432e076",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7357848d-de00-448c-a0bd-c39d16cee26b"
+    },
+    {
+      "id": "e1720335-ed90-46d9-9b08-8ece6ab4a77f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7357848d-de00-448c-a0bd-c39d16cee26b"
+    },
+    {
+      "id": "2270627e-2a2f-4a1c-a767-ca064b15bee0",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "75625293-fd9c-4bd1-a6b5-4aaad5d83b0a"
+    },
+    {
+      "id": "b2f7b058-3376-4785-bc50-0d40085c46be",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "75625293-fd9c-4bd1-a6b5-4aaad5d83b0a"
+    },
+    {
+      "id": "17ce28e5-9162-47f0-8048-b3c4e96ddabb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "76eed511-6de0-4e23-bb3b-b61af3a8a449"
+    },
+    {
+      "id": "a49ea232-88cd-4da1-a516-5d232bac61e4",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "76eed511-6de0-4e23-bb3b-b61af3a8a449"
+    },
+    {
+      "id": "91e61d0a-8ecf-4b65-b441-3036c2041f98",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7757ca13-adfb-44f6-9a53-091049bb0f96"
+    },
+    {
+      "id": "bd770ea8-3e6f-4d69-8601-f56202f6a42f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7757ca13-adfb-44f6-9a53-091049bb0f96"
+    },
+    {
+      "id": "9da7ae8b-984f-44a6-8916-5ab5265c3756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7d5fb158-562f-4ec6-9c51-d5aebab64e18"
+    },
+    {
+      "id": "54844cfc-d08e-4e70-ba32-2a66730e9044",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7d5fb158-562f-4ec6-9c51-d5aebab64e18"
+    },
+    {
+      "id": "9714c60c-364a-412b-8136-44eed1620d1c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "7f2b9909-4473-4c34-94b5-e06e1995e8f1"
+    },
+    {
+      "id": "d1ee7cf8-735c-4fb8-b681-0980bfda0842",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "7f2b9909-4473-4c34-94b5-e06e1995e8f1"
+    },
+    {
+      "id": "d78cbb70-9758-4ad4-9bf4-9be1cd7befcb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "815f1ccd-b780-4541-992e-06df8cae3a1e"
+    },
+    {
+      "id": "aa4468da-a0f1-44e2-90c7-a7fc17197b6b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "815f1ccd-b780-4541-992e-06df8cae3a1e"
+    },
+    {
+      "id": "e91062d7-4dcf-4f1c-8720-005dad187089",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83cdb339-d105-4bcf-b545-3efd80a10d6b"
+    },
+    {
+      "id": "939927d0-b746-4a52-abaa-296880e3ad12",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "83cdb339-d105-4bcf-b545-3efd80a10d6b"
+    },
+    {
+      "id": "4ee55304-6356-44a0-8143-c33a2085137b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "83de3ac4-b57a-44c1-8c55-8b7752834231"
+    },
+    {
+      "id": "e33c3ce2-25ff-4177-bef2-94dc9bee3fa0",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "83de3ac4-b57a-44c1-8c55-8b7752834231"
+    },
+    {
+      "id": "3202957c-b6c0-4072-ae21-828fbafd4663",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "85f977f6-d92e-4e86-a696-68db873b3afd"
+    },
+    {
+      "id": "8fa143c3-0227-4fe7-84a8-f16518390386",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "85f977f6-d92e-4e86-a696-68db873b3afd"
+    },
+    {
+      "id": "486d7194-626a-4086-86e0-50cc538de7d5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "874ab15e-4b76-4cf2-902f-dc35e445c747"
+    },
+    {
+      "id": "632da83a-5ccb-4eac-ba63-7636098d6473",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "874ab15e-4b76-4cf2-902f-dc35e445c747"
+    },
+    {
+      "id": "b7ca53b7-cff4-4370-8ca0-e3dfed0c3c88",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "887d6318-fc1b-44d2-ba58-5861d7337f88"
+    },
+    {
+      "id": "33ee6f13-31e8-49c0-9b96-6b436dc17b21",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "887d6318-fc1b-44d2-ba58-5861d7337f88"
+    },
+    {
+      "id": "babe7d35-cc47-4cac-b1c3-01c1e8a119a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "8bd07931-33f5-476c-8c1f-64762730fc60"
+    },
+    {
+      "id": "576b31ce-5bc0-4304-8cd3-22069e4506f9",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "8bd07931-33f5-476c-8c1f-64762730fc60"
+    },
+    {
+      "id": "111e0f58-2bf6-481c-9f3c-fae0582ca405",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "9025299a-46cb-4793-b1b8-5281e71eda4c"
+    },
+    {
+      "id": "6c351f6a-1984-4735-b9f1-05fdccbc998e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "9025299a-46cb-4793-b1b8-5281e71eda4c"
+    },
+    {
+      "id": "d5107417-fedd-45f1-a430-73f852422479",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "91188d0e-a532-4e63-8b14-ae60ab6f86b7"
+    },
+    {
+      "id": "1bd1b21b-a29f-498b-860f-ef7aee923ee8",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "91188d0e-a532-4e63-8b14-ae60ab6f86b7"
+    },
+    {
+      "id": "9ea7aecc-6f36-4710-830f-5c9422288400",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "92ce53e8-9ee5-4eca-ab12-c3bb6e23bc9f"
+    },
+    {
+      "id": "7c957e7a-dbf7-49f7-85ec-50505ce22297",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "92ce53e8-9ee5-4eca-ab12-c3bb6e23bc9f"
+    },
+    {
+      "id": "6bc5444e-464e-4c7b-b207-fb5d6346d603",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "95d53b99-1597-4444-b993-527df1ccebf3"
+    },
+    {
+      "id": "1e11a6a5-2244-4cf0-9485-ba7d89e1abed",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "95d53b99-1597-4444-b993-527df1ccebf3"
+    },
+    {
+      "id": "73370b86-66ce-4f6b-9f8b-2c0cea3aac13",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "97cbc411-879e-48e9-b869-8a55afa41090"
+    },
+    {
+      "id": "4493eb52-53a3-43bd-9311-b11b4bf9d3c2",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "97cbc411-879e-48e9-b869-8a55afa41090"
+    },
+    {
+      "id": "15ff5c47-d23d-4faf-b1d3-3f46a08ddfc4",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "996df6f9-cf4c-4853-944d-d7db32984e7f"
+    },
+    {
+      "id": "f5e914d4-fc6f-4a3e-86e5-9d895a0c1b54",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "996df6f9-cf4c-4853-944d-d7db32984e7f"
+    },
+    {
+      "id": "3a0782ed-02f0-4b8b-856b-5a48020f038d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "99c0a586-4046-4760-8bbf-ba32930282c7"
+    },
+    {
+      "id": "28b560e5-a95f-49b8-8e23-23092238494c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "99c0a586-4046-4760-8bbf-ba32930282c7"
+    },
+    {
+      "id": "01bee3bd-e6d8-4485-bc81-58345aff8856",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "9c032753-98bb-4f12-b83e-14fc9021ecd8"
+    },
+    {
+      "id": "07a42019-3591-4284-bd1e-0c615f9ccd43",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "9c032753-98bb-4f12-b83e-14fc9021ecd8"
+    },
+    {
+      "id": "e44f6330-f4a9-4981-bec6-e1a004de39ec",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a2c90b29-884b-4c3f-8fe4-f4eb7815f8b0"
+    },
+    {
+      "id": "f526a726-8ec1-4172-bb29-598ec97d51b6",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a2c90b29-884b-4c3f-8fe4-f4eb7815f8b0"
+    },
+    {
+      "id": "1a02eafe-945a-4afb-a2e6-e9da5b654a83",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a360ee62-c030-41fc-abda-ec987b36d5e2"
+    },
+    {
+      "id": "cd31cf6a-810e-40b7-ad28-a79ee88f5a8f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a360ee62-c030-41fc-abda-ec987b36d5e2"
+    },
+    {
+      "id": "9e6a9491-c05e-4d00-946f-cd8400bdd361",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a3ead96b-c524-496e-b4fd-a9b6ac24db50"
+    },
+    {
+      "id": "cd6e7db7-7115-418b-abf8-ed8f97d8d674",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a3ead96b-c524-496e-b4fd-a9b6ac24db50"
+    },
+    {
+      "id": "b52e6d66-cd08-48ba-8957-dcc3ef013645",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a687bbdd-949d-45c2-8b61-5af6c7f8ccbd"
+    },
+    {
+      "id": "2a88a25d-2fa9-4fbd-86fe-3178c852bb1e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a687bbdd-949d-45c2-8b61-5af6c7f8ccbd"
+    },
+    {
+      "id": "363ac789-43ee-4671-849f-703c0b6eb27f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a844ff90-3557-49c4-920f-6be929d4ddb8"
+    },
+    {
+      "id": "f5b03ee4-6619-43f1-aa52-3d16591c0af0",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a844ff90-3557-49c4-920f-6be929d4ddb8"
+    },
+    {
+      "id": "8733e859-eeef-42c2-ba56-f66f9ca1f35f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "a9e3fa98-9626-4848-a7cd-583be703b5f3"
+    },
+    {
+      "id": "fe1a3d14-9c66-44f9-8ce5-006a67b94abd",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "a9e3fa98-9626-4848-a7cd-583be703b5f3"
+    },
+    {
+      "id": "ada1d953-5e80-460d-bcbb-c94d3b61b5a9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "aac1d53e-ed49-48e4-8d30-eb978df0dc66"
+    },
+    {
+      "id": "ee3624bc-fd09-4252-b539-8649e608c0ef",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "aac1d53e-ed49-48e4-8d30-eb978df0dc66"
+    },
+    {
+      "id": "989592ea-eb2f-4e57-9164-e07abe7d685f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ad3be288-5813-4403-ba03-8e54c29871c2"
+    },
+    {
+      "id": "0baba5a1-11c7-459b-b46d-f91fdc933879",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ad3be288-5813-4403-ba03-8e54c29871c2"
+    },
+    {
+      "id": "9e23b5d1-7544-4f2f-9bd6-dab4f4920c20",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ae2907cc-0787-4041-af52-277c5b7fa018"
+    },
+    {
+      "id": "7cbf8f1f-c43d-4298-ab5b-76ba31c4e56a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ae2907cc-0787-4041-af52-277c5b7fa018"
+    },
+    {
+      "id": "881450ae-8b26-4c79-a6b7-168289dbcd66",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0360e22-b4e9-433f-bed8-90a80d7247ec"
+    },
+    {
+      "id": "13085b52-6862-48e9-b20b-1df16a2e9479",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "b0360e22-b4e9-433f-bed8-90a80d7247ec"
+    },
+    {
+      "id": "45898c8c-8a9e-4482-b43d-367332c75156",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b0d772b5-4483-4d2a-b6c7-c7b4cdad0f79"
+    },
+    {
+      "id": "4a29d804-f067-43d1-80bc-468651d2844c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "b0d772b5-4483-4d2a-b6c7-c7b4cdad0f79"
+    },
+    {
+      "id": "581d19ad-3681-4a8f-bb68-d94a4a618ff8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "b2b9da14-5e34-40be-a251-f8c43170c267"
+    },
+    {
+      "id": "c5d7e8da-1a30-48a5-a75d-94f361d7f0d1",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "b2b9da14-5e34-40be-a251-f8c43170c267"
+    },
+    {
+      "id": "5bfc0b5b-817c-4deb-8ae2-794532951b00",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bab993ab-1242-44ed-bdfd-547ae3cde53d"
+    },
+    {
+      "id": "9081a1ca-4136-4575-bffa-fcb582f84bc7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bab993ab-1242-44ed-bdfd-547ae3cde53d"
+    },
+    {
+      "id": "8b5462d8-b430-44b8-aa1d-1c623de30756",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bf34d173-c2c4-4fa4-b620-40990180ee04"
+    },
+    {
+      "id": "fbc17957-b298-413b-977a-7a146b72c6fa",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bf34d173-c2c4-4fa4-b620-40990180ee04"
+    },
+    {
+      "id": "98a3c0d6-d4af-4702-aa5d-8477c2667a99",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfbb2957-1f35-4bd3-867d-74c1c9a2b0ff"
+    },
+    {
+      "id": "68b75679-2d49-4501-b66e-b278b524c63d",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bfbb2957-1f35-4bd3-867d-74c1c9a2b0ff"
+    },
+    {
+      "id": "bbdde4ee-445c-4c04-bc14-ea75f2718c7c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "bfe42149-ff1c-432f-87ea-6e352e029c2d"
+    },
+    {
+      "id": "5114b30b-12d3-44c5-8a77-31d0cb5e08ce",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "bfe42149-ff1c-432f-87ea-6e352e029c2d"
+    },
+    {
+      "id": "f33088bd-5993-4f65-bef1-0a3abca24a97",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0dceb21-b206-4239-a7e7-5c87019d503e"
+    },
+    {
+      "id": "247448a1-d53d-4cde-a93c-aa00e06bcc1e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c0dceb21-b206-4239-a7e7-5c87019d503e"
+    },
+    {
+      "id": "8d52778c-0c4f-4acf-a0c6-ebeb0b06784f",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c0ecee8e-7e6c-42a7-b132-e3dacb15af64"
+    },
+    {
+      "id": "deca13c9-7b85-4dba-abc2-e45a0e42b9b2",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c0ecee8e-7e6c-42a7-b132-e3dacb15af64"
+    },
+    {
+      "id": "9fe7407a-b847-4f5d-840c-4c61e98ef739",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5542092-d005-4b18-8625-96a5d5f7b2dc"
+    },
+    {
+      "id": "b91f5948-80b8-4bc6-9f36-b44f2b96f45d",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c5542092-d005-4b18-8625-96a5d5f7b2dc"
+    },
+    {
+      "id": "fb19b92a-d71b-4675-8568-b38c7c629f6b",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c5f0b932-f200-46c6-948f-62b82ecb1e12"
+    },
+    {
+      "id": "67bbc246-9ea7-4dc9-9c8a-1772fa780530",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c5f0b932-f200-46c6-948f-62b82ecb1e12"
+    },
+    {
+      "id": "60806f0e-f422-4a0a-b875-96fb065bf712",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c69d1467-bbb7-4c88-8994-ed3d9891ea61"
+    },
+    {
+      "id": "ceb6b125-0cbe-4fd9-9306-69a23c9c9611",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c69d1467-bbb7-4c88-8994-ed3d9891ea61"
+    },
+    {
+      "id": "fe076bcf-cd72-4e84-9200-1ea57ff02e93",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "c79b6112-d0c8-4759-8111-9dc41a4f2eb7"
+    },
+    {
+      "id": "f948744a-be92-48b2-82a0-a7e0cd97f30f",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "c79b6112-d0c8-4759-8111-9dc41a4f2eb7"
+    },
+    {
+      "id": "f8421634-3478-4b16-8866-b3b97c54dcd6",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d07ce626-a755-4248-97c7-b39bbab5a96f"
+    },
+    {
+      "id": "9a7f2cda-fb08-4d81-b292-7c3c3367f51e",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d07ce626-a755-4248-97c7-b39bbab5a96f"
+    },
+    {
+      "id": "88964032-4c08-45d1-b5a2-c4428241f395",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d6bb573d-6f43-448e-b73e-b6db5ba9d850"
+    },
+    {
+      "id": "38213c76-3dfc-451d-846c-b47fc72831ed",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d6bb573d-6f43-448e-b73e-b6db5ba9d850"
+    },
+    {
+      "id": "8ac42dfb-044c-42bb-b866-5b8b03afa0df",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9a7717d-d862-4ea6-b03f-8106779dda88"
+    },
+    {
+      "id": "3ab59d2d-9e36-48f9-9672-3370e321b113",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d9a7717d-d862-4ea6-b03f-8106779dda88"
+    },
+    {
+      "id": "0a927479-ba1c-4391-843f-436f574fbff9",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "d9e1f554-5130-4595-bf31-2f40407abb08"
+    },
+    {
+      "id": "00e5047e-d704-4b19-8c2d-595ab54ab01b",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "d9e1f554-5130-4595-bf31-2f40407abb08"
+    },
+    {
+      "id": "b9d4fc15-04c9-4700-af4e-c93db471e0a5",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "db3667b2-7590-4b62-9b50-ed5529f92a08"
+    },
+    {
+      "id": "0d902dc2-fdd8-499e-85af-0e3e116265b1",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "db3667b2-7590-4b62-9b50-ed5529f92a08"
+    },
+    {
+      "id": "13f6a83f-38e0-4a79-b7e0-d03a8af8f536",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "dd10c923-3afd-4819-88c4-7d9556ce4278"
+    },
+    {
+      "id": "b849a589-fd79-4129-a68b-fcd53a2f0589",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "dd10c923-3afd-4819-88c4-7d9556ce4278"
+    },
+    {
+      "id": "d037da74-eb05-439c-bed4-1177d85385eb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e14a07f2-c509-4f2b-accf-e2dfe9afb8bd"
+    },
+    {
+      "id": "da744bfe-4691-4b5a-b61a-dcd9365805de",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "e14a07f2-c509-4f2b-accf-e2dfe9afb8bd"
+    },
+    {
+      "id": "87b344a3-45c6-4c3e-ab40-fc32d4a267cb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e8f18266-8492-4ff2-8c88-962174b21da5"
+    },
+    {
+      "id": "b39d2a42-b834-403e-9863-f0486e9c15de",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "e8f18266-8492-4ff2-8c88-962174b21da5"
+    },
+    {
+      "id": "c4cb139a-b678-4aab-90b6-b2c3d07678bb",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "e9440683-ff23-4f80-94bb-bacb51cf3ea9"
+    },
+    {
+      "id": "fc2f09ce-e513-42f0-bf1b-48071dfc7019",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "e9440683-ff23-4f80-94bb-bacb51cf3ea9"
+    },
+    {
+      "id": "752c2086-89f1-4fc2-90f8-014a26e04981",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ed0302db-26aa-4276-a9f0-78e9dc564aca"
+    },
+    {
+      "id": "66ce0d88-2bc6-4255-bc7b-6e81394703fa",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ed0302db-26aa-4276-a9f0-78e9dc564aca"
+    },
+    {
+      "id": "65c9d9b1-07b4-425b-9ea6-533a3c84e5be",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eea22c27-3d7d-46a9-a69a-000cd24ce85e"
+    },
+    {
+      "id": "162e0e2b-ca3a-4a7f-a976-c87df7b22590",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "eea22c27-3d7d-46a9-a69a-000cd24ce85e"
+    },
+    {
+      "id": "eb404cbf-1d0e-4cd8-a9a3-4e1e77dfaf3e",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "eed61bbb-a742-4b2f-a740-94c05f6f4f24"
+    },
+    {
+      "id": "470a40af-95dc-4026-84dc-19dcb385a4e3",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "eed61bbb-a742-4b2f-a740-94c05f6f4f24"
+    },
+    {
+      "id": "64f206d8-548d-4f8d-9ea6-26d92f5f8271",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "ef58ba70-9ea8-437f-bfb5-c21e992e5c95"
+    },
+    {
+      "id": "e39ee05e-070c-442d-9f8d-d782b9878936",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "ef58ba70-9ea8-437f-bfb5-c21e992e5c95"
+    },
+    {
+      "id": "8f8d358a-142e-4cff-be2e-c6e27b838244",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f2b5ef75-e846-4ac4-92b1-124c8720e14c"
+    },
+    {
+      "id": "e0d6c895-2311-4f22-aef5-fc3b3094d2e0",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f2b5ef75-e846-4ac4-92b1-124c8720e14c"
+    },
+    {
+      "id": "3efaceb2-5ab5-4217-8eb2-10e30c493d77",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f3774fe4-976c-4c61-b570-854d0cbd547f"
+    },
+    {
+      "id": "185209fc-7526-44e2-b6c4-da720a21a993",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f3774fe4-976c-4c61-b570-854d0cbd547f"
+    },
+    {
+      "id": "5c3a366f-58e5-4d73-b38d-c7aed64bbbae",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f39425d7-a23c-48f8-bac0-1d8459ff9b04"
+    },
+    {
+      "id": "d0af3542-8d4b-405e-996b-b5afbd6ece2a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f39425d7-a23c-48f8-bac0-1d8459ff9b04"
+    },
+    {
+      "id": "102ad8a6-660b-4ae7-bdae-6cdcc8082e37",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "f64c5dc5-678f-42cf-af57-9dcb225ce479"
+    },
+    {
+      "id": "e20aaf9e-88d0-4344-9b2f-5e540ec3791c",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "f64c5dc5-678f-42cf-af57-9dcb225ce479"
+    },
+    {
+      "id": "b017cbc0-5ef7-474e-9f47-51bef2d2cc2d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa1534e6-2279-4567-9019-6af88a6c3689"
+    },
+    {
+      "id": "5aa1db08-733d-4d63-b5ad-37caf3dc6bbf",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fa1534e6-2279-4567-9019-6af88a6c3689"
+    },
+    {
+      "id": "0de8a1da-640a-4bd6-983d-5e8a56368965",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fa8193a4-a289-48da-b18f-4ac9f66e4e9c"
+    },
+    {
+      "id": "3f6b44e4-0af1-48ff-b326-61b16eff6ea7",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fa8193a4-a289-48da-b18f-4ac9f66e4e9c"
+    },
+    {
+      "id": "aea9393a-52b3-4235-9c52-790cc9a97ce8",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "faf22799-7f6f-48fb-a58e-04a30b37e0c9"
+    },
+    {
+      "id": "7e23af80-df68-43bc-8afb-f02615786938",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "faf22799-7f6f-48fb-a58e-04a30b37e0c9"
+    },
+    {
+      "id": "3374b1a3-6a20-4db2-80ca-d2d3002a879d",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fb62dbd4-5911-410e-8b14-814b5a6a3e81"
+    },
+    {
+      "id": "6a5660a4-a535-4e33-bbe3-eb7eaf07ac89",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fb62dbd4-5911-410e-8b14-814b5a6a3e81"
+    },
+    {
+      "id": "0f7060c8-8ced-46e7-b614-ad0a690b730c",
+      "entity_name": "The Arnhem Land Progress Aboriginal Corporation",
+      "community_id": "fe5e105f-a264-4ea6-ab09-025ffaf1d149"
+    },
+    {
+      "id": "fb4d2db8-3417-4e25-8121-f62e95cbe33a",
+      "entity_name": "THE ARNHEM LAND PROGRESS ABORIGINAL CORPORATION (52 755 439 387)",
+      "community_id": "fe5e105f-a264-4ea6-ab09-025ffaf1d149"
+    }
+  ]
+}

--- a/thoughts/shared/handoffs/goods-capital-procurement-scoping-2026-05-27.md
+++ b/thoughts/shared/handoffs/goods-capital-procurement-scoping-2026-05-27.md
@@ -1,0 +1,141 @@
+# GrantScope architecture map — CAPITAL + PROCUREMENT pipeline scoping
+
+**Date:** 2026-05-27
+**Scope:** ARCHITECTURE MAPPING ONLY. Documents what exists. No design, no recommendations.
+**Repo:** `/Users/benknight/Code/grantscope`
+**Supabase project:** `tednluwflfhxyucgwigh`
+
+All citations are `file:line`. "Verified" = read the code. "Inferred" = derived, not directly confirmed. "NOT FOUND" = searched and absent.
+
+---
+
+## Q1 — CRAWLER / SOURCE PATTERN
+
+### How `nightly-grant-pipeline.mjs` orchestrates (Verified)
+- It is a **process orchestrator**, not a crawler. It spawns child processes per step (`scripts/nightly-grant-pipeline.mjs:73-90`).
+- 9 steps, declared in a `STEPS` array (`:61-71`): step 1 `scrape-state-grants`, 2 promote `grant_opportunities → alma`, 3 promote `foundation_programs → alma`, 4 `auto-classify-llm`, 5 `backfill-alma-fields`, 6 `verify-alma-opportunities`, 7 `refresh-funder-context`, 8 internal MV refresh, 9 internal blocklist re-eval.
+- Phaseable: `--phase=ingest|enrich|finalize|all` via `PHASE_KEYS` (`:46-52`); each phase scheduled separately to fit cron timeouts.
+- Each step logs to `agent_runs` via the child's own `lib/log-agent-run.mjs`; the wrapper just summarizes (`:27`, header `:13-15`).
+- **Only step 1 (`scrape-state-grants`) writes net-new `grant_opportunities` rows.** Steps 2-9 promote/enrich/verify existing rows. So a new SOURCE crawler is fundamentally a new step-1-style scraper.
+
+### The actual source-crawler pattern (Verified)
+`scripts/scrape-state-grants.mjs` is the canonical crawler-runner. The crawlers themselves are **TypeScript "source plugins"** under `packages/grant-engine/src/sources/`, NOT in `scripts/`:
+- `scrape-state-grants.mjs:17-24` imports 8 plugin factories (`createNTGrantsPlugin`, etc.) directly from `../packages/grant-engine/src/sources/*.ts`, instantiates them into a `statePlugins` array (`:41-50`).
+- It runs each plugin's async generator (`:100` `for await (const grant of plugin.discover(...))`) and upserts the collected `RawGrant`s into `grant_opportunities` (`:124-181`).
+
+**Plugin interface** (`packages/grant-engine/src/types.ts`):
+- `interface SourcePlugin` (`:85`) has `id`, `name`, and `discover(query): AsyncGenerator<RawGrant>` (`:90`).
+- `interface RawGrant` (`:39`): fields include `provider` (`:41`), `sourceUrl?` (`:42`), `sourceId: string` ("which plugin found this", `:50`), `discoveryMethod: string` (`:70`), `dedupKey` ("lowercase(provider):lowercase(name)", `:71`).
+- A `SourceRegistry` class exists (`packages/grant-engine/src/sources/registry.ts:10`) with `register()`, `configure()`, `getEnabled()`, `discoverAll()`. **HOWEVER**, `scrape-state-grants.mjs` does NOT use the registry — it hand-lists plugins in an array (`:41-50`). The registry is a separate path (used by `grantscope-discovery.mjs` per the agent-registry entry — unverified which exactly).
+
+**How plugins fetch:** each source plugin fetches its own pages. NT plugin (`packages/grant-engine/src/sources/nt-grants.ts`) uses raw `fetch()` + `cheerio.load()` for static pages (`:14, :78, :101`), with a **Firecrawl fallback** for JS-heavy pages (`:166-171`, dynamic `import('@mendable/firecrawl-js')` gated on `FIRECRAWL_API_KEY`). 29 of the source plugins call `fetch(`; 19 use `cheerio` (counted via grep).
+
+### How rows are written to `grant_opportunities` (Verified)
+`scrape-state-grants.mjs:127-146` maps each `RawGrant` to a row and upserts:
+```
+name, provider, url(=sourceUrl), description, amount_min, amount_max,
+deadline, categories, source_id(=sourceId), geography(=geography[0]||'AU'),
+status:'open', grant_type:'open_opportunity',
+source: g.provider || 'state-grants',
+upsert onConflict: 'name,source_id'
+```
+Note: this scraper sets `source` from the provider name, NOT a fixed crawler id. It does **not** set `discovery_method` (left null for the LLM-classify step / the matcher to handle).
+
+### How `source` and `discovery_method` get set (Verified)
+- `source` is set per-row by each ingestor (e.g. `scrape-state-grants` uses provider; the manual seed uses `'manual-research-2026-05-27'`, `seed-goods-source-vector-programs-2026-05-27.mjs:25,174`).
+- `discovery_method` is a free-text column. Writers found: `import-gov-grants.mjs:242,303,361` (`'scraper'`, `'data.gov.au'`, `'open-data-api'`); `import-public-discovered-grant-pages.mjs:312`; and the **new capital/procurement seed** `seed-goods-source-vector-programs-2026-05-27.mjs` which sets `discovery_method: 'indigenous-finance'` (`:38,62,70`), `'procurement'` (`:46`), or `'grant'` (`:54+`).
+- The scorer `scripts/lib/goods-relevance.mjs:74-77` has `BOOSTED_DISCOVERY_METHODS = new Set(['indigenous-finance','procurement'])` and applies a +25 boost (`:89,167-169`) so capital/procurement rows aren't squashed by the grant-tuned scorer.
+
+### Is there a source registry/config? (Verified)
+Two distinct registries:
+1. **`scripts/lib/agent-registry.mjs`** — the operational registry. Every runnable agent/crawler is an entry in `AGENTS` (`:9`) with `{command, displayName, category, defaultPriority, timeoutMs, dependencies}`. A new crawler script gets registered here to be schedulable (categories include `discovery`, `import`, `goods`, `scraping`). Relevant existing entries: `sync-austender-contracts` (`:35`), `ingest-supply-nation` (via `import-social-traders`? no — `ingest-supply-nation.mjs` is NOT in the registry, unverified if scheduled), `import-nt-contracts` (`:1169`), `ingest-state-procurement` (`:1217`), `goods-*` agents (`:986-1042`).
+2. **`packages/grant-engine/src/sources/registry.ts`** — the in-code `SourceRegistry` for grant source plugins.
+
+### Exact mechanism to add a new source crawler (e.g. iba.gov.au) (Verified pattern)
+Two viable shapes exist in the codebase:
+- **(A) TS source plugin** under `packages/grant-engine/src/sources/iba-finance.ts` implementing `SourcePlugin` (`discover()` async generator yielding `RawGrant`), then either add to the `statePlugins` array in a runner like `scrape-state-grants.mjs:41-50` OR register in `SourceRegistry`. Fetch via `fetch`+`cheerio` (static) or Firecrawl fallback (JS).
+- **(B) Standalone `.mjs` ingestor** in `scripts/` (the more common pattern for non-portal sources — e.g. `import-gov-grants.mjs`, `seed-goods-source-vector-programs-2026-05-27.mjs`): create Supabase client, fetch/parse, build row objects with `name/provider/url/description/amount_*/status/source/discovery_method/...`, `supabase.from('grant_opportunities').upsert(...)`. Register in `agent-registry.mjs` AGENTS to schedule it. Set `discovery_method:'indigenous-finance'` for IBA/NAIF/Many Rivers so the scorer boost applies.
+
+### GAPS / ABSENT (Q1)
+- NOT FOUND: any iba.gov.au / NAIF / Many Rivers crawler. Those programs exist ONLY as the 10 manual-seed rows in `seed-goods-source-vector-programs-2026-05-27.mjs` (curated, `source='manual-research-2026-05-27'`), not as automated crawlers. Searched `scripts/`, `packages/grant-engine/src/sources/`.
+- The state scraper does not set `discovery_method`; only specific ingestors and the manual seed do.
+
+---
+
+## Q2 — PROCUREMENT DATA MODEL
+
+### `goods-procurement-matcher.mjs` (Verified)
+- It is a **MATCHER, not an ingestor**. For each `goods_procurement_signal` (status new/reviewing), it: assigns a buyer entity from `goods_procurement_entities` (`:205-215`), matches top-3 open grants from `grant_opportunities` where `goods_relevance_score >= 30` (`loadGoodsGrantPool :86-100`), matches top-3 `foundations` (`:102-113`), sets `funding_confidence` (`:80-84`), and generates `demand_unmet` signals for unserved priority communities (`:251-281`).
+- It does NOT write to `grant_opportunities` or create buyer entities. It reads `goods_procurement_entities`, `goods_communities`, `grant_opportunities`, `foundations`; writes `goods_procurement_signals`.
+
+### How `goods_procurement_entities` is populated (Verified)
+Multiple writers (grep `from('goods_procurement_entities')` + insert/upsert):
+- **`scripts/import-agil-communities.mjs:421`** — bulk insert. Source = AGIL dataset (Australian Government Indigenous Programs & Policy Locations, 1,546 locations) cross-referenced with BushTel NT, CivicGraph `postcode_geo`, and CivicGraph `gs_entities` (header `:3-16`). This is the primary census-style populator (registered as `goods-community-census` → `import-agil-communities.mjs`, `agent-registry.mjs:987-993`).
+- **`scripts/add-goods-anchor-buyers.mjs:66`** and **`scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs:65`** — curated anchor-buyer inserts (councils, ACCHOs) matched by ABN.
+- **`scripts/seed-goods-communities.mjs`**, `fix-alpa-overmatch.mjs`, `drop-goods-noise-localities.mjs`, `push-goods-top25-to-demand-register.mjs`, `sync-ghl-goods-buyers.mjs` — seed/cleanup/sync helpers.
+- **Spend columns hydrated from contracts:** `scripts/hydrate-goods-procurement.mjs` fills `estimated_annual_spend`, `govt_contract_value`, `govt_contract_count` on `goods_procurement_entities` FROM the `austender_contracts` table (header `:3-14`; notes austender table is **~672K rows**). Uses goods keyword boost list (furniture/bed/mattress/housing/appliance/washing/etc., `:43+`).
+
+### Tender / contract ingestion that DOES exist (Verified)
+- **`scripts/sync-austender-contracts.mjs`** — the real tender/contract ingestor. Source: **AusTender OCDS 1.1 API at `https://api.tenders.gov.au/ocds`, no auth** (`:18, :6`). Syncs by month chunks, `contractPublished`/`contractLastModified` endpoints (`:22-23`). Extracts supplier ABN (`:48-66`), buyer/procuring entity (`:68-80`), contract value (`:82+`). Upserts into **`austender_contracts`** table `onConflict:'ocid'` (`:225`, also `:124,262,272`).
+- State-level awarded-contracts importers exist: `import-nsw-contracts.mjs`, `import-qld-contracts.mjs`, `import-nt-contracts.mjs`, `import-act-contracts.mjs`, `scrape-tas-contracts.mjs`, `ingest-state-procurement.mjs` (NSW+QLD) — all registered in `agent-registry.mjs:1152-1224`. (Did not verify each one's target table individually; `austender_contracts` confirmed for the federal sync.)
+- `scripts/ingest-supply-nation.mjs` — ingests Supply Nation IBD directory FROM a local CSV (`data/supply-nation/supply_nation_businesses.csv`, header `:6`), target = `social_enterprises` + `gs_entities` cross-ref (header `:7`). NOT a live scraper; CSV-fed. NOT in agent-registry (unverified if scheduled).
+
+### NT $4B remote-housing program ingestion (Verified absent)
+- NOT FOUND: any dedicated NT remote-housing / "$4B" / "Room to Breathe" / "HomeBuild" program ingestion. Grep for `remote.housing|$4B|4 billion|room to breathe` returned only generic keyword matches in unrelated scripts (seed/demand/scrape scripts), no dedicated program ingestor. Remote-housing demand is represented indirectly via `goods_communities.demand_beds/demand_washers` and the keyword boost in `hydrate-goods-procurement.mjs`, not as a tracked tender/program.
+
+### What demand-side ingestion exists today vs absent (Verified)
+- **Exists:** AusTender federal contracts (live OCDS API → `austender_contracts`, 672K rows); state awarded-contracts importers; AGIL community census → `goods_procurement_entities`; Supply Nation directory (CSV → `social_enterprises`/`gs_entities`); spend-column hydration of buyer entities from austender.
+- **Absent / NOT FOUND:** live tender-OPPORTUNITY (open RFT) ingestion as buyable signals (austender sync targets awarded *contracts*, not open tenders surfaced to Goods); NT remote-housing program as a tracked entity; any pipeline turning austender contracts directly into `grant_opportunities`-style procurement opportunities (procurement currently lives in `austender_contracts` + `goods_procurement_entities`/`_signals`, separate from `grant_opportunities` except the 1 manual Supply Nation seed row).
+
+---
+
+## Q3 — FRONTEND SURFACES
+
+### Where Goods grants/opportunities surface (Verified)
+1. **Public `/grants` page** — `apps/web/src/app/grants/page.tsx`. Reads `grant_opportunities` (`PUBLIC_GRANTS_LIST_TABLE = 'grant_opportunities'`, `:329`; queries `:660-661, :769, :849`). Supports semantic search via `searchGrantsSemantic` (`:2, :667`) gated on `OPENAI_API_KEY`.
+   - **The "pile"-equivalent here is `PROJECT_PRESETS`** (`:81-131`), keyed off the `aligned_projects` array column. There is a `goods` preset (`:82-89`) with `value:'goods'`, `orgHref:'/org/act/goods#funding-feed'`, and a `terms` keyword list (procurement/social enterprise/first nations/remote/etc.). Filtering uses `grant.aligned_projects` (`:156, :688`). **There is NO `pile` column** in this app — "pile" is an ACT-finance term elsewhere; GrantScope's grouping mechanism is `aligned_projects` (project tags like `'goods'`, `'picc'`, `'justicehub'`) + `discovery_method` + `goods_relevance_score`.
+   - A fast-path `FAST_ACT_PIPELINE_GRANTS` / `isFastGrantIndex` constant exists (`:644-646`).
+2. **Goods signals workbench** — `apps/web/src/lib/services/goods-signals-workbench.ts`. `getGoodsSignalsWorkbench()` (`:117`) reads `goods_procurement_signals` and joins `goods_communities`, `goods_procurement_entities` (buyers), `grant_opportunities` (matched grants, `:188`), `foundations`. Computes fit/noise/triage. Footprint filter `GOODS_FOOTPRINT_STATES = {NT,QLD,WA,SA}` (`:79`). Rendered by `apps/web/src/app/org/[slug]/wiki/goods-signals/page.tsx`.
+3. **Goods community detail** — `apps/web/src/lib/services/goods-community-detail.ts`. `CommunityDetail` type carries `total_govt_contract_value`, `total_justice_funding`, `total_foundation_grants` (`:19-21`); `MappedBuyer` (`:26-45`) and `MatchedGrant` (`:72-80`) types. Rendered by `apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx`.
+4. Other goods routes: `org/[slug]/goods/communities/page.tsx`, `org/[slug]/wiki/goods-operating-system/page.tsx`, `org/_components/org-sections.tsx`, `org/[slug]/page.tsx` (funding-feed anchor).
+
+### How a new capital/procurement pile/view would attach (Verified facts only)
+- The existing per-project grouping on `/grants` is `PROJECT_PRESETS` keyed on `aligned_projects` (`page.tsx:81-131,156,1026`). The seed rows tag `aligned_projects: ['ACT-GD','goods']` for score>=50 (`seed-...-2026-05-27.mjs:26,180`). Capital/procurement rows are already in `grant_opportunities` distinguished by `discovery_method ∈ {indigenous-finance, procurement}`.
+- The goods-signals workbench and community-detail services already join `grant_opportunities` by matched IDs and surface `goods_relevance_score`; neither currently filters/segments by `discovery_method` (Verified — grep showed `discovery_method` is not selected in `goods-signals-workbench.ts` or `goods-community-detail.ts`).
+
+### GAPS / ABSENT (Q3)
+- NOT FOUND: any UI component that filters or segments by `discovery_method`. The frontend grouping primitive is `aligned_projects` (project preset) + `goods_relevance_score`, not `discovery_method`. A capital/procurement "view" today has no dedicated filter chip — capital rows surface only insofar as they carry `goods` in `aligned_projects` or appear as matched grants on a signal.
+- NOT FOUND: a `pile` column/concept in the GrantScope web app (it's an ACT-finance term).
+
+---
+
+## Q4 — INGESTION INFRA AVAILABLE
+
+### Scraping / fetch infra (Verified)
+- **Firecrawl** — `@mendable/firecrawl-js`, dynamically imported, gated on `FIRECRAWL_API_KEY`. Used in source plugins (`nt-grants.ts:166-171`, also `vic-grants.ts`, `business-gov-au.ts`) and `grant-engine/src/agents/grant-monitor.ts`, `grant-engine/src/foundations/annual-report-scraper.ts`, plus many `scripts/` (e.g. `scrape-charity-annual-reports.mjs`, `build-foundation-profiles.mjs`, `enrich-annual-reports-llm.mjs`).
+- **Playwright** — used by JS-heavy scrapers (`scrape-qld-bills.mjs`, `scrape-qld-coroners.mjs`, `scrape-*-bills.mjs`, `scrape-lobbying-qld-playwright.mjs`). Template at `scripts/stubs/PLAYWRIGHT-SCRAPER-TEMPLATE.md`. `grant-engine/src/playwright.d.ts` + `sources/grantconnect.ts` use it.
+- **cheerio** — static HTML parsing, used in 19 source plugins.
+- **Raw `fetch()`** — 29 source plugins; the default for static + JSON APIs (e.g. austender OCDS).
+
+### LLM-extraction helpers (Verified)
+- `scripts/lib/minimax.mjs` — MiniMax M2.7 reasoning model client (`MINIMAX_API_KEY`, `MINIMAX_BASE_URL`); `stripThinkTags()` helper.
+- `scripts/lib/local-llm.mjs` — local Gemma via llama-server (`LOCAL_LLM_URL`, `LOCAL_LLM_MODEL`); drop-in provider for the multi-provider round-robin pattern.
+- `@anthropic-ai/sdk` — used directly by `auto-classify-llm.mjs:28,47` (`ANTHROPIC_API_KEY`) for grant-type classification. `backfill-alma-fields.mjs` (LLM field extraction) is the field-extraction step in the nightly pipeline.
+- OpenAI — embeddings/semantic search (`searchGrantsSemantic`, gated on `OPENAI_API_KEY`); `grant-engine/src/embeddings.ts`.
+- Gemini — `GEMINI_API_KEY` present (used for OCR/extraction elsewhere in ACT; presence verified in `.env`).
+
+### ABN / entity resolution infra (Verified)
+- `ABN_LOOKUP_GUID` env key present (ABR lookup). `scripts/ingest-abr-bulk.mjs`, `sweep-abn-entities.mjs`, `backfill-oric-abns.mjs`, `link-justice-abns.mjs` exist for ABN matching. Supply Nation / buyer entities are ABN-keyed (`add-goods-anchor-buyers.mjs`, `backfill-goods-anchor-councils-acchos-2026-05-27.mjs`). `GOODS_TRACKED_ABNS` env key exists.
+
+### Logging / scheduling infra (Verified)
+- `scripts/lib/log-agent-run.mjs` — `logStart/logComplete/logFailed` → `agent_runs` table. Every ingestor uses it.
+- `scripts/lib/agent-registry.mjs` — schedulable agent registry (see Q1).
+- `scripts/lib/psql.mjs` — direct psql helper (for DDL / MV refresh that `exec_sql` RPC can't do).
+
+### Relevant env KEY NAMES (names only, no values) (Verified)
+`.env`: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `DATABASE_URL`, `DATABASE_PASSWORD`, `FIRECRAWL_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MINIMAX_API_KEY`, `MINIMAX_BASE_URL`, `GEMINI_API_KEY`, `ABN_LOOKUP_GUID`, `GOODS_TRACKED_ABNS`, `GHL_*` (incl. `GHL_GOODS_PIPELINE_ID`), `NOTION_*` (incl. `NOTION_GRANT_PIPELINE_DB`, `NOTION_FOUNDATION_TARGETS_DB`).
+`apps/web/.env.local` adds: `GHL_GOODS_CAPITAL_STAGE_ID`, `GHL_GOODS_BUYER_STAGE_ID`, `GHL_GOODS_PARTNER_STAGE_ID`, etc. (GHL Goods pipeline stage IDs incl. a CAPITAL stage), `GOOGLE_SERVICE_ACCOUNT_KEY`, `GOOGLE_DELEGATED_USER`.
+
+### GAPS / ABSENT (Q4)
+- NOT FOUND: any dedicated AusTender / tenders.gov.au API key — the OCDS API is **no-auth** (`sync-austender-contracts.mjs:6,18`), so no key needed.
+- NOT FOUND: a single shared `fetchHtml`/`scrapeUrl` helper in `grant-engine` exported outside `sources/` — each plugin embeds its own fetch+cheerio+firecrawl-fallback logic.

--- a/thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md
+++ b/thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md
@@ -1,6 +1,6 @@
 ---
 title: Goods capital + procurement pipelines — SCOPE (item #3)
-status: scoping — needs Ben's phase-priority + build-vs-curate calls before a build session
+status: scoped — Ben chose PHASE 3 (open-tender feed) as the build-session starting point (2026-05-27)
 date: 2026-05-27
 repo: grantscope
 related:
@@ -54,10 +54,18 @@ Goods needs four money-types; GrantScope's grant scorer only finds the weakest w
 ### Phase 4 — NT $4B remote-housing tracker (M–L)
 - Dedicated source for NT DHLGCD remote-housing program + contract vehicles (likely Firecrawl — JS-heavy). Track as procurement opportunities / a tracked program entity. The whale; highest effort, highest ceiling.
 
-## Decisions needed from Ben (gates the build session)
-1. **Phase priority** — start with Phase 1 (surface existing, fastest visible win) or jump to a specific gap (e.g. Phase 3 open-tenders, or Phase 4 NT housing)?
-2. **D3 capital: watch/flag vs auto-crawl vs quarterly-manual.**
-3. **GHL flow now or later** — wire capital/procurement → GHL stages this round, or keep GrantScope-only first?
+## Decisions
+1. **Phase priority — DECIDED: start with PHASE 3 (open-tender feed).** Ben's call, 2026-05-27: the "purchase order > grant" value is the priority. Phase 1 surfacing + Phase 2/4 deferred.
+2. **D3 capital: watch/flag vs auto-crawl vs quarterly-manual** — open, only relevant when Phase 2 is built.
+3. **GHL flow now or later** — for Phase 3: decide whether open-tender opportunities flow to the GHL Buyer stage this round, or land in `grant_opportunities` first and wire GHL after.
+
+## Phase 3 build-session kickoff notes (start here next session)
+Goal: a `sync-austender-open-tenders.mjs` that ingests OPEN AusTender ATMs (Approach To Market), filtered to Goods product, as `grant_opportunities` rows (`discovery_method='procurement'`, `status='open'`).
+First three things to verify before coding:
+1. **Does the AusTender OCDS API expose open-tender / ATM (planning/tender) releases**, not just the `contractPublished`/`contractLastModified` releases the existing `sync-austender-contracts.mjs` uses? Check `https://api.tenders.gov.au/ocds` release types. If OCDS only carries awarded contracts, fall back to the AusTender ATM RSS/HTML or CKAN dataset.
+2. **UNSPSC / category codes for Goods product** — beds/mattresses (UNSPSC 56101500s), whitegoods/appliances (52141500s), furniture (56101700s). Confirm against what ATM records carry; reuse the keyword list already in `hydrate-goods-procurement.mjs`.
+3. **Target shape** — reuse the `grant_opportunities` upsert pattern (D1); set `source='austender-open-tenders'`, `discovery_method='procurement'`; do NOT mark manual (let the scorer's +25 procurement boost score them). Register in `agent-registry.mjs`.
+Fallback if open-ATM ingestion proves infeasible: pivot to Phase 1 repeat-buyer intelligence (mine the existing 672K `austender_contracts` for buyers who already purchase beds/whitegoods) — data already present, no new source.
 
 ## Out of scope
 Re-scoring tuning (done), the GHL Buyer Pipeline itself (built prior sessions), Supply Nation live scraping (currently CSV-fed; separate question).

--- a/thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md
+++ b/thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md
@@ -1,0 +1,63 @@
+---
+title: Goods capital + procurement pipelines — SCOPE (item #3)
+status: scoping — needs Ben's phase-priority + build-vs-curate calls before a build session
+date: 2026-05-27
+repo: grantscope
+related:
+  - grantscope thoughts/shared/handoffs/goods-capital-procurement-scoping-2026-05-27.md (architecture map, file:line cites)
+  - grantscope thoughts/shared/plans/2026-05-27-goods-scoring-noise-fix.md (DONE — discovery_method hook)
+  - grantscope thoughts/shared/plans/2026-05-27-goods-ingest-source-vector-programs.md (DONE — 10 seed rows)
+  - act-infra thoughts/shared/handoffs/goods-grants-sweep-2026-05-27.md (§4 — the four money-types)
+---
+
+# Goods capital + procurement pipelines — scope
+
+## The problem (sweep §4)
+Goods needs four money-types; GrantScope's grant scorer only finds the weakest well (competitive grants). The two structural blind spots:
+- **CAPITAL** — loans-with-grant-features: IBA Start-Up Finance (30% grant), NAIF, Many Rivers, ILSC, ABA. *Buys the beds/washers/plant.*
+- **PROCUREMENT** — the demand side: open tenders + the $4B NT remote-housing program + Supply Nation. *A purchase order beats a grant and repeats.*
+
+## What ALREADY exists (don't rebuild — verified, see architecture map)
+- **The 10 seed rows** (capital + procurement programs) live in `grant_opportunities` with `discovery_method ∈ {indigenous-finance, procurement}`; the scorer gives them a +25 boost (`goods-relevance.mjs:74-77`). Foundation laid.
+- **Live demand-side data:** `sync-austender-contracts.mjs` pulls the AusTender OCDS API (no-auth) into `austender_contracts` (~672K rows). `hydrate-goods-procurement.mjs` already hydrates buyer spend onto `goods_procurement_entities` using a Goods keyword list (furniture/bed/mattress/appliance/washing…).
+- **Buyer model + matcher:** `goods_procurement_entities` (buyers, AGIL census + curated anchors) + `goods_procurement_signals` + `goods-procurement-matcher.mjs` (matches signals→buyers→grants→foundations).
+- **GHL pipeline stages already provisioned:** `GHL_GOODS_CAPITAL_STAGE_ID`, `GHL_GOODS_BUYER_STAGE_ID`, `GHL_GOODS_PARTNER_STAGE_ID` (`apps/web/.env.local`). The GHL Goods Buyer Pipeline was built in prior sessions — **a Capital stage already exists and is unused.**
+- **Crawler infra:** standalone `.mjs` upsert ingestors (pattern at `import-gov-grants.mjs`) or TS `SourcePlugin`s; fetch+cheerio, Firecrawl fallback (`FIRECRAWL_API_KEY`), LLM extraction (minimax/anthropic), ABN lookup, `agent-registry.mjs` scheduling.
+
+## The actual gaps (verified absent)
+1. **No freshness for the ~6 capital programs** — they exist only as static manual-seed rows; amounts/dates go stale. No crawler.
+2. **No open-tender feed** — the AusTender sync tracks *awarded contracts*, not open opportunities (ATM/RFT). "What can Goods bid on right now?" is unanswered.
+3. **NT $4B remote-housing program: zero ingestion** (the single biggest demand whale).
+4. **No UI segmentation by `discovery_method`** — capital/procurement rows surface only via `aligned_projects='goods'` + score; no capital/procurement filter chip or workbench section.
+5. **GHL Capital stage unused** — no flow pushing high-fit capital opportunities into it (the Buyer stage flow exists as the prior-session pattern to mirror).
+
+## Cross-cutting design decisions (resolve before building)
+- **D1 — Where do these opportunities live?** Keep them as `grant_opportunities` rows distinguished by `discovery_method` (reuses scorer + `/grants` + workbench + GHL sync), vs. new tables. **Lean: keep in `grant_opportunities`** — the hook is already there; a separate table fragments the matcher/UI.
+- **D2 — GrantScope = discovery, GHL = action.** These pipelines should *feed* GHL stages (capital→Capital, procurement→Buyer), mirroring the buyer-pipeline pattern. Procurement pipeline is the **opportunity feed upstream of** the existing GHL Buyer Pipeline — NOT a duplicate of it.
+- **D3 — Capital: crawl vs curate?** Only ~6 stable program pages, manual-guard-protected. A change-detection "watch" (re-fetch monthly, diff, flag for review) likely beats 6 fragile auto-overwrite scrapers. Or a quarterly manual seeder refresh.
+
+## Proposed phasing (lowest-effort/highest-ROI first)
+
+### Phase 1 — Surface what exists (S, no new ingestion)
+- Add a `discovery_method` filter chip to `/grants` (capital / procurement / grant) — small frontend change on the existing `PROJECT_PRESETS` mechanism (`grants/page.tsx:81-131`).
+- Add capital + procurement sections to the goods workbench (`goods-signals-workbench.ts` already joins `grant_opportunities`; select `discovery_method` and segment).
+- **Repeat-buyer intelligence:** query `austender_contracts` (data already there) for buyers who've purchased beds/whitegoods/furniture → rank as warmest procurement targets. Surfaces the 672K-row asset we already pay to sync.
+
+### Phase 2 — Capital freshness + GHL Capital flow (M)
+- Per D3: a `watch-goods-capital-programs.mjs` change-detector for the ~6 Indigenous-finance program pages (fetch+cheerio/Firecrawl) → flag amount/status/deadline changes for review (respects manual-guard), don't auto-overwrite curated rows.
+- Push high-fit (`discovery_method='indigenous-finance'`, score≥threshold) rows → GHL Goods pipeline **Capital stage** (`GHL_GOODS_CAPITAL_STAGE_ID`), mirroring the buyer-pipeline sync.
+
+### Phase 3 — Open-tender (procurement) feed (M)
+- New `sync-austender-open-tenders.mjs` — same OCDS API (no-auth), but the *tender/planning* releases, filtered to Goods UNSPSC/keywords (furniture/beds/whitegoods/appliances). Upsert as `grant_opportunities` rows, `discovery_method='procurement'`, `status='open'`.
+- Matcher + GHL Buyer stage flow picks them up.
+
+### Phase 4 — NT $4B remote-housing tracker (M–L)
+- Dedicated source for NT DHLGCD remote-housing program + contract vehicles (likely Firecrawl — JS-heavy). Track as procurement opportunities / a tracked program entity. The whale; highest effort, highest ceiling.
+
+## Decisions needed from Ben (gates the build session)
+1. **Phase priority** — start with Phase 1 (surface existing, fastest visible win) or jump to a specific gap (e.g. Phase 3 open-tenders, or Phase 4 NT housing)?
+2. **D3 capital: watch/flag vs auto-crawl vs quarterly-manual.**
+3. **GHL flow now or later** — wire capital/procurement → GHL stages this round, or keep GrantScope-only first?
+
+## Out of scope
+Re-scoring tuning (done), the GHL Buyer Pipeline itself (built prior sessions), Supply Nation live scraping (currently CSV-fed; separate question).

--- a/thoughts/shared/plans/2026-05-27-goods-ingest-source-vector-programs.md
+++ b/thoughts/shared/plans/2026-05-27-goods-ingest-source-vector-programs.md
@@ -1,0 +1,58 @@
+---
+title: Goods — ingest the source-vector programs (corrected for dedup)
+status: proposed — needs Ben review of data values before any insert
+date: 2026-05-27
+repo: grantscope
+related:
+  - act-infra thoughts/shared/handoffs/goods-grants-sweep-2026-05-27.md (§3, §4)
+  - grantscope thoughts/shared/plans/2026-05-27-goods-scoring-noise-fix.md (DONE — discovery_method hook)
+---
+
+# Goods — ingest the source-vector programs
+
+## Correction to the sweep §3 ("~17 net-new programs")
+
+Verified against live DB `tednluwflfhxyucgwigh` 2026-05-27 — **~6 of the 17 already exist** (the sweep's "net-new unless noted" was optimistic). So this is **insert ~10 net-new + enrich/dedup ~6 existing**, not "insert 17."
+
+### Already in DB (ENRICH / DEDUP / re-score — do NOT re-insert)
+| Program | Current row(s) | Action |
+|---|---|---|
+| ILSC Our Country Our Future | `ilsc` (40) + `ghl_sync` dup (6) | retire ghl_sync dup; enrich + re-score |
+| Westpac Inclusive Employment Grant | `foundation_program` (13) | enrich (amount $50K/2yr, opens 2026); re-score |
+| Westpac Social Change Fellowship | `foundation_program` (0 ×2) | dedup; **scores 0 — fellowship disqualifier (policy Q below)** |
+| FRRR Strengthening Rural Communities | `foundation_program` (22 + 30) | dedup the two; enrich (Round 30 opens 25 Jun, closes 17 Sep) |
+| Telstra Connected Communities | `web-search` (6) + "Connected Communities Grant" (4) | dedup; mark CLOSED this cycle (low priority) |
+
+### Genuinely net-new (INSERT, review-first)
+discovery_method drives the scorer's new +25 capital/procurement boost (shipped in the scoring-noise fix).
+
+| Program | Provider | discovery_method | amount_max | status | proposed score* |
+|---|---|---|---|---|---|
+| IBA Start-Up Finance Package | Indigenous Business Australia | indigenous-finance | 150000 | open | ~82 |
+| Supply Nation (certification + buyer access) | Supply Nation | procurement | (null — demand) | open | ~82 |
+| Aboriginals Benefit Account (ABA) | NIAA / Aboriginal Investment NT | grant | (null — project) | open | ~75 |
+| NAIF Small Loans Program | Northern Australia Infrastructure Facility | indigenous-finance | (null — loan) | open | ~62 |
+| Many Rivers Microfinance | Many Rivers | indigenous-finance | (null — micro) | open | ~60 |
+| Barayamal Accelerator | Barayamal | grant | 10000 | open (EOI) | ~55 |
+| ILSC Future Industries Grant Program | ILSC | grant | (null — advice) | check | ~55 |
+| FRRR / ANZ Seeds of Renewal | FRRR + ANZ | grant | (null) | upcoming | ~45 |
+| Lowitja Institute Seeding / GLOWS | Lowitja Institute | grant | (null — seeding) | closes 2026-06-10 | ~40 |
+| Macquarie Group Foundation | Macquarie Group Foundation | grant | (null) | relationship | ~40 |
+
+\* *Proposed scores are curated (marked `source='manual-research-2026-05-27'` so the manual-guard protects them). Most sweep amounts/dates are "Inferred" — **every value needs a click-through before insert.***
+
+## Scoring-policy decision needed (Ben)
+**Westpac Social Change Fellowship scores 0** because `fellowship` is in `DISQUALIFIERS`. The sweep rated it "Medium — founder capability." Options:
+1. **Keep disqualified** (recommended) — it funds a *person's* development, not the enterprise; Goods' need is org capital/capability/procurement. Leave at 0.
+2. Carve an exception so founder-development fellowships aren't zeroed. Touches the scorer again.
+
+## Apply mechanism (review-first, after data verification)
+Idempotent seeder `scripts/seed-goods-source-vector-programs-2026-05-27.mjs` (mirrors the goods seeders): `--dry-run` prints the rows; `--apply` upserts on `(source, name)`. Sets `discovery_method`, `accepts_pty_ltd/charity`, curated score, `goods_relevance_scored_at=now()` so the next rescore's manual-guard preserves them. Enrich/dedup the 6 existing rows in the same script (UPDATE by id).
+
+## Verification (post-apply)
+- New + enriched rows present at expected scores; capital/procurement rows surfaced via discovery_method boost.
+- No `(source,name)` or `url` unique-constraint violations.
+- ACT-GD-tagged count moves from 110 by ~the number of new ≥50 rows.
+
+## Out of scope (item #3, separate)
+Dedicated capital/procurement *crawlers* + a pipeline view. This task only lands the rows; it does not build new source crawlers.

--- a/thoughts/shared/plans/2026-05-27-goods-scoring-noise-fix.md
+++ b/thoughts/shared/plans/2026-05-27-goods-scoring-noise-fix.md
@@ -1,0 +1,69 @@
+---
+title: Goods GrantScope scoring-noise fix
+status: proposed
+date: 2026-05-27
+repo: grantscope
+related:
+  - act-infra thoughts/shared/handoffs/goods-grants-sweep-2026-05-27.md (§5)
+  - act-infra memory goods-foundation-pipeline
+---
+
+# Goods GrantScope scoring-noise fix
+
+## Problem (verified against live DB `tednluwflfhxyucgwigh`, 2026-05-27)
+
+Of 195 rows at `goods_relevance_score >= 60`, **94 are `arc-grants` + 45 are `qld-arts-data` = 71% noise.** 315 rows sit at ≥50 (the `ACT-GD` tag threshold), so the noise is auto-tagging Goods onto grants it cannot apply to.
+
+## Diagnosis correction (the sweep §5 hypothesis was partly wrong)
+
+The grants-sweep §5 listed a **"SEDI↔sediment substring bug."** I verified against the code and DB — **it does not exist**:
+
+- `scripts/lib/goods-relevance.mjs` has **no `sedi` keyword** and no substring matcher for it.
+- The actual sediment grants score **low** (`Shallow water carbonate sediment dissolu…` = 21, `Sedimentary basins…` = 14, others 0). They are not the noise.
+- The 94 high-scoring ARC rows are **real First Nations research projects** ("Settlement agreements between First Peoples…", "Policy for self-determination: ATSIC") scoring 100 on legitimate Tier-1 Indigenous keywords + big dollars.
+
+So the real problem is **structural eligibility**, not a substring false-match: a Pty Ltd social enterprise cannot apply to ARC university research, no matter how Indigenous-themed. The fix is source/provider exclusion, not regex surgery. SEDI scored 6 simply because its row lacked Goods keywords — the fix there is to *add* a word-boundary SEDI acronym signal (which, as a bonus, will never match "sediment").
+
+Eligibility booleans are too sparse to gate on: `accepts_pty_ltd` populated on only 1,746/24,977 rows (7%); `accepts_charity` 418 (2%). A "require accepts_pty_ltd=true" gate would zero almost everything. So the gate keys on **source + provider**, not the booleans.
+
+## Fix (in `grantscope`, 2 code files + 1 test + rescore)
+
+### 1. `scripts/lib/goods-relevance.mjs` — add source/provider-aware disqualifiers
+- New early-return hard-zero when:
+  - `source === 'arc-grants'` (94 rows; ARC = university research, structurally ineligible)
+  - `source === 'qld-arts-data'` (45 rows; arts dataset — Goods is not an arts producer; §2 already excluded arts)
+  - `provider` matches `/\buniversit(y|ies)\b/i` (belt-and-suspenders for research grants from other sources — **verified zero non-arc rows at ≥50 have a university provider**, so no legit loss today)
+- New **positive** SEDI recognition (fixes SEDI scoring 6, and is the honest reading of the §5 "SEDI" item):
+  - word-boundary `\bsedi\b` acronym match → Tier-1 strength (will not match "sediment")
+  - `social enterprise development initiative` phrase + DSS/IIA provider → capability signal
+- New forward-looking up-weight: `discovery_method ∈ {indigenous-finance, procurement}` → additive boost so capital/procurement rows (task 2/3) aren't squashed for not reading like a grant. (No such rows exist yet — this is a hook.)
+- Function signature gains `source` + `discovery_method` (provider already passed).
+
+### 2. `scripts/score-goods-relevance.mjs` — pass new fields + manual-score guard
+- `pickColumns` + `fetchBatch` select: add `source`, `discovery_method`.
+- **Manual-score guard** (mirrors act-infra auto-tagger guard): when applying scores, **skip rows where `source ILIKE 'manual%'`** — protects 19 curated rows incl. SEDI First Nations (88). Without this, `--rescore-all` clobbers them.
+- **SEDI `dss` row**: source is `dss` not `manual`, so the manual guard won't save its curated 82 — but the new positive SEDI signal (#1) makes it score high on its own merits, surviving rescore. (Verify post-rescore; if it lands low, re-apply the §1c enrichment.)
+
+### 3. `scripts/lib/goods-relevance.test.mjs` — new pure-function test
+Lock the behaviour so it can't silently regress:
+- arc-grants source → 0
+- qld-arts-data source → 0
+- university provider → 0
+- "Sediment…" name → low (no SEDI boost)
+- "SEDI Capability Building Grant" / DSS-IIA provider → high (≥ tag threshold)
+- a real Indigenous-housing grant → high (unchanged)
+
+### 4. Re-score + verify
+- `cd grantscope && node --env-file=.env scripts/score-goods-relevance.mjs --rescore-all`
+- Verify (SQL against live DB): **zero** arc-grants/qld-arts-data at ≥60; SEDI Capability + SEDI First Nations land high; the ≥50 survivors are Goods-shaped funders (Lotterywest, foundation_program, NSW Aboriginal Affairs/Housing, grantconnect). Spot-check top-20.
+
+## NOT in this task (separate sessions, per handoff)
+- Ingest the ~17 new source-vector programs (IBA/ILSC/NIAA/ABA/Westpac/Lowitja/Supply Nation).
+- Build the capital + procurement pipelines.
+
+## Decision needed from Ben
+**Hard-zero `arc-grants` and `qld-arts-data` by source** (vs. down-weighting them). Recommendation: hard-zero — both are structurally ineligible for Goods and the sweep §5 + §2 already concluded this. Down-weighting leaves them lingering in the ≥50 tag pool.
+
+## Risk / reversibility
+- The rescore is a bulk UPDATE of `goods_relevance_score`/`goods_relevance_signals`/`aligned_projects` on ~24k rows in the shared GrantScope DB. Reversible by re-running the scorer (deterministic pure function). No schema change.
+- Manual guard prevents loss of curated rows. University gate verified non-destructive to current data.


### PR DESCRIPTION
## Phase 3 — open-tender (procurement) feed

Builds `scripts/sync-austender-open-tenders.mjs`: ingests **open** AusTender ATMs as `grant_opportunities` rows (`discovery_method='procurement'`, `status='open'`), registered as the `sync-austender-open-tenders` agent.

Plan: `thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md` (§Phase-3).

### Gating finding (verified)
The OCDS API exposes **only awarded contracts** — `findByDates` DateType is restricted to `['contractPublished','contractLastModified','contractStart','contractEnd']`, no tender/ATM/planning release type. So the open-tender feed uses:
- **Current ATM RSS** (`tenders.gov.au/public_data/rss/rss.xml`) → ~90 live open ATMs, daily-refreshed (needs a browser-like UA or 403).
- Per-ATM detail page → embedded object with **`atmCategoryCode` (UNSPSC)**, agency, ATM type, close date.

### Design — UNSPSC precision gate
Keyword pre-filter (mirrors `hydrate-goods-procurement` GOODS_KEYWORDS) → fetch detail → **a present-but-non-Goods UNSPSC rejects the row**. Goods allowlist = family `56` (furniture/furnishings) + `5210/5212/5213/5214` (floor coverings / linens / kitchenware / whitegoods), excludes `5216/5217` electronics. Upsert dedups on the non-partial unique `url` index; scored inline via the scorer's +25 procurement boost.

### First run (verified live in DB)
- ✓ DHA Furnishings/Storage/Logistics EOI — UNSPSC 56101500, score **56**, AU-WA, closes 2026-05-29
- ✓ Cockatoo Island Linen Supply — UNSPSC 52120000, score **61**, closes 2026-06-12
- Both tagged `[ACT-GD, goods]`. **5/5 keyword false-positives** (seabed dredging, road-bed asphalt, medical "appliance", DHA civil works, warehousing review) **correctly rejected** by the UNSPSC gate.
- `--all` (UNSPSC-only over all 90) finds the same 2 → keyword pre-filter has full recall.

---
## ⚠ This PR stacks unmerged 2026-05-27 Goods work
Phase-3 depends on the scorer's `+25 procurement boost` (`b843ee9`), which isn't on `main` yet — so this branch carries the prior unmerged stack. Clean merge (0 conflicts, fast-forwardable). Commits, oldest→newest:

| Commit | Theme |
|---|---|
| `259d090` | buyer-pipeline activation + entity-graph data-quality |
| `5ef9d6c` | backfill anchor councils + ACCHOs into `goods_procurement_entities` |
| `b843ee9` | de-noise grant scoring — source/provider disqualifiers + SEDI signal **(Phase-3 dep)** |
| `d9a40cc` | source-vector ingest seeder + fellowship scoring carve |
| `c435b74` | seeder net-new path — INSERT + 23505-skip |
| `5910b20` | scope item #3 — capital + procurement pipelines |
| `f8f0bdc` | lock Phase 3 as build priority |
| `a2831bb` | **Phase 3 — open-tender (ATM) ingestion (this work)** |

If you'd rather land Phase-3 alone, tell me and I'll split it out once the scoring-noise branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)