### PR TITLE
fix(discover): exclude non-grantmaker types (universities, PHNs) from discovery

### DIFF
--- a/scripts/discover-foundation-programs.mjs
+++ b/scripts/discover-foundation-programs.mjs
@@ -759,7 +759,17 @@ async function getFoundationsToScan() {
         return true;
       });
 
-  const candidates = [...strictCandidates, ...fallbackCandidates];
+  // Hard-exclude types that never run community grant rounds: universities and
+  // schools fund scholarships/research; service-delivery orgs, PHNs and legal aid
+  // operate rather than grant. Aligns with this script's intent to avoid operating
+  // charities/schools, and stops a few high-giving universities (e.g. USQ) from
+  // monopolising the giving-sorted scan order. Applied to the merged set (strict +
+  // fallback) so it catches every candidate source, not just strict selection.
+  const NON_GRANTMAKER_TYPES = new Set([
+    'university', 'education_body', 'service_delivery', 'primary_health_network', 'legal_aid',
+  ]);
+  const candidates = [...strictCandidates, ...fallbackCandidates]
+    .filter((foundation) => !NON_GRANTMAKER_TYPES.has(String(foundation.type || '').toLowerCase()));
   const scoredCandidates = candidates
     .map((foundation) => ({
       foundation,


### PR DESCRIPTION
Follow-up to #49. Refines the program-discovery targeting so it hits community grantmakers, not universities.

## Problem
The scan list (strict + fallback candidates, sorted by giving) was topped by high-giving **universities** (USQ, Griffith) and **operating orgs** (PHNs) — they fund scholarships/research or deliver services, not community grant rounds. They're slow to scrape (huge sites) and yield little. In a `--geo=AU-QLD` dry-run they monopolised the top of the list.

## Fix
Hard-exclude `type IN (university, education_body, service_delivery, primary_health_network, legal_aid)` at the **merged** candidate set (strict + fallback), so it catches every source. The `type` column is authoritative, and this aligns with the script's own docstring intent ("avoid operating charities/schools"). The bulk of QLD targets (490 corporate_foundation + 141 trust + ancillary/community funds) are untouched.

## Verified
`node --check` passes. `--geo=AU-QLD --dry-run` before: USQ, Griffith, Partners 4 Health on top. After: Rio Tinto Foundation, NRM bodies (Burnett Mary, Fitzroy Basin), SEFA — actual grantmakers.

## Run (after merge, on cron/infra)
`node --env-file=.env scripts/discover-foundation-programs.mjs --geo=AU-QLD --limit=737 --concurrency=2` then `node scripts/sync-foundation-programs.mjs`. Multi-hour job; resumable via agent_runtime_state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)