### PR TITLE
feat(goods): live funnel dashboard (3 pipelines on the 5-stage spine)

### DIFF
--- a/apps/web/src/app/org/[slug]/goods/funnel/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/funnel/page.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import { getGoodsFunnel, SPINE, SPINE_LABELS, type PipelineFunnel } from '@/lib/services/goods-funnel';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  return { title: 'Goods Funnel — need · procurement · support' };
+}
+
+const money = (n: number) => `$${Math.round(n || 0).toLocaleString('en-AU')}`;
+const num = (n: number) => (n || 0).toLocaleString('en-AU');
+
+function Stat({ label, beds, washers, value, accent }: { label: string; beds?: number | null; washers?: number | null; value?: number | null; accent?: boolean }) {
+  return (
+    <div className={`border-4 ${accent ? 'border-bauhaus-blue bg-link-light' : 'border-bauhaus-black bg-white'} p-3`}>
+      <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">{label}</div>
+      <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-0.5 text-bauhaus-black">
+        {beds != null && <span className="text-lg font-black">{num(beds)} <span className="text-xs font-bold">beds</span></span>}
+        {washers != null && <span className="text-sm font-black">{num(washers)} <span className="text-[10px] font-bold">wash</span></span>}
+        {value != null && <span className="text-sm font-black text-bauhaus-blue">{money(value)}</span>}
+      </div>
+    </div>
+  );
+}
+
+function FunnelColumn({ p }: { p: PipelineFunnel }) {
+  const max = Math.max(1, ...SPINE.filter(s => s !== 'dead').map(s => p.spine[s].n));
+  return (
+    <div className="border-4 border-bauhaus-black bg-white p-3">
+      <div className="mb-2">
+        <div className="text-xs font-black uppercase tracking-widest text-bauhaus-black">{p.label}</div>
+        <div className="text-[11px] text-bauhaus-muted">
+          {p.total} open · {p.beds ? `${num(p.beds)} beds · ` : ''}{p.washers ? `${num(p.washers)} wash · ` : ''}{p.value ? money(p.value) : '$0'}
+        </div>
+      </div>
+      <div className="space-y-1">
+        {SPINE.map(s => {
+          const c = p.spine[s];
+          const isDead = s === 'dead';
+          const w = isDead ? 0 : Math.round((c.n / max) * 100);
+          return (
+            <div key={s} className="flex items-center gap-2 text-[11px]">
+              <div className="w-16 shrink-0 font-bold uppercase tracking-wide text-bauhaus-muted">{SPINE_LABELS[s]}</div>
+              <div className="relative h-5 flex-1 bg-bauhaus-canvas">
+                {!isDead && c.n > 0 && <div className="absolute inset-y-0 left-0 bg-bauhaus-blue/70" style={{ width: `${Math.max(w, 6)}%` }} />}
+                <div className="absolute inset-0 flex items-center px-1.5 font-black text-bauhaus-black">
+                  {c.n > 0 ? (
+                    <span>{c.n}{c.beds ? ` · ${num(c.beds)}b` : ''}{c.washers ? ` · ${num(c.washers)}w` : ''}{c.value ? ` · ${money(c.value)}` : ''}</span>
+                  ) : <span className="text-bauhaus-muted">—</span>}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default async function GoodsFunnelPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const profile = shouldUseFastLocalOrg() && isActSlug(slug) ? ACT_FAST_PROFILE : await getOrgProfileBySlug(slug);
+  if (!profile) notFound();
+
+  const f = await getGoodsFunnel();
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
+      <div className="border-b-4 border-bauhaus-black bg-bauhaus-black text-white">
+        <div className="mx-auto max-w-7xl px-4 py-8">
+          <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
+            <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
+            <span>/</span>
+            <Link href={`/org/${slug}/wiki/goods-operating-system`} className="hover:text-white">Goods OS</Link>
+            <span>/</span>
+            <span className="text-white">Funnel</span>
+          </nav>
+          <h1 className="text-4xl font-black uppercase tracking-widest">Goods Funnel</h1>
+          <p className="mt-2 max-w-3xl text-sm text-gray-300">
+            One need, two funding routes, one delivery — in beds, washing machines and $. A community <strong className="text-white">need</strong> is met by a buyer who <strong className="text-white">pays</strong> (procurement) or a funder who <strong className="text-white">donates</strong> (support), both ending in <strong className="text-white">delivery</strong>.
+          </p>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        {/* Cockpit */}
+        <div className="mb-2 text-xs font-black uppercase tracking-widest text-bauhaus-black">Cockpit — curated priority slice (active + lead)</div>
+        <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <Stat label={`Need (${f.need.communities} communities)`} beds={f.need.beds} washers={f.need.washers} accent />
+          <Stat label="Ordered (Buyer)" beds={f.ordered.beds} washers={f.ordered.washers} value={f.ordered.value} />
+          <Stat label="Funded (Supporter)" beds={f.funded.beds} washers={f.funded.washers} value={f.funded.value} />
+          <Stat label="Delivered" beds={f.delivered.beds} washers={f.delivered.washers} />
+          <Stat label="Gap (need − delivered)" beds={f.gap.beds} washers={f.gap.washers} accent />
+        </div>
+        <p className="mb-6 text-[11px] text-bauhaus-muted">
+          Addressable demand (all {num(f.addressable.communities)} communities): {num(f.addressable.beds)} beds · {num(f.addressable.washers)} washers.
+          Delivered is a cited constant — {f.delivered.source}.
+          {!f.ghlConnected && <span className="text-bauhaus-red"> · GHL not connected in this environment — Ordered/Funded show 0.</span>}
+        </p>
+
+        {/* Funnel by pipeline, collapsed to the 5-stage spine */}
+        <div className="mb-2 text-xs font-black uppercase tracking-widest text-bauhaus-black">Pipelines — collapsed to the 5-stage spine</div>
+        <div className="grid gap-3 lg:grid-cols-3">
+          {f.pipelines.length === 0 ? (
+            <div className="border-4 border-bauhaus-black bg-white p-6 text-sm text-bauhaus-muted lg:col-span-3">
+              No live pipeline data (GHL not connected here). The cockpit above still shows need, delivered and gap from the data model.
+            </div>
+          ) : (
+            f.pipelines.map(p => <FunnelColumn key={p.key} p={p} />)
+          )}
+        </div>
+
+        <div className="mt-8 border-4 border-bauhaus-black bg-bauhaus-yellow p-4 text-xs">
+          The 3 GHL pipelines keep their own operational stages (Buyer 12 · Supporter 10 · Demand 4); this view collapses them to a shared spine by stage name. Need comes from <code>goods_communities</code> (the Demand Register tracks relationships, not quantities). As deals get scoped — beds/washers set on their GHL opps — Ordered/Funded fill in and the Gap closes.
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/services/goods-funnel.ts
+++ b/apps/web/src/lib/services/goods-funnel.ts
@@ -1,0 +1,159 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Goods 3-pipeline funnel — the management cockpit. One need, two funding routes,
+ * one delivery, in beds / washing machines / $.
+ *
+ *   NEED      ← goods_communities (curated priority slice: active + lead)
+ *   ORDERED   ← GHL Buyer Pipeline      (best-effort; degrades to 0 if GHL env absent)
+ *   FUNDED    ← GHL Supporter Journey   (best-effort)
+ *   DELIVERED ← Goods v2 assets sync    (cited constant — different DB)
+ *   GAP       = NEED − DELIVERED
+ *
+ * The 3 GHL pipelines keep their own (12 / 10 / 4) operational stages; this view
+ * collapses them to a shared 5-stage spine for legibility. Stage→spine is matched
+ * by NAME so it survives GHL stage renames.
+ *
+ * Plan: act-infra thoughts/shared/plans/2026-05-28-goods-three-pipeline-operating-model.md
+ */
+
+const GHL_API_URL = 'https://services.leadconnectorhq.com';
+const GHL_API_KEY = process.env.GHL_API_KEY;
+const GHL_LOCATION_ID = process.env.GHL_LOCATION_ID;
+
+const PIPELINES = {
+  buyer:     { id: 'FjMyJM3YzWQFmKqR9fur', label: 'Procurement — Buyer Pipeline', role: 'ordered' as const },
+  supporter: { id: 'JvBFYpVpyKsw899lkFgj', label: 'Support — Supporter Journey', role: 'funded' as const },
+  demand:    { id: 'UQsrmuqzxMSdCTklxEcG', label: 'Need — Demand Register', role: 'need' as const },
+};
+const BEDS_FIELD = 'mi9ZW3KLhmpcez14cNbx';
+const WASHERS_FIELD = 'UtxtfnyEd6p1epMEJ0b2';
+
+// DELIVERED — physical goods delivered to date. Source: Goods v2 `assets`
+// (project cwsyhpiuepvdjtxaozwf) via sync-goods-impact-rollups.mjs — a different DB
+// than this app reaches, so carried as a cited constant.
+export const DELIVERED = { beds: 520, washers: 41, source: 'Goods v2 assets sync, 2026-05-27' };
+
+export const SPINE = ['identified', 'qualified', 'committed', 'delivering', 'closed', 'dead'] as const;
+export type SpineStage = (typeof SPINE)[number];
+export const SPINE_LABELS: Record<SpineStage, string> = {
+  identified: 'Identified', qualified: 'Qualified', committed: 'Committed',
+  delivering: 'Delivering', closed: 'Closed', dead: 'Dead',
+};
+
+function spineOf(stageName: string): SpineStage {
+  const s = (stageName || '').toLowerCase();
+  if (/lapsed|declined|parked|dormant|lost|not yet|out of scope/.test(s)) return 'dead';
+  if (/paid|invoiced|steward|renew/.test(s)) return 'closed';
+  if (/deliver/.test(s)) return 'delivering';
+  if (/proposed|negotiat|committed|ask made|converted/.test(s)) return 'committed';
+  if (/conversation|qualified|scoped|cultivat|matched|assessment/.test(s)) return 'qualified';
+  return 'identified'; // outreach, first contact, identified, signal, new
+}
+
+export type SpineCell = { n: number; beds: number; washers: number; value: number };
+export type PipelineFunnel = {
+  key: string;
+  label: string;
+  role: 'need' | 'ordered' | 'funded';
+  total: number;
+  beds: number;
+  washers: number;
+  value: number;
+  spine: Record<SpineStage, SpineCell>;
+};
+export type GoodsFunnel = {
+  generatedAt: string;
+  ghlConnected: boolean;
+  need: { beds: number; washers: number; communities: number };
+  addressable: { beds: number; washers: number; communities: number };
+  ordered: { beds: number; washers: number; value: number };
+  funded: { beds: number; washers: number; value: number };
+  delivered: typeof DELIVERED;
+  gap: { beds: number; washers: number };
+  pipelines: PipelineFunnel[];
+};
+
+async function ghlFetch(path: string) {
+  const res = await fetch(`${GHL_API_URL}${path}`, {
+    headers: { Authorization: `Bearer ${GHL_API_KEY}`, 'Content-Type': 'application/json', Version: '2021-07-28' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`GHL ${path}: ${res.status}`);
+  return res.json();
+}
+
+function unitOf(opp: any, fieldId: string): number {
+  const cf = (opp.customFields || []).find((c: any) => c.id === fieldId);
+  // GHL opportunity search returns numeric custom fields under `fieldValueNumber`.
+  const v = cf ? (cf.fieldValueNumber ?? cf.fieldValueString ?? cf.field_value ?? cf.value) : 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function emptySpine(): Record<SpineStage, SpineCell> {
+  return Object.fromEntries(SPINE.map(s => [s, { n: 0, beds: 0, washers: 0, value: 0 }])) as Record<SpineStage, SpineCell>;
+}
+
+async function rollupPipeline(p: { id: string; label: string; role: 'need' | 'ordered' | 'funded'; key: string }): Promise<PipelineFunnel> {
+  const spine = emptySpine();
+  let total = 0, beds = 0, washers = 0, value = 0;
+  // Stage map for this pipeline.
+  let stageMap = new Map<string, string>();
+  try {
+    const data = await ghlFetch(`/opportunities/pipelines?locationId=${GHL_LOCATION_ID}`);
+    const pl = (data.pipelines || []).find((x: any) => x.id === p.id);
+    stageMap = new Map((pl?.stages || []).map((s: any) => [s.id, s.name]));
+  } catch { /* leave empty → unknown stages fall to identified */ }
+  // Opps (paginated).
+  const opps: any[] = [];
+  for (let page = 1; page <= 20; page++) {
+    const data = await ghlFetch(`/opportunities/search?location_id=${GHL_LOCATION_ID}&pipeline_id=${p.id}&limit=100&page=${page}`);
+    const batch = data.opportunities || [];
+    opps.push(...batch);
+    if (batch.length < 100) break;
+  }
+  for (const o of opps) {
+    if ((o.status || 'open') !== 'open') continue;
+    const b = unitOf(o, BEDS_FIELD), w = unitOf(o, WASHERS_FIELD), v = Number(o.monetaryValue) || 0;
+    total++; beds += b; washers += w; value += v;
+    const sp = spineOf(stageMap.get(o.pipelineStageId) || '');
+    const cell = spine[sp];
+    cell.n++; cell.beds += b; cell.washers += w; cell.value += v;
+  }
+  return { key: p.key, label: p.label, role: p.role, total, beds, washers, value, spine };
+}
+
+export async function getGoodsFunnel(): Promise<GoodsFunnel> {
+  const db = getServiceSupabase();
+  const [{ data: needRows }, { data: addrRows }] = await Promise.all([
+    db.from('goods_communities').select('demand_beds, demand_washers').in('priority', ['active', 'lead']),
+    db.from('goods_communities').select('demand_beds, demand_washers'),
+  ]);
+  const sum = (rows: any[] | null, col: string) => (rows || []).reduce((a, r) => a + (Number(r[col]) || 0), 0);
+  const need = { beds: sum(needRows, 'demand_beds'), washers: sum(needRows, 'demand_washers'), communities: (needRows || []).length };
+  const addressable = { beds: sum(addrRows, 'demand_beds'), washers: sum(addrRows, 'demand_washers'), communities: (addrRows || []).length };
+
+  const ghlConnected = Boolean(GHL_API_KEY && GHL_LOCATION_ID);
+  let pipelines: PipelineFunnel[] = [];
+  if (ghlConnected) {
+    try {
+      pipelines = await Promise.all([
+        rollupPipeline({ ...PIPELINES.demand, key: 'demand' }),
+        rollupPipeline({ ...PIPELINES.buyer, key: 'buyer' }),
+        rollupPipeline({ ...PIPELINES.supporter, key: 'supporter' }),
+      ]);
+    } catch { pipelines = []; }
+  }
+  const buyer = pipelines.find(p => p.key === 'buyer');
+  const supporter = pipelines.find(p => p.key === 'supporter');
+  const ordered = { beds: buyer?.beds || 0, washers: buyer?.washers || 0, value: buyer?.value || 0 };
+  const funded = { beds: supporter?.beds || 0, washers: supporter?.washers || 0, value: supporter?.value || 0 };
+  const gap = { beds: Math.max(0, need.beds - DELIVERED.beds), washers: Math.max(0, need.washers - DELIVERED.washers) };
+
+  return {
+    generatedAt: new Date().toISOString(),
+    ghlConnected: ghlConnected && pipelines.length > 0,
+    need, addressable, ordered, funded, delivered: DELIVERED, gap, pipelines,
+  };
+}


### PR DESCRIPTION
Build C — the management cockpit for the Goods 3-pipeline operating model, as a live page at **`/org/[slug]/goods/funnel`**.

One need, two funding routes, one delivery — in beds / washing machines / $:
- **Cockpit**: NEED (goods_communities curated active+lead) · ORDERED (Buyer) · FUNDED (Supporter) · DELIVERED (cited) · GAP.
- **Per-pipeline funnel**: each GHL pipeline's stages collapsed to a shared **5-stage spine** (Identified → Qualified → Committed → Delivering → Closed) by stage **name**, with counts + beds/washers/$ per stage.

**Design call:** the 3 GHL pipelines KEEP their operational stages (Buyer 12 / Supporter 10 / Demand 4) — Proposed/Negotiating/Committed and Invoiced/Paid are real distinctions operators + finance use. This view collapses to the spine for management legibility *without destroying* that granularity. (Destroying GHL stages was offered as an alternative but not done.)

GHL fetch is best-effort: if `GHL_API_KEY` isn't in the environment, Ordered/Funded show 0 and the cockpit still renders Need/Delivered/Gap from the data model. tsc + next build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)