### PR TITLE
chore(goods): register build-goods-impact-data agent

### DIFF
--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -51,6 +51,17 @@ export const AGENTS = {
     timeoutMs: 600_000,
     dependencies: [],
   },
+  // Refreshes the Goods impact film's data module (apps/video/src/goodsImpactData.ts)
+  // from live goods_communities (need/gap) + the v2 assets-sync delivered constant.
+  // Data refresh only — the render (cd apps/video && npm run render:goods) stays manual.
+  'build-goods-impact-data': {
+    command: ['node', '--env-file=.env', 'scripts/build-goods-impact-data.mjs'],
+    displayName: 'Build Goods Impact Film Data',
+    category: 'analytics',
+    defaultPriority: 5,
+    timeoutMs: 120_000,
+    dependencies: [],
+  },
   'sync-ato-tax-transparency': {
     command: ['node', '--env-file=.env', 'scripts/sync-ato-tax-transparency.mjs'],
     displayName: 'Sync ATO Tax Transparency',


### PR DESCRIPTION
Follow-up to #44 (impact film). Registers the film's data-refresh script (`build-goods-impact-data`) in `scripts/lib/agent-registry.mjs` so it runs on cadence via the agent system.

- Data refresh only — regenerates `apps/video/src/goodsImpactData.ts` from live `goods_communities` (need/gap) + the v2 assets-sync delivered constant.
- The Remotion render (`cd apps/video && npm run render:goods`) stays a deliberate manual step.
- `category: analytics`, priority 5 (monthly cadence), 120s timeout.

Branched off latest `main` (post-#44/#40 merges) per the handoff note, since #44's branch predated the Phase-1 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)