### PR TITLE
fix(sync): unique per-program URLs + carry geography (foundation programs)

### DIFF
--- a/scripts/sync-foundation-programs.mjs
+++ b/scripts/sync-foundation-programs.mjs
@@ -149,6 +149,18 @@ function normalizeUrl(url) {
   return /^https?:\/\//i.test(text) ? text : `https://${text}`;
 }
 
+// Stable, readable slug used as a per-program URL fragment so a foundation's
+// many programs (which often share one page URL) each get a distinct,
+// constraint-safe URL. Same program name always yields the same slug, so
+// re-syncs update in place rather than churning.
+function programSlug(name) {
+  return String(name || 'program')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'program';
+}
+
 function detectProgramType(name, description) {
   const text = `${name} ${description || ''}`.toLowerCase();
   if (/fellowship/.test(text)) return 'fellowship';
@@ -165,6 +177,12 @@ function buildProgramKey(program) {
 
 function buildGrantPayload(program, foundation) {
   const desiredStatus = getDesiredProgramStatus(program, foundation);
+  // Foundations expose many programs from one page URL, which collides on the
+  // unique-URL index (only one program per foundation would land). Append a
+  // stable per-program fragment (servers ignore it) so each is a distinct,
+  // findable grant. Matching is by source_id/key, not URL, so existing rows
+  // update in place rather than duplicating.
+  const baseUrl = normalizeUrl(program.url || foundation.website);
   return {
     name: program.name,
     provider: foundation.name,
@@ -174,7 +192,12 @@ function buildGrantPayload(program, foundation) {
     amount_max: program.amount_max ? Number(program.amount_max) : null,
     deadline: program.deadline,
     closes_at: program.deadline,
-    url: normalizeUrl(program.url || foundation.website),
+    url: baseUrl ? `${baseUrl.split('#')[0]}#${programSlug(program.name)}` : null,
+    // Carry the funder's geography so state-filtered searches ("queensland ...")
+    // surface these programs; previously left null, so geo queries missed them.
+    geography: Array.isArray(foundation.geographic_focus) && foundation.geographic_focus.length
+      ? foundation.geographic_focus.join(', ')
+      : null,
     source: 'foundation_program',
     source_id: String(program.id),
     grant_type: 'open_opportunity',
@@ -213,6 +236,7 @@ function grantNeedsUpdate(existingGrant, desiredGrant) {
     'application_status',
     'status',
     'source_id',
+    'geography',
   ];
 
   for (const field of comparableFields) {


### PR DESCRIPTION
Makes discovered foundation programs actually land + be findable. Two gaps fixed in `sync-foundation-programs.mjs`.

## 1. URL collisions
Programs from one foundation share a page URL and collide on the unique-URL index, so only one per foundation landed. A QLD sync logged **0 inserted / 284 dup-URL errors**. Now each program gets a stable per-program slug fragment (`…/grants#program-name`), which servers ignore but makes the URL unique. Matching stays by `source_id`/key (not URL), so existing rows update in place — no duplicates.

## 2. Geography dropped
`buildGrantPayload` never set `geography`, so synced programs were geo-untagged and a state-filtered "queensland …" search missed them. Now carries the funder's `geographic_focus` into `geography`, and `geography` is added to `grantNeedsUpdate` so re-syncs backfill existing rows.

## Verified (re-ran the sync against live data)
| Metric | Before | After |
|---|--:|--:|
| Sync dup-URL errors | 284 | **0** (8 unrelated: a source+name dup, one decimal-in-int amount) |
| Updated this run | 26 | **1,173** |
| QLD foundation grants in finder | 13 | **17** |
| Geo-tagged QLD (findable via "queensland …") | 2 | **17 / 17** |
| Unique per-program URLs | — | **17 / 17** |

**Live finder**: `GET /grants?q=queensland+community+grants` → returns QCoal Foundation Community Grant Program (was 0 QLD community results before the whole chain).

Completes the foundation-program enrichment path: discover (#49/#50 targeting) → sync (this) → findable. The QLD batch was 30 foundations; the full 737 runs on cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)