### PR TITLE
feat(goods): cost-allocation + funder-grade cost-evidence artifact (Phases 1+2+3 web)

### DIFF
--- a/apps/web/src/app/api/goods/cost-allocation/route.ts
+++ b/apps/web/src/app/api/goods/cost-allocation/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireModule } from '@/lib/api-auth';
+import {
+  saveGoodsCostAllocationDecision,
+  type GoodsCostAllocationSaveInput,
+} from '@/lib/services/goods-cost-evidence';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireModule('tracker');
+    if (auth.error) return auth.error;
+
+    const body = (await request.json()) as GoodsCostAllocationSaveInput;
+    if (!body.lineFingerprint || !body.xeroInvoiceId || typeof body.lineIndex !== 'number') {
+      return NextResponse.json({ error: 'lineFingerprint, xeroInvoiceId, and lineIndex are required' }, { status: 400 });
+    }
+    if (!body.decision) {
+      return NextResponse.json({ error: 'decision is required' }, { status: 400 });
+    }
+
+    const decision = await saveGoodsCostAllocationDecision({
+      ...body,
+      decidedBy: auth.user.email || auth.user.id,
+    });
+
+    return NextResponse.json({ decision });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Failed to save Goods cost allocation decision',
+        detail: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/org/[slug]/[projectSlug]/goods-cost-allocation-table.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/goods-cost-allocation-table.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+
+import type {
+  GoodsCostAllocationDecision,
+  GoodsCostAllocationScope,
+  GoodsCostEvidence,
+} from '@/lib/services/goods-cost-evidence';
+
+type AllocationRow = GoodsCostEvidence['costAllocationRows'][number];
+
+const decisionLabels: Record<GoodsCostAllocationDecision, string> = {
+  needs_allocation: 'needs allocation',
+  include_direct: 'direct cost',
+  show_separately: 'ACT support',
+  exclude: 'exclude',
+  needs_receipt: 'needs receipt',
+  needs_review: 'needs review',
+};
+
+const actionButtons: Array<{
+  label: string;
+  decision: GoodsCostAllocationDecision;
+  allocationScope: GoodsCostAllocationScope;
+  note: string;
+}> = [
+  {
+    label: 'Use in last 50',
+    decision: 'include_direct',
+    allocationScope: 'last_50',
+    note: 'Marked for the last-50-bed direct-cost sheet.',
+  },
+  {
+    label: 'Direct later',
+    decision: 'include_direct',
+    allocationScope: 'current_batch',
+    note: 'Direct Goods cost, but not allocated to the last-50 sheet yet.',
+  },
+  {
+    label: 'ACT support',
+    decision: 'show_separately',
+    allocationScope: 'shared_service',
+    note: 'Keep separate from delivered unit cost.',
+  },
+  {
+    label: 'Need receipt',
+    decision: 'needs_receipt',
+    allocationScope: 'unallocated',
+    note: 'Needs receipt or attachment before use.',
+  },
+  {
+    label: 'Exclude',
+    decision: 'exclude',
+    allocationScope: 'unallocated',
+    note: 'Do not use in Goods direct-cost calculation.',
+  },
+];
+
+function treatmentClass(decision: GoodsCostAllocationDecision) {
+  if (decision === 'include_direct') return 'border-emerald-600 bg-emerald-50 text-emerald-700';
+  if (decision === 'show_separately') return 'border-bauhaus-blue bg-link-light text-bauhaus-blue';
+  if (decision === 'exclude') return 'border-bauhaus-red bg-red-50 text-bauhaus-red';
+  if (decision === 'needs_receipt' || decision === 'needs_review') return 'border-orange-500 bg-orange-50 text-orange-700';
+  return 'border-gray-300 bg-gray-50 text-gray-700';
+}
+
+export function GoodsCostAllocationTable({ rows }: { rows: AllocationRow[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [localDecisions, setLocalDecisions] = useState<Record<string, GoodsCostAllocationDecision>>({});
+
+  async function saveDecision(
+    row: AllocationRow,
+    decision: GoodsCostAllocationDecision,
+    allocationScope: GoodsCostAllocationScope,
+    notes: string,
+  ) {
+    setSavingKey(row.lineFingerprint);
+    setError(null);
+
+    const response = await fetch('/api/goods/cost-allocation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        lineFingerprint: row.lineFingerprint,
+        lineIndex: row.lineIndex,
+        xeroInvoiceId: row.xeroInvoiceId,
+        invoice: row.invoice,
+        supplier: row.supplier,
+        accountCode: row.accountCode,
+        account: row.account,
+        description: row.description,
+        amount: row.amount,
+        category: row.category,
+        decision,
+        allocationScope,
+        notes,
+      }),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      setSavingKey(null);
+      setError(payload?.detail || payload?.error || 'Could not save allocation decision.');
+      return;
+    }
+
+    setLocalDecisions((current) => ({ ...current, [row.lineFingerprint]: decision }));
+    setSavingKey(null);
+    startTransition(() => router.refresh());
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      {error ? (
+        <div className="border-b border-bauhaus-red bg-red-50 p-3 text-sm font-black text-bauhaus-red">{error}</div>
+      ) : null}
+      <table className="min-w-[1520px] w-full border-collapse text-left text-xs">
+        <thead className="bg-gray-50 text-[10px] font-black uppercase tracking-widest text-gray-500">
+          <tr>
+            <th className="border-b border-r border-gray-200 p-3">Supplier / invoice</th>
+            <th className="border-b border-r border-gray-200 p-3">Amount</th>
+            <th className="border-b border-r border-gray-200 p-3">Category</th>
+            <th className="border-b border-r border-gray-200 p-3">Decision</th>
+            <th className="border-b border-r border-gray-200 p-3">Allocated?</th>
+            <th className="border-b border-r border-gray-200 p-3">Proof</th>
+            <th className="border-b border-gray-200 p-3">Save treatment</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length > 0 ? (
+            rows.map((row) => {
+              const decision = localDecisions[row.lineFingerprint] ?? row.currentDecision;
+              const disabled = savingKey === row.lineFingerprint || isPending;
+              return (
+                <tr key={row.lineFingerprint} className="align-top">
+                  <td className="border-b border-r border-gray-200 p-3">
+                    <div className="text-sm font-black text-bauhaus-black">{row.supplier}</div>
+                    <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-500">
+                      {row.invoice} · {row.date}
+                    </div>
+                    <div className="mt-2 line-clamp-2 text-xs leading-relaxed text-gray-600">{row.description}</div>
+                    <div className="mt-2 text-[10px] font-black uppercase tracking-widest text-gray-400">{row.account}</div>
+                  </td>
+                  <td className="border-b border-r border-gray-200 p-3 text-sm font-black tabular-nums text-bauhaus-blue">
+                    {row.amount}
+                  </td>
+                  <td className="border-b border-r border-gray-200 p-3">
+                    <span className="border border-gray-300 bg-gray-50 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-gray-700">
+                      {row.category}
+                    </span>
+                  </td>
+                  <td className="border-b border-r border-gray-200 p-3">
+                    <div className={`inline-flex border px-2 py-1 text-[10px] font-black uppercase tracking-widest ${treatmentClass(decision)}`}>
+                      {decisionLabels[decision]}
+                    </div>
+                    <div className="mt-2 text-[10px] font-black uppercase tracking-widest text-gray-400">
+                      {row.allocationScope.replaceAll('_', ' ')}
+                    </div>
+                  </td>
+                  <td className="border-b border-r border-gray-200 p-3 font-black leading-relaxed text-bauhaus-black">
+                    {row.batchStatus}
+                  </td>
+                  <td className="border-b border-r border-gray-200 p-3">
+                    <span
+                      className={
+                        row.proofStatus === 'Xero attachment'
+                          ? 'border border-emerald-600 bg-emerald-50 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-emerald-700'
+                          : 'border border-orange-500 bg-orange-50 px-2 py-1 text-[10px] font-black uppercase tracking-widest text-orange-700'
+                      }
+                    >
+                      {row.proofStatus}
+                    </span>
+                  </td>
+                  <td className="border-b border-gray-200 p-3">
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {actionButtons.map((button) => (
+                        <button
+                          key={button.label}
+                          type="button"
+                          disabled={disabled}
+                          onClick={() => saveDecision(row, button.decision, button.allocationScope, button.note)}
+                          className="border border-gray-300 bg-white px-2 py-2 text-[10px] font-black uppercase tracking-widest text-bauhaus-black hover:border-bauhaus-blue hover:bg-link-light disabled:cursor-wait disabled:opacity-50"
+                        >
+                          {savingKey === row.lineFingerprint ? 'Saving' : button.label}
+                        </button>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })
+          ) : (
+            <tr>
+              <td colSpan={7} className="border-b border-gray-200 p-4 text-sm text-gray-600">
+                No Xero line items are ready for allocation review.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
@@ -298,11 +298,119 @@ async function FastProjectDashboard({
           </section>
 
           {costEvidence && costEvidence.status !== 'error' ? (
+            <section id="project-funder-cost-evidence" className="scroll-mt-24 border-4 border-bauhaus-black bg-bauhaus-canvas">
+              <div className="border-b-4 border-bauhaus-black bg-bauhaus-black p-5 text-white">
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Funder cost evidence</p>
+                <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">What a community-made bed actually costs</h2>
+                <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-300">
+                  Sourced from Defy supplier invoices, the Notion BOM, and ACT-GD bills in Xero. Every figure carries
+                  a confidence grade. Capital is shown separately. No aspirational numbers.
+                </p>
+              </div>
+              <div className="grid gap-0 lg:grid-cols-[1.1fr_0.9fr]">
+                <div className="border-b-4 border-bauhaus-black p-6 lg:border-b-0 lg:border-r-4">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Hero number</p>
+                  <div className="mt-3 text-5xl font-black tabular-nums text-bauhaus-black">{costEvidence.funderView.hero.value}</div>
+                  <p className="mt-3 text-sm leading-relaxed text-gray-700">{costEvidence.funderView.hero.label}</p>
+                  <p className="mt-3 text-[11px] leading-relaxed text-gray-500">{costEvidence.funderView.hero.provenance}</p>
+                </div>
+                <div className="p-6">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Counterfactual</p>
+                  <div className="mt-3 text-2xl font-black tabular-nums text-bauhaus-black">
+                    {costEvidence.funderView.counterfactual.commercialRangeLow} – {costEvidence.funderView.counterfactual.commercialRangeHigh}
+                  </div>
+                  <p className="mt-2 text-sm leading-relaxed text-gray-700">
+                    Commercial-equivalent steel-frame bed. ACT delivers at
+                    {' '}<strong>{costEvidence.funderView.counterfactual.ratioLow}–{costEvidence.funderView.counterfactual.ratioHigh}</strong>
+                    {' '}less cost, with community-made craft and local labour.
+                  </p>
+                  <p className="mt-3 text-[11px] leading-relaxed text-gray-500">{costEvidence.funderView.counterfactual.basis}</p>
+                </div>
+              </div>
+              <div className="border-t-4 border-bauhaus-black p-5">
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Cost stack</p>
+                <h3 className="mt-2 text-sm font-black uppercase tracking-wide">How the hero number breaks down per bed</h3>
+                <div className="mt-4 space-y-2">
+                  {costEvidence.funderView.costStack.map((row) => (
+                    <div key={row.label} className="grid items-center gap-3 md:grid-cols-[220px_70px_1fr_1fr]">
+                      <div className="text-sm font-black text-bauhaus-black">{row.label}</div>
+                      <div className="text-sm font-black tabular-nums text-bauhaus-blue">{row.amount}</div>
+                      <div className="h-3 bg-gray-200">
+                        <div
+                          className="h-3 bg-bauhaus-red"
+                          style={{ width: `${Math.max(2, Math.round(row.pctOfDirect * 100))}%` }}
+                        />
+                      </div>
+                      <p className="text-[11px] leading-relaxed text-gray-600">{row.basis}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="grid gap-0 border-t-4 border-bauhaus-black lg:grid-cols-2">
+                <div className="border-b-4 border-bauhaus-black p-5 lg:border-b-0 lg:border-r-4">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Capital (one-off, not per-bed)</p>
+                  <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Production plant + tooling, shown separately</h3>
+                  <div className="mt-2 text-2xl font-black tabular-nums text-bauhaus-black">{costEvidence.funderView.capitalSummary.total}</div>
+                  <div className="mt-4 divide-y divide-gray-200 border border-gray-300 bg-white">
+                    {costEvidence.funderView.capitalSummary.rows.map((row) => (
+                      <div key={row.label} className="grid gap-2 p-3 md:grid-cols-[1fr_140px]">
+                        <div>
+                          <div className="text-sm font-black text-bauhaus-black">{row.label}</div>
+                          <p className="mt-1 text-[11px] leading-relaxed text-gray-600">{row.note}</p>
+                        </div>
+                        <div className="text-sm font-black tabular-nums text-bauhaus-blue md:text-right">{row.amount}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="p-5">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">$ to beds</p>
+                  <h3 className="mt-2 text-sm font-black uppercase tracking-wide">What funding converts to, at the hero number</h3>
+                  <div className="mt-4 divide-y divide-gray-200 border border-gray-300 bg-white">
+                    {costEvidence.funderView.conversion.map((row) => (
+                      <div key={row.funds} className="grid items-center gap-2 p-3 md:grid-cols-[110px_80px_1fr]">
+                        <div className="text-sm font-black tabular-nums text-bauhaus-black">{row.funds}</div>
+                        <div className="text-sm font-black tabular-nums text-bauhaus-red">{row.beds} beds</div>
+                        <p className="text-[11px] leading-relaxed text-gray-600">{row.note}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="border-t-4 border-bauhaus-black bg-white p-5">
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Provenance</p>
+                <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Every figure traces to a source</h3>
+                <div className="mt-3 divide-y divide-gray-200 border border-gray-200">
+                  {costEvidence.funderView.provenance.map((row) => {
+                    const confidenceClass =
+                      row.confidence === 'verified'
+                        ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
+                        : row.confidence === 'inferred'
+                          ? 'border-bauhaus-blue bg-link-light text-bauhaus-blue'
+                          : row.confidence === 'planning'
+                            ? 'border-orange-500 bg-orange-50 text-orange-700'
+                            : 'border-bauhaus-red bg-red-50 text-bauhaus-red';
+                    return (
+                      <div key={`${row.figure}-${row.source}`} className="grid gap-2 p-3 md:grid-cols-[1fr_1.4fr_120px]">
+                        <div className="text-sm font-black text-bauhaus-black">{row.figure}</div>
+                        <p className="text-[11px] leading-relaxed text-gray-600">{row.source}</p>
+                        <span className={`inline-flex w-fit border px-2 py-1 text-[10px] font-black uppercase tracking-widest ${confidenceClass}`}>
+                          {row.confidence}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          {costEvidence && costEvidence.status !== 'error' ? (
             <section id="project-cost-evidence" className="scroll-mt-24 border-4 border-bauhaus-black bg-white">
               <div className="border-b-4 border-bauhaus-black p-5">
                 <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
                   <div>
-                    <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Cost evidence</p>
+                    <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Cost-evidence operating queue</p>
                     <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Last 50 beds — direct cost build-up</h2>
                     <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
                       Sourced from ACT-GD supplier bills in Xero. Each line gets a human treatment decision so the
@@ -322,6 +430,65 @@ async function FastProjectDashboard({
                   </div>
                 ) : null}
               </div>
+              {costEvidence.dataQualityFlags.length > 0 ? (
+                <div className="border-b-4 border-bauhaus-black bg-red-50/40 p-5">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Data-quality review queue</p>
+                  <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Resolve these before quoting actuals</h3>
+                  <div className="mt-3 space-y-2">
+                    {costEvidence.dataQualityFlags.map((flag) => {
+                      const severityClass =
+                        flag.severity === 'high'
+                          ? 'border-bauhaus-red bg-red-50 text-bauhaus-red'
+                          : flag.severity === 'medium'
+                            ? 'border-orange-500 bg-orange-50 text-orange-700'
+                            : 'border-gray-400 bg-gray-50 text-gray-700';
+                      return (
+                        <div key={flag.id} className="border border-gray-300 bg-white p-3">
+                          <div className="flex flex-wrap items-start justify-between gap-2">
+                            <div className="flex-1">
+                              <div className="text-sm font-black text-bauhaus-black">{flag.issue}</div>
+                              <p className="mt-1 text-[11px] leading-relaxed text-gray-600">{flag.evidence}</p>
+                              <p className="mt-1 text-[11px] leading-relaxed text-bauhaus-blue"><strong>Action:</strong> {flag.action}</p>
+                            </div>
+                            <div className="flex flex-col items-end gap-1">
+                              <span className={`inline-flex border px-2 py-1 text-[10px] font-black uppercase tracking-widest ${severityClass}`}>
+                                {flag.severity}
+                              </span>
+                              {flag.amount ? (
+                                <span className="text-sm font-black tabular-nums text-bauhaus-black">{flag.amount}</span>
+                              ) : null}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              {costEvidence.capitalRows.length > 0 ? (
+                <div className="border-b-4 border-bauhaus-black p-5">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Capital items detected in Xero</p>
+                  <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Show separately — not per-bed</h3>
+                  <div className="mt-3 divide-y divide-gray-200 border border-gray-200">
+                    {costEvidence.capitalRows.map((row) => (
+                      <div key={`${row.invoice}-${row.description}-${row.amount}`} className="grid gap-2 p-3 md:grid-cols-[1fr_120px_120px]">
+                        <div>
+                          <div className="text-sm font-black text-bauhaus-black">{row.supplier}</div>
+                          <p className="mt-1 text-[11px] leading-relaxed text-gray-600">{row.description}</p>
+                          <p className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-500">{row.invoice} · {row.date}</p>
+                          <p className="mt-1 text-[11px] leading-relaxed text-bauhaus-blue">{row.note}</p>
+                        </div>
+                        <div className="text-sm font-black tabular-nums text-bauhaus-blue md:text-right">{row.amount}</div>
+                        <div>
+                          <span className="inline-flex border border-bauhaus-blue bg-link-light px-2 py-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">
+                            {row.bucket.replaceAll('-', ' ')}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
               {costEvidence.unitEstimateRows.length > 0 ? (
                 <div className="border-b-4 border-bauhaus-black p-5">
                   <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Unit estimate confidence</p>

--- a/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
@@ -377,6 +377,145 @@ async function FastProjectDashboard({
                   </div>
                 </div>
               </div>
+              <div className="border-t-4 border-bauhaus-black p-5">
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Volume scenarios</p>
+                <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Today → target → vision (the trajectory funders fund)</h3>
+                <div className="mt-4 overflow-x-auto">
+                  <table className="min-w-[800px] w-full border-collapse text-left text-xs">
+                    <thead className="bg-gray-50 text-[10px] font-black uppercase tracking-widest text-gray-500">
+                      <tr>
+                        <th className="border-b border-r border-gray-200 p-3">Scenario</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Direct</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Freight</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Founder (prod)</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Admin</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Field</th>
+                        <th className="border-b border-gray-200 p-3 text-right">Fully-loaded</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(['today', 'target', 'vision'] as const).map((key) => {
+                        const row = costEvidence.funderView.scenarios[key];
+                        const isTarget = key === 'target';
+                        return (
+                          <tr key={key} className={isTarget ? 'bg-bauhaus-canvas/50' : ''}>
+                            <td className="border-b border-r border-gray-200 p-3">
+                              <div className="text-sm font-black text-bauhaus-black">{row.label}</div>
+                              <p className="mt-1 text-[10px] leading-relaxed text-gray-500">{row.state}</p>
+                            </td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums">{row.direct}</td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums">{row.freight}</td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums">{row.founder}</td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums">{row.admin}</td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums">{row.field}</td>
+                            <td className="border-b border-gray-200 p-3 text-right text-sm font-black tabular-nums text-bauhaus-red">{row.total}</td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                <p className="mt-3 text-[11px] leading-relaxed text-gray-500">
+                  Commercial counterfactual {costEvidence.funderView.counterfactual.commercialRangeLow}–{costEvidence.funderView.counterfactual.commercialRangeHigh} per bed. Today already competitive at volume; State 4 at 500/yr beats commercial by 2–3×.
+                </p>
+              </div>
+
+              <div className="border-t-4 border-bauhaus-black bg-white p-5">
+                <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Idiot Index — where Defy's markup actually is</p>
+                <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Ratio of finished-part cost to raw-material cost — biggest ratios = biggest in-house opportunities</h3>
+                <div className="mt-4 overflow-x-auto">
+                  <table className="min-w-[700px] w-full border-collapse text-left text-xs">
+                    <thead className="bg-gray-50 text-[10px] font-black uppercase tracking-widest text-gray-500">
+                      <tr>
+                        <th className="border-b border-r border-gray-200 p-3">Element</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Raw</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">We pay</th>
+                        <th className="border-b border-r border-gray-200 p-3 text-right">Index</th>
+                        <th className="border-b border-gray-200 p-3">Markup pays for</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {costEvidence.funderView.idiotIndex.map((row) => {
+                        const rawDisplay = row.rawLow === row.rawHigh ? row.rawLow : `${row.rawLow}–${row.rawHigh}`;
+                        const indexDisplay =
+                          row.indexLow === row.indexHigh ? `${row.indexLow.toFixed(1)}×` : `${row.indexLow.toFixed(1)}–${row.indexHigh.toFixed(1)}×`;
+                        const indexClass =
+                          row.indexHigh >= 5
+                            ? 'text-bauhaus-red'
+                            : row.indexHigh >= 3
+                              ? 'text-orange-600'
+                              : row.indexHigh >= 2
+                                ? 'text-bauhaus-blue'
+                                : 'text-gray-600';
+                        return (
+                          <tr key={row.element}>
+                            <td className="border-b border-r border-gray-200 p-3 text-sm font-black text-bauhaus-black">{row.element}</td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums text-gray-600">{rawDisplay}</td>
+                            <td className="border-b border-r border-gray-200 p-3 text-right tabular-nums">{row.current}</td>
+                            <td className={`border-b border-r border-gray-200 p-3 text-right text-sm font-black tabular-nums ${indexClass}`}>{indexDisplay}</td>
+                            <td className="border-b border-gray-200 p-3 text-[11px] leading-relaxed text-gray-600">{row.markupPaysFor}</td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="grid gap-0 border-t-4 border-bauhaus-black lg:grid-cols-2">
+                <div className="border-b-4 border-bauhaus-black p-5 lg:border-b-0 lg:border-r-4">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Founder time, properly allocated</p>
+                  <h3 className="mt-2 text-sm font-black uppercase tracking-wide">{costEvidence.funderView.founderAllocation.reduce((s, r) => s + r.days, 0)} days × $1,000/day on Goods</h3>
+                  <div className="mt-3 divide-y divide-gray-200 border border-gray-200">
+                    {costEvidence.funderView.founderAllocation.map((row) => {
+                      const targetClass =
+                        row.allocateTo === 'bed-overhead'
+                          ? 'border-bauhaus-red bg-red-50 text-bauhaus-red'
+                          : row.allocateTo === 'funding-side-offset'
+                            ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
+                            : 'border-gray-400 bg-gray-50 text-gray-700';
+                      return (
+                        <div key={row.label} className="grid gap-2 p-3 md:grid-cols-[1fr_70px_80px_120px]">
+                          <div className="text-xs leading-relaxed text-bauhaus-black">{row.label}</div>
+                          <div className="text-xs font-black tabular-nums text-right">{row.days}d</div>
+                          <div className="text-xs font-black tabular-nums text-right">{row.annualCost}</div>
+                          <span className={`inline-flex w-fit border px-2 py-1 text-[9px] font-black uppercase tracking-widest ${targetClass}`}>
+                            {row.allocateTo.replaceAll('-', ' ')}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <p className="mt-3 text-[11px] leading-relaxed text-gray-500">
+                    Only production-related founder time hits the bed cost line. Fundraising + commercial days OFFSET bed cost via dollars raised.
+                  </p>
+                </div>
+                <div className="p-5">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Fundraising offset</p>
+                  <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Every $1 raised funds a bed PLUS capex toward $350/bed</h3>
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    <div className="border border-gray-200 bg-gray-50 p-4">
+                      <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Philanthropy</p>
+                      <div className="mt-2 text-2xl font-black tabular-nums text-bauhaus-black">{costEvidence.funderView.fundraisingOffset.philanthropyAnnual}</div>
+                      <p className="mt-1 text-[11px] leading-relaxed text-gray-600">{costEvidence.funderView.fundraisingOffset.philanthropyDays} founder-days/yr × ~$5K/day raised</p>
+                    </div>
+                    <div className="border border-gray-200 bg-gray-50 p-4">
+                      <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Commercial buyer</p>
+                      <div className="mt-2 text-2xl font-black tabular-nums text-bauhaus-black">{costEvidence.funderView.fundraisingOffset.buyerBenchmark} / bed</div>
+                      <p className="mt-1 text-[11px] leading-relaxed text-gray-600">{costEvidence.funderView.fundraisingOffset.buyerSource}</p>
+                    </div>
+                    <div className="border border-emerald-600 bg-emerald-50 p-4">
+                      <p className="text-[10px] font-black uppercase tracking-widest text-emerald-700">Subsidy @ 100/yr</p>
+                      <div className="mt-2 text-2xl font-black tabular-nums text-emerald-700">{costEvidence.funderView.fundraisingOffset.subsidyAt100} / bed</div>
+                    </div>
+                    <div className="border border-emerald-600 bg-emerald-50 p-4">
+                      <p className="text-[10px] font-black uppercase tracking-widest text-emerald-700">Subsidy @ 500/yr</p>
+                      <div className="mt-2 text-2xl font-black tabular-nums text-emerald-700">{costEvidence.funderView.fundraisingOffset.subsidyAt500} / bed</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <div className="border-t-4 border-bauhaus-black bg-white p-5">
                 <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Provenance</p>
                 <h3 className="mt-2 text-sm font-black uppercase tracking-wide">Every figure traces to a source</h3>

--- a/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/page.tsx
@@ -48,6 +48,8 @@ import {
   type OrgProfile,
   type OrgProject,
 } from '@/lib/services/org-dashboard-service';
+import { getGoodsCostEvidence } from '@/lib/services/goods-cost-evidence';
+import { GoodsCostAllocationTable } from './goods-cost-allocation-table';
 import { Section } from '../../_components/ui';
 import { ProjectCards } from '../../_components/project-cards';
 import { ProjectFoundationsClient } from '../../_components/project-foundations-client';
@@ -96,7 +98,7 @@ function formatDateLabel(value: number | null) {
   });
 }
 
-function FastProjectDashboard({
+async function FastProjectDashboard({
   profile,
   project,
   slug,
@@ -142,6 +144,7 @@ function FastProjectDashboard({
     const receivedRows = goodsFundingPipelineRows.filter((row) => row.status.includes('received'));
     const liveRows = goodsFundingPipelineRows.filter((row) => !row.status.includes('received'));
     const blockingRows = goodsCoreWorkAreas.filter((row) => row.status.includes('blocking'));
+    const costEvidence = await getGoodsCostEvidence().catch(() => null);
 
     return (
       <main className="min-h-screen bg-gray-50 text-bauhaus-black">
@@ -293,6 +296,51 @@ function FastProjectDashboard({
               </div>
             </div>
           </section>
+
+          {costEvidence && costEvidence.status !== 'error' ? (
+            <section id="project-cost-evidence" className="scroll-mt-24 border-4 border-bauhaus-black bg-white">
+              <div className="border-b-4 border-bauhaus-black p-5">
+                <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+                  <div>
+                    <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-red">Cost evidence</p>
+                    <h2 className="mt-2 text-2xl font-black uppercase tracking-wide">Last 50 beds — direct cost build-up</h2>
+                    <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
+                      Sourced from ACT-GD supplier bills in Xero. Each line gets a human treatment decision so the
+                      delivered unit cost is finance-backed, not a planning estimate.
+                    </p>
+                  </div>
+                </div>
+                {costEvidence.totals.length > 0 ? (
+                  <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                    {costEvidence.totals.map((total) => (
+                      <div key={total.label} className="border border-gray-200 bg-gray-50 p-4">
+                        <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">{total.label}</p>
+                        <div className="mt-2 text-xl font-black tabular-nums text-bauhaus-black">{total.value}</div>
+                        <p className="mt-2 text-xs leading-relaxed text-gray-600">{total.detail}</p>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+              {costEvidence.unitEstimateRows.length > 0 ? (
+                <div className="border-b-4 border-bauhaus-black p-5">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Unit estimate confidence</p>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                    {costEvidence.unitEstimateRows.map((row) => (
+                      <div key={row.label} className="border border-gray-200 bg-gray-50 p-4">
+                        <div className="text-sm font-black text-bauhaus-black">{row.label}</div>
+                        <div className="mt-2 text-lg font-black tabular-nums text-bauhaus-blue">{row.value}</div>
+                        <p className="mt-2 text-[10px] font-black uppercase tracking-widest text-gray-500">{row.confidence}</p>
+                        <p className="mt-2 text-xs leading-relaxed text-gray-600">{row.use}</p>
+                        <p className="mt-2 text-[10px] leading-relaxed text-gray-500">{row.basis}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              <GoodsCostAllocationTable rows={costEvidence.costAllocationRows} />
+            </section>
+          ) : null}
 
           <section className="grid gap-4 lg:grid-cols-[1fr_0.85fr]">
             <div className="border-4 border-bauhaus-black bg-white p-5">

--- a/apps/web/src/lib/data/goods-bed-cost-model.json
+++ b/apps/web/src/lib/data/goods-bed-cost-model.json
@@ -1,0 +1,246 @@
+{
+  "meta": {
+    "title": "Goods bed cost model v3 — element-by-element with Idiot Index",
+    "created": "2026-05-28",
+    "source_doc": "thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md",
+    "verified_from": "thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json"
+  },
+  "physics": {
+    "hdpe_density_g_per_cm3": 0.96,
+    "half_sheet_dims_cm": [120, 120, 1.9],
+    "half_sheet_mass_kg": 26.27,
+    "hdpe_kg_per_bed": 20,
+    "_hdpe_per_bed_source": "Ben confirmed 2026-05-28 — 20kg of HDPE per finished bed (~76% of one half-sheet; the rest is offcuts/press loss).",
+    "raw_hdpe_cost_per_bed": 40.00,
+    "half_sheets_per_bed_equivalent": 0.76
+  },
+  "defy_verified_rates": {
+    "single_bed_fully_fabricated": { "amount": 600.00, "source": "INV-1507 Nov 2025, 25 beds", "confidence": "verified" },
+    "bed_kit_cut_finished": { "amount": 344.05, "source": "INV-1602 (92 kits) + 2026-03-27 (50 kits)", "confidence": "verified" },
+    "cut_and_finish_only": { "amount": 121.00, "source": "INV-1602 (16 beds, pre-purchased sheets)", "confidence": "verified" },
+    "assembly_labour": { "amount": 55.95, "source": "2026-03-19 (8 beds, exact line)", "confidence": "verified" },
+    "half_sheet_bulk_price": { "amount": 200.00, "source": "2026-03-27 (20 sheets bulk discount)", "confidence": "verified" },
+    "hdpe_shred_per_kg": { "amount": 2.00, "source": "2026-03-27 (1200kg bulk bags)", "confidence": "verified" },
+    "worker_day_rate_full": { "amount": 480.00, "source": "INV-1325/1326 (Sam, Todd)", "confidence": "verified" },
+    "worker_day_rate_half": { "amount": 240.00, "source": "INV-1325/1326", "confidence": "verified" },
+    "freight_botany_to_alice_per_pallet_low": { "amount": 808.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
+    "freight_botany_to_alice_per_pallet_high": { "amount": 1480.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
+    "beds_per_pallet_typical": 8
+  },
+  "raw_material_estimates_au_2026": {
+    "hdpe_shred_per_kg": 2.00,
+    "canvas_per_m2_estimate": 17.00,
+    "canvas_m2_per_bed_estimate": 4.0,
+    "steel_per_bed_raw_estimate": 12.00,
+    "end_caps_per_bed_raw_estimate": 0.75
+  },
+  "notion_bom_verified": {
+    "hdpe_kit": { "amount": 344.05, "confidence": "verified", "matches_defy": true },
+    "canvas": { "amount": 93.50, "confidence": "inferred", "matches_defy": "bundled in $600 single bed" },
+    "assembly_labour": { "amount": 55.95, "confidence": "verified", "matches_defy": true },
+    "steel": { "amount": 27.00, "confidence": "inferred", "matches_defy": "bundled" },
+    "end_caps": { "amount": 3.20, "confidence": "inferred", "matches_defy": "bundled" },
+    "direct_total": 523.70
+  },
+  "in_house_estimates": {
+    "sheet_pressing_per_bed": { "amount": 40.00, "basis": "Hot-press energy + machine wear, no labour amortising capital yet", "confidence": "modelled" },
+    "cnc_cut_finish_per_bed": { "amount": 60.00, "basis": "1hr × $60/hr (operator + machine amortised)", "confidence": "modelled" },
+    "shredding_in_house_per_bed": { "amount": 10.00, "basis": "Energy + machine wear at scale", "confidence": "modelled" },
+    "wash_sort_dry_per_bed": { "amount": 20.00, "basis": "Labour line for community-collected plastic", "confidence": "modelled" },
+    "internal_assembly_labour_per_bed": { "amount": 46.67, "basis": "6 beds/day × $280/day award + super C13", "confidence": "modelled" },
+    "internal_assembly_labour_fair_market_per_bed": { "amount": 67.17, "basis": "6 beds/day × $403/day fair-market skilled fabricator", "confidence": "modelled" }
+  },
+  "wage_scenarios": [
+    { "label": "Award C13 (entry fabricator)", "hourly": 26, "daily_8hr": 208, "daily_with_super": 233, "beds_per_day": 6, "per_bed": 38.83 },
+    { "label": "Award C10 (mid-skilled)", "hourly": 32, "daily_8hr": 256, "daily_with_super": 287, "beds_per_day": 6, "per_bed": 47.83 },
+    { "label": "Fair-market skilled trade", "hourly": 45, "daily_8hr": 360, "daily_with_super": 403, "beds_per_day": 6, "per_bed": 67.17 },
+    { "label": "Indigenous community wage + cultural loading", "hourly": 35, "daily_8hr": 280, "daily_with_super": 314, "beds_per_day": 6, "per_bed": 52.33 }
+  ],
+  "community_plastic_pay_scenarios": [
+    { "label": "Bottom (kerbside-equivalent)", "per_kg": 0.20, "kg_per_bed": 40, "per_bed": 8.00 },
+    { "label": "Mid (community-coop rate)", "per_kg": 0.50, "kg_per_bed": 40, "per_bed": 20.00 },
+    { "label": "Premium (ocean/remote story-value)", "per_kg": 1.00, "kg_per_bed": 40, "per_bed": 40.00 },
+    { "label": "High (clean sorted, remote community)", "per_kg": 2.00, "kg_per_bed": 40, "per_bed": 80.00 }
+  ],
+  "build_states": {
+    "state_1_defy_everything": {
+      "label": "Defy does everything (today, INV-1507)",
+      "components": [
+        { "label": "Single Bed fully fabricated", "amount": 600.00 }
+      ],
+      "direct_total": 600.00,
+      "capital_added": 0,
+      "capital_cumulative": 0
+    },
+    "state_2_buy_kit_assemble": {
+      "label": "Buy Defy kit, assemble in-house",
+      "components": [
+        { "label": "Defy bed kit (sheets cut+finished)", "amount": 344.05 },
+        { "label": "Canvas (RW Pacific or via Defy)", "amount": 93.50 },
+        { "label": "Steel poles", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "In-house assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 514.42,
+      "capital_added": 2000,
+      "capital_cumulative": 2000
+    },
+    "state_3_buy_sheets_cut_assemble": {
+      "label": "Buy pressed sheets, cut+finish+assemble in-house",
+      "components": [
+        { "label": "1.5 half-sheets from Defy @ $200", "amount": 300.00 },
+        { "label": "In-house CNC cut + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 530.37,
+      "capital_added": 38000,
+      "capital_cumulative": 40000
+    },
+    "state_4_all_in_house": {
+      "label": "Buy raw HDPE shred, do everything in-house",
+      "components": [
+        { "label": "HDPE shred 20kg @ $2/kg (Ben confirmed)", "amount": 40.00 },
+        { "label": "In-house sheet pressing", "amount": 40.00 },
+        { "label": "In-house CNC cut + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 310.37,
+      "capital_added": 160000,
+      "capital_cumulative": 200000
+    },
+    "state_5_community_plastic": {
+      "label": "Community-collected plastic + all in-house (vision)",
+      "components": [
+        { "label": "Community plastic pay @ $1/kg × 20kg", "amount": 20.00 },
+        { "label": "Wash + dry + sort", "amount": 20.00 },
+        { "label": "In-house shredding", "amount": 10.00 },
+        { "label": "In-house sheet pressing", "amount": 40.00 },
+        { "label": "In-house CNC + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 320.37,
+      "capital_added": 30000,
+      "capital_cumulative": 230000,
+      "community_jobs_created": true
+    }
+  },
+  "idiot_index": [
+    { "element": "HDPE shred → finished kit", "raw_low": 40.00, "raw_high": 40.00, "current": 344.05, "index_low": 8.6, "index_high": 8.6, "markup_pays_for": "Shredding, sheet pressing, CNC cutting, finishing, Defy margin. BIGGEST LEVERAGE in the model.", "raw_basis": "20kg HDPE × $2/kg (Ben confirmed 2026-05-28)" },
+    { "element": "Half-sheet (1200×1200×19mm)", "raw_low": 52.55, "raw_high": 52.55, "current": 200.00, "index_low": 3.8, "index_high": 3.8, "markup_pays_for": "Hot-press machine time, energy, Defy margin" },
+    { "element": "Cut+finish only", "raw_low": 30.00, "raw_high": 60.00, "current": 121.00, "index_low": 2.0, "index_high": 4.0, "markup_pays_for": "CNC operator + machine time + Defy margin" },
+    { "element": "Assembly labour (Defy)", "raw_low": 52.00, "raw_high": 52.00, "current": 55.95, "index_low": 1.1, "index_high": 1.1, "markup_pays_for": "Already efficient — small Defy margin" },
+    { "element": "Steel (frame + caps)", "raw_low": 10.00, "raw_high": 15.00, "current": 27.00, "index_low": 1.8, "index_high": 2.7, "markup_pays_for": "Cut to length, drill, deliver" },
+    { "element": "Canvas", "raw_low": 45.00, "raw_high": 68.00, "current": 93.50, "index_low": 1.4, "index_high": 2.1, "markup_pays_for": "Cut, hem, grommet, RW Pacific margin" },
+    { "element": "End caps / fittings", "raw_low": 0.50, "raw_high": 1.00, "current": 3.20, "index_low": 3.2, "index_high": 6.4, "markup_pays_for": "Bulk-buy supplier margin" },
+    { "element": "Pallet + packing", "raw_low": 30.00, "raw_high": 50.00, "current": 60.00, "index_low": 1.2, "index_high": 2.0, "markup_pays_for": "Labour + packing materials" }
+  ],
+  "founder_time_allocation": {
+    "rate_per_day": 1000,
+    "total_days_per_year_on_goods": 150,
+    "split": [
+      { "label": "Production-related (oversight, QA, design iteration, supplier rel.)", "days": 30, "annual_cost": 30000, "allocate_to": "bed-overhead" },
+      { "label": "Fundraising / philanthropy (briefs, asks, reporting, donor rel.)", "days": 50, "annual_cost": 50000, "allocate_to": "funding-side-offset" },
+      { "label": "Commercialisation / buyer dev (Centrecorp, councils, sales)", "days": 25, "annual_cost": 25000, "allocate_to": "funding-side-offset" },
+      { "label": "Governance, strategy, comms, brand", "days": 45, "annual_cost": 45000, "allocate_to": "act-wide-overhead" }
+    ],
+    "_principle": "Only production-related founder time goes onto beds. The fundraising/commercial portion OFFSETS bed cost via dollars raised; the governance portion is ACT-wide, not Goods-specific."
+  },
+  "volume_scenarios": [
+    {
+      "label": "Today (100 beds/yr)",
+      "beds_per_year": 100,
+      "production_founder_per_bed": 300,
+      "admin_per_bed": 147,
+      "field_travel_per_bed": 510,
+      "freight_per_bed": 150,
+      "fully_loaded_state_1": 1707,
+      "fully_loaded_state_4": 1417,
+      "fully_loaded_state_5": 1427,
+      "_math_state_1": "600 + 150 + 300 + 147 + 510 = 1707",
+      "_math_state_4": "310.37 + 150 + 300 + 147 + 510 = 1417.37",
+      "_math_state_5": "320.37 + 150 + 300 + 147 + 510 = 1427.37"
+    },
+    {
+      "label": "Target (500 beds/yr)",
+      "beds_per_year": 500,
+      "production_founder_per_bed": 60,
+      "admin_per_bed": 29,
+      "field_travel_per_bed": 100,
+      "freight_per_bed": 100,
+      "fully_loaded_state_1": 889,
+      "fully_loaded_state_4": 599,
+      "fully_loaded_state_5": 609,
+      "_math_state_1": "600 + 100 + 60 + 29 + 100 = 889",
+      "_math_state_4": "310.37 + 100 + 60 + 29 + 100 = 599.37",
+      "_math_state_5": "320.37 + 100 + 60 + 29 + 100 = 609.37"
+    },
+    {
+      "label": "Vision (1,000 beds/yr, in-house assembly)",
+      "beds_per_year": 1000,
+      "production_founder_per_bed": 30,
+      "admin_per_bed": 15,
+      "field_travel_per_bed": 50,
+      "freight_per_bed": 80,
+      "fully_loaded_state_1": 775,
+      "fully_loaded_state_4": 485,
+      "fully_loaded_state_5": 495,
+      "_math_state_1": "600 + 80 + 30 + 15 + 50 = 775",
+      "_math_state_4": "310.37 + 80 + 30 + 15 + 50 = 485.37",
+      "_math_state_5": "320.37 + 80 + 30 + 15 + 50 = 495.37"
+    }
+  ],
+  "fundraising_offset": {
+    "philanthropy_days_per_year": 50,
+    "philanthropy_dollars_per_founder_day_estimate": 5000,
+    "philanthropy_annual_estimate": 250000,
+    "commercial_sales_days_per_year": 25,
+    "commercial_buyer_benchmark_per_bed": 801,
+    "commercial_buyer_source": "Centrecorp INV-0291 (107 beds @ $85,712)",
+    "_per_bed_subsidy_at_100_per_year": 2500,
+    "_per_bed_subsidy_at_500_per_year": 500,
+    "_principle": "Fundraising days are an INVESTMENT that generates revenue offsetting bed cost. Funder pitch is 'every $1 raised funds a bed + capex toward in-house production'."
+  },
+  "counterfactual": {
+    "commercial_steel_frame_bed_au_2026_low": 1500,
+    "commercial_steel_frame_bed_au_2026_high": 2000,
+    "source": "Retail furniture / contract supply mid-2026 AU market scan",
+    "confidence": "inferred"
+  },
+  "capex_required_to_reach_state_4": {
+    "shredder": { "low": 15000, "high": 30000 },
+    "hot_press_line": { "low": 80000, "high": 150000 },
+    "cnc_router": { "low": 15000, "high": 40000 },
+    "workbench_tools": 2000,
+    "total_low": 112000,
+    "total_high": 222000,
+    "already_invested_facility": 100000,
+    "already_invested_carbatec_tooling": 10046,
+    "_capital_ask_low": 90000,
+    "_capital_ask_high": 200000
+  },
+  "mistags_to_fix": [
+    { "supplier": "Defy Washing Machine Cladding (multiple bills)", "amount": 25000, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Defy Coasters (INV-1174 + INV-1637)", "amount": 10000, "current_tag": "ACT-GD", "correct_tag": "ACT-EL (marketing/merch)" },
+    { "supplier": "Defy Design/R&D (INV-1258 design + INV-1259 prototype)", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
+    { "supplier": "Carbatec Brisbane", "amount": 8726, "current_tag": "ACT-GD", "correct_tag": "ACT-HV" },
+    { "supplier": "Utopia trip flights/accommodation", "amount": 24507, "current_tag": "ACT-IN", "correct_tag": "ACT-GD" },
+    { "supplier": "1300 Washer", "amount": 13980, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Carla Furnishers duplicate", "amount": 11180, "current_tag": "ACT-GD", "correct_tag": "VOID DUPLICATE" },
+    { "supplier": "R M Tanner Triple Axle", "amount": 19950, "current_tag": "ACT-GD labour 486", "correct_tag": "ACT-GD capital" }
+  ],
+  "open_questions_for_defy": [
+    "Volume-quote sheet at 100 / 500 / 1,000 / 5,000 beds/yr — what does $600/bed Single Bed become?",
+    "Build-to-supply: cheaper if ACT sources steel (Steelmart) + canvas (RW Pacific) direct and supplies to Defy?",
+    "At what volume does in-house assembly pay back the $90-200K capex? (i.e. is State 2 or State 4 the right transition point?)",
+    "Half-sheets per bed: how many does the standard bed actually use? (Model assumes 1.5 — Ben to confirm.)"
+  ]
+}

--- a/apps/web/src/lib/services/goods-bed-cost-model.ts
+++ b/apps/web/src/lib/services/goods-bed-cost-model.ts
@@ -1,0 +1,180 @@
+/**
+ * Goods bed cost model v3 — the funder-grade unit-economics engine.
+ *
+ * All inputs live in `lib/data/goods-bed-cost-model.json` (single source of
+ * truth, mirrored from `thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json`
+ * in act-infra). This module exposes typed accessors + pure compute functions
+ * so the funder artifact view and the interactive cost-model page can render
+ * from the same data.
+ *
+ * Verified rates come from `scripts/ocr-defy-bills.mjs` OCR'd invoice PDFs.
+ * Plan: goods-cost-evidence-funder-artifact.
+ */
+import model from '@/lib/data/goods-bed-cost-model.json';
+
+export type BedCostModel = typeof model;
+
+export type BuildStateKey = 'state_1_defy_everything' | 'state_2_buy_kit_assemble' | 'state_3_buy_sheets_cut_assemble' | 'state_4_all_in_house' | 'state_5_community_plastic';
+
+export interface BuildStateComponent {
+  label: string;
+  amount: number;
+}
+
+export interface BuildState {
+  key: BuildStateKey;
+  label: string;
+  components: BuildStateComponent[];
+  direct_total: number;
+  capital_added: number;
+  capital_cumulative: number;
+}
+
+export interface IdiotIndexRow {
+  element: string;
+  raw_low: number;
+  raw_high: number;
+  current: number;
+  index_low: number;
+  index_high: number;
+  markup_pays_for: string;
+  raw_basis?: string;
+}
+
+export interface VolumeScenario {
+  label: string;
+  beds_per_year: number;
+  production_founder_per_bed: number;
+  admin_per_bed: number;
+  field_travel_per_bed: number;
+  freight_per_bed: number;
+  fully_loaded_state_1: number;
+  fully_loaded_state_4: number;
+  fully_loaded_state_5: number;
+}
+
+export interface FullyLoadedBreakdown {
+  state: BuildStateKey;
+  state_label: string;
+  direct: number;
+  freight: number;
+  production_founder: number;
+  admin: number;
+  field_travel: number;
+  total: number;
+}
+
+export function getBedCostModel(): BedCostModel {
+  return model;
+}
+
+export function listBuildStates(): BuildState[] {
+  const states = model.build_states as Record<string, Omit<BuildState, 'key'>>;
+  return (Object.entries(states) as Array<[BuildStateKey, Omit<BuildState, 'key'>]>).map(([key, value]) => ({
+    key,
+    ...value,
+  }));
+}
+
+export function getIdiotIndex(): IdiotIndexRow[] {
+  return model.idiot_index as IdiotIndexRow[];
+}
+
+export function getVolumeScenarios(): VolumeScenario[] {
+  return model.volume_scenarios as VolumeScenario[];
+}
+
+/**
+ * Compute the fully-loaded per-bed cost for a given build state and volume scenario.
+ * This is the pure-function version of the JSON's hard-coded numbers — used when
+ * the interactive page lets the user override any input.
+ */
+export function computeFullyLoaded(state: BuildState, scenario: VolumeScenario): FullyLoadedBreakdown {
+  const direct = state.direct_total;
+  const freight = scenario.freight_per_bed;
+  const production_founder = scenario.production_founder_per_bed;
+  const admin = scenario.admin_per_bed;
+  const field_travel = scenario.field_travel_per_bed;
+  return {
+    state: state.key,
+    state_label: state.label,
+    direct,
+    freight,
+    production_founder,
+    admin,
+    field_travel,
+    total: direct + freight + production_founder + admin + field_travel,
+  };
+}
+
+/**
+ * The hero number for the funder artifact: today's State-1-Defy fully-loaded cost,
+ * presented as the honest starting point. The "path to" target is State-4 @ 500/yr.
+ */
+export function getHeroPicture() {
+  const states = listBuildStates();
+  const scenarios = getVolumeScenarios();
+  const today = scenarios[0]!; // 100/yr
+  const target = scenarios[1]!; // 500/yr
+  const vision = scenarios[2]!; // 1000/yr
+  const state1 = states.find((s) => s.key === 'state_1_defy_everything')!;
+  const state4 = states.find((s) => s.key === 'state_4_all_in_house')!;
+  const state5 = states.find((s) => s.key === 'state_5_community_plastic')!;
+  return {
+    today: computeFullyLoaded(state1, today),
+    target: computeFullyLoaded(state4, target),
+    vision: computeFullyLoaded(state5, vision),
+    commercial: {
+      low: model.counterfactual.commercial_steel_frame_bed_au_2026_low,
+      high: model.counterfactual.commercial_steel_frame_bed_au_2026_high,
+    },
+    capex_to_target: {
+      low: model.capex_required_to_reach_state_4._capital_ask_low,
+      high: model.capex_required_to_reach_state_4._capital_ask_high,
+    },
+  };
+}
+
+export function getFundraisingOffset() {
+  const fr = model.fundraising_offset;
+  return {
+    philanthropy_days: fr.philanthropy_days_per_year,
+    philanthropy_annual: fr.philanthropy_annual_estimate,
+    commercial_days: fr.commercial_sales_days_per_year,
+    buyer_benchmark: fr.commercial_buyer_benchmark_per_bed,
+    buyer_source: fr.commercial_buyer_source,
+    subsidy_at_100: fr._per_bed_subsidy_at_100_per_year,
+    subsidy_at_500: fr._per_bed_subsidy_at_500_per_year,
+  };
+}
+
+export function getFounderAllocation() {
+  return {
+    rate_per_day: model.founder_time_allocation.rate_per_day,
+    total_days: model.founder_time_allocation.total_days_per_year_on_goods,
+    split: model.founder_time_allocation.split,
+  };
+}
+
+export function getDefyVerifiedRates() {
+  return model.defy_verified_rates;
+}
+
+export function getMistagsToFix() {
+  return model.mistags_to_fix;
+}
+
+export function getOpenQuestionsForDefy() {
+  return model.open_questions_for_defy;
+}
+
+/**
+ * Format money in AUD with thousands separators, no decimals unless < $10.
+ */
+export function fmtMoney(value: number): string {
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: value < 10 ? 2 : 0,
+  }).format(value);
+}

--- a/apps/web/src/lib/services/goods-cost-evidence.ts
+++ b/apps/web/src/lib/services/goods-cost-evidence.ts
@@ -1,6 +1,9 @@
 import { createHash } from 'crypto';
 
 import { getServiceSupabase } from '@/lib/supabase';
+import bedCostModel from '@/lib/data/goods-bed-cost-model.json';
+
+type BedCostModelShape = typeof bedCostModel;
 
 const PROJECT_CODE = 'ACT-GD';
 const LAST_50_START = '2025-10-08';
@@ -214,8 +217,52 @@ export type GoodsCostEvidence = {
       source: string;
       confidence: 'verified' | 'inferred' | 'planning' | 'unverified';
     }>;
+    // v3 additions — scenarios + Idiot Index + fundraising offset, sourced
+    // from lib/data/goods-bed-cost-model.json (the OCR-verified model).
+    scenarios: {
+      today: ScenarioRow;
+      target: ScenarioRow;
+      vision: ScenarioRow;
+    };
+    idiotIndex: Array<{
+      element: string;
+      rawLow: string;
+      rawHigh: string;
+      current: string;
+      indexLow: number;
+      indexHigh: number;
+      markupPaysFor: string;
+    }>;
+    fundraisingOffset: {
+      philanthropyDays: number;
+      philanthropyAnnual: string;
+      commercialDays: number;
+      buyerBenchmark: string;
+      buyerSource: string;
+      subsidyAt100: string;
+      subsidyAt500: string;
+    };
+    founderAllocation: Array<{
+      label: string;
+      days: number;
+      annualCost: string;
+      allocateTo: string;
+    }>;
   };
   gaps: string[];
+};
+
+export type ScenarioRow = {
+  label: string;
+  bedsPerYear: number;
+  state: string;
+  direct: string;
+  freight: string;
+  founder: string;
+  admin: string;
+  field: string;
+  total: string;
+  totalNumeric: number;
 };
 
 function toNumber(value: number | string | null | undefined) {
@@ -787,73 +834,138 @@ function extractCapitalRows(bills: XeroSupplierBill[]): GoodsCostEvidence['capit
 }
 
 function buildFunderView(input: {
-  perBedDirect: number; // verified per-bed direct cost (excludes capital, freight TBD)
+  perBedDirect: number;
   capitalTotalKnown: number;
   totalBills: number;
 }): GoodsCostEvidence['funderView'] {
-  // Source-of-truth numbers from the plan + Ben's Notion Bed-Inputs DB (verified-where-possible).
-  const components = {
-    hdpe_kit: { amount: 344.05, label: 'HDPE kit', basis: 'Defy invoices, verified.' },
-    canvas: { amount: 93.50, label: 'Canvas', basis: 'Notion BOM, estimate.' },
-    assembly: { amount: 55.95, label: 'Assembly labour', basis: 'Defy invoices, verified.' },
-    steel: { amount: 27.00, label: 'Steel frame', basis: 'Notion BOM, estimate.' },
-    caps: { amount: 3.20, label: 'End caps / fittings', basis: 'Notion BOM, estimate.' },
-  };
-  const directComponents = Object.values(components).reduce((sum, c) => sum + c.amount, 0);
-  // Freight is the biggest gap (per plan); use the road-freight benchmark of $52
-  // as a placeholder until the actual Syd→Utopia freight invoice lands.
-  const freight = 52;
-  const overhead = Math.max(0, input.perBedDirect - directComponents - freight); // facility amortisation residual
-  const fullyLoaded = directComponents + freight + overhead;
-  const commercialLow = 1500;
-  const commercialHigh = 2000;
+  // v3 model — all numbers come from lib/data/goods-bed-cost-model.json
+  // which is the OCR-verified Defy invoice model. The hero number is the
+  // honest "today @ 100/yr Defy-everything" figure; target/vision are the
+  // trajectory funders fund.
+  const m = bedCostModel as BedCostModelShape;
+
+  const states = Object.entries(m.build_states).reduce(
+    (acc, [key, state]) => {
+      acc[key] = state;
+      return acc;
+    },
+    {} as Record<string, BedCostModelShape['build_states']['state_1_defy_everything']>,
+  );
+  const state1 = states['state_1_defy_everything']!;
+  const state4 = states['state_4_all_in_house']!;
+  const state5 = states['state_5_community_plastic']!;
+  const today = m.volume_scenarios[0]!;
+  const target = m.volume_scenarios[1]!;
+  const vision = m.volume_scenarios[2]!;
+
+  const heroFullyLoaded = today.fully_loaded_state_1; // Today @ 100/yr, Defy-everything — the honest starting point.
+  const directToday = state1.direct_total;
+  const costStack: GoodsCostEvidence['funderView']['costStack'] = state1.components.map((c) => ({
+    label: c.label,
+    amount: money(c.amount),
+    pctOfDirect: c.amount / directToday,
+    basis: 'Defy verified rate (invoice OCR).',
+  }));
+  costStack.push(
+    { label: 'Freight (per bed)', amount: money(today.freight_per_bed), pctOfDirect: today.freight_per_bed / heroFullyLoaded, basis: 'Botany NSW → remote AU benchmark.' },
+    { label: 'Production-related founder time', amount: money(today.production_founder_per_bed), pctOfDirect: today.production_founder_per_bed / heroFullyLoaded, basis: '30 days/yr × $1K/day modelled, allocated to beds only.' },
+    { label: 'Admin overhead', amount: money(today.admin_per_bed), pctOfDirect: today.admin_per_bed / heroFullyLoaded, basis: 'Byo + small accounts ÷ bed count.' },
+    { label: 'Field travel / ops', amount: money(today.field_travel_per_bed), pctOfDirect: today.field_travel_per_bed / heroFullyLoaded, basis: 'Account 493 + retagged Utopia trip costs.' },
+  );
+
+  const buildScenario = (
+    label: string,
+    bedsPerYear: number,
+    state: BedCostModelShape['build_states']['state_1_defy_everything'],
+    scenario: BedCostModelShape['volume_scenarios'][number],
+    fullyLoadedKey: 'fully_loaded_state_1' | 'fully_loaded_state_4' | 'fully_loaded_state_5',
+  ): ScenarioRow => ({
+    label,
+    bedsPerYear,
+    state: state.label,
+    direct: money(state.direct_total),
+    freight: money(scenario.freight_per_bed),
+    founder: money(scenario.production_founder_per_bed),
+    admin: money(scenario.admin_per_bed),
+    field: money(scenario.field_travel_per_bed),
+    total: money(scenario[fullyLoadedKey]),
+    totalNumeric: scenario[fullyLoadedKey],
+  });
+
+  const fr = m.fundraising_offset;
+  const fa = m.founder_time_allocation;
+
   return {
     hero: {
-      value: money(fullyLoaded),
-      label: 'delivers one community-made bed (fully-loaded, ex capital)',
-      provenance: `Components ${money(directComponents)} (HDPE kit + canvas + assembly + steel + caps) + freight ${money(freight)} + facility overhead ${money(overhead)}. Capital is shown separately.`,
+      value: money(heroFullyLoaded),
+      label: 'fully-loaded delivered bed today (~100 beds/yr, Defy-everything)',
+      provenance: `Direct ${money(state1.direct_total)} (Defy verified Single Bed) + freight ${money(today.freight_per_bed)} + production-only founder time ${money(today.production_founder_per_bed)} + admin ${money(today.admin_per_bed)} + field ops ${money(today.field_travel_per_bed)}. Target $${target.fully_loaded_state_4}/bed at 500/yr (State 4 in-house); vision $${vision.fully_loaded_state_5}/bed at 1,000/yr (community plastic).`,
     },
-    costStack: [
-      { label: components.hdpe_kit.label, amount: money(components.hdpe_kit.amount), pctOfDirect: components.hdpe_kit.amount / fullyLoaded, basis: components.hdpe_kit.basis },
-      { label: components.canvas.label, amount: money(components.canvas.amount), pctOfDirect: components.canvas.amount / fullyLoaded, basis: components.canvas.basis },
-      { label: components.assembly.label, amount: money(components.assembly.amount), pctOfDirect: components.assembly.amount / fullyLoaded, basis: components.assembly.basis },
-      { label: components.steel.label, amount: money(components.steel.amount), pctOfDirect: components.steel.amount / fullyLoaded, basis: components.steel.basis },
-      { label: components.caps.label, amount: money(components.caps.amount), pctOfDirect: components.caps.amount / fullyLoaded, basis: components.caps.basis },
-      { label: 'Freight (road)', amount: money(freight), pctOfDirect: freight / fullyLoaded, basis: 'Road-freight benchmark; remote routes higher. Actual Syd→Utopia invoice still TBC.' },
-      { label: 'Facility overhead', amount: money(overhead), pctOfDirect: overhead / fullyLoaded, basis: 'Amortised facility labour + materials per bed, derived from the $550–$650 production band.' },
-    ],
+    costStack,
     capitalSummary: {
-      total: input.capitalTotalKnown > 0 ? compactMoney(input.capitalTotalKnown) : 'identified items only',
+      total: `$${m.capex_required_to_reach_state_4._capital_ask_low / 1000}K–$${m.capex_required_to_reach_state_4._capital_ask_high / 1000}K capital ask`,
       rows: [
-        { label: 'Production facility', amount: '$100K invested to date', note: 'FRRR + initial fit-out; one-off, not per bed.' },
-        { label: 'Carbatec tooling', amount: '$10,046', note: 'Workshop tooling (verified Xero ACT-GD line).' },
-        { label: 'Defy facility materials', amount: '$11,725', note: 'Facility build materials (verified Xero ACT-GD line).' },
-        { label: 'Kirmos facility labour', amount: '$4,500 / month', note: 'Facility labour run-rate; amortised into per-bed overhead.' },
+        { label: 'Production facility (in)', amount: `$${m.capex_required_to_reach_state_4.already_invested_facility / 1000}K invested`, note: 'FRRR + initial fit-out — one-off, not per bed.' },
+        { label: 'Carbatec tooling (in)', amount: money(m.capex_required_to_reach_state_4.already_invested_carbatec_tooling), note: 'Workshop tooling already in place.' },
+        { label: 'Shredder', amount: `${money(m.capex_required_to_reach_state_4.shredder.low)}–${money(m.capex_required_to_reach_state_4.shredder.high)}`, note: 'In-house shred plant.' },
+        { label: 'Hot-press line', amount: `${money(m.capex_required_to_reach_state_4.hot_press_line.low)}–${money(m.capex_required_to_reach_state_4.hot_press_line.high)}`, note: 'In-house sheet pressing — biggest Idiot-Index saving.' },
+        { label: 'CNC router', amount: `${money(m.capex_required_to_reach_state_4.cnc_router.low)}–${money(m.capex_required_to_reach_state_4.cnc_router.high)}`, note: 'In-house cut + finish.' },
       ],
     },
     conversion: [
-      { funds: '$10,000', beds: Math.round(10000 / fullyLoaded), note: 'A single-funder cheque.' },
-      { funds: '$50,000', beds: Math.round(50000 / fullyLoaded), note: 'A typical foundation grant.' },
-      { funds: '$100,000', beds: Math.round(100000 / fullyLoaded), note: 'A community-partnership commitment.' },
-      { funds: '$500,000', beds: Math.round(500000 / fullyLoaded), note: 'Major-gift or capital allocation.' },
+      { funds: '$10,000', beds: Math.round(10000 / heroFullyLoaded), note: 'A single-funder cheque @ today rate.' },
+      { funds: '$50,000', beds: Math.round(50000 / heroFullyLoaded), note: 'A typical foundation grant @ today rate.' },
+      { funds: '$100,000', beds: Math.round(100000 / target.fully_loaded_state_4), note: `A partnership @ target rate ($${target.fully_loaded_state_4}/bed at 500/yr).` },
+      { funds: '$200,000', beds: Math.round(200000 / target.fully_loaded_state_4), note: 'Capital ask to unlock State 4 in-house production.' },
+      { funds: '$500,000', beds: Math.round(500000 / target.fully_loaded_state_4), note: 'Major gift @ target rate.' },
     ],
     counterfactual: {
-      commercialRangeLow: money(commercialLow),
-      commercialRangeHigh: money(commercialHigh),
-      ratioLow: `${(commercialLow / fullyLoaded).toFixed(1)}×`,
-      ratioHigh: `${(commercialHigh / fullyLoaded).toFixed(1)}×`,
-      basis: 'Commercial-equivalent steel-frame bed pricing (retail furniture/contract supply, mid-2026 AU market).',
+      commercialRangeLow: money(m.counterfactual.commercial_steel_frame_bed_au_2026_low),
+      commercialRangeHigh: money(m.counterfactual.commercial_steel_frame_bed_au_2026_high),
+      ratioLow: `${(m.counterfactual.commercial_steel_frame_bed_au_2026_low / heroFullyLoaded).toFixed(2)}×`,
+      ratioHigh: `${(m.counterfactual.commercial_steel_frame_bed_au_2026_high / heroFullyLoaded).toFixed(2)}×`,
+      basis: m.counterfactual.source,
     },
     provenance: [
-      { figure: `${components.hdpe_kit.label} ${money(components.hdpe_kit.amount)}`, source: 'Defy supplier invoices (Notion: Bed Inputs DB)', confidence: 'verified' },
-      { figure: `${components.assembly.label} ${money(components.assembly.amount)}`, source: 'Defy supplier invoices', confidence: 'verified' },
-      { figure: `${components.canvas.label} ${money(components.canvas.amount)}`, source: 'Notion BOM working figure', confidence: 'inferred' },
-      { figure: `${components.steel.label} ${money(components.steel.amount)}`, source: 'Notion BOM working figure', confidence: 'inferred' },
-      { figure: `Freight ${money(freight)}`, source: 'Road-freight benchmark; Syd→Utopia actual TBC', confidence: 'planning' },
-      { figure: `Facility overhead ${money(overhead)}`, source: 'Production-range residual ($550–$650 band)', confidence: 'planning' },
-      { figure: 'Commercial counterfactual $1.5K–$2K', source: 'Retail/contract-supply market scan, mid-2026 AU', confidence: 'inferred' },
-      { figure: `Xero supplier-bills total ${compactMoney(input.totalBills)}`, source: 'xero_invoices (ACT-GD, ACCPAY, non-voided)', confidence: 'verified' },
+      { figure: `Single Bed fully fab'd ${money(600)}`, source: 'INV-1507 Nov 2025 (25 beds, OCR-verified)', confidence: 'verified' },
+      { figure: `Bed kit cut+finished ${money(344.05)}`, source: 'INV-1602 + 2026-03-27 (multiple batches, OCR-verified)', confidence: 'verified' },
+      { figure: `Assembly labour ${money(55.95)}`, source: '2026-03-19 line (8 beds, OCR-verified)', confidence: 'verified' },
+      { figure: `HDPE shred $2/kg`, source: '2026-03-27 (1200kg bulk, OCR-verified)', confidence: 'verified' },
+      { figure: `Half-sheet $200`, source: '2026-03-27 (20 sheets bulk, OCR-verified)', confidence: 'verified' },
+      { figure: `HDPE per bed: 20kg`, source: 'Ben confirmed 2026-05-28', confidence: 'verified' },
+      { figure: `Founder time $1K/day × 150 days/yr`, source: 'Ben confirmed 2026-05-28', confidence: 'verified' },
+      { figure: 'Commercial counterfactual $1.5K–$2K', source: m.counterfactual.source, confidence: 'inferred' },
+      { figure: 'In-house cost estimates (sheet press, CNC, etc.)', source: 'Modelled — pending real quotes for hot-press + CNC capex', confidence: 'planning' },
     ],
+    scenarios: {
+      today: buildScenario(today.label, today.beds_per_year, state1, today, 'fully_loaded_state_1'),
+      target: buildScenario(target.label, target.beds_per_year, state4, target, 'fully_loaded_state_4'),
+      vision: buildScenario(vision.label, vision.beds_per_year, state5, vision, 'fully_loaded_state_5'),
+    },
+    idiotIndex: m.idiot_index.map((row) => ({
+      element: row.element,
+      rawLow: money(row.raw_low),
+      rawHigh: money(row.raw_high),
+      current: money(row.current),
+      indexLow: row.index_low,
+      indexHigh: row.index_high,
+      markupPaysFor: row.markup_pays_for,
+    })),
+    fundraisingOffset: {
+      philanthropyDays: fr.philanthropy_days_per_year,
+      philanthropyAnnual: compactMoney(fr.philanthropy_annual_estimate),
+      commercialDays: fr.commercial_sales_days_per_year,
+      buyerBenchmark: money(fr.commercial_buyer_benchmark_per_bed),
+      buyerSource: fr.commercial_buyer_source,
+      subsidyAt100: money(fr._per_bed_subsidy_at_100_per_year),
+      subsidyAt500: money(fr._per_bed_subsidy_at_500_per_year),
+    },
+    founderAllocation: fa.split.map((entry) => ({
+      label: entry.label,
+      days: entry.days,
+      annualCost: money(entry.annual_cost),
+      allocateTo: entry.allocate_to,
+    })),
   };
 }
 

--- a/apps/web/src/lib/services/goods-cost-evidence.ts
+++ b/apps/web/src/lib/services/goods-cost-evidence.ts
@@ -180,6 +180,41 @@ export type GoodsCostEvidence = {
     paid: string;
     due: string;
   }>;
+  dataQualityFlags: Array<{
+    id: string;
+    severity: 'high' | 'medium' | 'low';
+    issue: string;
+    amount: string | null;
+    evidence: string;
+    action: string;
+  }>;
+  capitalRows: Array<{
+    supplier: string;
+    invoice: string;
+    date: string;
+    amount: string;
+    description: string;
+    bucket: 'facility-tooling' | 'facility-materials' | 'facility-labour' | 'capital-asset';
+    note: string;
+  }>;
+  funderView: {
+    hero: { value: string; label: string; provenance: string };
+    costStack: Array<{ label: string; amount: string; pctOfDirect: number; basis: string }>;
+    capitalSummary: { total: string; rows: Array<{ label: string; amount: string; note: string }> };
+    conversion: Array<{ funds: string; beds: number; note: string }>;
+    counterfactual: {
+      commercialRangeLow: string;
+      commercialRangeHigh: string;
+      ratioLow: string;
+      ratioHigh: string;
+      basis: string;
+    };
+    provenance: Array<{
+      figure: string;
+      source: string;
+      confidence: 'verified' | 'inferred' | 'planning' | 'unverified';
+    }>;
+  };
   gaps: string[];
 };
 
@@ -250,13 +285,14 @@ function accountLabel(account: string) {
   const labels: Record<string, string> = {
     '400': 'Production / supplier cost bucket',
     '412': 'Bed manufacture / product work',
-    '446': 'Bedding / product inputs',
+    '413': 'Materials / production support',
     '425': 'Freight / couriers / delivery',
+    '429': 'Defy materials / production inputs',
+    '446': 'Bedding / product inputs',
+    '447': 'Equipment / field gear',
+    '451': 'Vehicle / mechanical support',
     '486': 'People / design / partner services',
     '493': 'Field travel / accommodation',
-    '451': 'Vehicle / mechanical support',
-    '447': 'Equipment / field gear',
-    '413': 'Materials / production support',
   };
   return labels[account] || 'Unmapped Xero account';
 }
@@ -280,6 +316,9 @@ function emptyEvidence(detail: string): GoodsCostEvidence {
     accountRows: [],
     directEvidenceRows: [],
     last50WindowRows: [],
+    dataQualityFlags: [],
+    capitalRows: [],
+    funderView: buildFunderView({ perBedDirect: 600, capitalTotalKnown: 0, totalBills: 0 }),
     gaps: [
       'No ACT-GD supplier bills were returned from Xero.',
       'Do not quote an actual delivered unit cost until finance rows are loaded.',
@@ -457,7 +496,7 @@ function goodsCostInputRows(): GoodsCostEvidence['costInputRows'] {
 function categoryForCostLine(account: string, description: string, supplier: string) {
   const haystack = `${accountLabel(account)} ${description} ${supplier}`.toLowerCase();
   if (account === '425') return 'Freight and delivery';
-  if (account === '446' || account === '413') return 'Materials';
+  if (account === '446' || account === '413' || account === '429') return 'Materials';
   if (account === '400' || account === '412') return 'Direct build / manufacture';
   if (account === '451') return 'Support and warranty';
   if (account === '493') return 'ACT shared-service support';
@@ -594,6 +633,228 @@ export async function saveGoodsCostAllocationDecision(input: GoodsCostAllocation
 
   if (error) throw new Error(error.message);
   return data;
+}
+
+// Known data-quality issues from the 2026-05-28 cost-evidence plan.
+// These are findings Ben/finance have surfaced but not yet resolved in Xero.
+// Surfacing them in the tool turns "buried in a spreadsheet" into "visible review queue".
+const KNOWN_QUALITY_ISSUES: Array<{
+  id: string;
+  severity: 'high' | 'medium' | 'low';
+  supplierIncludes: string;
+  descriptionIncludes?: string;
+  issue: string;
+  action: string;
+}> = [
+  {
+    id: 'rm-tanner-capital',
+    severity: 'high',
+    supplierIncludes: 'r m tanner',
+    descriptionIncludes: 'triple axle',
+    issue: 'R M Tanner "Triple Axle Tiny House" is coded as labour but is a capital asset.',
+    action: 'Reclassify as capital (facility-tooling). Exclude from per-bed direct cost.',
+  },
+  {
+    id: '1300-washer-mistag',
+    severity: 'high',
+    supplierIncludes: '1300 washer',
+    issue: '1300 Washer bill tagged ACT-GD but the line item reads ACT-FM.',
+    action: 'Retag to ACT-FM in Xero; will reduce ACT-GD spend.',
+  },
+  {
+    id: 'zinus-confirm',
+    severity: 'medium',
+    supplierIncludes: 'zinus',
+    issue: 'Zinus Australia spend — purpose unconfirmed (mattress input vs. resale noise).',
+    action: 'Confirm with Defy whether this is a bed component or trial-stock noise.',
+  },
+];
+
+// Suppliers/descriptions that flag capital (one-off facility/tooling) rather
+// than per-unit cost. Per the plan: facility ~$100K + tooling ~$10K (+ R M
+// Tanner $20K if reclassified). These do NOT belong in the delivered unit cost.
+const CAPITAL_HINTS: Array<{
+  supplierIncludes?: string;
+  descriptionIncludes?: string;
+  bucket: 'facility-tooling' | 'facility-materials' | 'facility-labour' | 'capital-asset';
+  note: string;
+}> = [
+  {
+    supplierIncludes: 'carbatec',
+    bucket: 'facility-tooling',
+    note: 'Workshop tooling — one-off capital, not per-bed.',
+  },
+  {
+    supplierIncludes: 'r m tanner',
+    descriptionIncludes: 'triple axle',
+    bucket: 'capital-asset',
+    note: 'Triple Axle Tiny House — capital asset, not per-bed labour.',
+  },
+  {
+    descriptionIncludes: 'facility',
+    bucket: 'facility-materials',
+    note: 'Facility build / fit-out — one-off capital, not per-bed.',
+  },
+];
+
+function detectDuplicateBills(bills: XeroSupplierBill[]) {
+  const flags: Array<{ id: string; severity: 'high'; issue: string; amount: string | null; evidence: string; action: string }> = [];
+  const byKey = new Map<string, XeroSupplierBill[]>();
+  for (const bill of bills) {
+    if (!bill.contact_name || !bill.total || bill.status === 'VOIDED' || bill.status === 'DELETED') continue;
+    // Match on supplier + total + month (date YYYY-MM). Tightens to "same supplier,
+    // same total, same month" — catches the Carla-Furnishers-style mirrored bill
+    // without false-positiving normal recurring vendors.
+    const monthKey = bill.date?.slice(0, 7) || 'unknown';
+    const key = `${bill.contact_name.toLowerCase()}::${toNumber(bill.total).toFixed(2)}::${monthKey}`;
+    const existing = byKey.get(key) ?? [];
+    existing.push(bill);
+    byKey.set(key, existing);
+  }
+  for (const [key, group] of byKey.entries()) {
+    if (group.length < 2) continue;
+    const supplier = group[0]?.contact_name || 'Unknown supplier';
+    const amount = toNumber(group[0]?.total);
+    const invoices = group.map((b) => b.invoice_number || 'no-number').join(', ');
+    flags.push({
+      id: `dup-${key.replace(/[^a-z0-9-]/gi, '-').slice(0, 60)}`,
+      severity: 'high',
+      issue: `${supplier} — ${group.length} bills with identical ${money(amount)} amount in the same month.`,
+      amount: money(amount * (group.length - 1)),
+      evidence: `Bills: ${invoices}.`,
+      action: 'Verify in Xero; void the duplicate if confirmed (use manual-duplicate-of-* source).',
+    });
+  }
+  return flags;
+}
+
+function detectKnownIssues(bills: XeroSupplierBill[]) {
+  const flags: GoodsCostEvidence['dataQualityFlags'] = [];
+  for (const issue of KNOWN_QUALITY_ISSUES) {
+    const matches = bills.filter((bill) => {
+      const supplier = (bill.contact_name || '').toLowerCase();
+      if (!supplier.includes(issue.supplierIncludes)) return false;
+      if (!issue.descriptionIncludes) return true;
+      const lines = normaliseLineItems(bill.line_items);
+      return lines.some((line) =>
+        String(line.description || '').toLowerCase().includes(issue.descriptionIncludes!),
+      );
+    });
+    if (matches.length === 0) continue;
+    const totalAmount = matches.reduce((sum, b) => sum + toNumber(b.total), 0);
+    flags.push({
+      id: issue.id,
+      severity: issue.severity,
+      issue: issue.issue,
+      amount: totalAmount > 0 ? money(totalAmount) : null,
+      evidence: `${matches.length} bill${matches.length === 1 ? '' : 's'}: ${matches.map((b) => b.invoice_number || 'no-number').slice(0, 4).join(', ')}.`,
+      action: issue.action,
+    });
+  }
+  return flags;
+}
+
+function extractCapitalRows(bills: XeroSupplierBill[]): GoodsCostEvidence['capitalRows'] {
+  const rows: GoodsCostEvidence['capitalRows'] = [];
+  for (const bill of bills) {
+    if (bill.status === 'VOIDED' || bill.status === 'DELETED') continue;
+    const supplier = (bill.contact_name || '').toLowerCase();
+    const lines = normaliseLineItems(bill.line_items);
+    for (const [lineIndex, item] of lines.entries()) {
+      const description = String(item.description || '').toLowerCase();
+      const hint = CAPITAL_HINTS.find((h) => {
+        if (h.supplierIncludes && !supplier.includes(h.supplierIncludes)) return false;
+        if (h.descriptionIncludes && !description.includes(h.descriptionIncludes)) return false;
+        return Boolean(h.supplierIncludes || h.descriptionIncludes);
+      });
+      if (!hint) continue;
+      const amount = toNumber(item.line_amount);
+      if (amount <= 0) continue;
+      rows.push({
+        supplier: bill.contact_name || 'Unknown supplier',
+        invoice: bill.invoice_number || 'missing',
+        date: dateLabel(bill.date),
+        amount: money(amount),
+        description: String(item.description || '').replace(/\s+/g, ' ').trim() || `Line ${lineIndex + 1}`,
+        bucket: hint.bucket,
+        note: hint.note,
+      });
+    }
+  }
+  return rows.sort((a, b) =>
+    moneyToNumber(b.amount) - moneyToNumber(a.amount),
+  );
+}
+
+function buildFunderView(input: {
+  perBedDirect: number; // verified per-bed direct cost (excludes capital, freight TBD)
+  capitalTotalKnown: number;
+  totalBills: number;
+}): GoodsCostEvidence['funderView'] {
+  // Source-of-truth numbers from the plan + Ben's Notion Bed-Inputs DB (verified-where-possible).
+  const components = {
+    hdpe_kit: { amount: 344.05, label: 'HDPE kit', basis: 'Defy invoices, verified.' },
+    canvas: { amount: 93.50, label: 'Canvas', basis: 'Notion BOM, estimate.' },
+    assembly: { amount: 55.95, label: 'Assembly labour', basis: 'Defy invoices, verified.' },
+    steel: { amount: 27.00, label: 'Steel frame', basis: 'Notion BOM, estimate.' },
+    caps: { amount: 3.20, label: 'End caps / fittings', basis: 'Notion BOM, estimate.' },
+  };
+  const directComponents = Object.values(components).reduce((sum, c) => sum + c.amount, 0);
+  // Freight is the biggest gap (per plan); use the road-freight benchmark of $52
+  // as a placeholder until the actual Syd→Utopia freight invoice lands.
+  const freight = 52;
+  const overhead = Math.max(0, input.perBedDirect - directComponents - freight); // facility amortisation residual
+  const fullyLoaded = directComponents + freight + overhead;
+  const commercialLow = 1500;
+  const commercialHigh = 2000;
+  return {
+    hero: {
+      value: money(fullyLoaded),
+      label: 'delivers one community-made bed (fully-loaded, ex capital)',
+      provenance: `Components ${money(directComponents)} (HDPE kit + canvas + assembly + steel + caps) + freight ${money(freight)} + facility overhead ${money(overhead)}. Capital is shown separately.`,
+    },
+    costStack: [
+      { label: components.hdpe_kit.label, amount: money(components.hdpe_kit.amount), pctOfDirect: components.hdpe_kit.amount / fullyLoaded, basis: components.hdpe_kit.basis },
+      { label: components.canvas.label, amount: money(components.canvas.amount), pctOfDirect: components.canvas.amount / fullyLoaded, basis: components.canvas.basis },
+      { label: components.assembly.label, amount: money(components.assembly.amount), pctOfDirect: components.assembly.amount / fullyLoaded, basis: components.assembly.basis },
+      { label: components.steel.label, amount: money(components.steel.amount), pctOfDirect: components.steel.amount / fullyLoaded, basis: components.steel.basis },
+      { label: components.caps.label, amount: money(components.caps.amount), pctOfDirect: components.caps.amount / fullyLoaded, basis: components.caps.basis },
+      { label: 'Freight (road)', amount: money(freight), pctOfDirect: freight / fullyLoaded, basis: 'Road-freight benchmark; remote routes higher. Actual Syd→Utopia invoice still TBC.' },
+      { label: 'Facility overhead', amount: money(overhead), pctOfDirect: overhead / fullyLoaded, basis: 'Amortised facility labour + materials per bed, derived from the $550–$650 production band.' },
+    ],
+    capitalSummary: {
+      total: input.capitalTotalKnown > 0 ? compactMoney(input.capitalTotalKnown) : 'identified items only',
+      rows: [
+        { label: 'Production facility', amount: '$100K invested to date', note: 'FRRR + initial fit-out; one-off, not per bed.' },
+        { label: 'Carbatec tooling', amount: '$10,046', note: 'Workshop tooling (verified Xero ACT-GD line).' },
+        { label: 'Defy facility materials', amount: '$11,725', note: 'Facility build materials (verified Xero ACT-GD line).' },
+        { label: 'Kirmos facility labour', amount: '$4,500 / month', note: 'Facility labour run-rate; amortised into per-bed overhead.' },
+      ],
+    },
+    conversion: [
+      { funds: '$10,000', beds: Math.round(10000 / fullyLoaded), note: 'A single-funder cheque.' },
+      { funds: '$50,000', beds: Math.round(50000 / fullyLoaded), note: 'A typical foundation grant.' },
+      { funds: '$100,000', beds: Math.round(100000 / fullyLoaded), note: 'A community-partnership commitment.' },
+      { funds: '$500,000', beds: Math.round(500000 / fullyLoaded), note: 'Major-gift or capital allocation.' },
+    ],
+    counterfactual: {
+      commercialRangeLow: money(commercialLow),
+      commercialRangeHigh: money(commercialHigh),
+      ratioLow: `${(commercialLow / fullyLoaded).toFixed(1)}×`,
+      ratioHigh: `${(commercialHigh / fullyLoaded).toFixed(1)}×`,
+      basis: 'Commercial-equivalent steel-frame bed pricing (retail furniture/contract supply, mid-2026 AU market).',
+    },
+    provenance: [
+      { figure: `${components.hdpe_kit.label} ${money(components.hdpe_kit.amount)}`, source: 'Defy supplier invoices (Notion: Bed Inputs DB)', confidence: 'verified' },
+      { figure: `${components.assembly.label} ${money(components.assembly.amount)}`, source: 'Defy supplier invoices', confidence: 'verified' },
+      { figure: `${components.canvas.label} ${money(components.canvas.amount)}`, source: 'Notion BOM working figure', confidence: 'inferred' },
+      { figure: `${components.steel.label} ${money(components.steel.amount)}`, source: 'Notion BOM working figure', confidence: 'inferred' },
+      { figure: `Freight ${money(freight)}`, source: 'Road-freight benchmark; Syd→Utopia actual TBC', confidence: 'planning' },
+      { figure: `Facility overhead ${money(overhead)}`, source: 'Production-range residual ($550–$650 band)', confidence: 'planning' },
+      { figure: 'Commercial counterfactual $1.5K–$2K', source: 'Retail/contract-supply market scan, mid-2026 AU', confidence: 'inferred' },
+      { figure: `Xero supplier-bills total ${compactMoney(input.totalBills)}`, source: 'xero_invoices (ACT-GD, ACCPAY, non-voided)', confidence: 'verified' },
+    ],
+  };
 }
 
 export async function getGoodsCostEvidence(): Promise<GoodsCostEvidence> {
@@ -843,6 +1104,16 @@ export async function getGoodsCostEvidence(): Promise<GoodsCostEvidence> {
         paid: money(toNumber(row.amount_paid)),
         due: money(toNumber(row.amount_due)),
       })),
+      dataQualityFlags: [...detectDuplicateBills(bills), ...detectKnownIssues(bills)].sort((a, b) => {
+        const order = { high: 0, medium: 1, low: 2 } as const;
+        return order[a.severity] - order[b.severity];
+      }),
+      capitalRows: extractCapitalRows(bills),
+      funderView: buildFunderView({
+        perBedDirect: 600,
+        capitalTotalKnown: extractCapitalRows(bills).reduce((sum, row) => sum + moneyToNumber(row.amount), 0),
+        totalBills: total,
+      }),
       gaps: [
         'Later finance cleanup: allocate supplier bill lines to Goods asset IDs or batch IDs when possible.',
         'Map Xero account codes to finance-approved labels before sharing externally.',

--- a/apps/web/src/lib/services/goods-cost-evidence.ts
+++ b/apps/web/src/lib/services/goods-cost-evidence.ts
@@ -1,0 +1,860 @@
+import { createHash } from 'crypto';
+
+import { getServiceSupabase } from '@/lib/supabase';
+
+const PROJECT_CODE = 'ACT-GD';
+const LAST_50_START = '2025-10-08';
+const LAST_50_END = '2025-12-02';
+const LAST_50_COUNT = 50;
+
+type XeroSupplierBill = {
+  id: string;
+  invoice_number: string | null;
+  contact_name: string | null;
+  status: string | null;
+  date: string | null;
+  total: number | string | null;
+  amount_paid: number | string | null;
+  amount_due: number | string | null;
+  has_attachments: boolean | null;
+  line_items: unknown;
+  synced_at: string | null;
+};
+
+type MonthlyFinancialRow = {
+  month: string | null;
+  fy_ytd_expenses: number | string | null;
+};
+
+type XeroTransactionRow = {
+  xero_transaction_id: string | null;
+  contact_name: string | null;
+  type: string | null;
+  total: number | string | null;
+  status: string | null;
+  date: string | null;
+  has_attachments: boolean | null;
+  is_reconciled: boolean | null;
+};
+
+type DextReceiptRow = {
+  xero_transaction_id: string | null;
+  vendor_name: string | null;
+  receipt_date: string | null;
+  filename: string | null;
+  match_confidence: number | null;
+  match_method: string | null;
+};
+
+type XeroLineItem = {
+  description?: string | null;
+  line_amount?: number | string | null;
+  account_code?: string | null;
+};
+
+export type GoodsCostAllocationDecision =
+  | 'needs_allocation'
+  | 'include_direct'
+  | 'show_separately'
+  | 'exclude'
+  | 'needs_receipt'
+  | 'needs_review';
+
+export type GoodsCostAllocationScope =
+  | 'unallocated'
+  | 'last_50'
+  | 'current_batch'
+  | 'specific_assets'
+  | 'shared_service';
+
+type GoodsCostAllocationDecisionRow = {
+  line_fingerprint: string;
+  decision: GoodsCostAllocationDecision;
+  allocation_scope: GoodsCostAllocationScope;
+  notes: string | null;
+  decided_at: string | null;
+};
+
+const GOODS_COST_DECISIONS: GoodsCostAllocationDecision[] = [
+  'needs_allocation',
+  'include_direct',
+  'show_separately',
+  'exclude',
+  'needs_receipt',
+  'needs_review',
+];
+
+export type GoodsCostAllocationSaveInput = {
+  lineFingerprint: string;
+  lineIndex: number;
+  xeroInvoiceId: string;
+  invoice: string;
+  supplier: string;
+  accountCode: string;
+  account: string;
+  description: string;
+  amount: string;
+  category: string;
+  decision: GoodsCostAllocationDecision;
+  allocationScope?: GoodsCostAllocationScope;
+  notes?: string | null;
+  decidedBy?: string | null;
+};
+
+export type GoodsCostEvidence = {
+  status: 'live' | 'empty' | 'error';
+  decision: string;
+  totals: Array<{ label: string; value: string; detail: string }>;
+  costBoundaryRows: Array<{
+    label: string;
+    treatment: 'quote in direct cost' | 'show separately' | 'approve before quoting';
+    detail: string;
+    examples: string;
+  }>;
+  unitEstimateRows: Array<{
+    label: string;
+    value: string;
+    use: string;
+    basis: string;
+    confidence: 'use now' | 'planning' | 'proxy only' | 'do not quote';
+  }>;
+  costInputRows: Array<{
+    input: string;
+    status: 'known-source' | 'finance-backed' | 'allocation-gap';
+    wikiEvidence: string;
+    financeEvidence: string;
+    stillNeeded: string;
+    sourceDocs: string;
+  }>;
+  costAllocationRows: Array<{
+    lineFingerprint: string;
+    lineIndex: number;
+    xeroInvoiceId: string;
+    supplier: string;
+    invoice: string;
+    date: string;
+    amount: string;
+    category: string;
+    directCostTreatment: 'include when allocated' | 'show separately' | 'review before quoting';
+    batchStatus: string;
+    proofStatus: string;
+    action: string;
+    account: string;
+    accountCode: string;
+    description: string;
+    currentDecision: GoodsCostAllocationDecision;
+    allocationScope: GoodsCostAllocationScope;
+    decisionNotes: string | null;
+    decidedAt: string | null;
+  }>;
+  supplierRows: Array<{
+    supplier: string;
+    rows: number;
+    total: string;
+    paid: string;
+    due: string;
+    period: string;
+  }>;
+  accountRows: Array<{
+    account: string;
+    label: string;
+    lines: number;
+    subtotal: string;
+    suppliers: string;
+  }>;
+  directEvidenceRows: Array<{
+    supplier: string;
+    invoice: string;
+    date: string;
+    amount: string;
+    account: string;
+    description: string;
+    note: string;
+  }>;
+  last50WindowRows: Array<{
+    supplier: string;
+    invoice: string;
+    date: string;
+    status: string;
+    total: string;
+    paid: string;
+    due: string;
+  }>;
+  gaps: string[];
+};
+
+function toNumber(value: number | string | null | undefined) {
+  if (value === null || value === undefined) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function moneyToNumber(value: string | null | undefined) {
+  if (!value) return 0;
+  const parsed = Number(value.replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function money(value: number) {
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  }).format(value);
+}
+
+function compactMoney(value: number) {
+  if (Math.abs(value) >= 1000000) return `$${(value / 1000000).toFixed(value % 1000000 === 0 ? 0 : 1)}M`;
+  if (Math.abs(value) >= 1000) return `$${Math.round(value / 1000)}K`;
+  return money(value);
+}
+
+function dateLabel(value: string | null | undefined) {
+  return value ? value.slice(0, 10) : 'unknown';
+}
+
+export function buildGoodsCostLineFingerprint(input: {
+  xeroInvoiceId: string;
+  lineIndex: number;
+  accountCode: string;
+  description: string;
+  lineAmount: number;
+}) {
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        input.xeroInvoiceId,
+        input.lineIndex,
+        input.accountCode,
+        input.description,
+        input.lineAmount,
+      ]),
+    )
+    .digest('hex');
+}
+
+function normaliseLineItems(value: unknown): XeroLineItem[] {
+  if (Array.isArray(value)) return value as XeroLineItem[];
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? (parsed as XeroLineItem[]) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function accountLabel(account: string) {
+  const labels: Record<string, string> = {
+    '400': 'Production / supplier cost bucket',
+    '412': 'Bed manufacture / product work',
+    '446': 'Bedding / product inputs',
+    '425': 'Freight / couriers / delivery',
+    '486': 'People / design / partner services',
+    '493': 'Field travel / accommodation',
+    '451': 'Vehicle / mechanical support',
+    '447': 'Equipment / field gear',
+    '413': 'Materials / production support',
+  };
+  return labels[account] || 'Unmapped Xero account';
+}
+
+function periodLabel(first: string | null, last: string | null) {
+  if (!first && !last) return 'unknown';
+  if (first === last) return dateLabel(first);
+  return `${dateLabel(first)} - ${dateLabel(last)}`;
+}
+
+function emptyEvidence(detail: string): GoodsCostEvidence {
+  return {
+    status: 'empty',
+    decision: detail,
+    totals: [{ label: 'Supplier bills', value: '$0', detail }],
+    costBoundaryRows: goodsCostBoundaryRows(),
+    unitEstimateRows: goodsUnitEstimateRows(),
+    costInputRows: goodsCostInputRows(),
+    costAllocationRows: [],
+    supplierRows: [],
+    accountRows: [],
+    directEvidenceRows: [],
+    last50WindowRows: [],
+    gaps: [
+      'No ACT-GD supplier bills were returned from Xero.',
+      'Do not quote an actual delivered unit cost until finance rows are loaded.',
+    ],
+  };
+}
+
+function goodsCostBoundaryRows(): GoodsCostEvidence['costBoundaryRows'] {
+  return [
+    {
+      label: 'Direct delivered cost',
+      treatment: 'quote in direct cost',
+      detail:
+        'This is the external unit-cost number for QBE, buyers, SEFA, Snow and foundations once allocation is complete.',
+      examples:
+        'Product materials, direct build labour, packaging, attributable freight/last-mile delivery, and a direct support/warranty allowance tied to asset batches.',
+    },
+    {
+      label: 'ACT shared-service support',
+      treatment: 'show separately',
+      detail:
+        'Do not blend this into the delivered bed unit cost. Show it as a separate operating-support or use-of-funds line.',
+      examples:
+        'Grant writing, finance/admin, CRM, reporting, evidence work, software, governance, founder time, entity transition, and shared ACT systems.',
+    },
+    {
+      label: 'Buyer price / margin',
+      treatment: 'approve before quoting',
+      detail:
+        'Buyer pricing can sit above direct delivered cost, but needs an explicit price, margin, warranty and contingency decision.',
+      examples:
+        'Government buyer price, retail/remote-store price, subsidised philanthropic price, contingency, margin, and repayment logic.',
+    },
+  ];
+}
+
+function moneyRange(low: number, high: number) {
+  return `${money(low)}-${money(high)}`;
+}
+
+function roundedMoneyRange(low: number, high: number) {
+  return `${money(Math.round(low / 5) * 5)}-${money(Math.round(high / 5) * 5)}`;
+}
+
+function goodsUnitEstimateRows(last50WindowTotal?: number): GoodsCostEvidence['unitEstimateRows'] {
+  const productionLow = 550;
+  const productionMid = 600;
+  const productionHigh = 650;
+  const roadFreight = 52;
+  const bargeFreight = 163;
+  const charterFreight = 455;
+  const rows: GoodsCostEvidence['unitEstimateRows'] = [
+    {
+      label: 'QBE working estimate',
+      value: `${money(productionMid)} / bed + route freight`,
+      use: 'Use this in the QBE budget draft now. Keep it labelled as a planning estimate.',
+      basis: '$60K / 100 beds in the QBE draft, cross-checked against the $550-$650 production range.',
+      confidence: 'use now',
+    },
+    {
+      label: 'Production range',
+      value: `${moneyRange(productionLow, productionHigh)} / bed`,
+      use: 'Use as the current bed production band before route freight, warranty, support, or margin.',
+      basis: 'Goods cost register, Snow review, and Catalysing Impact draft.',
+      confidence: 'planning',
+    },
+    {
+      label: 'Road delivered estimate',
+      value: `${roundedMoneyRange(productionLow + roadFreight, productionHigh + roadFreight)} / bed`,
+      use: 'Use for mainland road-access buyer and grant scenarios.',
+      basis: `Production range plus ${money(roadFreight)} road freight benchmark.`,
+      confidence: 'planning',
+    },
+    {
+      label: 'Island/barge estimate',
+      value: `${roundedMoneyRange(productionLow + bargeFreight, productionHigh + bargeFreight)} / bed`,
+      use: 'Use for Palm Island and similar barge/remote freight scenarios.',
+      basis: `Production range plus ${money(bargeFreight)} barge freight benchmark.`,
+      confidence: 'planning',
+    },
+    {
+      label: 'Very remote estimate',
+      value: `${roundedMoneyRange(productionLow + charterFreight, productionHigh + charterFreight)} / bed`,
+      use: 'Use only where charter or very high last-mile freight is realistic.',
+      basis: `Production range plus ${money(charterFreight)} charter freight benchmark.`,
+      confidence: 'planning',
+    },
+    {
+      label: 'Buyer price band',
+      value: '$850-$1,200 / bed',
+      use: 'Use as the buyer/sponsored price range to test after the product and freight route are clear.',
+      basis: 'Goods go-to-market and Catalysing Impact planning material.',
+      confidence: 'planning',
+    },
+  ];
+
+  if (last50WindowTotal && last50WindowTotal > 0) {
+    rows.splice(2, 0, {
+      label: 'Xero date-window proxy',
+      value: `${money(last50WindowTotal / LAST_50_COUNT)} / bed`,
+      use: 'Use internally to test whether the estimate is plausible. Do not quote as actual delivered cost.',
+      basis: `${money(last50WindowTotal)} in ACT-GD supplier bills dated ${LAST_50_START} to ${LAST_50_END}, divided by ${LAST_50_COUNT} bed rows.`,
+      confidence: 'proxy only',
+    });
+  }
+
+  return rows;
+}
+
+function goodsCostInputRows(): GoodsCostEvidence['costInputRows'] {
+  return [
+    {
+      input: 'Materials',
+      status: 'finance-backed',
+      wikiEvidence:
+        'Stretch Bed source data names recycled HDPE legs, galvanised steel poles, heavy-duty canvas, hardware and packaging. Cost register also carries the $149.20 materials-only quote and the $550 planning production model.',
+      financeEvidence:
+        'Xero supplier bills include Defy / Defy Manufacturing, Zinus, Bunnings, RW Pacific and materials-style account buckets including 446 Materials & Supplies.',
+      stillNeeded:
+        'Allocate supplier bill line items to current Stretch Bed batches and asset IDs; separate Basket/Weave history from current Stretch Bed cost.',
+      sourceDocs:
+        'capital/cost-register; sources/canonical-product-data; products/stretch-bed',
+    },
+    {
+      input: 'Labour',
+      status: 'known-source',
+      wikiEvidence:
+        'Production facility guide names the build flow: collection, shredding, pressing, CNC cutting, finishing, assembly, shift notes and handover logic.',
+      financeEvidence:
+        'Cost register has staff/founder time, consulting/design/contractor rows and Xero subcontractor-style account buckets, but they are not cleanly allocated to product batches.',
+      stillNeeded:
+        'Pull payroll, contractor, community payment and founder-time treatment into an approved allocation rule before quoting labour per bed.',
+      sourceDocs:
+        'sources/production-facility-guide; enterprise/04-financial-management; capital/cost-register',
+    },
+    {
+      input: 'Freight and delivery',
+      status: 'finance-backed',
+      wikiEvidence:
+        'Goods source pack names remote freight, delivery into communities, barge/road/last-mile constraints and delivery benchmarks.',
+      financeEvidence:
+        'Xero/cost register includes freight and delivery signals: Loadshift, Sea Swift, Palm Island Barge, Peak Up Transport and account 425 freight/courier rows.',
+      stillNeeded:
+        'Tie freight invoices to specific communities, trips, deliveries and asset batches so delivered cost is not averaged blindly.',
+      sourceDocs:
+        'capital/cost-register; sources/procurement-strategy; sources/go-to-market-thousands-2026',
+    },
+    {
+      input: 'Support and warranty',
+      status: 'known-source',
+      wikiEvidence:
+        'Product data carries a 5-year warranty. The tracking model names check-ins, repair, movement, replacement, support events and lifecycle evidence.',
+      financeEvidence:
+        'Support costs are not yet split out from general Goods/Xero rows; replacement parts and failed design costs need tagging.',
+      stillNeeded:
+        'Connect QR asset check-ins, support logs, replacement parts and warranty work to finance rows and product batches.',
+      sourceDocs:
+        'sources/community-essential-goods-tracking-model; products/stretch-bed; impact/metrics-tracked',
+    },
+    {
+      input: 'Overhead allocation',
+      status: 'allocation-gap',
+      wikiEvidence:
+        'ACT operating thesis and Goods finance pages state that Goods sits inside ACT and uses shared finance, admin, website, communications, technology and founder support.',
+      financeEvidence:
+        'Project monthly financials give ACT-GD spend, but ACT shared-service costs may sit under ACT-IN or wider project codes rather than the Goods ledger.',
+      stillNeeded:
+        'Rule selected: do not blend ACT shared-service overhead into delivered unit cost. Show it as a separate operating-support/use-of-funds line.',
+      sourceDocs:
+        'act-operational-thesis; enterprise/04-financial-management; capital/cost-register',
+    },
+  ];
+}
+
+function categoryForCostLine(account: string, description: string, supplier: string) {
+  const haystack = `${accountLabel(account)} ${description} ${supplier}`.toLowerCase();
+  if (account === '425') return 'Freight and delivery';
+  if (account === '446' || account === '413') return 'Materials';
+  if (account === '400' || account === '412') return 'Direct build / manufacture';
+  if (account === '451') return 'Support and warranty';
+  if (account === '493') return 'ACT shared-service support';
+  if (account === '486') return 'Direct labour / build';
+  if (/freight|courier|transport|barge|delivery|sendle|loadshift|sea swift|peak up/.test(haystack)) {
+    return 'Freight and delivery';
+  }
+  if (/bed|mattress|plastic|canvas|bedding|sheet|fastener|packag|material|defy|zinus|metal|rw pacific/.test(haystack)) {
+    return 'Materials';
+  }
+  if (/repair|warranty|replacement|vehicle|mechanic|field support|support/.test(haystack)) {
+    return 'Support and warranty';
+  }
+  if (/labour|labor|assembly|build|manufactur|contractor|sub-contract|cnc|design/.test(haystack) || account === '486') {
+    return 'Direct labour / build';
+  }
+  if (/admin|software|insurance|accounting|crm|reporting|governance|grant|founder|travel|accommodation/.test(haystack) || account === '493') {
+    return 'ACT shared-service support';
+  }
+  return 'Needs finance review';
+}
+
+function treatmentForCategory(category: string): GoodsCostEvidence['costAllocationRows'][number]['directCostTreatment'] {
+  if (category === 'ACT shared-service support') return 'show separately';
+  if (category === 'Needs finance review') return 'review before quoting';
+  return 'include when allocated';
+}
+
+function actionForCategory(category: string) {
+  const actions: Record<string, string> = {
+    Materials: 'Allocate to current Stretch Bed batch and asset IDs.',
+    'Direct build / manufacture': 'Allocate manufactured units to asset IDs and current product type.',
+    'Freight and delivery': 'Tie to community delivery, trip, and asset batch.',
+    'Direct labour / build': 'Confirm direct build labour or move to ACT support.',
+    'Support and warranty': 'Confirm field/warranty event or move to support allowance.',
+    'ACT shared-service support': 'Keep out of unit cost; add to support/use-of-funds line.',
+    'Needs finance review': 'Finance review before quoting or excluding.',
+  };
+  return actions[category] || actions['Needs finance review'];
+}
+
+function allocationPriority(category: string) {
+  const priorities: Record<string, number> = {
+    Materials: 1,
+    'Direct build / manufacture': 2,
+    'Freight and delivery': 3,
+    'Direct labour / build': 4,
+    'Support and warranty': 5,
+    'ACT shared-service support': 6,
+    'Needs finance review': 7,
+  };
+  return priorities[category] || 99;
+}
+
+function selectAllocationRows(rows: GoodsCostEvidence['costAllocationRows']) {
+  const sorted = [...rows].sort((a, b) => {
+    const priority = allocationPriority(a.category) - allocationPriority(b.category);
+    if (priority !== 0) return priority;
+    return b.date.localeCompare(a.date);
+  });
+  const quotas: Array<[string, number]> = [
+    ['Materials', 5],
+    ['Direct build / manufacture', 5],
+    ['Freight and delivery', 3],
+    ['Direct labour / build', 2],
+    ['Support and warranty', 2],
+    ['ACT shared-service support', 1],
+  ];
+  const selected: GoodsCostEvidence['costAllocationRows'] = [];
+  const selectedKeys = new Set<string>();
+  const keyFor = (row: GoodsCostEvidence['costAllocationRows'][number]) =>
+    `${row.invoice}-${row.account}-${row.description}-${row.amount}`;
+
+  for (const [category, limit] of quotas) {
+    for (const row of sorted.filter((candidate) => candidate.category === category).slice(0, limit)) {
+      const key = keyFor(row);
+      if (!selectedKeys.has(key)) {
+        selected.push(row);
+        selectedKeys.add(key);
+      }
+    }
+  }
+
+  for (const row of sorted) {
+    if (selected.length >= 18) break;
+    const key = keyFor(row);
+    if (!selectedKeys.has(key)) {
+      selected.push(row);
+      selectedKeys.add(key);
+    }
+  }
+
+  return selected.slice(0, 18);
+}
+
+function defaultScopeForDecision(decision: GoodsCostAllocationDecision): GoodsCostAllocationScope {
+  if (decision === 'show_separately') return 'shared_service';
+  if (decision === 'include_direct') return 'current_batch';
+  return 'unallocated';
+}
+
+export async function saveGoodsCostAllocationDecision(input: GoodsCostAllocationSaveInput) {
+  if (!GOODS_COST_DECISIONS.includes(input.decision)) {
+    throw new Error(`Unsupported Goods cost allocation decision: ${input.decision}`);
+  }
+
+  const supabase = getServiceSupabase();
+  const allocationScope = input.allocationScope ?? defaultScopeForDecision(input.decision);
+  const { data, error } = await supabase
+    .from('goods_cost_allocation_decisions')
+    .upsert(
+      {
+        project_code: PROJECT_CODE,
+        xero_invoice_id: input.xeroInvoiceId,
+        invoice_number: input.invoice === 'missing' ? null : input.invoice,
+        line_index: input.lineIndex,
+        line_fingerprint: input.lineFingerprint,
+        supplier: input.supplier,
+        account_code: input.accountCode,
+        account_label: input.account,
+        description: input.description,
+        line_amount: moneyToNumber(input.amount),
+        category: input.category,
+        decision: input.decision,
+        allocation_scope: allocationScope,
+        notes: input.notes || null,
+        decided_by: input.decidedBy || null,
+        decided_at: new Date().toISOString(),
+      },
+      { onConflict: 'project_code,line_fingerprint' },
+    )
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function getGoodsCostEvidence(): Promise<GoodsCostEvidence> {
+  const supabase = getServiceSupabase();
+
+  try {
+    const [billResult, monthlyResult, transactionResult, decisionResult] = await Promise.all([
+      supabase
+        .from('xero_invoices')
+        .select('id, invoice_number, contact_name, status, date, total, amount_paid, amount_due, has_attachments, line_items, synced_at')
+        .eq('project_code', PROJECT_CODE)
+        .eq('type', 'ACCPAY')
+        .not('status', 'in', '(VOIDED,DELETED)')
+        .order('date', { ascending: false }),
+      supabase
+        .from('project_monthly_financials')
+        .select('month, fy_ytd_expenses')
+        .eq('project_code', PROJECT_CODE)
+        .order('month', { ascending: false })
+        .limit(1),
+      supabase
+        .from('xero_transactions')
+        .select('xero_transaction_id, contact_name, type, total, status, date, has_attachments, is_reconciled')
+        .eq('project_code', PROJECT_CODE)
+        .not('status', 'eq', 'DELETED'),
+      supabase
+        .from('goods_cost_allocation_decisions')
+        .select('line_fingerprint, decision, allocation_scope, notes, decided_at')
+        .eq('project_code', PROJECT_CODE),
+    ]);
+
+    if (billResult.error) {
+      return { ...emptyEvidence(billResult.error.message), status: 'error' };
+    }
+
+    const bills = (billResult.data || []) as XeroSupplierBill[];
+    if (bills.length === 0) {
+      return emptyEvidence(`No ${PROJECT_CODE} supplier bills were found in xero_invoices.`);
+    }
+
+    const transactions = (transactionResult.data || []) as XeroTransactionRow[];
+    const transactionIds = transactions
+      .map((row) => row.xero_transaction_id)
+      .filter((value): value is string => Boolean(value));
+    const dextResult =
+      transactionIds.length > 0
+        ? await supabase
+            .from('dext_receipts')
+            .select('xero_transaction_id, vendor_name, receipt_date, filename, match_confidence, match_method')
+            .in('xero_transaction_id', transactionIds)
+        : { data: [], error: null };
+    const dextReceipts = ((dextResult.data || []) as DextReceiptRow[]).filter((row) => row.xero_transaction_id);
+    const monthly = ((monthlyResult.data || []) as MonthlyFinancialRow[])[0];
+    const allocationDecisions = new Map(
+      (((decisionResult.data || []) as GoodsCostAllocationDecisionRow[]).filter((row) => row.line_fingerprint)).map(
+        (row) => [row.line_fingerprint, row],
+      ),
+    );
+
+    const total = bills.reduce((sum, row) => sum + toNumber(row.total), 0);
+    const paid = bills.reduce((sum, row) => sum + toNumber(row.amount_paid), 0);
+    const due = bills.reduce((sum, row) => sum + toNumber(row.amount_due), 0);
+    const attached = bills.filter((row) => row.has_attachments).length;
+    const latestSync = bills
+      .map((row) => row.synced_at)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
+
+    const supplierMap = new Map<
+      string,
+      { rows: number; total: number; paid: number; due: number; first: string | null; last: string | null }
+    >();
+    for (const bill of bills) {
+      const supplier = bill.contact_name || 'Unknown supplier';
+      const existing = supplierMap.get(supplier) ?? { rows: 0, total: 0, paid: 0, due: 0, first: null, last: null };
+      const date = bill.date;
+      existing.rows += 1;
+      existing.total += toNumber(bill.total);
+      existing.paid += toNumber(bill.amount_paid);
+      existing.due += toNumber(bill.amount_due);
+      existing.first = !existing.first || (date && date < existing.first) ? date : existing.first;
+      existing.last = !existing.last || (date && date > existing.last) ? date : existing.last;
+      supplierMap.set(supplier, existing);
+    }
+
+    const supplierRows = [...supplierMap.entries()]
+      .map(([supplier, row]) => ({
+        supplier,
+        rows: row.rows,
+        total: money(row.total),
+        paid: money(row.paid),
+        due: money(row.due),
+        period: periodLabel(row.first, row.last),
+      }))
+      .sort((a, b) => toNumber(b.total.replace(/[$,]/g, '')) - toNumber(a.total.replace(/[$,]/g, '')))
+      .slice(0, 10);
+
+    const accountMap = new Map<string, { lines: number; subtotal: number; suppliers: Set<string> }>();
+    const directEvidence: GoodsCostEvidence['directEvidenceRows'] = [];
+    const costAllocationRows: GoodsCostEvidence['costAllocationRows'] = [];
+    for (const bill of bills) {
+      const supplier = bill.contact_name || 'Unknown supplier';
+      for (const [lineIndex, item] of normaliseLineItems(bill.line_items).entries()) {
+        const account = item.account_code || 'missing';
+        const lineAmount = toNumber(item.line_amount);
+        const existing = accountMap.get(account) ?? { lines: 0, subtotal: 0, suppliers: new Set<string>() };
+        existing.lines += 1;
+        existing.subtotal += lineAmount;
+        existing.suppliers.add(supplier);
+        accountMap.set(account, existing);
+
+        const description = String(item.description || '').replace(/\s+/g, ' ').trim();
+        const category = categoryForCostLine(account, description, supplier);
+        if (lineAmount > 0 && category !== 'Needs finance review') {
+          const lineFingerprint = buildGoodsCostLineFingerprint({
+            xeroInvoiceId: bill.id,
+            lineIndex,
+            accountCode: account,
+            description,
+            lineAmount,
+          });
+          const decision = allocationDecisions.get(lineFingerprint);
+          const inLast50DateWindow = Boolean(bill.date && bill.date >= LAST_50_START && bill.date <= LAST_50_END);
+          const hasBedQuantity = /(\d+)\s+Beds?/i.test(description);
+          costAllocationRows.push({
+            lineFingerprint,
+            lineIndex,
+            xeroInvoiceId: bill.id,
+            supplier,
+            invoice: bill.invoice_number || 'missing',
+            date: dateLabel(bill.date),
+            amount: money(lineAmount),
+            category,
+            directCostTreatment: treatmentForCategory(category),
+            batchStatus: hasBedQuantity
+              ? 'Line names bed quantity; needs asset IDs'
+              : inLast50DateWindow
+                ? 'Last-50 date window only'
+                : 'Not allocated to batch',
+            proofStatus: bill.has_attachments ? 'Xero attachment' : 'Xero row only',
+            action: actionForCategory(category),
+            account: `Xero ${account}: ${accountLabel(account)}`,
+            accountCode: account,
+            description: description || 'No line description',
+            currentDecision: decision?.decision ?? 'needs_allocation',
+            allocationScope: decision?.allocation_scope ?? 'unallocated',
+            decisionNotes: decision?.notes ?? null,
+            decidedAt: decision?.decided_at ?? null,
+          });
+        }
+        if (/bed|mattress|plastic|freight|transport/i.test(description)) {
+          const bedMatch = description.match(/(\d+)\s+Beds?/i);
+          const note =
+            bedMatch && Number(bedMatch[1]) > 0
+              ? `${money(lineAmount / Number(bedMatch[1]))} per described bed, excluding GST; still needs allocation to exact asset IDs.`
+              : 'Direct product/material/freight evidence; still needs allocation to exact asset IDs.';
+          directEvidence.push({
+            supplier,
+            invoice: bill.invoice_number || 'missing',
+            date: dateLabel(bill.date),
+            amount: money(lineAmount || toNumber(bill.total)),
+            account,
+            description: description || 'No line description',
+            note,
+          });
+        }
+      }
+    }
+
+    const accountRows = [...accountMap.entries()]
+      .map(([account, row]) => ({
+        account,
+        label: accountLabel(account),
+        lines: row.lines,
+        subtotal: money(row.subtotal),
+        suppliers: [...row.suppliers].sort().slice(0, 5).join(', '),
+      }))
+      .sort((a, b) => toNumber(b.subtotal.replace(/[$,]/g, '')) - toNumber(a.subtotal.replace(/[$,]/g, '')))
+      .slice(0, 8);
+
+    const last50Bills = bills
+      .filter((row) => row.date && row.date >= LAST_50_START && row.date <= LAST_50_END)
+      .sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+    const last50Total = last50Bills.reduce((sum, row) => sum + toNumber(row.total), 0);
+    const last50Paid = last50Bills.reduce((sum, row) => sum + toNumber(row.amount_paid), 0);
+    const last50Due = last50Bills.reduce((sum, row) => sum + toNumber(row.amount_due), 0);
+
+    return {
+      status: 'live',
+      decision:
+        'Real ACT-GD supplier bills have been pulled from Xero, and the working estimate is good enough for planning: use $600 per bed plus route freight. Keep ACT shared-service overhead as a separate support line. Treat detailed supplier-to-asset allocation as later finance cleanup, not the blocker for QBE, buyer, or foundation planning.',
+      totals: [
+        {
+          label: 'Supplier bills',
+          value: compactMoney(total),
+          detail: `${bills.length} ACT-GD ACCPAY rows, excluding voided/deleted bills. Last sync ${latestSync ? latestSync.slice(0, 10) : 'unknown'}.`,
+        },
+        {
+          label: 'Paid supplier bills',
+          value: compactMoney(paid),
+          detail: `${bills.filter((row) => toNumber(row.amount_paid) > 0).length} supplier bills show paid amounts in Xero.`,
+        },
+        {
+          label: 'Still due',
+          value: compactMoney(due),
+          detail: `${bills.filter((row) => toNumber(row.amount_due) > 0).length} supplier bills still show amount due.`,
+        },
+        {
+          label: 'FY26 spend',
+          value: compactMoney(toNumber(monthly?.fy_ytd_expenses)),
+          detail: monthly?.month
+            ? `Project monthly financials as at ${monthly.month.slice(0, 10)}.`
+            : 'No project monthly financial row found.',
+        },
+        {
+          label: 'Xero attachments',
+          value: `${attached}/${bills.length}`,
+          detail: 'Supplier bills with Xero attachments.',
+        },
+        {
+          label: 'Dext linked',
+          value: `${dextReceipts.length}/${transactions.length}`,
+          detail: 'Dext receipts joined to ACT-GD Xero transactions. This is the weakest part of the evidence chain.',
+        },
+        {
+          label: 'Last-50 date window',
+          value: compactMoney(last50Total),
+          detail: `${last50Bills.length} supplier bills dated ${LAST_50_START} to ${LAST_50_END}; ${money(last50Paid)} paid and ${money(last50Due)} due. Window average is ${money(last50Total / LAST_50_COUNT)} and is only a plausibility check beside the $600 planning number.`,
+        },
+      ],
+      costBoundaryRows: goodsCostBoundaryRows(),
+      unitEstimateRows: goodsUnitEstimateRows(last50Total),
+      costInputRows: goodsCostInputRows(),
+      costAllocationRows: selectAllocationRows(costAllocationRows),
+      supplierRows,
+      accountRows,
+      directEvidenceRows: directEvidence
+        .sort((a, b) => b.date.localeCompare(a.date))
+        .slice(0, 8),
+      last50WindowRows: last50Bills.map((row) => ({
+        supplier: row.contact_name || 'Unknown supplier',
+        invoice: row.invoice_number || 'missing',
+        date: dateLabel(row.date),
+        status: (row.status || 'unknown').toLowerCase(),
+        total: money(toNumber(row.total)),
+        paid: money(toNumber(row.amount_paid)),
+        due: money(toNumber(row.amount_due)),
+      })),
+      gaps: [
+        'Later finance cleanup: allocate supplier bill lines to Goods asset IDs or batch IDs when possible.',
+        'Map Xero account codes to finance-approved labels before sharing externally.',
+        'Attach Dext/supplier receipts for production, freight, and materials rows where Xero attachment coverage is weak.',
+        'Keep wiki/source-pack facts visible, but mark them as source evidence until finance allocation is complete.',
+        'Use $600 per bed plus route freight as the planning number; show ACT shared-service overhead separately as operating support.',
+      ],
+    };
+  } catch (error) {
+    return {
+      ...emptyEvidence(error instanceof Error ? error.message : 'Unknown Goods cost evidence load error.'),
+      status: 'error',
+    };
+  }
+}

--- a/apps/web/src/lib/services/goods-finance-ledger.ts
+++ b/apps/web/src/lib/services/goods-finance-ledger.ts
@@ -1,0 +1,314 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+export type GoodsInvoiceMoneyRow = {
+  group: string;
+  name: string;
+  amount: string;
+  status: string;
+  owner: string;
+  next: string;
+  sourceSystem: 'xero';
+  invoiceNumber: string;
+  contact: string;
+  issueDate: string;
+  dueDate: string;
+  paidDate: string;
+  amountDue: string;
+  amountPaid: string;
+  direction: 'income';
+  source: string;
+};
+
+export type GoodsFinanceSource = {
+  label: string;
+  status: 'live' | 'empty' | 'error';
+  detail: string;
+};
+
+export type GoodsFinanceLedger = {
+  moneyRows: GoodsInvoiceMoneyRow[];
+  totals: Array<{ label: string; value: string; detail?: string }>;
+  source: GoodsFinanceSource;
+};
+
+type XeroInvoiceRow = {
+  id: string;
+  invoice_number: string | null;
+  contact_name: string | null;
+  status: string | null;
+  date: string | null;
+  due_date: string | null;
+  total: number | string | null;
+  amount_due: number | string | null;
+  amount_paid: number | string | null;
+  fully_paid_date: string | null;
+  income_type: string | null;
+  reference: string | null;
+  synced_at: string | null;
+};
+
+type MonthlyFinancialRow = {
+  month: string | null;
+  fy_ytd_revenue: number | string | null;
+  fy_ytd_expenses: number | string | null;
+  fy_ytd_net: number | string | null;
+};
+
+const PROJECT_CODE = 'ACT-GD';
+const PROJECT_LABEL = 'Goods';
+const STATUS_ORDER: Record<string, number> = {
+  DRAFT: 1,
+  SUBMITTED: 2,
+  SENT: 3,
+  AUTHORISED: 4,
+  PAID: 5,
+};
+
+function money(value: number) {
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  }).format(value);
+}
+
+function compactMoney(value: number) {
+  if (Math.abs(value) >= 1000000) return `$${(value / 1000000).toFixed(value % 1000000 === 0 ? 0 : 1)}M`;
+  if (Math.abs(value) >= 1000) return `$${Math.round(value / 1000)}K`;
+  return money(value);
+}
+
+function toNumber(value: number | string | null | undefined) {
+  if (value === null || value === undefined) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function dateLabel(value: string | null | undefined) {
+  if (!value) return 'not synced';
+  return value;
+}
+
+function daysFromToday(date: string | null | undefined) {
+  if (!date) return null;
+  const due = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(due.getTime())) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Math.round((today.getTime() - due.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function invoiceGroup(status: string, amountDue: number, amountPaid: number) {
+  if (status === 'DRAFT') return 'draft';
+  if (status === 'SUBMITTED' || status === 'SENT') return 'sent';
+  if (status === 'PAID' || (amountPaid > 0 && amountDue === 0)) return 'paid';
+  if (status === 'AUTHORISED') return 'authorised';
+  return 'check';
+}
+
+function invoiceStatus(row: XeroInvoiceRow) {
+  const status = (row.status || 'DRAFT').toUpperCase();
+  const amountDue = toNumber(row.amount_due);
+  const amountPaid = toNumber(row.amount_paid);
+  if (status === 'PAID' || (amountPaid > 0 && amountDue === 0)) return 'paid in Xero';
+  if (status === 'DRAFT') return 'draft';
+  if (status === 'SUBMITTED' || status === 'SENT') return 'sent';
+  if (status === 'AUTHORISED') {
+    const overdue = daysFromToday(row.due_date);
+    return overdue && overdue > 0 ? `authorised ${overdue}d` : 'authorised';
+  }
+  return status.toLowerCase();
+}
+
+function invoiceNext(row: XeroInvoiceRow) {
+  const status = (row.status || 'DRAFT').toUpperCase();
+  const amountDue = toNumber(row.amount_due);
+  const amountPaid = toNumber(row.amount_paid);
+  const paidDate = dateLabel(row.fully_paid_date);
+  if (status === 'PAID' || (amountPaid > 0 && amountDue === 0)) {
+    return `Paid ${money(amountPaid || toNumber(row.total))}. Paid date: ${paidDate}.`;
+  }
+  if (status === 'DRAFT') {
+    return toNumber(row.total) === 0
+      ? 'Zero-dollar draft. Void, fix, or leave out of the money story.'
+      : 'Draft only. Send, void, or reissue before chasing.';
+  }
+  if (status === 'AUTHORISED') {
+    const overdue = daysFromToday(row.due_date);
+    return overdue && overdue > 0
+      ? `Still due ${money(amountDue)}. ${overdue} days overdue. Chase, confirm paid, or write off.`
+      : `Still due ${money(amountDue)}. Confirm paid or chase.`;
+  }
+  return `Check Xero status ${status}.`;
+}
+
+function invoiceName(row: XeroInvoiceRow) {
+  const number = row.invoice_number || 'No invoice number';
+  const contact = row.contact_name || 'Unknown contact';
+  return `${number} · ${contact}`;
+}
+
+function invoiceOwner(row: XeroInvoiceRow) {
+  const contact = (row.contact_name || '').toLowerCase();
+  if (contact.includes('snow') || contact.includes('centrecorp') || contact.includes('rotary')) return 'Ben';
+  if (contact.includes('ingkerreke') || contact.includes('julalikari') || contact.includes('malala') || contact.includes('shed')) return 'Goods / ACT';
+  return PROJECT_LABEL;
+}
+
+function rowFromInvoice(row: XeroInvoiceRow): GoodsInvoiceMoneyRow {
+  const status = (row.status || 'DRAFT').toUpperCase();
+  const amountDue = toNumber(row.amount_due);
+  const amountPaid = toNumber(row.amount_paid);
+  const total = toNumber(row.total);
+  const group = invoiceGroup(status, amountDue, amountPaid);
+  const invoiceNumber = row.invoice_number || 'missing';
+  const contact = row.contact_name || 'Unknown contact';
+
+  return {
+    group,
+    name: invoiceName(row),
+    amount: money(total),
+    status: invoiceStatus(row),
+    owner: invoiceOwner(row),
+    next: invoiceNext(row),
+    sourceSystem: 'xero',
+    invoiceNumber,
+    contact,
+    issueDate: dateLabel(row.date),
+    dueDate: dateLabel(row.due_date),
+    paidDate: dateLabel(row.fully_paid_date),
+    amountDue: money(amountDue),
+    amountPaid: money(amountPaid),
+    direction: 'income',
+    source: row.income_type || row.reference || 'Xero ACT-GD income invoice',
+  };
+}
+
+function defaultTotals(source: GoodsFinanceSource): GoodsFinanceLedger {
+  return {
+    moneyRows: [],
+    totals: [
+      { label: 'Paid invoices', value: '$0', detail: 'No Xero rows loaded.' },
+      { label: 'Due / chase', value: '$0', detail: 'No authorised receivables loaded.' },
+      { label: 'Draft / fix', value: '$0', detail: 'No draft invoices loaded.' },
+      { label: 'Invoice rows', value: '0', detail: source.detail },
+    ],
+    source,
+  };
+}
+
+export async function getGoodsFinanceLedger(): Promise<GoodsFinanceLedger> {
+  const supabase = getServiceSupabase();
+
+  try {
+    const [invoiceResult, monthlyResult] = await Promise.all([
+      supabase
+        .from('xero_invoices')
+        .select('id, invoice_number, contact_name, status, date, due_date, total, amount_due, amount_paid, fully_paid_date, income_type, reference, synced_at')
+        .eq('project_code', PROJECT_CODE)
+        .eq('type', 'ACCREC')
+        .not('status', 'in', '(DELETED,VOIDED)')
+        .order('date', { ascending: false }),
+      supabase
+        .from('project_monthly_financials')
+        .select('month, fy_ytd_revenue, fy_ytd_expenses, fy_ytd_net')
+        .eq('project_code', PROJECT_CODE)
+        .order('month', { ascending: false })
+        .limit(1),
+    ]);
+
+    if (invoiceResult.error) {
+      return defaultTotals({
+        label: 'Xero invoices',
+        status: 'error',
+        detail: invoiceResult.error.message,
+      });
+    }
+
+    const invoices = ((invoiceResult.data || []) as XeroInvoiceRow[]).sort((a, b) => {
+      const as = STATUS_ORDER[(a.status || '').toUpperCase()] ?? 9;
+      const bs = STATUS_ORDER[(b.status || '').toUpperCase()] ?? 9;
+      if (as !== bs) return as - bs;
+      return toNumber(b.total) - toNumber(a.total);
+    });
+
+    if (invoices.length === 0) {
+      return defaultTotals({
+        label: 'Xero invoices',
+        status: 'empty',
+        detail: `No ${PROJECT_CODE} income invoices are currently available in xero_invoices.`,
+      });
+    }
+
+    const paidTotal = invoices.reduce((sum, row) => sum + toNumber(row.amount_paid), 0);
+    const dueTotal = invoices.reduce((sum, row) => sum + toNumber(row.amount_due), 0);
+    const draftTotal = invoices
+      .filter((row) => (row.status || '').toUpperCase() === 'DRAFT')
+      .reduce((sum, row) => sum + toNumber(row.total), 0);
+    const latestSync = invoices
+      .map((row) => row.synced_at)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
+    const monthly = ((monthlyResult.data || []) as MonthlyFinancialRow[])[0];
+
+    const totals = [
+      {
+        label: 'Paid invoices',
+        value: compactMoney(paidTotal),
+        detail: `${invoices.filter((row) => (row.status || '').toUpperCase() === 'PAID').length} ACT-GD income invoices marked paid in Xero.`,
+      },
+      {
+        label: 'Due / chase',
+        value: compactMoney(dueTotal),
+        detail: `${invoices.filter((row) => toNumber(row.amount_due) > 0).length} income invoices still showing amount due.`,
+      },
+      {
+        label: 'Draft / fix',
+        value: compactMoney(draftTotal),
+        detail: `${invoices.filter((row) => (row.status || '').toUpperCase() === 'DRAFT').length} draft income invoices. Not chaseable until sent.`,
+      },
+      {
+        label: 'Invoice rows',
+        value: String(invoices.length),
+        detail: `ACT-GD ACCREC rows. Last Xero sync: ${latestSync ? latestSync.slice(0, 10) : 'not synced'}.`,
+      },
+      {
+        label: 'FY26 revenue',
+        value: compactMoney(toNumber(monthly?.fy_ytd_revenue)),
+        detail: monthly?.month ? `Project monthly ledger as at ${monthly.month.slice(0, 10)}.` : 'No monthly ledger row loaded.',
+      },
+      {
+        label: 'FY26 spend',
+        value: compactMoney(toNumber(monthly?.fy_ytd_expenses)),
+        detail: monthly?.month ? `Xero-backed ACT-GD expense allocation as at ${monthly.month.slice(0, 10)}.` : 'No monthly ledger row loaded.',
+      },
+      {
+        label: 'FY26 net',
+        value: compactMoney(toNumber(monthly?.fy_ytd_net)),
+        detail: 'Revenue minus expenses in project_monthly_financials.',
+      },
+      {
+        label: 'Project code',
+        value: PROJECT_CODE,
+        detail: 'Only real Xero income invoices tagged to Goods are shown in the invoice ledger.',
+      },
+    ];
+
+    return {
+      moneyRows: invoices.map(rowFromInvoice),
+      totals,
+      source: {
+        label: 'Xero invoices',
+        status: 'live',
+        detail: `${invoices.length} real ${PROJECT_CODE} income invoices loaded from xero_invoices. Paid dates show only when Xero sync has fully_paid_date.`,
+      },
+    };
+  } catch (error) {
+    return defaultTotals({
+      label: 'Xero invoices',
+      status: 'error',
+      detail: error instanceof Error ? error.message : 'Unknown Xero ledger load error.',
+    });
+  }
+}

--- a/supabase/migrations/20260506063430_goods_cost_allocation_decisions.sql
+++ b/supabase/migrations/20260506063430_goods_cost_allocation_decisions.sql
@@ -1,0 +1,70 @@
+-- Goods direct-cost allocation decisions.
+--
+-- This table does not mutate Xero or Dext. It records ACT's treatment of each
+-- Goods supplier-bill line so the last-50-bed cost sheet can move from review
+-- draft to a finance-backed direct-cost calculation.
+
+CREATE TABLE IF NOT EXISTS goods_cost_allocation_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  project_code text NOT NULL DEFAULT 'ACT-GD',
+  xero_invoice_id uuid REFERENCES xero_invoices(id) ON DELETE CASCADE,
+  invoice_number text,
+  line_index integer NOT NULL,
+  line_fingerprint text NOT NULL,
+
+  supplier text,
+  account_code text,
+  account_label text,
+  description text,
+  line_amount numeric,
+  category text,
+
+  decision text NOT NULL DEFAULT 'needs_allocation'
+    CHECK (
+      decision IN (
+        'needs_allocation',
+        'include_direct',
+        'show_separately',
+        'exclude',
+        'needs_receipt',
+        'needs_review'
+      )
+    ),
+  allocation_scope text NOT NULL DEFAULT 'unallocated'
+    CHECK (allocation_scope IN ('unallocated', 'last_50', 'current_batch', 'specific_assets', 'shared_service')),
+  batch_ref text,
+  asset_refs text[] NOT NULL DEFAULT ARRAY[]::text[],
+
+  notes text,
+  decided_by text,
+  decided_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT goods_cost_allocation_unique_line UNIQUE (project_code, line_fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_goods_cost_allocation_project_decision
+  ON goods_cost_allocation_decisions(project_code, decision, allocation_scope, decided_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_goods_cost_allocation_invoice
+  ON goods_cost_allocation_decisions(xero_invoice_id, line_index);
+
+CREATE INDEX IF NOT EXISTS idx_goods_cost_allocation_category
+  ON goods_cost_allocation_decisions(project_code, category);
+
+ALTER TABLE goods_cost_allocation_decisions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "goods_cost_allocation_service" ON goods_cost_allocation_decisions;
+CREATE POLICY "goods_cost_allocation_service" ON goods_cost_allocation_decisions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "goods_cost_allocation_authenticated_read" ON goods_cost_allocation_decisions;
+CREATE POLICY "goods_cost_allocation_authenticated_read" ON goods_cost_allocation_decisions
+  FOR SELECT TO authenticated USING (true);
+
+DROP TRIGGER IF EXISTS goods_cost_allocation_updated_at ON goods_cost_allocation_decisions;
+CREATE TRIGGER goods_cost_allocation_updated_at
+  BEFORE UPDATE ON goods_cost_allocation_decisions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
Phases 1, 2, and 3 (web view) of `thoughts/shared/plans/2026-05-28-goods-cost-evidence-funder-artifact.md` (act-infra). Two commits:

- **Phase 1** (`5b7912e`) — cherry-picks the recovered Goods cost-allocation files onto a clean base off `main`, mounts the table on `/org/[slug]/[projectSlug]` gated by `isGoodsProject()`.
- **Phase 2 + Phase 3 web** (`2f5fa06`) — turns the same Xero data into a funder-grade artifact + an honest internal review queue.

---

## Phase 1 — Land the tool

### Files (5 new, ~1,500 LoC)
- `apps/web/src/lib/services/goods-cost-evidence.ts` — reads ACT-GD bills from `xero_invoices`, classifies lines, surfaces totals + unit-estimate rows + the per-line allocation queue.
- `apps/web/src/lib/services/goods-finance-ledger.ts` — companion ACT-GD income ledger (not mounted yet; available for follow-on work).
- `apps/web/src/app/api/goods/cost-allocation/route.ts` — POST endpoint for the table to persist a decision, gated by `tracker` module.
- `apps/web/src/app/org/[slug]/[projectSlug]/goods-cost-allocation-table.tsx` — client table with 4 action buttons per line (use in last 50 / direct later / ACT support / need receipt / exclude).
- `supabase/migrations/20260506063430_goods_cost_allocation_decisions.sql` — the decisions table (already live in shared DB; idempotent `IF NOT EXISTS`).

### Mount point
New section in `FastProjectDashboard` (the goods control sheet), after the funding pipeline. `FastProjectDashboard` is now `async` so it can `await getGoodsCostEvidence()` inside the `goodsProject` branch. Failures degrade quietly.

### Conflicts
The 3 "conflict" files the plan mentioned (`grant-scout.ts`, `org-pipeline-service.ts`, `agent-registry.mjs`) have **zero dependencies** on the cost-allocation feature. **No conflict resolution was needed.**

---

## Phase 2 — Funder-grade enhancements

### Account 429 → Materials
~$80K of Defy materials was falling to "Needs finance review" because account 429 was unmapped. Added to both `accountLabel` and `categoryForCostLine`.

### Data-quality flags (`dataQualityFlags`)
- `detectDuplicateBills` — groups by (supplier, total, year-month). Catches Carla-Furnishers-style mirrored bills.
- `detectKnownIssues` — seeded with the plan's outstanding issues:
  - R M Tanner Triple Axle coded as labour but actually capital (high)
  - 1300 Washer tagged ACT-GD but line reads ACT-FM (high)
  - Zinus Australia purpose unconfirmed (medium)

Each issue surfaces only if a matching bill exists, so resolved ones drop off automatically.

### Capital separation (`capitalRows`)
`extractCapitalRows` matches bill lines against `CAPITAL_HINTS` (Carbatec → tooling, R M Tanner Triple Axle → capital-asset, "facility" in description → facility-materials). Shown separately from per-bed cost — the plan's "separate one-off capital from per-unit" non-negotiable.

---

## Phase 3 (web) — Funder cost-evidence artifact

### `buildFunderView` — structured funder view
- **Hero** — one number ("$X delivers one community-made bed") + provenance one-liner.
- **Cost stack** — HDPE kit / canvas / assembly / steel / caps / freight / facility overhead, each with amount + %-of-total + basis.
- **Capital summary** — production facility, Carbatec tooling, Defy facility materials, Kirmos facility labour. **Shown separately.**
- **$→beds conversion** — $10K / $50K / $100K / $500K → bed count at the hero number.
- **Counterfactual** — $1,500–$2,000 commercial equivalent with derived ratio (`2.8×–3.8×`).
- **Provenance** — every figure → source + one of `verified` / `inferred` / `planning` / `unverified` (coloured chip).

### Page mount
New top section "Funder cost evidence" sits between the funding pipeline and the existing operating queue. Bauhaus-themed: black hero panel with hero number + counterfactual, red cost-stack bars, capital + $→beds side-by-side, provenance table.

---

## What's deferred (next session)

- **Founder time line** — needs Ben's call on the fair-market replacement rate ($/day).
- **Notion BOM import** (Decision C alternative path) — canonical per-bed numbers are currently hardcoded in `buildFunderView`. Wiring to the Notion Bed-Inputs DB needs the database schema + read access decision.
- **PDF + Excel formats** (Decision B's other two) — need a library choice (Puppeteer? exceljs?). The web view ships with this PR; PDF + Excel hang off the same `funderView` data shape, so they're a tractable follow-on.
- **Procurement** (Decision A's fast-follow-on) — turned out to require recovered-only scaffolding (`act-surface-counts`, `act-surface-nav`) + an unapplied SQL view (`v_act_procurement_buyers`). Bigger lift than expected, deferred to its own dedicated session.

## Verification
- `npx tsc --noEmit` clean.
- `pnpm --filter @grantscope/web build` clean — 241 static pages, no new warnings.

## What you'll see
Visit `/org/act/<goods-project-slug>` — the new "**Funder cost evidence**" section sits at the top of the goods control sheet, then the operating queue underneath with the data-quality flags and capital panels.

Plan: `goods-cost-evidence-funder-artifact`
