### PR TITLE
feat(goods): link funnel dashboard from Goods OS header

### DIFF
--- a/apps/web/src/app/org/[slug]/wiki/goods-operating-system/page.tsx
+++ b/apps/web/src/app/org/[slug]/wiki/goods-operating-system/page.tsx
@@ -103,6 +103,12 @@ export default async function GoodsOperatingSystemWikiPage({ params }: { params:
                 Goods workspace
               </Link>
               <Link
+                href={`/org/${slug}/goods/funnel`}
+                className="border border-bauhaus-blue bg-bauhaus-blue px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
+              >
+                Goods funnel
+              </Link>
+              <Link
                 href="/grants?type=open_opportunity&sort=closing_asc&project=goods&quality=ready"
                 className="border border-bauhaus-red bg-bauhaus-red px-4 py-2 text-xs font-black uppercase tracking-widest text-white hover:bg-white hover:text-bauhaus-black"
               >


### PR DESCRIPTION
One-line nav: adds a **Goods funnel** button on the Goods operating-system page header → `/org/[slug]/goods/funnel` (was URL-only). Follows #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)