### PR TITLE
feat(goods): Phase 1 — surface capital/procurement + repeat-buyer intel

### DIFF
--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -14,6 +14,7 @@ interface Grant extends GrantListItem {
   geography?: string | null;
   aligned_projects?: string[] | null;
   grant_type?: string | null;
+  discovery_method?: string | null;
 }
 
 interface CoverageRow {
@@ -137,6 +138,26 @@ interface ActiveProjectPreset extends Omit<ProjectPreset, 'terms'> {
 
 const RESEARCH_SOURCES = new Set(['arc-grants', 'nhmrc']);
 const RESEARCH_TERMS = ['research', 'fellowship', 'scholarship', 'phd', 'postdoctoral', 'clinical trial', 'discovery project'];
+
+// Funding-type segmentation by discovery_method (set by the source-vector seed +
+// open-tender feed). Capital = loans-with-grant-features (IBA/NAIF/Many Rivers/ABA);
+// Procurement = the demand side (Supply Nation + AusTender open tenders); Grant =
+// everything else, including uncategorised rows (so nothing disappears by default).
+const METHOD_CHIPS = [
+  { value: '', label: 'All types', hint: 'capital, procurement and grants' },
+  { value: 'capital', label: 'Capital', hint: 'loans-with-grant: IBA Start-Up Finance, NAIF, Many Rivers, ABA' },
+  { value: 'procurement', label: 'Procurement', hint: 'demand side: Supply Nation + AusTender open tenders' },
+  { value: 'grant', label: 'Grants', hint: 'competitive grant programs' },
+] as const;
+
+function matchesDiscoveryMethod(grant: Grant, method: string): boolean {
+  if (!method) return true;
+  const dm = normalize(grant.discovery_method);
+  if (method === 'capital') return dm === 'indigenous-finance';
+  if (method === 'procurement') return dm === 'procurement';
+  if (method === 'grant') return dm !== 'indigenous-finance' && dm !== 'procurement';
+  return true;
+}
 
 function normalize(value: string | null | undefined): string {
   return (value || '').toLowerCase();
@@ -589,6 +610,7 @@ interface SearchParams {
   include_research?: string;
   family?: string;
   quality?: string;
+  method?: string;
 }
 
 export default async function GrantsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
@@ -608,6 +630,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
   const projectFilter = params.project || '';
   const familyFilter = params.family || '';
   const qualityFilter = params.quality || '';
+  const methodFilter = params.method || '';
   const activeProjectPreset = enrichProjectPreset(findProjectPreset(projectFilter));
   const includeResearchParam = params.include_research === '1';
   const includeResearch = shouldIncludeResearch(query, sourceFilter, programTypeFilter, includeResearchParam);
@@ -631,6 +654,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
     !familyFilter &&
     !qualityFilter &&
     !includeResearchParam &&
+    !methodFilter &&
     page === 1;
 
   const supabase = getServiceSupabase();
@@ -658,7 +682,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
       const { data: semanticDetails } = semanticIds.length > 0
         ? await supabase
             .from(PUBLIC_GRANTS_LIST_TABLE)
-            .select('id, program, program_type, grant_type, source, status, sources, created_at, updated_at, last_verified_at, focus_areas, target_recipients, geography, aligned_projects')
+            .select('id, program, program_type, grant_type, source, status, sources, created_at, updated_at, last_verified_at, focus_areas, target_recipients, geography, aligned_projects, discovery_method')
             .in('id', semanticIds)
         : { data: [] };
       const semanticDetailMap = new Map(
@@ -686,6 +710,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
         target_recipients: semanticDetailMap.get(r.id)?.target_recipients ?? [],
         geography: semanticDetailMap.get(r.id)?.geography ?? null,
         aligned_projects: semanticDetailMap.get(r.id)?.aligned_projects ?? [],
+        discovery_method: semanticDetailMap.get(r.id)?.discovery_method ?? null,
         similarity: r.similarity,
       }));
 
@@ -708,6 +733,9 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
       }
       if (activeProjectPreset) {
         grants = grants.filter(g => matchesProjectPreset(g, activeProjectPreset));
+      }
+      if (methodFilter) {
+        grants = grants.filter(g => matchesDiscoveryMethod(g, methodFilter));
       }
       if (familyFilter) {
         grants = grants.filter(g => matchesSourceFamily(g, familyFilter));
@@ -757,6 +785,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
       'target_recipients',
       'geography',
       'aligned_projects',
+      'discovery_method',
       'source',
       'status',
       'sources',
@@ -797,6 +826,14 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
       dbQuery = dbQuery.eq('program_type', programTypeFilter);
     }
 
+    // Capital/procurement are tiny sets; pin them at the DB so they survive the
+    // candidate cap. 'grant' is the majority — handled by the client residual filter.
+    if (methodFilter === 'capital') {
+      dbQuery = dbQuery.eq('discovery_method', 'indigenous-finance');
+    } else if (methodFilter === 'procurement') {
+      dbQuery = dbQuery.eq('discovery_method', 'procurement');
+    }
+
     if (closingFilter === '30') {
       dbQuery = dbQuery.gt('closes_at', new Date().toISOString());
       dbQuery = dbQuery.lt('closes_at', new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString());
@@ -829,6 +866,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
       .filter((grant) => matchesSearchText(grant, query))
       .filter((grant) => matchesGeography(grant, geoFilter))
       .filter((grant) => matchesProjectPreset(grant, activeProjectPreset))
+      .filter((grant) => matchesDiscoveryMethod(grant, methodFilter))
       .filter((grant) => matchesSourceFamily(grant, familyFilter))
       .filter((grant) => matchesQuality(grant, qualityFilter))
       .filter((grant) => includeResearch || !isResearchHeavy(grant));
@@ -902,6 +940,7 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
   if (sourceFilter) filterParams.set('source', sourceFilter);
   if (programTypeFilter) filterParams.set('program_type', programTypeFilter);
   if (projectFilter) filterParams.set('project', projectFilter);
+  if (methodFilter) filterParams.set('method', methodFilter);
   if (includeResearchParam) filterParams.set('include_research', '1');
   if (familyFilter) filterParams.set('family', familyFilter);
   if (qualityFilter) filterParams.set('quality', qualityFilter);
@@ -938,6 +977,8 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
     if (nextProgramType) next.set('program_type', nextProgramType);
     const nextProject = updates.project ?? projectFilter;
     if (nextProject) next.set('project', nextProject);
+    const nextMethod = updates.method ?? methodFilter;
+    if (nextMethod) next.set('method', nextMethod);
     const nextIncludeResearch = updates.include_research ?? (includeResearchParam ? '1' : '');
     if (nextIncludeResearch) next.set('include_research', nextIncludeResearch);
     return `/grants?${next.toString()}`;
@@ -1043,11 +1084,35 @@ export default async function GrantsPage({ searchParams }: { searchParams: Promi
         )}
       </div>
 
+      <div className="mb-4 border border-bauhaus-black/10 rounded-lg bg-white p-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-black">Funding type</div>
+            <div className="text-xs text-bauhaus-muted mt-0.5">
+              Capital (loans-with-grant), procurement (tenders &amp; supply), or competitive grants.
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {METHOD_CHIPS.map((chip) => (
+              <a
+                key={chip.value || 'all'}
+                href={hrefFor({ method: chip.value })}
+                title={chip.hint}
+                className={`px-3 py-1.5 text-xs font-semibold rounded-full transition-colors ${methodFilter === chip.value ? 'bg-bauhaus-blue text-white' : 'bg-bauhaus-canvas text-bauhaus-muted hover:bg-bauhaus-black/10'}`}
+              >
+                {chip.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+
       {/* Search bar */}
       <form method="get" className="flex gap-2 mb-3">
         <input type="hidden" name="type" value={grantType} />
         <input type="hidden" name="mode" value={searchMode} />
         {projectFilter && <input type="hidden" name="project" value={projectFilter} />}
+        {methodFilter && <input type="hidden" name="method" value={methodFilter} />}
         {familyFilter && <input type="hidden" name="family" value={familyFilter} />}
         {qualityFilter && <input type="hidden" name="quality" value={qualityFilter} />}
         {includeResearchParam && <input type="hidden" name="include_research" value="1" />}

--- a/apps/web/src/app/org/[slug]/wiki/goods-signals/page.tsx
+++ b/apps/web/src/app/org/[slug]/wiki/goods-signals/page.tsx
@@ -74,7 +74,7 @@ export default async function GoodsSignalsWorkbenchPage({
   const closingSoon = sp.closing === 'soon';
   const typeFilter = sp.type;
 
-  const { signals: allSignals, summary } = await getGoodsSignalsWorkbench({
+  const { signals: allSignals, summary, capital_opportunities } = await getGoodsSignalsWorkbench({
     status: statusFilter,
     priority: sp.priority,
     state: sp.state,
@@ -131,6 +131,27 @@ export default async function GoodsSignalsWorkbenchPage({
           <SummaryCell label="Likely" value={summary.by_confidence.likely || 0} accent />
           <SummaryCell label="Possible" value={summary.by_confidence.possible || 0} />
         </div>
+
+        {/* Capital pipeline — standalone (not signal-bound) */}
+        {capital_opportunities.length > 0 && (
+          <div className="mb-6 border-4 border-bauhaus-black bg-white p-4">
+            <div className="mb-2 flex items-baseline justify-between">
+              <h2 className="text-sm font-black uppercase tracking-widest text-bauhaus-black">Capital pipeline ({capital_opportunities.length})</h2>
+              <span className="text-[10px] uppercase tracking-widest text-gray-500">loans-with-grant · IBA / NAIF / Many Rivers · not signal-bound</span>
+            </div>
+            <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {capital_opportunities.map(c => (
+                <li key={c.id} className="border-2 border-bauhaus-black p-2 text-xs">
+                  <div className="flex items-start justify-between gap-2">
+                    <Link href={`/grants/${c.id}`} className="font-black hover:underline">{c.name.slice(0, 60)}{c.name.length > 60 ? '…' : ''}</Link>
+                    <span className="shrink-0 rounded-sm bg-bauhaus-blue px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wider text-white">Capital</span>
+                  </div>
+                  <div className="mt-1 text-gray-700">{c.provider?.slice(0, 32) || '—'} · {money(c.amount_max)} · score {c.goods_relevance_score}</div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {/* Toolbar: view switcher + search */}
         <ToolbarRow slug={slug} sp={sp} view={view} />
@@ -266,6 +287,8 @@ function SignalCard({ signal, orgSlug }: { signal: GoodsSignalRow; orgSlug: stri
               {signal.matched_grants.slice(0, 3).map(g => (
                 <li key={g.id} className="border-l-2 border-bauhaus-black pl-2">
                   <Link href={`/grants/${g.id}`} className="font-black hover:underline">{g.name.slice(0, 65)}{g.name.length > 65 ? '…' : ''}</Link>
+                  {g.discovery_method === 'procurement' && <span className="ml-1 rounded-sm bg-bauhaus-black px-1 py-0.5 text-[9px] font-black uppercase tracking-wider text-bauhaus-yellow">Procurement</span>}
+                  {g.discovery_method === 'indigenous-finance' && <span className="ml-1 rounded-sm bg-bauhaus-blue px-1 py-0.5 text-[9px] font-black uppercase tracking-wider text-white">Capital</span>}
                   <div className="text-gray-700">
                     {g.provider?.slice(0, 30) || '—'} · {g.geography || '—'} · {money(g.amount_max)} · closes {relDate(g.closes_at)} · score {g.goods_relevance_score}
                   </div>

--- a/apps/web/src/lib/services/goods-signals-workbench.ts
+++ b/apps/web/src/lib/services/goods-signals-workbench.ts
@@ -32,6 +32,7 @@ export type GoodsSignalRow = {
     geography: string | null;
     closes_at: string | null;
     goods_relevance_score: number | null;
+    discovery_method: string | null;
   }>;
   matched_foundations: Array<{
     id: string;
@@ -61,9 +62,25 @@ export type GoodsSignalsSummary = {
   with_buyer: number;
 };
 
+// Capital opportunities (loans-with-grant-features: IBA / NAIF / Many Rivers) live
+// in grant_opportunities as discovery_method='indigenous-finance' rows. They are NOT
+// tied to a demand signal, so they can't surface in the signal cards — this standalone
+// list is the workbench's window onto Goods' capital pipeline.
+export type GoodsCapitalOpportunity = {
+  id: string;
+  name: string;
+  provider: string | null;
+  amount_max: number | null;
+  geography: string | null;
+  closes_at: string | null;
+  goods_relevance_score: number | null;
+  url: string | null;
+};
+
 export type GoodsSignalsWorkbench = {
   signals: GoodsSignalRow[];
   summary: GoodsSignalsSummary;
+  capital_opportunities: GoodsCapitalOpportunity[];
 };
 
 const DEFAULT_LIMIT = 200;
@@ -185,7 +202,7 @@ export async function getGoodsSignalsWorkbench({
   const [communitiesData, buyersData, grantsData, foundationsData] = await Promise.all([
     fetchChunked('goods_communities', 'id, community_name, state, postcode, priority', communityIds),
     fetchChunked('goods_procurement_entities', 'id, entity_name, buyer_role', buyerIds),
-    fetchChunked('grant_opportunities', 'id, name, provider, amount_max, geography, closes_at, goods_relevance_score', grantIds),
+    fetchChunked('grant_opportunities', 'id, name, provider, amount_max, geography, closes_at, goods_relevance_score, discovery_method', grantIds),
     fetchChunked('foundations', 'id, name, total_giving_annual, geographic_focus, thematic_focus', foundationIds),
   ]);
   const communityMap = new Map(communitiesData.map((c: any) => [c.id, c]));
@@ -353,5 +370,15 @@ export async function getGoodsSignalsWorkbench({
     if (s.buyer) summary.with_buyer++;
   }
 
-  return { signals, summary };
+  // Capital pipeline — standalone (not signal-bound). High-fit indigenous-finance rows.
+  const { data: capitalRows } = await db
+    .from('grant_opportunities')
+    .select('id, name, provider, amount_max, geography, closes_at, goods_relevance_score, url')
+    .eq('discovery_method', 'indigenous-finance')
+    .gte('goods_relevance_score', 50)
+    .order('goods_relevance_score', { ascending: false, nullsFirst: false })
+    .limit(25);
+  const capital_opportunities = (capitalRows || []) as GoodsCapitalOpportunity[];
+
+  return { signals, summary, capital_opportunities };
 }

--- a/scripts/goods-repeat-buyer-intel.mjs
+++ b/scripts/goods-repeat-buyer-intel.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * goods-repeat-buyer-intel.mjs — Goods Phase 1 (surface what exists; READ-ONLY)
+ *
+ * Mines `austender_contracts` (~672K rows) BY BUYER for government agencies that
+ * REPEATEDLY purchase Goods-type products (beds / mattresses / whitegoods /
+ * furniture / linen / laundry). Output = a ranked report of the warmest
+ * procurement targets for Goods on Country.
+ *
+ * Inverse of hydrate-goods-procurement.mjs, which groups by SUPPLIER (who Goods
+ * competes with). This groups by buyer_name — the DEMAND side, who to sell to.
+ *
+ * NO DB WRITES this phase. `--apply` is reserved (no-op) so a later phase can
+ * promote top buyers into goods_procurement_entities / _signals.
+ *
+ * Run: node --env-file=.env scripts/goods-repeat-buyer-intel.mjs
+ *
+ * Plan: 2026-05-28-goods-phase1-discovery-surface
+ */
+import { psql } from './lib/psql.mjs';
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const APPLY = process.argv.includes('--apply');
+const TOP_N = 60;
+const MIN_CONTRACTS = 2; // "repeat" buyer
+
+// Goods product words — mirrors GOODS_KEYWORDS in hydrate-goods-procurement.mjs
+// and sync-austender-open-tenders.mjs. Word-boundary matched (\m) to avoid
+// 'bed' → 'seabed'/'embedded' noise.
+const GOODS_KEYWORDS = [
+  'furniture', 'bed', 'mattress', 'housing', 'accommodation',
+  'white goods', 'whitegood', 'appliance', 'washing', 'refrigerat', 'linen',
+  'fitout', 'fit-out', 'furnish', 'kitchen', 'laundry',
+  'fridge', 'freezer', 'dryer',
+];
+// UNSPSC families that ARE Goods product (assigned by the agency = authoritative):
+//   56xx furniture/furnishings · 5210 floor coverings · 5212 bedding/linen ·
+//   5213 kitchenware · 5214 domestic appliances (whitegoods). Excludes 5216/5217.
+const GOODS_UNSPSC_PREFIXES = ['5210', '5212', '5213', '5214'];
+
+const KW_REGEX = `\\m(${GOODS_KEYWORDS.join('|')})`;
+const GOODS_PREDICATE = `(
+    title ~* '${KW_REGEX}'
+    OR category ~* '${KW_REGEX}'
+    OR category LIKE 'UNSPSC:56%'
+    ${GOODS_UNSPSC_PREFIXES.map(p => `OR category LIKE 'UNSPSC:${p}%'`).join('\n    ')}
+  )`;
+
+// Buyer-relevance gate for the actionable shortlist: agencies whose remit is
+// housing / community / First Nations / local-govt — the buyers a remote-community
+// bed+washer enterprise can realistically sell to (vs Defence/ATO office furniture).
+const BUYER_RELEVANCE = `buyer_name ~* '\\m(housing|communit|aborigin|indigenous|first nation|torres|land council|regional council|shire|district council|remote)'`;
+
+// Parse a Postgres array literal like {"a","b, c",NULL} → string[]
+function parsePgArray(raw) {
+  if (!raw || raw === '{}' || raw === 'NULL') return [];
+  const body = raw.replace(/^\{/, '').replace(/\}$/, '');
+  const out = [];
+  let cur = '', inQ = false;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '"') {
+      if (inQ && body[i + 1] === '"') { cur += '"'; i++; continue; }
+      inQ = !inQ; continue;
+    }
+    if (ch === ',' && !inQ) { out.push(cur); cur = ''; continue; }
+    cur += ch;
+  }
+  if (cur) out.push(cur);
+  return out.map(s => s.trim()).filter(s => s && s !== 'NULL');
+}
+
+const money = (n) => `$${Math.round(Number(n) || 0).toLocaleString('en-AU')}`;
+
+function main() {
+  console.log('=== Goods repeat-buyer intelligence (austender_contracts, read-only) ===\n');
+
+  // 1. Headline diagnostics — how much goods demand is in the table at all.
+  const [diag] = psql(`
+    SELECT
+      COUNT(*) AS goods_contracts,
+      COUNT(DISTINCT buyer_name) FILTER (WHERE buyer_name IS NOT NULL AND buyer_name <> '') AS distinct_buyers,
+      ROUND(SUM(COALESCE(contract_value,0))::numeric, 0) AS total_value
+    FROM austender_contracts
+    WHERE ${GOODS_PREDICATE};
+  `, { timeout: 300000, label: 'goods-buyer-diag' });
+  console.log(`Goods-matching contracts: ${diag.goods_contracts}`);
+  console.log(`Distinct buyers:          ${diag.distinct_buyers}`);
+  console.log(`Total contract value:     ${money(diag.total_value)}\n`);
+
+  // 2. Ranked repeat buyers (the report core).
+  const rows = psql(`
+    SELECT
+      buyer_name,
+      COUNT(*) AS contract_count,
+      ROUND(SUM(COALESCE(contract_value,0))::numeric, 0) AS total_value,
+      MIN(EXTRACT(YEAR FROM contract_start))::int AS first_year,
+      MAX(EXTRACT(YEAR FROM contract_start))::int AS last_year,
+      COUNT(DISTINCT EXTRACT(YEAR FROM contract_start)) AS active_years,
+      (array_agg(DISTINCT left(title, 90)) FILTER (WHERE title IS NOT NULL))[1:3] AS sample_titles
+    FROM austender_contracts
+    WHERE buyer_name IS NOT NULL AND buyer_name <> ''
+      AND ${GOODS_PREDICATE}
+    GROUP BY buyer_name
+    HAVING COUNT(*) >= ${MIN_CONTRACTS}
+    ORDER BY contract_count DESC, total_value DESC
+    LIMIT ${TOP_N};
+  `, { timeout: 300000, label: 'goods-buyer-rank' });
+
+  console.log(`Top ${rows.length} repeat buyers (>= ${MIN_CONTRACTS} goods contracts):\n`);
+  rows.slice(0, 15).forEach((r, i) => {
+    console.log(`${String(i + 1).padStart(2)}. ${r.buyer_name}`);
+    console.log(`    ${r.contract_count} contracts · ${money(r.total_value)} · ${r.first_year}–${r.last_year} (${r.active_years} active yrs)`);
+  });
+
+  // 2b. Actionable shortlist — repeat buyers whose remit fits Goods (housing /
+  //     community / First Nations / local-govt). This is the warm-targets table.
+  const relevantRows = psql(`
+    SELECT
+      buyer_name,
+      COUNT(*) AS contract_count,
+      ROUND(SUM(COALESCE(contract_value,0))::numeric, 0) AS total_value,
+      MIN(EXTRACT(YEAR FROM contract_start))::int AS first_year,
+      MAX(EXTRACT(YEAR FROM contract_start))::int AS last_year,
+      COUNT(DISTINCT EXTRACT(YEAR FROM contract_start)) AS active_years,
+      (array_agg(DISTINCT left(title, 90)) FILTER (WHERE title IS NOT NULL))[1:3] AS sample_titles
+    FROM austender_contracts
+    WHERE buyer_name IS NOT NULL AND buyer_name <> ''
+      AND ${BUYER_RELEVANCE}
+      AND ${GOODS_PREDICATE}
+    GROUP BY buyer_name
+    HAVING COUNT(*) >= ${MIN_CONTRACTS}
+    ORDER BY contract_count DESC, total_value DESC
+    LIMIT ${TOP_N};
+  `, { timeout: 300000, label: 'goods-buyer-relevant' });
+
+  console.log(`\nWarm targets (housing/community/First Nations remit): ${relevantRows.length}`);
+  relevantRows.slice(0, 10).forEach((r, i) => {
+    console.log(`  ${String(i + 1).padStart(2)}. ${r.buyer_name} — ${r.contract_count} contracts · ${money(r.total_value)}`);
+  });
+
+  // 3. Write report artifacts. Date in AEST (Goods is QLD/Jinibara Country) so it
+  //    lines up with the working day, not UTC.
+  const date = new Date().toLocaleDateString('en-CA', { timeZone: 'Australia/Brisbane' });
+  const mdPath = `thoughts/shared/reports/goods-repeat-buyers-${date}.md`;
+  const jsonPath = `thoughts/shared/reports/goods-repeat-buyers-${date}.json`;
+  mkdirSync(dirname(mdPath), { recursive: true });
+
+  const buildTable = (list) => list.map((r, i) => {
+    const titles = parsePgArray(r.sample_titles).map(t => t.replace(/\|/g, '/')).join('; ');
+    return `| ${i + 1} | ${(r.buyer_name || '').replace(/\|/g, '/')} | ${r.contract_count} | ${money(r.total_value)} | ${r.first_year}–${r.last_year} | ${r.active_years} | ${titles} |`;
+  }).join('\n');
+  const header = `| # | Buyer (agency) | Contracts | Total value | Years | Active yrs | Sample titles |\n|---|----------------|-----------|-------------|-------|------------|---------------|`;
+
+  const md = `# Goods on Country — repeat government buyers (procurement targets)
+
+**Generated:** ${date} · \`scripts/goods-repeat-buyer-intel.mjs\` (read-only, no DB writes)
+**Source:** \`austender_contracts\` (AusTender OCDS federal awarded contracts, ~672K rows)
+**Method:** group by \`buyer_name\`, keep buyers with ≥${MIN_CONTRACTS} contracts matching Goods product (word-boundary keyword on title/category OR Goods UNSPSC family 56 / 5210 / 5212 / 5213 / 5214). Ranked by contract count, then total value.
+
+> These are agencies that **repeatedly buy beds / whitegoods / furniture / linen** — the warmest demand-side targets for Goods. A purchase order beats a grant and repeats. Verify each before outreach: AusTender records awarded *federal* contracts only (state/NT procurement is in separate tables), and keyword matching can still admit adjacent categories — read the sample titles.
+
+## Headline
+- **${diag.goods_contracts}** goods-matching federal contracts across **${diag.distinct_buyers}** distinct buyers, **${money(diag.total_value)}** total.
+- **${relevantRows.length}** of those buyers have a housing / community / First Nations / local-government remit — the actionable shortlist below. The raw top-${rows.length} list (which Defence & ATO dominate with barracks/office furniture) follows as context only.
+
+## ⭐ Warm targets — housing / community / First Nations buyers
+Filtered to buyers whose remit fits a remote-community bed+washer enterprise (\`housing|communit|aborigin|indigenous|first nation|torres|land council|regional council|shire|district council|remote\`).
+
+${header}
+${buildTable(relevantRows)}
+
+## All repeat buyers (context — includes off-target agencies)
+${header}
+${buildTable(rows)}
+
+## Caveats / provenance
+- **Federal only.** \`austender_contracts\` is the AusTender OCDS feed (federal). NT/state remote-housing procurement (the $4B whale, Phase 4) is **not** here.
+- **Awarded, not open.** These are past awards (demand signal), not open tenders. Open tenders are the Phase-3 \`austender-open-tenders\` feed in \`grant_opportunities\`.
+- **Keyword recall vs precision.** \`bed\`/\`linen\`/\`kitchen\` are word-boundary matched but adjacent categories can still appear — the sample titles are there to sanity-check each row.
+- **No DB writes.** \`--apply\` is reserved; promoting top buyers into \`goods_procurement_entities\`/\`_signals\` is a later-phase decision.
+`;
+
+  writeFileSync(mdPath, md);
+  writeFileSync(jsonPath, JSON.stringify({ generated: date, diagnostics: diag, warm_targets: relevantRows, all_repeat_buyers: rows }, null, 2));
+  console.log(`\n✓ Wrote ${mdPath}`);
+  console.log(`✓ Wrote ${jsonPath}`);
+  if (APPLY) console.log('\n(--apply is a reserved no-op this phase; no DB writes performed.)');
+}
+
+main();

--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -1017,6 +1017,14 @@ export const AGENTS = {
     timeoutMs: 300_000,
     dependencies: ['goods-community-census'],
   },
+  'goods-repeat-buyer-intel': {
+    command: ['node', '--env-file=.env', 'scripts/goods-repeat-buyer-intel.mjs'],
+    displayName: 'Goods Repeat-Buyer Intel (procurement targets)',
+    category: 'goods',
+    defaultPriority: 3,
+    timeoutMs: 300_000,
+    dependencies: ['sync-austender-contracts'],
+  },
   'sync-ghl-goods-buyers': {
     command: ['node', '--env-file=.env', '--env-file=apps/web/.env.local', 'scripts/sync-ghl-goods-buyers.mjs'],
     displayName: 'Sync GHL Goods Buyers',

--- a/thoughts/shared/plans/2026-05-28-goods-phase1-discovery-surface.md
+++ b/thoughts/shared/plans/2026-05-28-goods-phase1-discovery-surface.md
@@ -1,0 +1,63 @@
+---
+title: Goods Phase 1 — surface capital/procurement (discovery_method) + repeat-buyer intel
+status: approved — building (2026-05-28). D1=report-only · D2=include B (minimal) · D3=Grant bucket = not-capital/procurement.
+date: 2026-05-28
+repo: grantscope
+branch: wip/goods-phase1-discovery-surface-2026-05-28
+worktree: .claude/worktrees/goods-phase1-a1b2c3
+base: origin/main @ d3d19ab
+related:
+  - thoughts/shared/plans/2026-05-27-goods-capital-procurement-pipelines-scope.md (Phase 1 def)
+  - thoughts/shared/handoffs/goods-capital-procurement-scoping-2026-05-27.md (file:line map)
+---
+
+# Goods Phase 1 — Surface what already exists
+
+**Goal:** make the capital + procurement opportunities (already in `grant_opportunities`, tagged `discovery_method ∈ {indigenous-finance, procurement}`) and the 672K-row `austender_contracts` asset *visible* — no new ingestion. Three independent, additive, low-risk changes.
+
+## Pre-work facts (verified this session)
+- `discovery_method` is NOT selected or filtered anywhere in `/grants` (`apps/web/src/app/grants/page.tsx`). DB values seen: `indigenous-finance`, `procurement`, `grant`, plus crawler tags (`scraper`, `data.gov.au`, `open-data-api`, null).
+- `FilterBar` (`apps/web/src/app/components/filter-bar.tsx`) is just a mobile-toggle wrapper; the chips render as `children` built inside `page.tsx`.
+- Workbench (`goods-signals-workbench.ts:188`) joins matched grants but selects no `discovery_method`. It is **signal-centric** — capital opps (no procurement signal) don't map to a signal row.
+- `austender_contracts` columns: `buyer_name`, `buyer_id`, `supplier_name`, `supplier_abn`, `title`, `category` (UNSPSC), `contract_value`, `contract_start`, `ocid`.
+- `hydrate-goods-procurement.mjs` groups by **supplier** (who Goods competes with). Repeat-buyer intel groups by **buyer_name** (who to sell to) — the inverse.
+- `exec_sql` RPC is PostgREST-1000-row capped → paginate at 900 (pattern already in hydrate script).
+
+## Task A — `discovery_method` filter chip on `/grants` (S, frontend)
+**Files:** `apps/web/src/app/grants/page.tsx` (only).
+1. Add `discovery_method?: string | null` to the `Grant` interface (`:11`).
+2. Add `'discovery_method'` to the non-semantic `grantFields` select (`:743-766`) and the semantic detail select (`:661`); carry it through the semantic `.map` (`:668-690`).
+3. Add `method?: string` to `SearchParams` (`:574`); parse `methodFilter = params.method || ''` (`:~608`); add `!methodFilter` to the `isFastGrantIndex` guard (`:617`).
+4. Filter:
+   - non-semantic path: map chip→DB. Capital→`.eq('discovery_method','indigenous-finance')`; Procurement→`.eq('discovery_method','procurement')`; Grant→`.not('discovery_method','in','("indigenous-finance","procurement")')` OR is-null (i.e. "everything that isn't capital/procurement"). Add near the other `.eq` filters (`:792-798`).
+   - semantic path: mirror with a client `.filter` (`:709-717` block).
+5. Render a chip group (All · Capital · Procurement · Grant) in the filter JSX, mirroring the existing project-preset chip markup. Bauhaus styling consistent with siblings.
+**Acceptance:** `?method=capital` shows only the ~6 indigenous-finance rows (IBA/NAIF/Many Rivers/ABA/ILSC…); `?method=procurement` shows Supply Nation + the 2 AusTender open-tenders; chip persists across other filters; `tsc` + `next build` clean.
+
+## Task B — capital/procurement labels in the goods workbench (S–M, reframed)
+The signals workbench can't host a "capital section" cleanly (capital opps aren't signals). Minimal honest change:
+**Files:** `goods-signals-workbench.ts` + its page `org/[slug]/wiki/goods-signals/page.tsx`.
+1. Add `discovery_method` to the matched-grant select (`:188`) and to the matched-grant type, so procurement-tagged matched grants render a "Procurement" label/badge.
+2. Add a standalone **"Capital opportunities"** read-only panel: one extra query `grant_opportunities` where `discovery_method='indigenous-finance'` AND `goods_relevance_score >= 50`, ordered by score — listed independent of signals (IBA, NAIF, etc.). Mirrors how the page already lists matched grants.
+**Acceptance:** workbench shows a Capital panel with the indigenous-finance rows + procurement matched-grants badged; `tsc` + build clean. *(If Ben prefers, defer B — A+C deliver most of the value.)*
+
+## Task C — repeat-buyer intelligence (S, new read-only script)
+**File:** `scripts/goods-repeat-buyer-intel.mjs` (new) + register in `scripts/lib/agent-registry.mjs`.
+- Query `austender_contracts`, `GROUP BY buyer_name`, `WHERE (title ILIKE goods-keyword OR category goods-UNSPSC)`, ranked by `contract_count DESC, total_goods_value DESC`. Reuse `GOODS_KEYWORDS` from hydrate + the UNSPSC allowlist from `sync-austender-open-tenders.mjs` (family 56 + 5210/5212/5213/5214).
+- Paginate via `exec_sql` at 900 rows.
+- **Output: report-only, no DB writes this phase.** Write `thoughts/shared/reports/goods-repeat-buyers-<date>.md` + `.json` — ranked govt buyers who repeatedly purchase Goods-type products = warmest procurement targets. `--apply` flag reserved (no-op for now) so a later phase can promote top buyers into `goods_procurement_entities`/`_signals`.
+**Acceptance:** script runs against the live DB, emits a ranked report (top ~30 buyers with count + $ + sample contract titles); spot-check 3 rows against `austender_contracts`; zero DB mutations.
+
+## Build order & commits
+1. Task C first (self-contained, no UI risk, highest "surface the asset" value) → commit.
+2. Task A (filter chip) → `tsc` + build → commit.
+3. Task B (workbench) → `tsc` + build → commit.
+Each task = its own commit with `Plan: 2026-05-28-goods-phase1-discovery-surface` trailer. Then push branch + open PR (Tier 3 — on Ben's go).
+
+## Decisions for Ben
+- **D1 — Task C output:** report-only (no DB write) this phase? *(my default: yes — keep Phase 1 read-only; promote-to-CRM is a Phase-1.5/2 follow-up.)*
+- **D2 — Include Task B**, or ship A+C and defer the workbench? *(my default: include B but keep it minimal — the Capital panel is the genuinely new surface.)*
+- **D3 — chip "Grant" bucket semantics:** "not capital/procurement" (incl. nulls) vs only `discovery_method='grant'`. *(my default: not-capital/procurement, so nothing disappears from the default view.)*
+
+## Out of scope (later phases)
+New ingestion (Phase 3 done), capital freshness crawler + GHL Capital flow (Phase 2), NT $4B housing (Phase 4), promoting repeat-buyers into the CRM.

--- a/thoughts/shared/plans/2026-05-28-goods-phase1-discovery-surface.md
+++ b/thoughts/shared/plans/2026-05-28-goods-phase1-discovery-surface.md
@@ -1,6 +1,6 @@
 ---
 title: Goods Phase 1 — surface capital/procurement (discovery_method) + repeat-buyer intel
-status: approved — building (2026-05-28). D1=report-only · D2=include B (minimal) · D3=Grant bucket = not-capital/procurement.
+status: BUILT (2026-05-28) — C=0fc6e11 · A=1778d7c · B=f6ab6af on wip/goods-phase1-discovery-surface-2026-05-28. tsc + next build clean; 3 buyer rows verified vs live DB. NOT pushed/PR'd (Tier 3 — awaiting Ben's verb). D1=report-only · D2=include B (minimal) · D3=Grant bucket = not-capital/procurement.
 date: 2026-05-28
 repo: grantscope
 branch: wip/goods-phase1-discovery-surface-2026-05-28

--- a/thoughts/shared/reports/goods-repeat-buyers-2026-05-28.json
+++ b/thoughts/shared/reports/goods-repeat-buyers-2026-05-28.json
@@ -1,0 +1,831 @@
+{
+  "generated": "2026-05-28",
+  "diagnostics": {
+    "goods_contracts": "10626",
+    "distinct_buyers": "366",
+    "total_value": "15102785530"
+  },
+  "warm_targets": [
+    {
+      "buyer_name": "NSW Department of Communities and Justice",
+      "contract_count": "236",
+      "total_value": "1571510596",
+      "first_year": "2008",
+      "last_year": "2025",
+      "active_years": "13",
+      "sample_titles": "{\"A Place To Go (APTG) Home - Mackillop Family Services (prj_5068)\",\"Aboriginal Homelessness Support Service\",\"Aboriginal Outreach Casework Project\"}"
+    },
+    {
+      "buyer_name": "NT Department of Infrastructure, Planning and Logistics - Housing Program Office",
+      "contract_count": "91",
+      "total_value": "211957652",
+      "first_year": "2021",
+      "last_year": "2024",
+      "active_years": "4",
+      "sample_titles": "{\"Alice Springs - Central Australia Region - Provision of Remote Housing Maintenance Service\",\"Alice Springs - Mount Nancy Town Camp - Demolition and Construction of Housing on 9 lots\",\"Alice Springs - Panel Contract for Responsive Maintenance Services to Urban Housing for a \"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Housing",
+      "contract_count": "36",
+      "total_value": "39172650",
+      "first_year": "2013",
+      "last_year": "2015",
+      "active_years": "3",
+      "sample_titles": "{\"Alice Springs - Provision of Repairs and Maintenance Services to Evaporative Air Condition\",\"Alice Springs - Provision of Vacate and Planned Works to Department of Housing Assets for \",\"Alice Springs - Real Housing for Growth - Elliott Street Key Worker Rental Initiative Prop\"}"
+    },
+    {
+      "buyer_name": "ACT Community Services Directorate",
+      "contract_count": "23",
+      "total_value": "34719241",
+      "first_year": "2013",
+      "last_year": "2016",
+      "active_years": "3",
+      "sample_titles": "{\"Blue Door Family Service Samaritan House Young Parents Accommodation Support Program Stree\",\"Community Development Services and Social Housing and Homelessness Services\",\"Financial Analysis for Housing and Community Services Total Facilities Management Project\"}"
+    },
+    {
+      "buyer_name": "Department of Families, Housing, Community Services and Indigenous Affairs",
+      "contract_count": "17",
+      "total_value": "3084849",
+      "first_year": "2012",
+      "last_year": "2013",
+      "active_years": "2",
+      "sample_titles": "{45408224,90001410,90001440}"
+    },
+    {
+      "buyer_name": "Dept of Planning, Housing and Infrastructure",
+      "contract_count": "15",
+      "total_value": "33880203",
+      "first_year": "2021",
+      "last_year": "2024",
+      "active_years": "3",
+      "sample_titles": "{\"Architectural Services for the Low and Mid-Rise Housing Pattern Book - Low Rise Apartment \",\"Architectural Services for the Low and Mid-Rise Housing Pattern Book - Semi-Detached Typol\",\"Architectural Services for the Low and Mid-Rise Housing Pattern Book - Terrace Housing Typ\"}"
+    },
+    {
+      "buyer_name": "National Indigenous Australians Agency",
+      "contract_count": "14",
+      "total_value": "1077607",
+      "first_year": "2019",
+      "last_year": "2026",
+      "active_years": "5",
+      "sample_titles": "{NCD09258,NCD09453,NCD09530}"
+    },
+    {
+      "buyer_name": "NT Department of Local Government, Housing and Community Development - Housing Program Delivery",
+      "contract_count": "12",
+      "total_value": "956614",
+      "first_year": "2019",
+      "last_year": "2020",
+      "active_years": "2",
+      "sample_titles": "{\"$100m Stimulus - Alice Springs - Kitchen  Refurbish - Unit 7/57 Albrecht Drive, Larapinta\",\"$100M Stimulus - Alice Springs - Kitchen Refurbishment - 11 Holtermann Court, Larapinta\",\"$100M Stimulus - Alice Springs - Kitchen Refurbishment - 24 Engoordina Drive, Larapinta\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Service Delivery South",
+      "contract_count": "11",
+      "total_value": "12219588",
+      "first_year": "2015",
+      "last_year": "2016",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Provision of Grounds Maintenance, Litter Control and Cleaning Services to \",\"Alice Springs - Provision of Responsive Repairs and Maintenance Works to Department of Hou\",\"Alice Springs - Yulara - Upgrades to Six (6) Government Employee Housing (GEH) Dwellings\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Housing Supply",
+      "contract_count": "9",
+      "total_value": "1442946",
+      "first_year": "2015",
+      "last_year": "2016",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Provision of Marketing and Auctioneering Services of Department of Housing\",\"Alice Springs - Provision of Real Housing for Growth Intitiative - Property and Tenancy Ma\",\"Darwin - Consultancy - Business Documentation Consultancy - Real Housing for Growth\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Service Delivery North",
+      "contract_count": "8",
+      "total_value": "11147665",
+      "first_year": "2015",
+      "last_year": "2016",
+      "active_years": "2",
+      "sample_titles": "{\"Darwin - Batchelor - Provision of Grounds Maintenance, Litter Control and Cleaning Service\",\"Darwin - Provision of Arboreal Services to Department of Housing Assets for a Period of 24\",\"Darwin - Provision of Ground Maintenance, Litter Control and Cleaning Services to Departme\"}"
+    },
+    {
+      "buyer_name": "NT Power and Water Corporation - Remote Services",
+      "contract_count": "8",
+      "total_value": "1406311",
+      "first_year": "2019",
+      "last_year": "2019",
+      "active_years": "1",
+      "sample_titles": "{\"Engagement of Hydraulic Engineering Services to Support the Housing Program Works\",\"Gunbalanya and Ramingining - Construction of New Water and Sewer Infrastructures Related t\",\"Kalkarindji, Lajamanu and Pigeon Hole - Construction of New Water and Sewer Infrastructure\"}"
+    },
+    {
+      "buyer_name": "NT Department of Territory Families, Housing and Communities - Housing Programs and Support Services",
+      "contract_count": "6",
+      "total_value": "4289573",
+      "first_year": "2021",
+      "last_year": "2022",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs, Darwin and Palmerston - Provision of Marketing and Auctioneering Services f\",\"Consultancy - Assess The Economic Viability of Delivery Options and Pilot Sites under the \",\"Darwin - Consultancy - Request for Services under Panel Contract - D18-0031 - Provision of\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing and Community Development - Housing Program Delivery",
+      "contract_count": "6",
+      "total_value": "1782715",
+      "first_year": "2017",
+      "last_year": "2018",
+      "active_years": "2",
+      "sample_titles": "{\"$69m Stimulus - Darwin - Painting, Kitchen Benches and Concreting - 114 Dickward Dr - Coco\",\"$69m Stimulus - Darwin - Roof Replacements - 9 and 10 Bedwell Court, Gray, Palmerston\",\"Darwin - Affordable Housing Head Leased Dwellings -  Servicing of Split System Air Conditi\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Contract Implementation",
+      "contract_count": "6",
+      "total_value": "1729301",
+      "first_year": "2015",
+      "last_year": "2016",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Consultancy - Project  Development for Nyrripi, Kintore and Areyonga  SFNT\",\"Alice Springs - Consultancy - Project Development for SFNT Housing Upgrades in Santa Teres\",\"All Centres - Supply and Delivery of Stoves to Department of Housing for a Period of 12 Mo\"}"
+    },
+    {
+      "buyer_name": "NT Department of Logistics and Infrastructure - Housing Program Office",
+      "contract_count": "5",
+      "total_value": "26410525",
+      "first_year": "2024",
+      "last_year": "2025",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs Region - Mutitjulu And Imanpa - Design, Construction, Demolition and Upgrade\",\"Northern Region - Panel Contract - Design and Construct, Storage and Installation of Modul\",\"Southern Region - Panel Contract - Design and Construct, Storage and Installation of Modul\"}"
+    },
+    {
+      "buyer_name": "NT Department of Logistics and Infrastructure - Housing and Land Services",
+      "contract_count": "3",
+      "total_value": "55191963",
+      "first_year": "2025",
+      "last_year": "2025",
+      "active_years": "1",
+      "sample_titles": "{\"Darwin Region - Wurrumiyanga - Demolition of 45 Dwellings and Construction of 44 Replaceme\",\"Tennant Creek Region - Imangara and Wutungurra (Epenarra) - Security Upgrades and Refurbis\",\"Tennant Creek Region - Rockhampton Downs (Wogyala) and Newcastle Waters - Security Upgrade\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing and Community Development - Remote Program Delivery Office",
+      "contract_count": "3",
+      "total_value": "2546585",
+      "first_year": "2017",
+      "last_year": "2018",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Provision of Marketing and Auctioneering Services for Chief Executive Offi\",\"Housing Maintenance Program - 2017/2018 - Fencing - Supply, Delivery and Installation of F\",\"Nhulunbuy - Groote Eylandt - Consultancy - Architechtural Services to Assist with the Deli\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Executive",
+      "contract_count": "3",
+      "total_value": "1199688",
+      "first_year": "2013",
+      "last_year": "2014",
+      "active_years": "2",
+      "sample_titles": "{\"Darwin - Consultancy - Provision of Probity Assurance Advisor Services - Remote Housing NT\",\"Darwin - Consultancy - Real Housing for Growth - Planning Consultant Runge Street Re-zonin\",\"Darwin, Katherine, Palmerston - Real Housing for Growth Head-Leasing Initiative - Provisio\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing and Community Development - Housing Delivery",
+      "contract_count": "3",
+      "total_value": "648946",
+      "first_year": "2017",
+      "last_year": "2017",
+      "active_years": "1",
+      "sample_titles": "{\"Alice Springs - Provision of Property and Tenancy Management of Affordable Housing Dwellin\",\"Consultancy - Identification, Labelling, Recording and Assessment of Risk and Asbestos Con\",\"Tennant Creek - Provision of Property and Tenancy Management of Affordable Housing Dwellin\"}"
+    },
+    {
+      "buyer_name": "ACT Justice and Community Safety Directorate",
+      "contract_count": "3",
+      "total_value": "280988",
+      "first_year": "2016",
+      "last_year": "2016",
+      "active_years": "1",
+      "sample_titles": "{\"12 Moore St - Lpp Level 4 Fitout\",\"Provision of Linen Supply AMC\",\"Supply and Delivery of Bed lights AMC\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing, Local Government and Community Development - Assets, Infrastructure and Maintenance",
+      "contract_count": "2",
+      "total_value": "5288199",
+      "first_year": "2024",
+      "last_year": "2024",
+      "active_years": "1",
+      "sample_titles": "{\"Alice Springs Region - Repairs and Maintenance of Remote Community Housing and Government \",\"Tennant Creek Region - Repairs and Maintenance of Remote Community Housing and Government \"}"
+    },
+    {
+      "buyer_name": "Department of Communities Tasmania",
+      "contract_count": "2",
+      "total_value": "2996641",
+      "first_year": "2018",
+      "last_year": "2018",
+      "active_years": "1",
+      "sample_titles": "{\"Stronger Remote Aboriginal Services – Cape Barren Island Aboriginal Housing Upgrades\",\"Stronger Remote Aboriginal Services – Flinders Island Aboriginal Housing Upgrades\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing and Community Development - Service Delivery South",
+      "contract_count": "2",
+      "total_value": "2683116",
+      "first_year": "2017",
+      "last_year": "2019",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Provision of Housing Management Services in Alice Springs Town Camps for a\",\"Alice Springs - Provision of Responsive Repairs and Maintenance to Public Housing Assets f\"}"
+    },
+    {
+      "buyer_name": "NT Department of Health - Remote Health",
+      "contract_count": "2",
+      "total_value": "1618940",
+      "first_year": "2013",
+      "last_year": "2013",
+      "active_years": "1",
+      "sample_titles": "{\"Alice Springs - Supply Delivery and Installation of EMERGENCY VEHICLE FITOUT REGO 826 783\",\"Alice Springs, Darwin - Customised Fitout of Remote Emergency Vehicles - Toyota Troop Carr\"}"
+    },
+    {
+      "buyer_name": "NSW Aboriginal Housing Office",
+      "contract_count": "2",
+      "total_value": "497842",
+      "first_year": "2025",
+      "last_year": "2025",
+      "active_years": "1",
+      "sample_titles": "{\"Aboriginal Housing Office Asset Portfolio Review\"}"
+    },
+    {
+      "buyer_name": "NT Department of Local Government, Housing and Community Development - Corporate Services",
+      "contract_count": "2",
+      "total_value": "125814",
+      "first_year": "2019",
+      "last_year": "2020",
+      "active_years": "2",
+      "sample_titles": "{\"Darwin - Public Liability Insurance for Urban Public Housing\",\"Public Liability Insurance for Urban Public Housing\"}"
+    },
+    {
+      "buyer_name": "NT Department of Housing and Community Development - Corporate Services",
+      "contract_count": "2",
+      "total_value": "104671",
+      "first_year": "2018",
+      "last_year": "2018",
+      "active_years": "1",
+      "sample_titles": "{\"Darwin - Provision of Public Liability Insurance for Urban Public Housing\",\"Darwin - Supply Delivery and Installation of Office Furniture for CASCOM 5\"}"
+    },
+    {
+      "buyer_name": "NT Department of Local Government, Housing and Community Development - Remote Program Delivery",
+      "contract_count": "2",
+      "total_value": "91177",
+      "first_year": "2019",
+      "last_year": "2019",
+      "active_years": "1",
+      "sample_titles": "{\"Katherine and Alice Springs - Peppimenarti and Willowra Community - Drone Services for Rem\",\"Request for Quantity Surveyor Services - Housing Upgrades - Utopia Homelands\"}"
+    },
+    {
+      "buyer_name": "NT Department of Territory Families, Housing and Communities - Southern Region",
+      "contract_count": "2",
+      "total_value": "70759",
+      "first_year": "2021",
+      "last_year": "2021",
+      "active_years": "1",
+      "sample_titles": "{\"Alice Springs - Supply and Delivery of Office Furniture\",\"Supply Delivery and Installation of Elliot - Supply and Delivery of Office Furniture\"}"
+    },
+    {
+      "buyer_name": "NT Department of Correctional Services - NT Community Corrections",
+      "contract_count": "2",
+      "total_value": "64658",
+      "first_year": "2014",
+      "last_year": "2016",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Purchase od Two Beds in One Room at Stuart Lodge  for a Period of 14 Month\",\"Alice Springs - Supply and Delivery of Office Furniture\"}"
+    }
+  ],
+  "all_repeat_buyers": [
+    {
+      "buyer_name": "Department of Defence",
+      "contract_count": "3558",
+      "total_value": "364838395",
+      "first_year": "2007",
+      "last_year": "2026",
+      "active_years": "16",
+      "sample_titles": "{1900623817,1900624455,1900624503}"
+    },
+    {
+      "buyer_name": "Services Australia",
+      "contract_count": "1447",
+      "total_value": "171411676",
+      "first_year": "2011",
+      "last_year": "2026",
+      "active_years": "15",
+      "sample_titles": "{8100003176,8100003799,8100004513}"
+    },
+    {
+      "buyer_name": "NT Department of Infrastructure, Planning and Logistics - Infrastructure, Investment and Contracts",
+      "contract_count": "418",
+      "total_value": "470160145",
+      "first_year": "2016",
+      "last_year": "2024",
+      "active_years": "9",
+      "sample_titles": "{\"Alice Spring Region - Nturiya - Remote Community Housing (RCH) Upgrade\",\"Alice Springs - Alice Spring Correctional Centre - Supply and Delivery of Modular Accommod\",\"Alice Springs - Anangu House  - Pandemic Coordination Cell - Fitout\"}"
+    },
+    {
+      "buyer_name": "Homes NSW",
+      "contract_count": "251",
+      "total_value": "419091953",
+      "first_year": "2017",
+      "last_year": "2025",
+      "active_years": "7",
+      "sample_titles": "{\"Architect for Seniors Housing - Merrylands\",\"Architectural and Design Services - Seniors Housing - North St Marys\",\"Architectural Design for Airds Stage 9 Seniors Housing\"}"
+    },
+    {
+      "buyer_name": "NSW Department of Communities and Justice",
+      "contract_count": "236",
+      "total_value": "1571510596",
+      "first_year": "2008",
+      "last_year": "2025",
+      "active_years": "13",
+      "sample_titles": "{\"A Place To Go (APTG) Home - Mackillop Family Services (prj_5068)\",\"Aboriginal Homelessness Support Service\",\"Aboriginal Outreach Casework Project\"}"
+    },
+    {
+      "buyer_name": "Australian Federal Police",
+      "contract_count": "203",
+      "total_value": "9990326",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "13",
+      "sample_titles": "{0030013644,0030017050,0030017950}"
+    },
+    {
+      "buyer_name": "Department of Health and Human Services",
+      "contract_count": "192",
+      "total_value": "619477021",
+      "first_year": "2002",
+      "last_year": "2018",
+      "active_years": "17",
+      "sample_titles": "{\"1 Carbeen Street Mornington Housing Construction\",\"1 Teal Street Claremont Housing Construction\",\"15 Murray St Evandale Housing Construction\"}"
+    },
+    {
+      "buyer_name": "Department of Industry, Science and Resources",
+      "contract_count": "184",
+      "total_value": "13420618",
+      "first_year": "2011",
+      "last_year": "2026",
+      "active_years": "14",
+      "sample_titles": "{\"AI Bendigo Accommodation MOU\",CON000845,CON001652}"
+    },
+    {
+      "buyer_name": "DoE",
+      "contract_count": "138",
+      "total_value": "12570069",
+      "first_year": "2019",
+      "last_year": "2019",
+      "active_years": "1",
+      "sample_titles": "{\"0036-S00004352-002612 - Travel - Accommodation incl meals\",\"0059-S00057655-00002505 -Travel - Accommodation incl meals\",\"0074-S00012244-7787 -Travel - Accommodation incl meals\"}"
+    },
+    {
+      "buyer_name": "Australian Taxation Office",
+      "contract_count": "135",
+      "total_value": "17535647",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "12",
+      "sample_titles": "{06.296-0-2,13.123-0-1,13.129}"
+    },
+    {
+      "buyer_name": "Department of Home Affairs",
+      "contract_count": "131",
+      "total_value": "24272611",
+      "first_year": "2012",
+      "last_year": "2025",
+      "active_years": "13",
+      "sample_titles": "{0070000627,0070006082,0070007286}"
+    },
+    {
+      "buyer_name": "Department of Parliamentary Services",
+      "contract_count": "131",
+      "total_value": "8789007",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "10",
+      "sample_titles": "{0000050855,0000050925,0000050950}"
+    },
+    {
+      "buyer_name": "Department of Foreign Affairs and Trade",
+      "contract_count": "111",
+      "total_value": "23353082",
+      "first_year": "2012",
+      "last_year": "2026",
+      "active_years": "14",
+      "sample_titles": "{4500000529,4500000715,4500000932}"
+    },
+    {
+      "buyer_name": "Department of the House of Representatives",
+      "contract_count": "101",
+      "total_value": "7444955",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "10",
+      "sample_titles": "{CON/GAUCON/CON000022/1,CON000154,D001470}"
+    },
+    {
+      "buyer_name": "Department of the Prime Minister and Cabinet",
+      "contract_count": "99",
+      "total_value": "5791928",
+      "first_year": "2013",
+      "last_year": "2025",
+      "active_years": "12",
+      "sample_titles": "{CA000503,CA005537,CD007856}"
+    },
+    {
+      "buyer_name": "Department of Finance",
+      "contract_count": "93",
+      "total_value": "5995519",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "12",
+      "sample_titles": "{2100003741,2100004380,2100004881}"
+    },
+    {
+      "buyer_name": "NT Department of Infrastructure, Planning and Logistics - Housing Program Office",
+      "contract_count": "91",
+      "total_value": "211957652",
+      "first_year": "2021",
+      "last_year": "2024",
+      "active_years": "4",
+      "sample_titles": "{\"Alice Springs - Central Australia Region - Provision of Remote Housing Maintenance Service\",\"Alice Springs - Mount Nancy Town Camp - Demolition and Construction of Housing on 9 lots\",\"Alice Springs - Panel Contract for Responsive Maintenance Services to Urban Housing for a \"}"
+    },
+    {
+      "buyer_name": "Australian Electoral Commission",
+      "contract_count": "89",
+      "total_value": "21391548",
+      "first_year": "2013",
+      "last_year": "2023",
+      "active_years": "11",
+      "sample_titles": "{$700000.00,001198,001777}"
+    },
+    {
+      "buyer_name": "Department of Agriculture, Fisheries and Forestry",
+      "contract_count": "89",
+      "total_value": "4316559",
+      "first_year": "2013",
+      "last_year": "2021",
+      "active_years": "9",
+      "sample_titles": "{0045077507,0045077715,0045078290}"
+    },
+    {
+      "buyer_name": "Australian Signals Directorate",
+      "contract_count": "87",
+      "total_value": "6190498",
+      "first_year": "2018",
+      "last_year": "2026",
+      "active_years": "8",
+      "sample_titles": "{1900001258,3000384431,3000522246}"
+    },
+    {
+      "buyer_name": "Department of Health and Aged Care",
+      "contract_count": "79",
+      "total_value": "7976024",
+      "first_year": "2012",
+      "last_year": "2022",
+      "active_years": "11",
+      "sample_titles": "{4500103681,4500108637,4500109515}"
+    },
+    {
+      "buyer_name": "Department of Agriculture",
+      "contract_count": "77",
+      "total_value": "7333058",
+      "first_year": "2014",
+      "last_year": "2019",
+      "active_years": "6",
+      "sample_titles": "{21867,22680,22759}"
+    },
+    {
+      "buyer_name": "Attorney-General's Department",
+      "contract_count": "75",
+      "total_value": "6362004",
+      "first_year": "2013",
+      "last_year": "2023",
+      "active_years": "10",
+      "sample_titles": "{0041000641,0041000705,0041001052}"
+    },
+    {
+      "buyer_name": "Department of the Treasury",
+      "contract_count": "68",
+      "total_value": "3882294",
+      "first_year": "2012",
+      "last_year": "2022",
+      "active_years": "11",
+      "sample_titles": "{000503-0,000544-0,000573-0}"
+    },
+    {
+      "buyer_name": "NT Department of Infrastructure - Construction",
+      "contract_count": "66",
+      "total_value": "40829602",
+      "first_year": "2013",
+      "last_year": "2014",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - Design and Construct a New Demountable Office/Training Accommodation for W\",\"Alice Springs Hospital - Fire Indicator Panel Replacement At Nurses Quarters and Wedge Acc\",\"Alice Springs Region  - Health Department - Refurbish Two Accommodation houses - Mandatory\"}"
+    },
+    {
+      "buyer_name": "Australian Securities and Investments Commission",
+      "contract_count": "65",
+      "total_value": "5181651",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "11",
+      "sample_titles": "{003086,003087,003526}"
+    },
+    {
+      "buyer_name": "Austrade",
+      "contract_count": "64",
+      "total_value": "14011475",
+      "first_year": "2010",
+      "last_year": "2025",
+      "active_years": "13",
+      "sample_titles": "{0046000536,0046000607,0046000627}"
+    },
+    {
+      "buyer_name": "Geoscience Australia",
+      "contract_count": "57",
+      "total_value": "4301523",
+      "first_year": "2013",
+      "last_year": "2021",
+      "active_years": "9",
+      "sample_titles": "{32172,33212,33217}"
+    },
+    {
+      "buyer_name": "NT Department of Infrastructure - Building Services",
+      "contract_count": "53",
+      "total_value": "44634323",
+      "first_year": "2014",
+      "last_year": "2016",
+      "active_years": "3",
+      "sample_titles": "{\"Alice Springs Region - 1620 Larapinta Drive - Simpson's Gap National Park - Design, Docume\",\"Alice Springs Region - Alice Plaza - Supply and Install Office Furniture\",\"Alice Springs Region - Areyonga - Government Employees Housing Upgrade\"}"
+    },
+    {
+      "buyer_name": "IP Australia",
+      "contract_count": "53",
+      "total_value": "3062096",
+      "first_year": "2012",
+      "last_year": "2018",
+      "active_years": "7",
+      "sample_titles": "{0000012585,0000012725,0000012986}"
+    },
+    {
+      "buyer_name": "Bureau of Meteorology",
+      "contract_count": "52",
+      "total_value": "6572291",
+      "first_year": "2010",
+      "last_year": "2023",
+      "active_years": "12",
+      "sample_titles": "{19006813,19516620,4500013556}"
+    },
+    {
+      "buyer_name": "Australian Competition and Consumer Commission",
+      "contract_count": "51",
+      "total_value": "7206696",
+      "first_year": "2012",
+      "last_year": "2022",
+      "active_years": "9",
+      "sample_titles": "{130138-C13098,130139-C13099,130176-C13105}"
+    },
+    {
+      "buyer_name": "The University of Queensland",
+      "contract_count": "48",
+      "total_value": "1830393",
+      "first_year": "2019",
+      "last_year": "2019",
+      "active_years": "1",
+      "sample_titles": "{\"Homestay accommodation\",\"Minor Equip / Furniture <$5000\"}"
+    },
+    {
+      "buyer_name": "Department of Education",
+      "contract_count": "44",
+      "total_value": "14750809",
+      "first_year": "2002",
+      "last_year": "2020",
+      "active_years": "15",
+      "sample_titles": "{4400030723,4400035632,4400041116}"
+    },
+    {
+      "buyer_name": "Australian Bureau of Statistics",
+      "contract_count": "41",
+      "total_value": "5131127",
+      "first_year": "2013",
+      "last_year": "2021",
+      "active_years": "9",
+      "sample_titles": "{236367,236470,ABS2015.225d}"
+    },
+    {
+      "buyer_name": "Australian Customs and Border Protection Service",
+      "contract_count": "41",
+      "total_value": "2106069",
+      "first_year": "2011",
+      "last_year": "2015",
+      "active_years": "4",
+      "sample_titles": "{102531,128413,1310472}"
+    },
+    {
+      "buyer_name": "Royal Australian Mint",
+      "contract_count": "40",
+      "total_value": "1056063",
+      "first_year": "2013",
+      "last_year": "2026",
+      "active_years": "11",
+      "sample_titles": "{25560,28443,28577}"
+    },
+    {
+      "buyer_name": "NT Department of Housing - Housing",
+      "contract_count": "36",
+      "total_value": "39172650",
+      "first_year": "2013",
+      "last_year": "2015",
+      "active_years": "3",
+      "sample_titles": "{\"Alice Springs - Provision of Repairs and Maintenance Services to Evaporative Air Condition\",\"Alice Springs - Provision of Vacate and Planned Works to Department of Housing Assets for \",\"Alice Springs - Real Housing for Growth - Elliott Street Key Worker Rental Initiative Prop\"}"
+    },
+    {
+      "buyer_name": "Digital Transformation Agency",
+      "contract_count": "36",
+      "total_value": "2023202",
+      "first_year": "2015",
+      "last_year": "2021",
+      "active_years": "7",
+      "sample_titles": "{4500141625,DTA-418,DTA-419}"
+    },
+    {
+      "buyer_name": "HealthShare NSW",
+      "contract_count": "33",
+      "total_value": "35256307",
+      "first_year": "2021",
+      "last_year": "2024",
+      "active_years": "3",
+      "sample_titles": "{\"Agreement for the Provision of Accommodation and Care Services for  certain patients of HN\",\"Agreement for the Provision of Accommodation and Care Services for certain patients of HNE\",\"BEDS, MATTRESSES & COTS\"}"
+    },
+    {
+      "buyer_name": "Department of Social Services",
+      "contract_count": "33",
+      "total_value": "3220849",
+      "first_year": "2014",
+      "last_year": "2023",
+      "active_years": "10",
+      "sample_titles": "{90003686,90004522,90005283}"
+    },
+    {
+      "buyer_name": "Future Fund Management Agency",
+      "contract_count": "32",
+      "total_value": "2119711",
+      "first_year": "2015",
+      "last_year": "2026",
+      "active_years": "8",
+      "sample_titles": "{FFMA0720,FFMA0726,FFMA0730}"
+    },
+    {
+      "buyer_name": "Old Parliament House",
+      "contract_count": "32",
+      "total_value": "1313374",
+      "first_year": "2013",
+      "last_year": "2022",
+      "active_years": "9",
+      "sample_titles": "{\"OPH 18/19-045\",OPH12/13-016,OPH12/13-050}"
+    },
+    {
+      "buyer_name": "Department of Communications and the Arts",
+      "contract_count": "31",
+      "total_value": "2093143",
+      "first_year": "2012",
+      "last_year": "2019",
+      "active_years": "8",
+      "sample_titles": "{0004602849,0004604036,0004604265}"
+    },
+    {
+      "buyer_name": "Department of Employment, Skills, Small and Family Business",
+      "contract_count": "31",
+      "total_value": "1344484",
+      "first_year": "2014",
+      "last_year": "2019",
+      "active_years": "6",
+      "sample_titles": "{4400018040,4400018190,4400020624}"
+    },
+    {
+      "buyer_name": "Federal Court of Australia",
+      "contract_count": "30",
+      "total_value": "2663092",
+      "first_year": "2014",
+      "last_year": "2025",
+      "active_years": "10",
+      "sample_titles": "{P0200023,P0200031,P0200041}"
+    },
+    {
+      "buyer_name": "QUT",
+      "contract_count": "30",
+      "total_value": "1116854",
+      "first_year": "",
+      "last_year": "",
+      "active_years": "0",
+      "sample_titles": "{\"FURNITURE & FITTINGS < $5000\",\"STAFF TRAVEL - DOMESTIC - ACCOMMODATION\",\"STAFF TRAVEL - INTERNATIONAL - ACCOMMODATION\"}"
+    },
+    {
+      "buyer_name": "James Cook University",
+      "contract_count": "28",
+      "total_value": "866385",
+      "first_year": "2019",
+      "last_year": "2019",
+      "active_years": "1",
+      "sample_titles": "{\"0200046392 - Furniture & Equipment (<$5000)\",\"0200046466 - Furniture & Equipment (<$5000)\",\"0200047062 - Furniture & Equipment (<$5000)\"}"
+    },
+    {
+      "buyer_name": "NT Territory Families - Corporate Services",
+      "contract_count": "27",
+      "total_value": "8632241",
+      "first_year": "2018",
+      "last_year": "2020",
+      "active_years": "2",
+      "sample_titles": "{\"Alice Springs - BIG4 MacDonnell Range Holiday Park - COVID-19 - Accommodation and Meals\",\"Alice Springs - COVID-19 - Aurora Resort - Accommodation and Meals\",\"Alice Springs - COVID-19 - Desert Palms - Accommodation and Meals\"}"
+    },
+    {
+      "buyer_name": "Australian Criminal Intelligence Commission",
+      "contract_count": "27",
+      "total_value": "2637777",
+      "first_year": "2013",
+      "last_year": "2025",
+      "active_years": "12",
+      "sample_titles": "{0000001595,0000001609,0000001663}"
+    },
+    {
+      "buyer_name": "Family Court and Federal Circuit Court",
+      "contract_count": "26",
+      "total_value": "1218365",
+      "first_year": "2013",
+      "last_year": "2016",
+      "active_years": "4",
+      "sample_titles": "{P0203537,P0203550,P0203553}"
+    },
+    {
+      "buyer_name": "NT Department of Infrastructure - Major Projects",
+      "contract_count": "25",
+      "total_value": "26358144",
+      "first_year": "2016",
+      "last_year": "2016",
+      "active_years": "1",
+      "sample_titles": "{\"Alice Springs Region - Areyonga - Demolition of 2 Dwellings and Construction of 2 x 3 Bedr\",\"Alice Springs Region - Atitjere - Demolition of 1 Dwelling and Construct 1 x 3 Bedroom Dwe\",\"Alice Springs Region - Engawala - Remote Community Housing (RCH) Upgrade\"}"
+    },
+    {
+      "buyer_name": "NT Department of Health - Top End Health Service",
+      "contract_count": "25",
+      "total_value": "3172286",
+      "first_year": "2014",
+      "last_year": "2021",
+      "active_years": "6",
+      "sample_titles": "{\"20-1456 - Hill-Rom Pty Ltd - SmartCareTM Beds Preventative Maintenance Service Agreement(C\",\"All Centres - Repairs and Maintenance of and Calibration of Blood Fridges and Freezers for\",\"Covid-19 for PRH Supply Delivery of Mattresses and Consumbales\"}"
+    },
+    {
+      "buyer_name": "Australian Transaction Reports and Analysis Centre",
+      "contract_count": "24",
+      "total_value": "2213695",
+      "first_year": "2013",
+      "last_year": "2023",
+      "active_years": "8",
+      "sample_titles": "{AC1124,AC1126,AC1127}"
+    },
+    {
+      "buyer_name": "ACT Community Services Directorate",
+      "contract_count": "23",
+      "total_value": "34719241",
+      "first_year": "2013",
+      "last_year": "2016",
+      "active_years": "3",
+      "sample_titles": "{\"Blue Door Family Service Samaritan House Young Parents Accommodation Support Program Stree\",\"Community Development Services and Social Housing and Homelessness Services\",\"Financial Analysis for Housing and Community Services Total Facilities Management Project\"}"
+    },
+    {
+      "buyer_name": "Department of Veterans' Affairs",
+      "contract_count": "23",
+      "total_value": "1064955",
+      "first_year": "2014",
+      "last_year": "2022",
+      "active_years": "9",
+      "sample_titles": "{CND002068/1,CND002132/2,CND002552/0}"
+    },
+    {
+      "buyer_name": "Department of Infrastructure, Transport, Regional Development, Communications and the Arts",
+      "contract_count": "23",
+      "total_value": "985260",
+      "first_year": "2014",
+      "last_year": "2023",
+      "active_years": "9",
+      "sample_titles": "{0041006705,0041007341,0041007404}"
+    },
+    {
+      "buyer_name": "Fire and Rescue NSW",
+      "contract_count": "22",
+      "total_value": "59200000",
+      "first_year": "2021",
+      "last_year": "2022",
+      "active_years": "2",
+      "sample_titles": "{\"Class 1 Firefighting Appliances for Fire and Rescue NSW\",\"Class 2 Firefighting Appliances for Fire and Rescue NSW\",\"Class 2 Refurbished Firefighting Appliances for Fire and Rescue NSW\"}"
+    },
+    {
+      "buyer_name": "National Archives of Australia",
+      "contract_count": "22",
+      "total_value": "2600972",
+      "first_year": "2012",
+      "last_year": "2022",
+      "active_years": "10",
+      "sample_titles": "{P12173,PO111200-PO1600167,PO1800047}"
+    },
+    {
+      "buyer_name": "Central Queensland University",
+      "contract_count": "22",
+      "total_value": "681526",
+      "first_year": "2019",
+      "last_year": "2019",
+      "active_years": "1",
+      "sample_titles": "{\"50 days Consulting for Project 8 days Onsite Consulting/Training for Flights & Accommodati\",\"Accommodation (including breakfast)\",\"Accommodation and Meals for Residential\"}"
+    }
+  ]
+}

--- a/thoughts/shared/reports/goods-repeat-buyers-2026-05-28.md
+++ b/thoughts/shared/reports/goods-repeat-buyers-2026-05-28.md
@@ -1,0 +1,118 @@
+# Goods on Country — repeat government buyers (procurement targets)
+
+**Generated:** 2026-05-28 · `scripts/goods-repeat-buyer-intel.mjs` (read-only, no DB writes)
+**Source:** `austender_contracts` (AusTender OCDS federal awarded contracts, ~672K rows)
+**Method:** group by `buyer_name`, keep buyers with ≥2 contracts matching Goods product (word-boundary keyword on title/category OR Goods UNSPSC family 56 / 5210 / 5212 / 5213 / 5214). Ranked by contract count, then total value.
+
+> These are agencies that **repeatedly buy beds / whitegoods / furniture / linen** — the warmest demand-side targets for Goods. A purchase order beats a grant and repeats. Verify each before outreach: AusTender records awarded *federal* contracts only (state/NT procurement is in separate tables), and keyword matching can still admit adjacent categories — read the sample titles.
+
+## Headline
+- **10626** goods-matching federal contracts across **366** distinct buyers, **$15,102,785,530** total.
+- **31** of those buyers have a housing / community / First Nations / local-government remit — the actionable shortlist below. The raw top-60 list (which Defence & ATO dominate with barracks/office furniture) follows as context only.
+
+## ⭐ Warm targets — housing / community / First Nations buyers
+Filtered to buyers whose remit fits a remote-community bed+washer enterprise (`housing|communit|aborigin|indigenous|first nation|torres|land council|regional council|shire|district council|remote`).
+
+| # | Buyer (agency) | Contracts | Total value | Years | Active yrs | Sample titles |
+|---|----------------|-----------|-------------|-------|------------|---------------|
+| 1 | NSW Department of Communities and Justice | 236 | $1,571,510,596 | 2008–2025 | 13 | A Place To Go (APTG) Home - Mackillop Family Services (prj_5068); Aboriginal Homelessness Support Service; Aboriginal Outreach Casework Project |
+| 2 | NT Department of Infrastructure, Planning and Logistics - Housing Program Office | 91 | $211,957,652 | 2021–2024 | 4 | Alice Springs - Central Australia Region - Provision of Remote Housing Maintenance Service; Alice Springs - Mount Nancy Town Camp - Demolition and Construction of Housing on 9 lots; Alice Springs - Panel Contract for Responsive Maintenance Services to Urban Housing for a |
+| 3 | NT Department of Housing - Housing | 36 | $39,172,650 | 2013–2015 | 3 | Alice Springs - Provision of Repairs and Maintenance Services to Evaporative Air Condition; Alice Springs - Provision of Vacate and Planned Works to Department of Housing Assets for; Alice Springs - Real Housing for Growth - Elliott Street Key Worker Rental Initiative Prop |
+| 4 | ACT Community Services Directorate | 23 | $34,719,241 | 2013–2016 | 3 | Blue Door Family Service Samaritan House Young Parents Accommodation Support Program Stree; Community Development Services and Social Housing and Homelessness Services; Financial Analysis for Housing and Community Services Total Facilities Management Project |
+| 5 | Department of Families, Housing, Community Services and Indigenous Affairs | 17 | $3,084,849 | 2012–2013 | 2 | 45408224; 90001410; 90001440 |
+| 6 | Dept of Planning, Housing and Infrastructure | 15 | $33,880,203 | 2021–2024 | 3 | Architectural Services for the Low and Mid-Rise Housing Pattern Book - Low Rise Apartment; Architectural Services for the Low and Mid-Rise Housing Pattern Book - Semi-Detached Typol; Architectural Services for the Low and Mid-Rise Housing Pattern Book - Terrace Housing Typ |
+| 7 | National Indigenous Australians Agency | 14 | $1,077,607 | 2019–2026 | 5 | NCD09258; NCD09453; NCD09530 |
+| 8 | NT Department of Local Government, Housing and Community Development - Housing Program Delivery | 12 | $956,614 | 2019–2020 | 2 | $100m Stimulus - Alice Springs - Kitchen  Refurbish - Unit 7/57 Albrecht Drive, Larapinta; $100M Stimulus - Alice Springs - Kitchen Refurbishment - 11 Holtermann Court, Larapinta; $100M Stimulus - Alice Springs - Kitchen Refurbishment - 24 Engoordina Drive, Larapinta |
+| 9 | NT Department of Housing - Service Delivery South | 11 | $12,219,588 | 2015–2016 | 2 | Alice Springs - Provision of Grounds Maintenance, Litter Control and Cleaning Services to; Alice Springs - Provision of Responsive Repairs and Maintenance Works to Department of Hou; Alice Springs - Yulara - Upgrades to Six (6) Government Employee Housing (GEH) Dwellings |
+| 10 | NT Department of Housing - Housing Supply | 9 | $1,442,946 | 2015–2016 | 2 | Alice Springs - Provision of Marketing and Auctioneering Services of Department of Housing; Alice Springs - Provision of Real Housing for Growth Intitiative - Property and Tenancy Ma; Darwin - Consultancy - Business Documentation Consultancy - Real Housing for Growth |
+| 11 | NT Department of Housing - Service Delivery North | 8 | $11,147,665 | 2015–2016 | 2 | Darwin - Batchelor - Provision of Grounds Maintenance, Litter Control and Cleaning Service; Darwin - Provision of Arboreal Services to Department of Housing Assets for a Period of 24; Darwin - Provision of Ground Maintenance, Litter Control and Cleaning Services to Departme |
+| 12 | NT Power and Water Corporation - Remote Services | 8 | $1,406,311 | 2019–2019 | 1 | Engagement of Hydraulic Engineering Services to Support the Housing Program Works; Gunbalanya and Ramingining - Construction of New Water and Sewer Infrastructures Related t; Kalkarindji, Lajamanu and Pigeon Hole - Construction of New Water and Sewer Infrastructure |
+| 13 | NT Department of Territory Families, Housing and Communities - Housing Programs and Support Services | 6 | $4,289,573 | 2021–2022 | 2 | Alice Springs, Darwin and Palmerston - Provision of Marketing and Auctioneering Services f; Consultancy - Assess The Economic Viability of Delivery Options and Pilot Sites under the; Darwin - Consultancy - Request for Services under Panel Contract - D18-0031 - Provision of |
+| 14 | NT Department of Housing and Community Development - Housing Program Delivery | 6 | $1,782,715 | 2017–2018 | 2 | $69m Stimulus - Darwin - Painting, Kitchen Benches and Concreting - 114 Dickward Dr - Coco; $69m Stimulus - Darwin - Roof Replacements - 9 and 10 Bedwell Court, Gray, Palmerston; Darwin - Affordable Housing Head Leased Dwellings -  Servicing of Split System Air Conditi |
+| 15 | NT Department of Housing - Contract Implementation | 6 | $1,729,301 | 2015–2016 | 2 | Alice Springs - Consultancy - Project  Development for Nyrripi, Kintore and Areyonga  SFNT; Alice Springs - Consultancy - Project Development for SFNT Housing Upgrades in Santa Teres; All Centres - Supply and Delivery of Stoves to Department of Housing for a Period of 12 Mo |
+| 16 | NT Department of Logistics and Infrastructure - Housing Program Office | 5 | $26,410,525 | 2024–2025 | 2 | Alice Springs Region - Mutitjulu And Imanpa - Design, Construction, Demolition and Upgrade; Northern Region - Panel Contract - Design and Construct, Storage and Installation of Modul; Southern Region - Panel Contract - Design and Construct, Storage and Installation of Modul |
+| 17 | NT Department of Logistics and Infrastructure - Housing and Land Services | 3 | $55,191,963 | 2025–2025 | 1 | Darwin Region - Wurrumiyanga - Demolition of 45 Dwellings and Construction of 44 Replaceme; Tennant Creek Region - Imangara and Wutungurra (Epenarra) - Security Upgrades and Refurbis; Tennant Creek Region - Rockhampton Downs (Wogyala) and Newcastle Waters - Security Upgrade |
+| 18 | NT Department of Housing and Community Development - Remote Program Delivery Office | 3 | $2,546,585 | 2017–2018 | 2 | Alice Springs - Provision of Marketing and Auctioneering Services for Chief Executive Offi; Housing Maintenance Program - 2017/2018 - Fencing - Supply, Delivery and Installation of F; Nhulunbuy - Groote Eylandt - Consultancy - Architechtural Services to Assist with the Deli |
+| 19 | NT Department of Housing - Executive | 3 | $1,199,688 | 2013–2014 | 2 | Darwin - Consultancy - Provision of Probity Assurance Advisor Services - Remote Housing NT; Darwin - Consultancy - Real Housing for Growth - Planning Consultant Runge Street Re-zonin; Darwin, Katherine, Palmerston - Real Housing for Growth Head-Leasing Initiative - Provisio |
+| 20 | NT Department of Housing and Community Development - Housing Delivery | 3 | $648,946 | 2017–2017 | 1 | Alice Springs - Provision of Property and Tenancy Management of Affordable Housing Dwellin; Consultancy - Identification, Labelling, Recording and Assessment of Risk and Asbestos Con; Tennant Creek - Provision of Property and Tenancy Management of Affordable Housing Dwellin |
+| 21 | ACT Justice and Community Safety Directorate | 3 | $280,988 | 2016–2016 | 1 | 12 Moore St - Lpp Level 4 Fitout; Provision of Linen Supply AMC; Supply and Delivery of Bed lights AMC |
+| 22 | NT Department of Housing, Local Government and Community Development - Assets, Infrastructure and Maintenance | 2 | $5,288,199 | 2024–2024 | 1 | Alice Springs Region - Repairs and Maintenance of Remote Community Housing and Government; Tennant Creek Region - Repairs and Maintenance of Remote Community Housing and Government |
+| 23 | Department of Communities Tasmania | 2 | $2,996,641 | 2018–2018 | 1 | Stronger Remote Aboriginal Services – Cape Barren Island Aboriginal Housing Upgrades; Stronger Remote Aboriginal Services – Flinders Island Aboriginal Housing Upgrades |
+| 24 | NT Department of Housing and Community Development - Service Delivery South | 2 | $2,683,116 | 2017–2019 | 2 | Alice Springs - Provision of Housing Management Services in Alice Springs Town Camps for a; Alice Springs - Provision of Responsive Repairs and Maintenance to Public Housing Assets f |
+| 25 | NT Department of Health - Remote Health | 2 | $1,618,940 | 2013–2013 | 1 | Alice Springs - Supply Delivery and Installation of EMERGENCY VEHICLE FITOUT REGO 826 783; Alice Springs, Darwin - Customised Fitout of Remote Emergency Vehicles - Toyota Troop Carr |
+| 26 | NSW Aboriginal Housing Office | 2 | $497,842 | 2025–2025 | 1 | Aboriginal Housing Office Asset Portfolio Review |
+| 27 | NT Department of Local Government, Housing and Community Development - Corporate Services | 2 | $125,814 | 2019–2020 | 2 | Darwin - Public Liability Insurance for Urban Public Housing; Public Liability Insurance for Urban Public Housing |
+| 28 | NT Department of Housing and Community Development - Corporate Services | 2 | $104,671 | 2018–2018 | 1 | Darwin - Provision of Public Liability Insurance for Urban Public Housing; Darwin - Supply Delivery and Installation of Office Furniture for CASCOM 5 |
+| 29 | NT Department of Local Government, Housing and Community Development - Remote Program Delivery | 2 | $91,177 | 2019–2019 | 1 | Katherine and Alice Springs - Peppimenarti and Willowra Community - Drone Services for Rem; Request for Quantity Surveyor Services - Housing Upgrades - Utopia Homelands |
+| 30 | NT Department of Territory Families, Housing and Communities - Southern Region | 2 | $70,759 | 2021–2021 | 1 | Alice Springs - Supply and Delivery of Office Furniture; Supply Delivery and Installation of Elliot - Supply and Delivery of Office Furniture |
+| 31 | NT Department of Correctional Services - NT Community Corrections | 2 | $64,658 | 2014–2016 | 2 | Alice Springs - Purchase od Two Beds in One Room at Stuart Lodge  for a Period of 14 Month; Alice Springs - Supply and Delivery of Office Furniture |
+
+## All repeat buyers (context — includes off-target agencies)
+| # | Buyer (agency) | Contracts | Total value | Years | Active yrs | Sample titles |
+|---|----------------|-----------|-------------|-------|------------|---------------|
+| 1 | Department of Defence | 3558 | $364,838,395 | 2007–2026 | 16 | 1900623817; 1900624455; 1900624503 |
+| 2 | Services Australia | 1447 | $171,411,676 | 2011–2026 | 15 | 8100003176; 8100003799; 8100004513 |
+| 3 | NT Department of Infrastructure, Planning and Logistics - Infrastructure, Investment and Contracts | 418 | $470,160,145 | 2016–2024 | 9 | Alice Spring Region - Nturiya - Remote Community Housing (RCH) Upgrade; Alice Springs - Alice Spring Correctional Centre - Supply and Delivery of Modular Accommod; Alice Springs - Anangu House  - Pandemic Coordination Cell - Fitout |
+| 4 | Homes NSW | 251 | $419,091,953 | 2017–2025 | 7 | Architect for Seniors Housing - Merrylands; Architectural and Design Services - Seniors Housing - North St Marys; Architectural Design for Airds Stage 9 Seniors Housing |
+| 5 | NSW Department of Communities and Justice | 236 | $1,571,510,596 | 2008–2025 | 13 | A Place To Go (APTG) Home - Mackillop Family Services (prj_5068); Aboriginal Homelessness Support Service; Aboriginal Outreach Casework Project |
+| 6 | Australian Federal Police | 203 | $9,990,326 | 2013–2026 | 13 | 0030013644; 0030017050; 0030017950 |
+| 7 | Department of Health and Human Services | 192 | $619,477,021 | 2002–2018 | 17 | 1 Carbeen Street Mornington Housing Construction; 1 Teal Street Claremont Housing Construction; 15 Murray St Evandale Housing Construction |
+| 8 | Department of Industry, Science and Resources | 184 | $13,420,618 | 2011–2026 | 14 | AI Bendigo Accommodation MOU; CON000845; CON001652 |
+| 9 | DoE | 138 | $12,570,069 | 2019–2019 | 1 | 0036-S00004352-002612 - Travel - Accommodation incl meals; 0059-S00057655-00002505 -Travel - Accommodation incl meals; 0074-S00012244-7787 -Travel - Accommodation incl meals |
+| 10 | Australian Taxation Office | 135 | $17,535,647 | 2013–2026 | 12 | 06.296-0-2; 13.123-0-1; 13.129 |
+| 11 | Department of Home Affairs | 131 | $24,272,611 | 2012–2025 | 13 | 0070000627; 0070006082; 0070007286 |
+| 12 | Department of Parliamentary Services | 131 | $8,789,007 | 2013–2026 | 10 | 0000050855; 0000050925; 0000050950 |
+| 13 | Department of Foreign Affairs and Trade | 111 | $23,353,082 | 2012–2026 | 14 | 4500000529; 4500000715; 4500000932 |
+| 14 | Department of the House of Representatives | 101 | $7,444,955 | 2013–2026 | 10 | CON/GAUCON/CON000022/1; CON000154; D001470 |
+| 15 | Department of the Prime Minister and Cabinet | 99 | $5,791,928 | 2013–2025 | 12 | CA000503; CA005537; CD007856 |
+| 16 | Department of Finance | 93 | $5,995,519 | 2013–2026 | 12 | 2100003741; 2100004380; 2100004881 |
+| 17 | NT Department of Infrastructure, Planning and Logistics - Housing Program Office | 91 | $211,957,652 | 2021–2024 | 4 | Alice Springs - Central Australia Region - Provision of Remote Housing Maintenance Service; Alice Springs - Mount Nancy Town Camp - Demolition and Construction of Housing on 9 lots; Alice Springs - Panel Contract for Responsive Maintenance Services to Urban Housing for a |
+| 18 | Australian Electoral Commission | 89 | $21,391,548 | 2013–2023 | 11 | $700000.00; 001198; 001777 |
+| 19 | Department of Agriculture, Fisheries and Forestry | 89 | $4,316,559 | 2013–2021 | 9 | 0045077507; 0045077715; 0045078290 |
+| 20 | Australian Signals Directorate | 87 | $6,190,498 | 2018–2026 | 8 | 1900001258; 3000384431; 3000522246 |
+| 21 | Department of Health and Aged Care | 79 | $7,976,024 | 2012–2022 | 11 | 4500103681; 4500108637; 4500109515 |
+| 22 | Department of Agriculture | 77 | $7,333,058 | 2014–2019 | 6 | 21867; 22680; 22759 |
+| 23 | Attorney-General's Department | 75 | $6,362,004 | 2013–2023 | 10 | 0041000641; 0041000705; 0041001052 |
+| 24 | Department of the Treasury | 68 | $3,882,294 | 2012–2022 | 11 | 000503-0; 000544-0; 000573-0 |
+| 25 | NT Department of Infrastructure - Construction | 66 | $40,829,602 | 2013–2014 | 2 | Alice Springs - Design and Construct a New Demountable Office/Training Accommodation for W; Alice Springs Hospital - Fire Indicator Panel Replacement At Nurses Quarters and Wedge Acc; Alice Springs Region  - Health Department - Refurbish Two Accommodation houses - Mandatory |
+| 26 | Australian Securities and Investments Commission | 65 | $5,181,651 | 2013–2026 | 11 | 003086; 003087; 003526 |
+| 27 | Austrade | 64 | $14,011,475 | 2010–2025 | 13 | 0046000536; 0046000607; 0046000627 |
+| 28 | Geoscience Australia | 57 | $4,301,523 | 2013–2021 | 9 | 32172; 33212; 33217 |
+| 29 | NT Department of Infrastructure - Building Services | 53 | $44,634,323 | 2014–2016 | 3 | Alice Springs Region - 1620 Larapinta Drive - Simpson's Gap National Park - Design, Docume; Alice Springs Region - Alice Plaza - Supply and Install Office Furniture; Alice Springs Region - Areyonga - Government Employees Housing Upgrade |
+| 30 | IP Australia | 53 | $3,062,096 | 2012–2018 | 7 | 0000012585; 0000012725; 0000012986 |
+| 31 | Bureau of Meteorology | 52 | $6,572,291 | 2010–2023 | 12 | 19006813; 19516620; 4500013556 |
+| 32 | Australian Competition and Consumer Commission | 51 | $7,206,696 | 2012–2022 | 9 | 130138-C13098; 130139-C13099; 130176-C13105 |
+| 33 | The University of Queensland | 48 | $1,830,393 | 2019–2019 | 1 | Homestay accommodation; Minor Equip / Furniture <$5000 |
+| 34 | Department of Education | 44 | $14,750,809 | 2002–2020 | 15 | 4400030723; 4400035632; 4400041116 |
+| 35 | Australian Bureau of Statistics | 41 | $5,131,127 | 2013–2021 | 9 | 236367; 236470; ABS2015.225d |
+| 36 | Australian Customs and Border Protection Service | 41 | $2,106,069 | 2011–2015 | 4 | 102531; 128413; 1310472 |
+| 37 | Royal Australian Mint | 40 | $1,056,063 | 2013–2026 | 11 | 25560; 28443; 28577 |
+| 38 | NT Department of Housing - Housing | 36 | $39,172,650 | 2013–2015 | 3 | Alice Springs - Provision of Repairs and Maintenance Services to Evaporative Air Condition; Alice Springs - Provision of Vacate and Planned Works to Department of Housing Assets for; Alice Springs - Real Housing for Growth - Elliott Street Key Worker Rental Initiative Prop |
+| 39 | Digital Transformation Agency | 36 | $2,023,202 | 2015–2021 | 7 | 4500141625; DTA-418; DTA-419 |
+| 40 | HealthShare NSW | 33 | $35,256,307 | 2021–2024 | 3 | Agreement for the Provision of Accommodation and Care Services for  certain patients of HN; Agreement for the Provision of Accommodation and Care Services for certain patients of HNE; BEDS, MATTRESSES & COTS |
+| 41 | Department of Social Services | 33 | $3,220,849 | 2014–2023 | 10 | 90003686; 90004522; 90005283 |
+| 42 | Future Fund Management Agency | 32 | $2,119,711 | 2015–2026 | 8 | FFMA0720; FFMA0726; FFMA0730 |
+| 43 | Old Parliament House | 32 | $1,313,374 | 2013–2022 | 9 | OPH 18/19-045; OPH12/13-016; OPH12/13-050 |
+| 44 | Department of Communications and the Arts | 31 | $2,093,143 | 2012–2019 | 8 | 0004602849; 0004604036; 0004604265 |
+| 45 | Department of Employment, Skills, Small and Family Business | 31 | $1,344,484 | 2014–2019 | 6 | 4400018040; 4400018190; 4400020624 |
+| 46 | Federal Court of Australia | 30 | $2,663,092 | 2014–2025 | 10 | P0200023; P0200031; P0200041 |
+| 47 | QUT | 30 | $1,116,854 | – | 0 | FURNITURE & FITTINGS < $5000; STAFF TRAVEL - DOMESTIC - ACCOMMODATION; STAFF TRAVEL - INTERNATIONAL - ACCOMMODATION |
+| 48 | James Cook University | 28 | $866,385 | 2019–2019 | 1 | 0200046392 - Furniture & Equipment (<$5000); 0200046466 - Furniture & Equipment (<$5000); 0200047062 - Furniture & Equipment (<$5000) |
+| 49 | NT Territory Families - Corporate Services | 27 | $8,632,241 | 2018–2020 | 2 | Alice Springs - BIG4 MacDonnell Range Holiday Park - COVID-19 - Accommodation and Meals; Alice Springs - COVID-19 - Aurora Resort - Accommodation and Meals; Alice Springs - COVID-19 - Desert Palms - Accommodation and Meals |
+| 50 | Australian Criminal Intelligence Commission | 27 | $2,637,777 | 2013–2025 | 12 | 0000001595; 0000001609; 0000001663 |
+| 51 | Family Court and Federal Circuit Court | 26 | $1,218,365 | 2013–2016 | 4 | P0203537; P0203550; P0203553 |
+| 52 | NT Department of Infrastructure - Major Projects | 25 | $26,358,144 | 2016–2016 | 1 | Alice Springs Region - Areyonga - Demolition of 2 Dwellings and Construction of 2 x 3 Bedr; Alice Springs Region - Atitjere - Demolition of 1 Dwelling and Construct 1 x 3 Bedroom Dwe; Alice Springs Region - Engawala - Remote Community Housing (RCH) Upgrade |
+| 53 | NT Department of Health - Top End Health Service | 25 | $3,172,286 | 2014–2021 | 6 | 20-1456 - Hill-Rom Pty Ltd - SmartCareTM Beds Preventative Maintenance Service Agreement(C; All Centres - Repairs and Maintenance of and Calibration of Blood Fridges and Freezers for; Covid-19 for PRH Supply Delivery of Mattresses and Consumbales |
+| 54 | Australian Transaction Reports and Analysis Centre | 24 | $2,213,695 | 2013–2023 | 8 | AC1124; AC1126; AC1127 |
+| 55 | ACT Community Services Directorate | 23 | $34,719,241 | 2013–2016 | 3 | Blue Door Family Service Samaritan House Young Parents Accommodation Support Program Stree; Community Development Services and Social Housing and Homelessness Services; Financial Analysis for Housing and Community Services Total Facilities Management Project |
+| 56 | Department of Veterans' Affairs | 23 | $1,064,955 | 2014–2022 | 9 | CND002068/1; CND002132/2; CND002552/0 |
+| 57 | Department of Infrastructure, Transport, Regional Development, Communications and the Arts | 23 | $985,260 | 2014–2023 | 9 | 0041006705; 0041007341; 0041007404 |
+| 58 | Fire and Rescue NSW | 22 | $59,200,000 | 2021–2022 | 2 | Class 1 Firefighting Appliances for Fire and Rescue NSW; Class 2 Firefighting Appliances for Fire and Rescue NSW; Class 2 Refurbished Firefighting Appliances for Fire and Rescue NSW |
+| 59 | National Archives of Australia | 22 | $2,600,972 | 2012–2022 | 10 | P12173; PO111200-PO1600167; PO1800047 |
+| 60 | Central Queensland University | 22 | $681,526 | 2019–2019 | 1 | 50 days Consulting for Project 8 days Onsite Consulting/Training for Flights & Accommodati; Accommodation (including breakfast); Accommodation and Meals for Residential |
+
+## Caveats / provenance
+- **Federal only.** `austender_contracts` is the AusTender OCDS feed (federal). NT/state remote-housing procurement (the $4B whale, Phase 4) is **not** here.
+- **Awarded, not open.** These are past awards (demand signal), not open tenders. Open tenders are the Phase-3 `austender-open-tenders` feed in `grant_opportunities`.
+- **Keyword recall vs precision.** `bed`/`linen`/`kitchen` are word-boundary matched but adjacent categories can still appear — the sample titles are there to sanity-check each row.
+- **No DB writes.** `--apply` is reserved; promoting top buyers into `goods_procurement_entities`/`_signals` is a later-phase decision.


### PR DESCRIPTION
Goods Phase 1 = **surface what already exists, no new ingestion**. Three additive, low-risk changes. Plan: `thoughts/shared/plans/2026-05-28-goods-phase1-discovery-surface.md`.

## Changes
- **Repeat-buyer intel** (`scripts/goods-repeat-buyer-intel.mjs`, read-only) — mines the 672K-row `austender_contracts` *by buyer* (inverse of `hydrate-goods-procurement`, which groups by supplier) for agencies that repeatedly purchase Goods product. Report: **10,626 goods contracts / 366 buyers / $15.1B**; **31 warm targets** (housing/community/First Nations remit) — NT Housing, NSW Communities & Justice, NIAA, ACT Community Services lead. `thoughts/shared/reports/goods-repeat-buyers-2026-05-28.{md,json}`. Registered in agent-registry. No DB writes (`--apply` reserved).
- **`/grants` funding-type chip** — All · Capital · Procurement · Grant, threaded through the DB query, semantic path, `hrefFor`, fast-index guard + a hidden form input. Capital→IBA/NAIF/Many Rivers; Procurement→Supply Nation + the 2 AusTender open tenders.
- **Goods Signals Workbench** — new standalone "Capital pipeline" panel (high-fit `indigenous-finance` rows, not signal-bound) + Capital/Procurement badges on matched grants.

## Verification
- `tsc --noEmit` clean · `next build` clean (both pages build as dynamic routes)
- 3 buyer rows verified exactly against live DB (NSW DCJ 236/$1.57B, NT Housing PO 91/$212M, NIAA 14/$1.08M)
- `discovery_method` distribution confirmed; capital/procurement chips surface the expected rows

CI note: the repo's pre-existing `entity-service.test.ts` failure (its own fix is PR #37, open since 2026-05-04) is unrelated — this branch touches scoring/scripts/grants UI, not entity-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)