### PR TITLE
feat(suppliers): Indigenous triple-proof tier — ORIC + federal contract + ACNC governance (OP8)

### DIFF
--- a/apps/web/src/app/social-enterprises/[id]/page.tsx
+++ b/apps/web/src/app/social-enterprises/[id]/page.tsx
@@ -128,6 +128,21 @@ function IndigenousProvenBadge({ shown }: { shown: boolean }) {
   );
 }
 
+// OP8 — the governance-deepened tier within the Indigenous axis: ORIC + federal contract + ACNC charity
+// governance. Black-fill = the registry's "deepest" convention; red text/border keeps it on the Indigenous
+// axis. Strongest-wins over the basic Indigenous-proven badge.
+function IndigenousTripleProofBadge({ shown }: { shown: boolean }) {
+  if (!shown) return null;
+  return (
+    <span
+      title="Indigenous triple-proof — a registered Indigenous corporation (ORIC) that has won a federal contract AND carries ACNC charity governance. Verified Indigenous-controlled supply with proven federal delivery that also clears a governance bar — the deepest Indigenous-procurement shortlist in the registry."
+      className="text-[11px] px-2.5 py-1 font-black uppercase tracking-widest border-2 border-bauhaus-red bg-bauhaus-black text-bauhaus-red"
+    >
+      Indigenous triple-proof
+    </span>
+  );
+}
+
 function orgTypeLabel(type: string): string {
   const labels: Record<string, string> = {
     social_enterprise: 'Social Enterprise',
@@ -345,7 +360,9 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
   // has_acnc / has_alma_evidence_outcomes flags that distinguish all three tiers).
   let evidenceTier: EvidenceTier | null = null;
   // OP1 — Indigenous-proven: registered ORIC corp + federal contract (orthogonal to the tier above).
+  // OP8 — Indigenous triple-proof: the above PLUS ACNC charity governance (deeper tier, strongest-wins).
   let indigenousProven = false;
+  let indigenousTripleProof = false;
 
   // Grant matching runs on sector + place, not ABN — every profile gets it
   const grantMatchPromise = matchGrantsForSocialEnterprise(supabase, enterprise);
@@ -357,7 +374,7 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
       supabase.from('austender_contracts').select('title, contract_value, buyer_name, contract_start', { count: 'exact' }).eq('supplier_abn', cleanAbn).not('contract_value', 'is', null).order('contract_value', { ascending: false }).limit(1000),
       supabase.from('justice_funding').select('program_name, amount_dollars, financial_year, source, sector').eq('recipient_abn', cleanAbn).order('amount_dollars', { ascending: false, nullsFirst: false }).limit(200),
       supabase.from('mv_justice_proven_suppliers').select('has_acnc, has_alma_evidence_outcomes').eq('abn', cleanAbn).maybeSingle(),
-      supabase.from('mv_indigenous_proven_suppliers').select('abn').eq('abn', cleanAbn).maybeSingle(),
+      supabase.from('mv_indigenous_proven_suppliers').select('abn, has_acnc').eq('abn', cleanAbn).maybeSingle(),
     ]);
     if (charityRes.data) matchedCharity = charityRes.data as { abn: string; name: string };
     if (graphRes.data) graphEntity = graphRes.data as GraphEntity;
@@ -368,7 +385,11 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
       const p = provenRes.data as { has_acnc: boolean | null; has_alma_evidence_outcomes: boolean | null };
       evidenceTier = p.has_alma_evidence_outcomes ? 'proven_outcomes' : p.has_acnc ? 'triple_proof' : 'proven_govt_delivery';
     }
-    indigenousProven = Boolean(indigenousRes.data);
+    if (indigenousRes.data) {
+      indigenousProven = true;
+      // OP8: ACNC governance upgrades it to the deeper Indigenous triple-proof tier.
+      indigenousTripleProof = Boolean((indigenousRes.data as { has_acnc: boolean | null }).has_acnc);
+    }
     // OP5 — ALMA evidence signals join on the entity UUID, so it runs once the
     // ABN→entity match resolves above.
     if (graphEntity?.id) {
@@ -402,7 +423,8 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
           <h1 className="text-2xl sm:text-3xl font-black text-bauhaus-black">{enterprise.name}</h1>
           <div className="flex gap-1.5 flex-shrink-0 flex-wrap">
             <EvidenceTierBadge tier={evidenceTier} />
-            <IndigenousProvenBadge shown={indigenousProven} />
+            <IndigenousTripleProofBadge shown={indigenousTripleProof} />
+            <IndigenousProvenBadge shown={indigenousProven && !indigenousTripleProof} />
             <TierBadge tier={enterprise.verification_tier} basis={enterprise.verification_basis} />
             <span className={`text-[11px] font-black px-2.5 py-1 border-2 uppercase tracking-widest ${orgTypeBadgeClass(enterprise.org_type)}`}>
               {orgTypeLabel(enterprise.org_type)}

--- a/apps/web/src/app/suppliers/page.tsx
+++ b/apps/web/src/app/suppliers/page.tsx
@@ -96,6 +96,20 @@ function IndigenousProvenBadge() {
   );
 }
 
+// OP8 — the governance-deepened tier within the Indigenous axis: ORIC + federal contract + ACNC charity
+// governance. Black-fill = the registry's "deepest" convention; red text/border keeps it on the Indigenous
+// axis. Strongest-wins over the basic Indigenous-proven badge.
+function IndigenousTripleProofBadge() {
+  return (
+    <span
+      title="Indigenous triple-proof — a registered Indigenous corporation (ORIC) that has won a federal contract AND carries ACNC charity governance. Verified Indigenous-controlled supply with proven federal delivery that also clears a governance bar — the deepest Indigenous-procurement shortlist in the registry."
+      className="text-[10px] px-2 py-0.5 font-black uppercase tracking-widest border-2 border-bauhaus-red bg-bauhaus-black text-bauhaus-red"
+    >
+      Indigenous triple-proof
+    </span>
+  );
+}
+
 function EvidenceLine({ r }: { r: SupplierResult }) {
   if (r.contract_count === 0) return null;
   const lastYear = r.last_contract_end ? new Date(r.last_contract_end).getFullYear() : null;
@@ -250,7 +264,7 @@ export default async function SupplierSearchPage({
                     </Link>
                     <div className="relative z-10 flex gap-1.5 flex-wrap">
                       {r.proven_outcomes ? <ProvenOutcomesBadge /> : r.triple_proof ? <TripleProofBadge /> : r.proven_govt_delivery ? <ProvenGovtDeliveryBadge /> : null}
-                      {r.indigenous_proven ? <IndigenousProvenBadge /> : null}
+                      {r.indigenous_triple_proof ? <IndigenousTripleProofBadge /> : r.indigenous_proven ? <IndigenousProvenBadge /> : null}
                       <TierBadge tier={r.verification_tier} />
                       {r.source_primary && (
                         <span className="text-[10px] px-2 py-0.5 font-black uppercase tracking-widest border-2 border-bauhaus-black/40 text-bauhaus-muted">

--- a/apps/web/src/lib/services/supplier-search.ts
+++ b/apps/web/src/lib/services/supplier-search.ts
@@ -40,6 +40,10 @@ export interface SupplierResult {
   /** OP1: a registered Indigenous corporation (ORIC) that has won a federal contract. Orthogonal to the
    * justice hierarchy above — an org can be both Indigenous-proven AND proven-govt-delivery at once. */
   indigenous_proven: boolean;
+  /** OP8: Indigenous triple-proof — an Indigenous-proven org (ORIC + federal contract) that ALSO carries
+   * ACNC charity governance. The deeper tier within the Indigenous axis; strongest-wins over the basic
+   * Indigenous-proven badge (mirrors OP3→OP7's has_acnc upgrade). */
+  indigenous_triple_proof: boolean;
 }
 
 export interface RegistryStats {
@@ -144,19 +148,21 @@ export async function searchSuppliers(
   // OP7/OP10: flag triple-proof suppliers (justice delivery + federal contract + ACNC governance)
   // and the quad-proof gold tier (those that ALSO carry ALMA evidence + measured outcomes).
   // Enrich the ≤30 results by ABN against mv_triple_proof_suppliers — the deepest evidence tiers.
-  const base = (data ?? []) as Omit<SupplierResult, 'proven_govt_delivery' | 'triple_proof' | 'proven_outcomes' | 'indigenous_proven'>[];
+  const base = (data ?? []) as Omit<SupplierResult, 'proven_govt_delivery' | 'triple_proof' | 'proven_outcomes' | 'indigenous_proven' | 'indigenous_triple_proof'>[];
   const abns = [...new Set(base.map((r) => r.abn).filter((a): a is string => Boolean(a)))];
   const proven = new Set<string>();
   const provenOutcomes = new Set<string>();
   const provenGovtDelivery = new Set<string>();
   const indigenousProven = new Set<string>();
+  const indigenousTripleProof = new Set<string>();
   if (abns.length > 0) {
     const [tpRes, jpRes, ipRes] = await Promise.all([
       supabase.from('mv_triple_proof_suppliers').select('abn, has_alma_evidence_outcomes').in('abn', abns),
       // OP3: broad justice + federal-contract tier
       supabase.from('mv_justice_proven_suppliers').select('abn, has_alma_evidence_outcomes').in('abn', abns),
-      // OP1: registered Indigenous corporation (ORIC) + federal contract — an orthogonal axis
-      supabase.from('mv_indigenous_proven_suppliers').select('abn, has_alma_evidence_outcomes').in('abn', abns),
+      // OP1/OP8: registered Indigenous corporation (ORIC) + federal contract — an orthogonal axis.
+      // has_acnc upgrades it to the deeper "Indigenous triple-proof" tier (OP8).
+      supabase.from('mv_indigenous_proven_suppliers').select('abn, has_acnc, has_alma_evidence_outcomes').in('abn', abns),
     ]);
     if (tpRes.error) {
       console.error('[supplier-search:triple-proof]', tpRes.error.message);
@@ -181,9 +187,11 @@ export async function searchSuppliers(
     if (ipRes.error) {
       console.error('[supplier-search:indigenous-proven]', ipRes.error.message);
     } else {
-      for (const row of (ipRes.data ?? []) as { abn: string | null; has_alma_evidence_outcomes: boolean | null }[]) {
+      for (const row of (ipRes.data ?? []) as { abn: string | null; has_acnc: boolean | null; has_alma_evidence_outcomes: boolean | null }[]) {
         if (!row.abn) continue;
         indigenousProven.add(row.abn);
+        // OP8: ACNC governance upgrades it to the deeper Indigenous triple-proof tier.
+        if (row.has_acnc) indigenousTripleProof.add(row.abn);
         // OP1 MV carries the gold flag too, so an Indigenous-proven org with ALMA evidence
         // also lights up "Proven outcomes".
         if (row.has_alma_evidence_outcomes) provenOutcomes.add(row.abn);
@@ -196,5 +204,6 @@ export async function searchSuppliers(
     triple_proof: Boolean(r.abn && proven.has(r.abn)),
     proven_outcomes: Boolean(r.abn && provenOutcomes.has(r.abn)),
     indigenous_proven: Boolean(r.abn && indigenousProven.has(r.abn)),
+    indigenous_triple_proof: Boolean(r.abn && indigenousTripleProof.has(r.abn)),
   }));
 }

--- a/docs/leverage-map.md
+++ b/docs/leverage-map.md
@@ -30,10 +30,11 @@ All three are **evidence-depth** plays — the wedge's stated #1 tie-breaker ("e
 > **Enabler underneath all three: OP2** — link the 1,116 new VIC supplier ABNs into `gs_entities` so the
 > fresh procurement evidence flows into the same profiles.
 
-> **Premium tier (iter 4): OP7/OP8** are the *governance-deepened* versions of OP3/OP1 — the same buyers,
-> the same wedge play, but each org carries **three** independent proof signals instead of two. Fewer rows
-> (724 / 278), strictly deeper evidence. Per the wedge ("depth beats row count"), OP7 is a candidate to
-> *replace* OP3 in the headline as the premium shortlist; OP3 stays as the broad tier.
+> **Premium tier (iter 4): OP7/OP8 — both BUILT 2026-06-08.** The *governance-deepened* versions of OP3/OP1
+> — the same buyers, the same wedge play, but each org carries **three** independent proof signals instead
+> of two. Fewer rows (724 / 265), strictly deeper evidence. Per the wedge ("depth beats row count"), OP7 is
+> a candidate to *replace* OP3 in the headline as the premium shortlist; OP3 stays as the broad tier. OP8
+> ships the same play for the Indigenous axis (**"Indigenous triple-proof"** badge, strongest-wins over OP1).
 
 ---
 
@@ -108,13 +109,21 @@ All three are **evidence-depth** plays — the wedge's stated #1 tie-breaker ("e
   premium tier.) **Follow-up:** a browsable buyer list for the 558 non-SE triple-proof orgs.
 
 - **OP8 — Triple-proof Indigenous suppliers.** Datasets: `oric_corporations` × `austender_contracts` ×
-  `acnc_charities` via ABN. Serves: **G4∩G1 (best quadrant)**. Why valuable: **278 of OP1's 325 (86%)
-  contract-winning ORIC corps are also ACNC charities** — Indigenous-controlled orgs with proven federal
-  delivery *and* charity-grade governance. A buyer with Indigenous-procurement targets gets a shortlist
-  that already clears the governance bar. The 86% co-incidence is itself a finding: contract-winning ORIC
-  corps are overwhelmingly ACNC-registered. Evidence: 278 ABN-matched across 3 sources. State:
-  **partially-built** (`mv_indigenous_procurement_score` has the oric×contracts pair; ACNC is the
-  deepening). Effort: S–M. Wedge: **green**. (Refines OP1.)
+  `acnc_charities` via ABN. Serves: **G4∩G1 (best quadrant)**. Why valuable: **265 of OP1's 301 (88%)**
+  *registered* contract-winning ORIC corps are also ACNC charities — Indigenous-controlled orgs with proven
+  federal delivery *and* charity-grade governance. A buyer with Indigenous-procurement targets gets a
+  shortlist that already clears the governance bar. The 88% co-incidence is itself a finding: contract-winning
+  ORIC corps are overwhelmingly ACNC-registered. Evidence: 265 ABN-matched across 3 sources. State:
+  **BUILT 2026-06-08** — ACNC governance added as an OPTIONAL `has_acnc` flag onto `mv_indigenous_proven_suppliers`
+  (migration `20260608100000`, mirroring OP3→OP7's pattern; the MV keeps all 301 rows, 36 stay
+  Indigenous-proven, 265 upgrade). Surfaces as the **"Indigenous triple-proof"** badge (red-on-black) on
+  `/suppliers` search + `/social-enterprises/[id]`, strongest-wins over the basic OP1 badge within the
+  Indigenous axis (orthogonal to the OP3 justice hierarchy — South Coast Medical Service carries BOTH the
+  justice "Triple-proof" and "Indigenous triple-proof"). New `indigenous_triple_proof` flag in
+  `supplier-search.ts`. No new cron migration (MV name + refresh registration unchanged). Verified live:
+  301 rows · 265 triple-proof · 9 gold; badge correct on all three surfaces. Effort: S–M. Wedge: **green**.
+  (Refines OP1 → premium Indigenous tier, the OP1 analogue of OP7.) **NB:** the 278/325 figure in the
+  original find predated OP1's registered-only scoping; 265/301 is the verified post-scope count.
 
 - **OP9 — Conflict-of-interest risk flag on supplier profiles (narrow).** Datasets: `mv_entity_power_index`
   (`in_procurement` × `in_political_donations` × `distinct_parties_funded` / `parties_funded`). Serves:

--- a/supabase/migrations/20260608100000_mv_indigenous_proven_add_acnc.sql
+++ b/supabase/migrations/20260608100000_mv_indigenous_proven_add_acnc.sql
@@ -1,0 +1,101 @@
+-- OP8 (leverage map) — Indigenous TRIPLE-PROOF: the governance-deepened Indigenous buyer shortlist.
+--
+-- Deepens OP1 (mv_indigenous_proven_suppliers) by adding ACNC charity governance as an OPTIONAL third
+-- proof signal — mirroring exactly how OP3 (mv_justice_proven_suppliers) carries has_acnc to compose
+-- OP7's triple-proof tier. An "Indigenous triple-proof" org carries THREE independent proofs at once:
+--   1. A registered Indigenous corporation  (oric_corporations, status='Registered')
+--   2. A won federal contract                (austender_contracts.supplier_abn)
+--   3. ACNC charity governance               (acnc_charities.abn)
+--
+-- 265 of the 301 Indigenous-proven orgs (88%) are also ACNC charities — Indigenous-controlled orgs with
+-- proven federal delivery AND charity-grade governance. Exactly the shortlist a buyer with Indigenous
+-- Procurement Policy (IPP) targets needs that ALSO clears a governance bar. (Verified live 2026-06-08.)
+--
+-- ACNC is a SIGNAL, NOT A GATE: a LEFT JOIN, present where it exists, null otherwise. The MV keeps all
+-- 301 rows — the 36 non-ACNC Indigenous-proven orgs still surface as "Indigenous-proven", the 265 ACNC
+-- ones upgrade to "Indigenous triple-proof". The app's strongest-badge-wins logic picks the deeper tier.
+--
+-- This is a pure column-addition rebuild: the MV name, abn unique index, and refresh registration
+-- (scripts/refresh-views-v2.mjs + pg_cron refresh_civicgraph_mvs() order array) are all unchanged, so no
+-- new cron migration is needed — only the SELECT and the index set are re-created.
+--
+-- Wrapped in a transaction so concurrent readers briefly block, then see the populated MV.
+
+BEGIN;
+
+DROP MATERIALIZED VIEW IF EXISTS mv_indigenous_proven_suppliers;
+
+CREATE MATERIALIZED VIEW mv_indigenous_proven_suppliers AS
+WITH oric AS (
+  -- one ACTIVE (Registered) ORIC corporation per ABN. Prefer the most-recently-registered row when an
+  -- ABN maps to multiple ICNs (one ABN has both a Registered and a Deregistered corp — Registered wins).
+  SELECT DISTINCT ON (o.abn)
+         o.abn,
+         o.icn               AS oric_icn,
+         o.name              AS oric_name,
+         o.status            AS oric_status,
+         o.corporation_size,
+         o.registered_on     AS oric_registered_on,
+         o.industry_sectors
+  FROM oric_corporations o
+  WHERE o.abn IS NOT NULL
+    AND o.status = 'Registered'
+  ORDER BY o.abn, o.registered_on DESC NULLS LAST
+),
+base AS (
+  -- one gs_entity per ABN (guarantees the unique index below for CONCURRENTLY refresh)
+  SELECT DISTINCT ON (g.abn)
+         g.id AS entity_id, g.gs_id, g.abn, g.canonical_name, g.entity_type, g.state, g.postcode,
+         g.sector, g.lga_name, g.is_community_controlled
+  FROM gs_entities g
+  WHERE g.abn IS NOT NULL
+    AND g.abn IN (SELECT abn FROM oric)
+    AND EXISTS (SELECT 1 FROM austender_contracts c WHERE c.supplier_abn = g.abn)
+  ORDER BY g.abn, g.gs_id
+),
+ct AS (
+  SELECT supplier_abn AS abn,
+         COUNT(*)                   AS contract_count,
+         SUM(contract_value)        AS contract_value,
+         COUNT(DISTINCT buyer_name) AS distinct_buyers,
+         MAX(contract_end)          AS last_contract_end,
+         MIN(contract_start)        AS first_contract_start
+  FROM austender_contracts
+  WHERE supplier_abn IN (SELECT abn FROM base)
+  GROUP BY supplier_abn
+),
+ac AS (
+  -- OP8: optional governance signal — NOT a gate. Present only for the orgs that are also charities.
+  -- One ACNC row per ABN (mirrors OP3's mv_justice_proven_suppliers).
+  SELECT DISTINCT ON (abn)
+         abn, charity_size, name AS acnc_name, registration_date AS acnc_registered_since
+  FROM acnc_charities
+  WHERE abn IN (SELECT abn FROM base)
+  ORDER BY abn, registration_date NULLS LAST
+)
+SELECT
+  b.gs_id, b.abn, b.canonical_name, b.entity_type, b.state, b.postcode,
+  b.sector, b.lga_name, b.is_community_controlled,
+  o.oric_icn, o.oric_name, o.oric_status, o.corporation_size, o.oric_registered_on, o.industry_sectors,
+  ct.contract_count, ct.contract_value, ct.distinct_buyers, ct.last_contract_end, ct.first_contract_start,
+  ac.charity_size, ac.acnc_name, ac.acnc_registered_since,
+  (ac.abn IS NOT NULL) AS has_acnc,
+  COALESCE(ct.contract_value, 0) AS total_evidence_dollars,
+  EXISTS (
+    SELECT 1 FROM alma_interventions ai
+    WHERE ai.gs_entity_id = b.entity_id
+      AND EXISTS (SELECT 1 FROM alma_intervention_evidence e WHERE e.intervention_id = ai.id)
+      AND EXISTS (SELECT 1 FROM alma_intervention_outcomes ao WHERE ao.intervention_id = ai.id)
+  ) AS has_alma_evidence_outcomes
+FROM base b
+JOIN oric o ON o.abn = b.abn
+LEFT JOIN ct ON ct.abn = b.abn
+LEFT JOIN ac ON ac.abn = b.abn;
+
+CREATE UNIQUE INDEX mv_indigenous_proven_suppliers_abn_idx     ON mv_indigenous_proven_suppliers (abn);
+CREATE INDEX        mv_indigenous_proven_suppliers_gsid_idx    ON mv_indigenous_proven_suppliers (gs_id);
+CREATE INDEX        mv_indigenous_proven_suppliers_state_idx   ON mv_indigenous_proven_suppliers (state);
+CREATE INDEX        mv_indigenous_proven_suppliers_dollars_idx ON mv_indigenous_proven_suppliers (total_evidence_dollars DESC);
+CREATE INDEX        mv_indigenous_proven_suppliers_alma_idx    ON mv_indigenous_proven_suppliers (has_alma_evidence_outcomes) WHERE has_alma_evidence_outcomes;
+
+COMMIT;


### PR DESCRIPTION
## OP8 — Indigenous triple-proof (leverage Top-tier, premium Indigenous shortlist)

The governance-deepened premium tier for the Indigenous axis — the OP1 analogue of how **OP7** deepened **OP3**. An "Indigenous triple-proof" org carries **three** independent proofs at once:

1. A **registered** Indigenous corporation (ORIC, `status='Registered'`)
2. A **won federal contract** (`austender_contracts`)
3. **ACNC charity governance** (`acnc_charities`)

**265 of OP1's 301** registered contract-winning ORIC corps (88%) are also ACNC charities — Indigenous-controlled supply with proven federal delivery that *also* clears a governance bar, exactly what a buyer with Indigenous Procurement Policy (IPP) targets needs.

### What changed
- **Migration `20260608100000`** — rebuilds `mv_indigenous_proven_suppliers` to add ACNC as an **optional** signal (`has_acnc` + `charity_size` / `acnc_name` / `acnc_registered_since`), a LEFT JOIN mirroring OP3's `mv_justice_proven_suppliers`. **Not a gate:** the MV keeps all 301 rows — 36 stay `Indigenous-proven`, 265 upgrade. Pure column-addition: MV name, abn unique index, and cron refresh registration are unchanged, so **no new cron migration**. **Applied live** (301 rows · 265 `has_acnc`).
- **`supplier-search.ts`** — new `indigenous_triple_proof` flag (selects `has_acnc` in the existing third MV lookup; strongest-wins set).
- **`/suppliers` + `/social-enterprises/[id]`** — `Indigenous triple-proof` badge (red-on-black: the registry's "deepest" black-fill convention kept on the Indigenous-axis red), **strongest-wins** over the basic OP1 badge. **Orthogonal** to the OP3 justice hierarchy — South Coast Medical Service carries BOTH the justice `Triple-proof` and `Indigenous triple-proof`.

### Verified live (all three surfaces)
| Surface | Result |
|---|---|
| Triple-proof profile (South Coast Medical) | `Indigenous triple-proof` + justice `Triple-proof`; basic badge suppressed |
| Proven-only profile (PY Ku, non-ACNC) | `Indigenous-proven`; no triple-proof (downgrade path correct) |
| Search (`?q=south coast medical`) | `Indigenous triple-proof` + `Triple-proof` |

Distribution: **301 rows · 265 Indigenous triple-proof · 36 proven-only · 9 gold.**

### Gates
- `tsc --noEmit`: **0 errors**
- `vitest run`: **221/221 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)