### PR TITLE
feat: justice-proven evidence tier — "Proven govt delivery" (OP3)

### DIFF
--- a/apps/web/src/app/social-enterprises/[id]/page.tsx
+++ b/apps/web/src/app/social-enterprises/[id]/page.tsx
@@ -83,6 +83,37 @@ function TierBadge({ tier, basis }: { tier: string | null; basis?: string | null
   );
 }
 
+// OP3 — buyer evidence-tier badge family (strongest applicable wins). Mirrors the /suppliers badges.
+type EvidenceTier = 'proven_outcomes' | 'triple_proof' | 'proven_govt_delivery';
+
+const EVIDENCE_TIER_META: Record<EvidenceTier, { label: string; title: string; className: string }> = {
+  proven_outcomes: {
+    label: 'Proven outcomes',
+    title: 'Proven outcomes — justice/community delivery, a won federal contract, ACNC governance, PLUS cited evidence and measured outcomes (ALMA). The deepest delivery proof in the registry.',
+    className: 'border-bauhaus-black bg-bauhaus-yellow text-bauhaus-black',
+  },
+  triple_proof: {
+    label: 'Triple-proof',
+    title: 'Triple-proof — justice/community delivery, a won federal contract, AND ACNC charity governance. The deepest delivery evidence in the registry.',
+    className: 'border-bauhaus-black bg-bauhaus-black text-bauhaus-yellow',
+  },
+  proven_govt_delivery: {
+    label: 'Proven govt delivery',
+    title: 'Proven govt delivery — both justice/community delivery and a won federal contract: documented capability on two independent registers.',
+    className: 'border-bauhaus-blue bg-link-light text-bauhaus-blue',
+  },
+};
+
+function EvidenceTierBadge({ tier }: { tier: EvidenceTier | null }) {
+  if (!tier) return null;
+  const m = EVIDENCE_TIER_META[tier];
+  return (
+    <span title={m.title} className={`text-[11px] px-2.5 py-1 font-black uppercase tracking-widest border-2 ${m.className}`}>
+      {m.label}
+    </span>
+  );
+}
+
 function orgTypeLabel(type: string): string {
   const labels: Record<string, string> = {
     social_enterprise: 'Social Enterprise',
@@ -296,22 +327,30 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
   let contractCount = 0;
   let justiceRows: JusticeRow[] = [];
   let evidencePrograms: AlmaEvidenceProgram[] = [];
+  // OP3 — strongest applicable proof tier (one lookup; mv_justice_proven_suppliers carries the
+  // has_acnc / has_alma_evidence_outcomes flags that distinguish all three tiers).
+  let evidenceTier: EvidenceTier | null = null;
 
   // Grant matching runs on sector + place, not ABN — every profile gets it
   const grantMatchPromise = matchGrantsForSocialEnterprise(supabase, enterprise);
 
   if (cleanAbn) {
-    const [charityRes, graphRes, contractRes, justiceRes] = await Promise.all([
+    const [charityRes, graphRes, contractRes, justiceRes, provenRes] = await Promise.all([
       supabase.from('acnc_charities').select('abn, name').eq('abn', cleanAbn).maybeSingle(),
       supabase.from('gs_entities').select('id, gs_id, remoteness, seifa_irsd_decile, is_community_controlled, lga_name, postcode').eq('abn', cleanAbn).not('gs_id', 'is', null).limit(1).maybeSingle(),
       supabase.from('austender_contracts').select('title, contract_value, buyer_name, contract_start', { count: 'exact' }).eq('supplier_abn', cleanAbn).not('contract_value', 'is', null).order('contract_value', { ascending: false }).limit(1000),
       supabase.from('justice_funding').select('program_name, amount_dollars, financial_year, source, sector').eq('recipient_abn', cleanAbn).order('amount_dollars', { ascending: false, nullsFirst: false }).limit(200),
+      supabase.from('mv_justice_proven_suppliers').select('has_acnc, has_alma_evidence_outcomes').eq('abn', cleanAbn).maybeSingle(),
     ]);
     if (charityRes.data) matchedCharity = charityRes.data as { abn: string; name: string };
     if (graphRes.data) graphEntity = graphRes.data as GraphEntity;
     contracts = (contractRes.data || []) as ContractRow[];
     contractCount = contractRes.count ?? contracts.length;
     justiceRows = (justiceRes.data || []) as JusticeRow[];
+    if (provenRes.data) {
+      const p = provenRes.data as { has_acnc: boolean | null; has_alma_evidence_outcomes: boolean | null };
+      evidenceTier = p.has_alma_evidence_outcomes ? 'proven_outcomes' : p.has_acnc ? 'triple_proof' : 'proven_govt_delivery';
+    }
     // OP5 — ALMA evidence signals join on the entity UUID, so it runs once the
     // ABN→entity match resolves above.
     if (graphEntity?.id) {
@@ -344,6 +383,7 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl sm:text-3xl font-black text-bauhaus-black">{enterprise.name}</h1>
           <div className="flex gap-1.5 flex-shrink-0 flex-wrap">
+            <EvidenceTierBadge tier={evidenceTier} />
             <TierBadge tier={enterprise.verification_tier} basis={enterprise.verification_basis} />
             <span className={`text-[11px] font-black px-2.5 py-1 border-2 uppercase tracking-widest ${orgTypeBadgeClass(enterprise.org_type)}`}>
               {orgTypeLabel(enterprise.org_type)}

--- a/apps/web/src/app/suppliers/page.tsx
+++ b/apps/web/src/app/suppliers/page.tsx
@@ -74,6 +74,17 @@ function ProvenOutcomesBadge() {
   );
 }
 
+function ProvenGovtDeliveryBadge() {
+  return (
+    <span
+      title="Proven govt delivery — this supplier has both justice/community delivery and a won federal contract: documented capability on two independent registers."
+      className="text-[10px] px-2 py-0.5 font-black uppercase tracking-widest border-2 border-bauhaus-blue bg-link-light text-bauhaus-blue"
+    >
+      Proven govt delivery
+    </span>
+  );
+}
+
 function EvidenceLine({ r }: { r: SupplierResult }) {
   if (r.contract_count === 0) return null;
   const lastYear = r.last_contract_end ? new Date(r.last_contract_end).getFullYear() : null;
@@ -227,7 +238,7 @@ export default async function SupplierSearchPage({
                       {r.name}
                     </Link>
                     <div className="relative z-10 flex gap-1.5 flex-wrap">
-                      {r.proven_outcomes ? <ProvenOutcomesBadge /> : r.triple_proof ? <TripleProofBadge /> : null}
+                      {r.proven_outcomes ? <ProvenOutcomesBadge /> : r.triple_proof ? <TripleProofBadge /> : r.proven_govt_delivery ? <ProvenGovtDeliveryBadge /> : null}
                       <TierBadge tier={r.verification_tier} />
                       {r.source_primary && (
                         <span className="text-[10px] px-2 py-0.5 font-black uppercase tracking-widest border-2 border-bauhaus-black/40 text-bauhaus-muted">

--- a/apps/web/src/lib/services/supplier-search.ts
+++ b/apps/web/src/lib/services/supplier-search.ts
@@ -30,6 +30,9 @@ export interface SupplierResult {
   /** Highlighted fragment of the matched field (ts_headline, «term» delimiters). Null for offering
    * matches (name/sectors already on the card) and in browse mode. */
   match_snippet: string | null;
+  /** OP3: broad tier — justice/community delivery + a won federal contract (no ACNC requirement).
+   * Superset of triple_proof; the strongest-badge-wins hierarchy shows the deeper badge where it applies. */
+  proven_govt_delivery: boolean;
   /** OP7: org carries all three proof signals — justice delivery + federal contract + ACNC governance. */
   triple_proof: boolean;
   /** OP10: quad-proof — triple-proof PLUS an ALMA intervention with cited evidence AND measured outcomes. */
@@ -138,27 +141,41 @@ export async function searchSuppliers(
   // OP7/OP10: flag triple-proof suppliers (justice delivery + federal contract + ACNC governance)
   // and the quad-proof gold tier (those that ALSO carry ALMA evidence + measured outcomes).
   // Enrich the ≤30 results by ABN against mv_triple_proof_suppliers — the deepest evidence tiers.
-  const base = (data ?? []) as Omit<SupplierResult, 'triple_proof' | 'proven_outcomes'>[];
+  const base = (data ?? []) as Omit<SupplierResult, 'proven_govt_delivery' | 'triple_proof' | 'proven_outcomes'>[];
   const abns = [...new Set(base.map((r) => r.abn).filter((a): a is string => Boolean(a)))];
   const proven = new Set<string>();
   const provenOutcomes = new Set<string>();
+  const provenGovtDelivery = new Set<string>();
   if (abns.length > 0) {
-    const { data: tp, error: tpError } = await supabase
-      .from('mv_triple_proof_suppliers')
-      .select('abn, has_alma_evidence_outcomes')
-      .in('abn', abns);
-    if (tpError) {
-      console.error('[supplier-search:triple-proof]', tpError.message);
+    const [tpRes, jpRes] = await Promise.all([
+      supabase.from('mv_triple_proof_suppliers').select('abn, has_alma_evidence_outcomes').in('abn', abns),
+      // OP3: broad justice + federal-contract tier
+      supabase.from('mv_justice_proven_suppliers').select('abn, has_alma_evidence_outcomes').in('abn', abns),
+    ]);
+    if (tpRes.error) {
+      console.error('[supplier-search:triple-proof]', tpRes.error.message);
     } else {
-      for (const row of (tp ?? []) as { abn: string | null; has_alma_evidence_outcomes: boolean | null }[]) {
+      for (const row of (tpRes.data ?? []) as { abn: string | null; has_alma_evidence_outcomes: boolean | null }[]) {
         if (!row.abn) continue;
         proven.add(row.abn);
+        if (row.has_alma_evidence_outcomes) provenOutcomes.add(row.abn);
+      }
+    }
+    if (jpRes.error) {
+      console.error('[supplier-search:justice-proven]', jpRes.error.message);
+    } else {
+      for (const row of (jpRes.data ?? []) as { abn: string | null; has_alma_evidence_outcomes: boolean | null }[]) {
+        if (!row.abn) continue;
+        provenGovtDelivery.add(row.abn);
+        // The OP3 MV also carries the gold flag, so a justice-proven org with ALMA evidence
+        // still lights up "Proven outcomes" even if it isn't triple-proof.
         if (row.has_alma_evidence_outcomes) provenOutcomes.add(row.abn);
       }
     }
   }
   return base.map((r) => ({
     ...r,
+    proven_govt_delivery: Boolean(r.abn && provenGovtDelivery.has(r.abn)),
     triple_proof: Boolean(r.abn && proven.has(r.abn)),
     proven_outcomes: Boolean(r.abn && provenOutcomes.has(r.abn)),
   }));

--- a/docs/leverage-map.md
+++ b/docs/leverage-map.md
@@ -57,8 +57,12 @@ All three are **evidence-depth** plays — the wedge's stated #1 tie-breaker ("e
   `austender_contracts` via ABN. Serves: **G3∩G1 (best quadrant)**. Why valuable: **4,225 of 36,805
   justice-funded orgs (11.5%) have also won federal contracts** — orgs with *both* domain credibility
   (justice delivery) and a proven procurement track record. A buyer needing community/justice services
-  gets a defensible shortlist. Evidence: 4,225 ABN-matched. State: **latent**. Effort: M. Wedge:
-  **green**. (Highest-volume best-quadrant find so far.)
+  gets a defensible shortlist. Evidence: 4,225 ABN-matched. State: **BUILT 2026-06-08** —
+  `mv_justice_proven_suppliers` (4,225 rows, migration `20260608060000`; triple-proof MV minus the
+  ACNC gate, ACNC kept as optional signal). Registered in manual + nightly cron refresh. Surfaces as
+  the **"Proven govt delivery"** badge on `/suppliers` search and `/social-enterprises/[id]` profiles
+  (strongest-of-three hierarchy: Proven outcomes > Triple-proof > Proven govt delivery). Commit
+  `5dcff2a`. Effort: M. Wedge: **green**. (Highest-volume best-quadrant find so far.)
 
 - **OP4 — Financial-health signal on justice-funded charities.** Datasets: `justice_funding` ×
   `acnc_charities` / `mv_acnc_ais_yearly` via ABN. Serves: **G3**. Why valuable: **4,366 (12%)** justice

--- a/scripts/refresh-views-v2.mjs
+++ b/scripts/refresh-views-v2.mjs
@@ -46,6 +46,7 @@ const VIEW_LIST = [
   'mv_donor_contract_crossref',
   'mv_org_justice_signals',
   'mv_triple_proof_suppliers',
+  'mv_justice_proven_suppliers',
   'mv_funding_by_postcode',
   'mv_funding_by_lga',
   'mv_funding_by_disadvantage',

--- a/supabase/migrations/20260608060000_mv_justice_proven_suppliers.sql
+++ b/supabase/migrations/20260608060000_mv_justice_proven_suppliers.sql
@@ -1,0 +1,88 @@
+-- OP3 (leverage map) — Justice-domain proven suppliers: the broad buyer evidence tier.
+--
+-- One row per org (by ABN) carrying TWO independent proof signals at once:
+--   1. Justice/community domain delivery   (justice_funding.recipient_abn)
+--   2. A won federal contract               (austender_contracts.supplier_abn)
+--
+-- ~4,225 orgs as of 2026-06-08 — the broad "real and capable" shortlist. This is
+-- mv_triple_proof_suppliers MINUS the ACNC requirement: the 724 triple-proof orgs are a strict
+-- subset, so the app's strongest-badge-wins hierarchy keeps showing them the deeper badge.
+-- ACNC is kept as an OPTIONAL signal (LEFT JOIN) — present where it exists, null otherwise — so a
+-- justice-proven org that also happens to be a charity still surfaces its governance data.
+-- Carries has_alma_evidence_outcomes so the gold "Proven outcomes" tier composes here too.
+-- Anchored on gs_entities (registry spine). Refresh registered in scripts/refresh-views-v2.mjs
+-- and the pg_cron refresh_civicgraph_mvs() order array (migration 20260608070000).
+--
+-- Wrapped in a transaction so concurrent readers briefly block, then see the populated MV.
+
+BEGIN;
+
+DROP MATERIALIZED VIEW IF EXISTS mv_justice_proven_suppliers;
+
+CREATE MATERIALIZED VIEW mv_justice_proven_suppliers AS
+WITH base AS (
+  -- one gs_entity per ABN (guarantees the unique index below for CONCURRENTLY refresh)
+  SELECT DISTINCT ON (g.abn)
+         g.id AS entity_id, g.gs_id, g.abn, g.canonical_name, g.entity_type, g.state, g.postcode,
+         g.sector, g.lga_name, g.is_community_controlled
+  FROM gs_entities g
+  WHERE g.abn IS NOT NULL
+    AND EXISTS (SELECT 1 FROM justice_funding    j WHERE j.recipient_abn = g.abn)
+    AND EXISTS (SELECT 1 FROM austender_contracts c WHERE c.supplier_abn  = g.abn)
+  ORDER BY g.abn, g.gs_id
+),
+jf AS (
+  SELECT recipient_abn AS abn,
+         SUM(amount_dollars)                                          AS justice_dollars,
+         COUNT(*)                                                     AS justice_record_count,
+         COUNT(DISTINCT program_name)                                 AS distinct_justice_programs,
+         array_agg(DISTINCT state) FILTER (WHERE state IS NOT NULL)   AS justice_states
+  FROM justice_funding
+  WHERE recipient_abn IN (SELECT abn FROM base)
+  GROUP BY recipient_abn
+),
+ct AS (
+  SELECT supplier_abn AS abn,
+         COUNT(*)                                                     AS contract_count,
+         SUM(contract_value)                                          AS contract_value,
+         COUNT(DISTINCT buyer_name)                                   AS distinct_buyers,
+         MAX(contract_end)                                            AS last_contract_end,
+         MIN(contract_start)                                          AS first_contract_start
+  FROM austender_contracts
+  WHERE supplier_abn IN (SELECT abn FROM base)
+  GROUP BY supplier_abn
+),
+ac AS (
+  -- Optional governance signal — NOT a gate. Present only for the orgs that are also charities.
+  SELECT DISTINCT ON (abn)
+         abn, charity_size, name AS acnc_name, registration_date AS acnc_registered_since
+  FROM acnc_charities
+  WHERE abn IN (SELECT abn FROM base)
+  ORDER BY abn, registration_date NULLS LAST
+)
+SELECT
+  b.gs_id, b.abn, b.canonical_name, b.entity_type, b.state, b.postcode,
+  b.sector, b.lga_name, b.is_community_controlled,
+  jf.justice_dollars, jf.justice_record_count, jf.distinct_justice_programs, jf.justice_states,
+  ct.contract_count, ct.contract_value, ct.distinct_buyers, ct.last_contract_end, ct.first_contract_start,
+  ac.charity_size, ac.acnc_name, ac.acnc_registered_since,
+  (ac.abn IS NOT NULL)                                            AS has_acnc,
+  COALESCE(jf.justice_dollars, 0) + COALESCE(ct.contract_value, 0) AS total_evidence_dollars,
+  EXISTS (
+    SELECT 1 FROM alma_interventions ai
+    WHERE ai.gs_entity_id = b.entity_id
+      AND EXISTS (SELECT 1 FROM alma_intervention_evidence e WHERE e.intervention_id = ai.id)
+      AND EXISTS (SELECT 1 FROM alma_intervention_outcomes o WHERE o.intervention_id = ai.id)
+  ) AS has_alma_evidence_outcomes
+FROM base b
+LEFT JOIN jf ON jf.abn = b.abn
+LEFT JOIN ct ON ct.abn = b.abn
+LEFT JOIN ac ON ac.abn = b.abn;
+
+CREATE UNIQUE INDEX mv_justice_proven_suppliers_abn_idx     ON mv_justice_proven_suppliers (abn);
+CREATE INDEX        mv_justice_proven_suppliers_gsid_idx    ON mv_justice_proven_suppliers (gs_id);
+CREATE INDEX        mv_justice_proven_suppliers_state_idx   ON mv_justice_proven_suppliers (state);
+CREATE INDEX        mv_justice_proven_suppliers_dollars_idx ON mv_justice_proven_suppliers (total_evidence_dollars DESC);
+CREATE INDEX        mv_justice_proven_suppliers_alma_idx    ON mv_justice_proven_suppliers (has_alma_evidence_outcomes) WHERE has_alma_evidence_outcomes;
+
+COMMIT;

--- a/supabase/migrations/20260608070000_cron_refresh_order_add_justice_proven.sql
+++ b/supabase/migrations/20260608070000_cron_refresh_order_add_justice_proven.sql
@@ -1,0 +1,121 @@
+-- OP3: register mv_justice_proven_suppliers in the nightly cron's refresh_order array.
+-- Re-dumped via pg_get_functiondef with one array line inserted after mv_triple_proof_suppliers.
+-- The 2026-06-08 cron fix (SET statement_timeout='0', SET search_path) is preserved verbatim.
+
+CREATE OR REPLACE FUNCTION public.refresh_civicgraph_mvs()
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_catalog'
+ SET statement_timeout TO '0'
+AS $function$
+DECLARE
+  v_started TIMESTAMPTZ;
+  v_finished TIMESTAMPTZ;
+  v_error TEXT;
+  v_mv TEXT;
+  -- MVs that need non-concurrent refresh (no unique index OR surrogate key issue
+  -- OR duplicate-key data quality issues in the MV definition).
+  -- 2026-04-27: funding_by_lga and funding_deserts have duplicates that block
+  -- a unique index until the underlying queries are deduped.
+  needs_non_concurrent TEXT[] := ARRAY[
+    'mv_funding_by_lga',
+    'mv_funding_deserts',
+    'mv_foundation_grantees',
+    'mv_donation_contract_timing'
+  ];
+  -- Refresh order — same as refresh-views-v2.mjs VIEW_LIST
+  refresh_order TEXT[] := ARRAY[
+    -- Tier 1
+    'mv_acnc_latest',
+    'mv_acnc_ais_yearly',
+    'v_grant_stats',
+    'v_grant_focus_areas',
+    'v_grant_provider_summary',
+    'mv_abr_name_lookup',
+    -- Tier 2
+    'mv_gs_entity_stats',
+    'mv_gs_donor_contractors',
+    'mv_donor_contract_crossref',
+    'mv_org_justice_signals',
+    'mv_triple_proof_suppliers',
+    'mv_justice_proven_suppliers',
+    'mv_funding_by_postcode',
+    'mv_funding_by_lga',
+    'mv_funding_by_disadvantage',
+    'mv_indigenous_funding_by_disadvantage',
+    -- Tier 3
+    'mv_entity_power_index',
+    'mv_funding_deserts',
+    'mv_revolving_door',
+    'mv_board_interlocks',
+    'mv_foundation_grantees',
+    'mv_donation_contract_timing',
+    -- Compounds (built today)
+    'mv_indigenous_procurement_score',
+    'mv_grant_contract_overlap',
+    'mv_lga_indigenous_proxy_score'
+  ];
+BEGIN
+  -- Ensure log table exists (refresh-views-v2.mjs also creates it)
+  CREATE TABLE IF NOT EXISTS mv_refresh_log (
+    id BIGSERIAL PRIMARY KEY,
+    mv_name TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    duration_ms INTEGER,
+    status TEXT NOT NULL,
+    used_concurrent BOOLEAN,
+    error_message TEXT,
+    triggered_by TEXT DEFAULT 'pg_cron'
+  );
+
+  -- Refresh each MV in order
+  FOREACH v_mv IN ARRAY refresh_order LOOP
+    v_started := now();
+    v_error := NULL;
+
+    BEGIN
+      IF v_mv = ANY(needs_non_concurrent) THEN
+        -- Non-concurrent path
+        EXECUTE format('REFRESH MATERIALIZED VIEW %I', v_mv);
+        v_finished := now();
+        INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, triggered_by)
+          VALUES (v_mv, v_started, v_finished,
+                  EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'success', false, 'pg_cron');
+      ELSE
+        -- CONCURRENTLY path — try first
+        BEGIN
+          EXECUTE format('REFRESH MATERIALIZED VIEW CONCURRENTLY %I', v_mv);
+          v_finished := now();
+          INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, triggered_by)
+            VALUES (v_mv, v_started, v_finished,
+                    EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'success', true, 'pg_cron');
+        EXCEPTION WHEN OTHERS THEN
+          -- Fallback to non-concurrent if CONCURRENTLY fails (no unique index, etc.)
+          v_started := now();  -- reset timer for non-concurrent attempt
+          BEGIN
+            EXECUTE format('REFRESH MATERIALIZED VIEW %I', v_mv);
+            v_finished := now();
+            INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, error_message, triggered_by)
+              VALUES (v_mv, v_started, v_finished,
+                      EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'success-fallback', false,
+                      'CONCURRENTLY failed, used non-concurrent', 'pg_cron');
+          EXCEPTION WHEN OTHERS THEN
+            v_finished := now();
+            v_error := SQLERRM;
+            INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, error_message, triggered_by)
+              VALUES (v_mv, v_started, v_finished,
+                      EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'failed', false, v_error, 'pg_cron');
+          END;
+        END;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      v_finished := now();
+      v_error := SQLERRM;
+      INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, error_message, triggered_by)
+        VALUES (v_mv, v_started, v_finished,
+                EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'failed', NULL, v_error, 'pg_cron');
+    END;
+  END LOOP;
+END;
+$function$

--- a/thoughts/shared/plans/op3-justice-proven-suppliers.md
+++ b/thoughts/shared/plans/op3-justice-proven-suppliers.md
@@ -1,0 +1,74 @@
+# OP3 — Justice-domain proven suppliers ("Proven govt delivery")
+
+**Status:** awaiting approval · **Wedge:** green (evidence depth) · **Created:** 2026-06-08
+
+## Goal
+Surface the broad evidence tier — **4,225 orgs (by ABN)** carrying BOTH justice/community-domain
+funding AND a won federal contract — as a buyer-facing **"Proven govt delivery"** badge on
+`/suppliers` search results and `/social-enterprises/[id]` profiles. Mirrors the OP7 triple-proof
+pattern exactly; broadens it by dropping the ACNC requirement.
+
+## Data (verified 2026-06-08, gsql)
+- **4,225** ABNs have justice ∩ contract (exact; matches leverage map)
+- **724** of those also have ACNC = the existing triple-proof subset (already badged)
+- **331** are in the SE registry → would badge on `/suppliers` + profiles
+- Wedge: green — evidence depth is the wedge's #1 tie-breaker
+
+## Badge hierarchy (strongest wins, per supplier)
+1. **Proven outcomes** (gold) — triple-proof + ALMA evidence/outcomes  *(exists)*
+2. **Triple-proof** — justice + contract + ACNC governance  *(exists)*
+3. **Proven govt delivery** (NEW) — justice + contract (the broad 4,225)
+
+The 724 triple-proof orgs are a strict subset of the 4,225, so they keep the stronger badge; the new
+badge fires for the ~3,500 that have justice+contract but not ACNC.
+
+## Build steps
+
+### Phase A — Migration (TIER 3 — requires explicit "apply"/"run" before any DB write)
+1. `supabase/migrations/20260608060000_mv_justice_proven_suppliers.sql`
+   - Clone `mv_triple_proof_suppliers` **minus the ACNC `EXISTS` gate**.
+   - ACNC kept as an **optional LEFT JOIN** (charity_size, acnc_registered_since): present where it
+     exists, null otherwise.
+   - Carry the `has_alma_evidence_outcomes` flag (same as triple-proof migration `20260608050000`)
+     so the gold "Proven outcomes" tier composes for justice-proven orgs too.
+   - Anchor on `gs_entities` (`DISTINCT ON (abn)`). Unique index on `abn` (for CONCURRENTLY refresh)
+     + gs_id / state / total_evidence_dollars indexes.
+   - Expected ≈ 4,225 rows (minus any ABN that doesn't resolve to a gs_entity — verify post-build).
+2. `supabase/migrations/20260608070000_cron_refresh_order_add_justice_proven.sql`
+   - Re-dump `refresh_civicgraph_mvs()` with `mv_justice_proven_suppliers` added to the
+     `refresh_order` array (after `mv_triple_proof_suppliers`), preserving the `statement_timeout=0`
+     + `search_path` fix verbatim.
+3. Apply both via `psql -f` (CLAUDE.md DDL rule).
+4. Register in `scripts/refresh-views-v2.mjs` VIEW_LIST.
+5. Verify: row count ≈ 4,225, unique index present, sample ABN.
+
+### Phase B — App surfaces (TIER 1)
+6. `lib/services/supplier-search.ts` — add `proven_govt_delivery: boolean` to `SupplierResult`;
+   extend the existing ABN-enrichment block to also check `mv_justice_proven_suppliers`.
+7. `/suppliers/page.tsx` — add `ProvenGovtDeliveryBadge`; render only when the stronger badges
+   don't fire (hierarchy).
+8. `/social-enterprises/[id]/page.tsx` — add the same badge to the header badge row via a cheap
+   one-row MV lookup by ABN.
+9. `lib/supplier-copy.ts` — badge tooltip copy if it lives there.
+
+### Phase C — Verify + ship
+10. Gates: `tsc --noEmit` (0) + `vitest run` (221/221).
+11. Live-verify: a justice-proven-but-not-triple-proof SE shows "Proven govt delivery"; a
+    triple-proof one still shows the stronger badge (hierarchy correct).
+12. Manual MV refresh once so it's populated (Tier 2 — will post first).
+13. Ship: branch `feat/op3-justice-proven-suppliers`, push + PR (Tier 2/3 — explicit verb).
+
+## Guardrails / NOT doing
+- No data widening (no new ingestion) — connect/deepen only.
+- Don't require ACNC (that's OP7) — keep OP3 broad.
+- Don't rebuild the badge system — extend it; strongest badge wins.
+- No browsable `/suppliers/justice-proven` list in v1 (deferred — possible phase 2).
+
+## Tier map
+- MV creation + migration apply + cron fn change = **Tier 3** (explicit verb gate).
+- Manual MV refresh = **Tier 2** (post "about to" first).
+- App code, migration *files*, refresh-views registration = **Tier 1**.
+
+## Rollback
+Fully reversible, no data mutation: `DROP MATERIALIZED VIEW mv_justice_proven_suppliers`, revert the
+cron-fn migration, revert app code.


### PR DESCRIPTION
## What

Adds the **broad buyer evidence tier** — **4,225 orgs** (by ABN) carrying BOTH justice/community-domain funding AND a won federal contract. It's the OP3 leverage play: the highest-volume best-quadrant (G3∩G1) find in the estate, surfaced as a buyer-facing badge.

## Data layer

New MV `mv_justice_proven_suppliers` = the `mv_triple_proof_suppliers` definition **minus the ACNC `EXISTS` gate**. ACNC is kept as an optional `LEFT JOIN` signal (present where it exists, null otherwise), so the 724 triple-proof orgs remain a **strict subset** and the strongest-badge-wins hierarchy keeps showing them the deeper badge.

Carries `has_acnc` + `has_alma_evidence_outcomes` so all three tiers derive from one lookup. Anchored on the `gs_entities` registry spine; unique index on `abn` for CONCURRENTLY refresh. Registered in `scripts/refresh-views-v2.mjs` and the pg_cron `refresh_civicgraph_mvs()` order array (migration `20260608070000`, live function re-dumped verbatim with one line added).

## Badge hierarchy (strongest wins)

1. **Proven outcomes** (gold) — triple-proof + ALMA evidence/outcomes *(exists)*
2. **Triple-proof** — justice + contract + ACNC *(exists)*
3. **Proven govt delivery** *(new)* — justice + contract

## Surfaces

- **`/suppliers` search** — new `ProvenGovtDeliveryBadge` (blue), enriched via a parallel ABN lookup against the MV; renders only when the stronger badges don't.
- **`/social-enterprises/[id]`** — header `EvidenceTierBadge`; one MV lookup derives the strongest applicable tier from `has_acnc` / `has_alma_evidence_outcomes`, so a triple-proof org isn't under-sold as merely justice-proven.

## Verification

- MV: **4,225 rows** · **724 `has_acnc`** (== `mv_triple_proof_suppliers`) · **71 gold**
- Unique index present; cron fn registered
- Live badge hierarchy correct on both surfaces (Bureau of Meteorology → govt-delivery, Red Cross → triple-proof, Save the Children → proven-outcomes)
- `tsc --noEmit`: 0 · `vitest run`: 221/221

**Migrations are already applied** to the shared project (the MV is inert until this UI deploys). Plan: `thoughts/shared/plans/op3-justice-proven-suppliers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)