### PR TITLE
feat(cron): QLD-prioritised foundation-program discovery agent

### DIFF
--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -397,6 +397,18 @@ export const AGENTS = {
     timeoutMs: 900_000,
     dependencies: [],
   },
+  // QLD-prioritised discovery. Distinct agent_id (own runtime cursor + avoids the
+  // orchestrator's per-agent dedup vs the global agent above). --geo=AU-QLD targets
+  // the ~737 QLD foundations with sites but no scraped programs; 40/run works
+  // through them over ~19 runs, then keeps them fresh via --rescan-days.
+  'discover-foundation-programs-qld': {
+    command: ['node', '--env-file=.env', 'scripts/discover-foundation-programs.mjs', '--geo=AU-QLD', '--refresh-existing', '--rescan-days=14', '--limit=40', '--concurrency=1', '--frontier-window-hours=48', '--frontier-pages=8', '--agent-id=discover-foundation-programs-qld', '--agent-name=Discover Foundation Programs (QLD)'],
+    displayName: 'Discover Foundation Programs (QLD)',
+    category: 'discovery',
+    defaultPriority: 4,
+    timeoutMs: 900_000,
+    dependencies: [],
+  },
   'nightly-grant-pipeline': {
     command: ['node', '--env-file=.env', 'scripts/nightly-grant-pipeline.mjs'],
     displayName: 'Nightly grant pipeline (scrape → promote → classify → backfill → verify → context → MV → blocklist)',


### PR DESCRIPTION
Wires the full QLD foundation-program discovery into the scheduled orchestrator so every QLD grantmaker's programs flow into the finder over time, geo-tagged.

## What
Adds `discover-foundation-programs-qld` to the agent registry:
- `--geo=AU-QLD` (the #49 targeting), `--limit=40`/run, own `--agent-id` (distinct runtime cursor + avoids the orchestrator's per-agent dedup vs the global discovery agent).
- Works through the ~737 QLD foundations with sites but no scraped programs (~19 runs), then keeps them fresh via `--rescan-days=14`.
- The existing `sync-foundation-programs` agent (every 48h) lands them in `grant_opportunities` — now unique-URL'd + geo-tagged per #52.

## Why a dedicated agent (not a param on the existing one)
The global `discover-foundation-programs` already has a schedule; a second schedule for the same `agent_id` would collide with the orchestrator's per-agent task dedup. A distinct `agent_id` runs independently and prioritises QLD without slowing the global sweep.

## Activation (sequence matters — registry loads at orchestrator start)
1. Merge this PR + deploy to the orchestrator host.
2. `pm2 restart orchestrator` (loads the new agent; the registry is read at startup).
3. Enable the schedule row (I've inserted it disabled):
   `UPDATE agent_schedules SET enabled = true WHERE agent_id = 'discover-foundation-programs-qld';`

Until step 2, the agent_id is unknown to the running orchestrator, which is why the schedule is seeded disabled. Cost is modest (MiniMax; ~$0.02–0.05/foundation) and spread over runs on the quiet server DB, not an ad-hoc burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)