### PR TITLE
fix(discover): survive transient Supabase failures instead of crashing

### DIFF
--- a/scripts/discover-foundation-programs.mjs
+++ b/scripts/discover-foundation-programs.mjs
@@ -489,19 +489,28 @@ async function getFoundationsToScan() {
     return query;
   };
 
-  const dueFrontierRows = await fetchAllRows((from, to) => (
-    buildFrontierQuery()
-      .lte('next_check_at', new Date().toISOString())
-      .order('priority', { ascending: false })
-      .range(from, to)
-  ));
-
-  const recentlyChangedFrontierRows = await fetchAllRows((from, to) => (
-    buildFrontierQuery()
-      .gte('last_changed_at', frontierCutoffIso)
-      .order('last_changed_at', { ascending: false })
-      .range(from, to)
-  ));
+  // The frontier fetch scans source_frontier globally (all foundations) and can
+  // hit Supabase's gateway timeout under load. It only informs scan-prioritisation
+  // scoring (everything downstream reads frontier?. optionally), so degrade
+  // gracefully instead of failing the whole discovery run.
+  let dueFrontierRows = [];
+  let recentlyChangedFrontierRows = [];
+  try {
+    dueFrontierRows = await fetchAllRows((from, to) => (
+      buildFrontierQuery()
+        .lte('next_check_at', new Date().toISOString())
+        .order('priority', { ascending: false })
+        .range(from, to)
+    ));
+    recentlyChangedFrontierRows = await fetchAllRows((from, to) => (
+      buildFrontierQuery()
+        .gte('last_changed_at', frontierCutoffIso)
+        .order('last_changed_at', { ascending: false })
+        .range(from, to)
+    ));
+  } catch (err) {
+    log(`Frontier fetch failed (${err?.message || err}); continuing without frontier prioritisation.`);
+  }
 
   const frontierRows = buildUniqueFrontierRows([
     ...(dueFrontierRows || []),
@@ -580,7 +589,7 @@ async function getFoundationsToScan() {
 
   if (error) {
     log(`Error fetching foundations: ${error.message}`);
-    return [];
+    return { foundations: [], fullSweepCursorStart: null, fullSweepCandidateCount: 0 };
   }
 
   const grantmakerSignals = /(grant|grants|fellowship|scholarship|philanthrop|funding|applications|awards?|EOI|apply now|grant round|community giving|open for applications|grant program)/i;


### PR DESCRIPTION
Hardening surfaced while running `--geo=AU-QLD` discovery ad-hoc against the shared Supabase under load.

## Two failure modes fixed
1. **Frontier fetch timeout was fatal.** `getFoundationsToScan` scans `source_frontier` globally (every foundation) via `fetchAllRows`, which hit Supabase's gateway timeout (`upstream request timeout`) under load and killed the whole run. It only informs scan-prioritisation scoring (downstream reads `frontier?.` optionally), so it's now wrapped in try/catch — a failure logs and continues without frontier prioritisation. **Verified**: the timeout is now caught (`Frontier fetch failed ...; continuing`) instead of fatal.
2. **Foundations-fetch error crashed `main`.** On a fetch error the function returned `[]`, but `main` destructures `{ foundations, ... }` and reads `foundations.length` → `TypeError: Cannot read properties of undefined`. Now returns the proper shape so a DB blip exits cleanly ("0 foundations to scan").

## Why
The scheduled discovery cron should survive a transient Supabase hiccup (timeout or network blip), not crash. Both paths are pure resilience — no behaviour change on the happy path.

## Note
These were found because an ad-hoc run kept failing — root cause was the sandbox losing its node→Supabase connection (`fetch failed`) under load, not these code paths. The actual QLD enrichment still needs to run where the DB is reachable and quiet (the cron). Code + targeting are in `main` via #48/#49/#50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)