### PR TITLE
feat(suppliers): financial-health signal on justice-funded charities (OP4)

### DIFF
--- a/apps/web/src/app/social-enterprises/[id]/page.tsx
+++ b/apps/web/src/app/social-enterprises/[id]/page.tsx
@@ -114,6 +114,137 @@ function EvidenceTierBadge({ tier }: { tier: EvidenceTier | null }) {
   );
 }
 
+// OP4 — financial-health signal from the latest ACNC Annual Information Statement (AIS),
+// for justice-funded charities. Framed as a CAPACITY signal (where support may be needed),
+// never a buyer warning. Liquidity is NULL when no balance sheet was filed — never inferred.
+type FinancialTier = 'healthy' | 'watch' | 'fragile' | 'unknown';
+
+interface FinancialHealth {
+  ais_year: number;
+  charity_size: string | null;
+  total_revenue: number | null;
+  total_expenses: number | null;
+  net_surplus_deficit: number | null;
+  net_assets_liabilities: number | null;
+  current_ratio: number | null;
+  months_of_reserves: number | null;
+  govt_revenue_share: number | null;
+  is_deficit: boolean | null;
+  net_assets_negative: boolean | null;
+  low_liquidity: boolean | null;
+  low_reserves: boolean | null;
+  high_govt_dependency: boolean | null;
+  fragility_tier: FinancialTier;
+}
+
+const FINANCIAL_TIER_META: Record<FinancialTier, { label: string; sub: string; className: string }> = {
+  healthy: {
+    label: 'Financially resilient',
+    sub: 'Latest ACNC filing shows reserves and a balanced result — well-placed to deliver.',
+    className: 'border-money bg-money-light text-money',
+  },
+  watch: {
+    label: 'Worth a closer look',
+    sub: 'One resilience signal worth noting in the latest filing — not a red flag on its own.',
+    className: 'border-bauhaus-black bg-bauhaus-yellow text-bauhaus-black',
+  },
+  fragile: {
+    label: 'Financially stretched',
+    sub: 'Thin reserves in the latest filing — a delivery partner who may benefit from multi-year or capacity support, not avoidance.',
+    className: 'border-bauhaus-red bg-bauhaus-red/10 text-bauhaus-red',
+  },
+  unknown: {
+    label: 'Limited financial data',
+    sub: 'The latest ACNC filing does not carry enough detail to assess financial resilience.',
+    className: 'border-bauhaus-black/40 bg-bauhaus-canvas text-bauhaus-muted',
+  },
+};
+
+// One metric cell in the financial snapshot grid.
+function FinStat({ label, value, tone }: { label: string; value: string; tone?: 'money' | 'red' | 'default' }) {
+  const valueColor = tone === 'money' ? 'text-money' : tone === 'red' ? 'text-bauhaus-red' : 'text-bauhaus-black';
+  return (
+    <div className="p-3 bg-white border-r-4 border-b-4 border-bauhaus-black last:border-r-0">
+      <div className="text-[10px] text-bauhaus-muted uppercase tracking-widest font-black mb-1 leading-tight">{label}</div>
+      <div className={`text-lg font-black ${valueColor}`}>{value}</div>
+    </div>
+  );
+}
+
+function FinancialHealthSection({ data }: { data: FinancialHealth }) {
+  const m = FINANCIAL_TIER_META[data.fragility_tier];
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+  const absMoney = (n: number | null | undefined) => (n == null ? '—' : `${n < 0 ? '−' : ''}${money(Math.abs(n))}`);
+
+  // Result: surplus (money-green) vs deficit (red).
+  const resultValue = data.net_surplus_deficit == null
+    ? '—'
+    : `${data.net_surplus_deficit < 0 ? '−' : '+'}${money(Math.abs(data.net_surplus_deficit))}`;
+  const resultTone: 'money' | 'red' | 'default' = data.net_surplus_deficit == null
+    ? 'default' : data.net_surplus_deficit < 0 ? 'red' : 'money';
+
+  // Reserves: months of runway, or net assets when months can't be computed.
+  const reservesValue = data.net_assets_negative
+    ? 'Negative'
+    : data.months_of_reserves != null
+      ? `${data.months_of_reserves < 10 ? data.months_of_reserves.toFixed(1) : Math.round(data.months_of_reserves)} mo`
+      : absMoney(data.net_assets_liabilities);
+  const reservesLabel = data.months_of_reserves != null && !data.net_assets_negative ? 'Reserves runway' : 'Net assets';
+
+  // Active warning signals — only the ones that are true. Govt concentration is a
+  // context flag (these orgs are govt-funded), shown in blue, not as a risk.
+  const signals: Array<{ label: string; className: string }> = [
+    data.net_assets_negative && { label: 'Negative net assets', className: 'border-bauhaus-red text-bauhaus-red' },
+    data.is_deficit && { label: 'Operating deficit', className: 'border-bauhaus-black text-bauhaus-black bg-bauhaus-yellow' },
+    data.low_reserves && { label: 'Under 3 months reserves', className: 'border-bauhaus-black text-bauhaus-black bg-bauhaus-yellow' },
+    data.low_liquidity && { label: 'Current ratio under 1', className: 'border-bauhaus-black text-bauhaus-black bg-bauhaus-yellow' },
+    data.high_govt_dependency && { label: 'Government-revenue concentrated', className: 'border-bauhaus-blue text-bauhaus-blue' },
+  ].filter(Boolean) as Array<{ label: string; className: string }>;
+
+  return (
+    <Section title="Financial Health">
+      <p className="text-xs text-bauhaus-muted font-medium mb-3 -mt-1">
+        A capacity signal from this charity&apos;s latest public ACNC filing — to show where a buyer or
+        funder might offer multi-year or capacity support, not to rank organisations. Not a CivicGraph
+        assessment of the organisation.
+      </p>
+      <div className="bg-white border-4 border-bauhaus-black">
+        <div className={`flex items-baseline justify-between gap-3 flex-wrap px-4 py-3 border-b-4 border-bauhaus-black ${m.className}`}>
+          <span className="text-sm font-black uppercase tracking-widest">{m.label}</span>
+          <span className="text-[11px] font-black uppercase tracking-widest opacity-80">ACNC AIS · FY{data.ais_year}</span>
+        </div>
+        <p className="text-xs font-medium px-4 py-2.5 border-b-4 border-bauhaus-black text-bauhaus-black">{m.sub}</p>
+        <div className="grid grid-cols-2 sm:grid-cols-4 border-b-4 border-bauhaus-black">
+          <FinStat label={`Income FY${String(data.ais_year).slice(-2)}`} value={money(data.total_revenue)} tone="money" />
+          <FinStat label="Surplus / deficit" value={resultValue} tone={resultTone} />
+          <FinStat label={reservesLabel} value={reservesValue} tone={data.net_assets_negative ? 'red' : 'default'} />
+          <FinStat
+            label="Liquidity (current ratio)"
+            value={data.current_ratio != null ? data.current_ratio.toFixed(2) : 'Not filed'}
+            tone={data.low_liquidity ? 'red' : 'default'}
+          />
+        </div>
+        {signals.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-4 py-3 border-b-4 border-bauhaus-black">
+            {signals.map((s) => (
+              <span key={s.label} className={`text-[10px] px-2 py-0.5 font-black uppercase tracking-widest border-2 ${s.className}`}>
+                {s.label}
+              </span>
+            ))}
+          </div>
+        )}
+        <p className="text-xs text-bauhaus-muted px-4 py-3 font-medium leading-relaxed">
+          Source: ACNC Annual Information Statement, FY{data.ais_year}
+          {data.charity_size ? ` · ${data.charity_size[0].toUpperCase()}${data.charity_size.slice(1)} charity` : ''}
+          {data.govt_revenue_share != null ? ` · ${pct(data.govt_revenue_share)} of income from government` : ''}.
+          A point-in-time regulatory snapshot — figures can lag a year and a single filing is not a full
+          picture of an organisation&apos;s health. Liquidity is shown only where a balance sheet was filed.
+        </p>
+      </div>
+    </Section>
+  );
+}
+
 // OP1 — Indigenous-proven badge. Orthogonal to the evidence-tier family above: a registered Indigenous
 // corporation (ORIC) with a won federal contract can ALSO be proven-govt-delivery, so both badges show.
 function IndigenousProvenBadge({ shown }: { shown: boolean }) {
@@ -363,18 +494,21 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
   // OP8 — Indigenous triple-proof: the above PLUS ACNC charity governance (deeper tier, strongest-wins).
   let indigenousProven = false;
   let indigenousTripleProof = false;
+  // OP4 — financial-health signal (latest ACNC AIS) for justice-funded charities.
+  let financialHealth: FinancialHealth | null = null;
 
   // Grant matching runs on sector + place, not ABN — every profile gets it
   const grantMatchPromise = matchGrantsForSocialEnterprise(supabase, enterprise);
 
   if (cleanAbn) {
-    const [charityRes, graphRes, contractRes, justiceRes, provenRes, indigenousRes] = await Promise.all([
+    const [charityRes, graphRes, contractRes, justiceRes, provenRes, indigenousRes, finHealthRes] = await Promise.all([
       supabase.from('acnc_charities').select('abn, name').eq('abn', cleanAbn).maybeSingle(),
       supabase.from('gs_entities').select('id, gs_id, remoteness, seifa_irsd_decile, is_community_controlled, lga_name, postcode').eq('abn', cleanAbn).not('gs_id', 'is', null).limit(1).maybeSingle(),
       supabase.from('austender_contracts').select('title, contract_value, buyer_name, contract_start', { count: 'exact' }).eq('supplier_abn', cleanAbn).not('contract_value', 'is', null).order('contract_value', { ascending: false }).limit(1000),
       supabase.from('justice_funding').select('program_name, amount_dollars, financial_year, source, sector').eq('recipient_abn', cleanAbn).order('amount_dollars', { ascending: false, nullsFirst: false }).limit(200),
       supabase.from('mv_justice_proven_suppliers').select('has_acnc, has_alma_evidence_outcomes').eq('abn', cleanAbn).maybeSingle(),
       supabase.from('mv_indigenous_proven_suppliers').select('abn, has_acnc').eq('abn', cleanAbn).maybeSingle(),
+      supabase.from('mv_justice_charity_financial_health').select('ais_year, charity_size, total_revenue, total_expenses, net_surplus_deficit, net_assets_liabilities, current_ratio, months_of_reserves, govt_revenue_share, is_deficit, net_assets_negative, low_liquidity, low_reserves, high_govt_dependency, fragility_tier').eq('abn', cleanAbn).maybeSingle(),
     ]);
     if (charityRes.data) matchedCharity = charityRes.data as { abn: string; name: string };
     if (graphRes.data) graphEntity = graphRes.data as GraphEntity;
@@ -390,6 +524,7 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
       // OP8: ACNC governance upgrades it to the deeper Indigenous triple-proof tier.
       indigenousTripleProof = Boolean((indigenousRes.data as { has_acnc: boolean | null }).has_acnc);
     }
+    if (finHealthRes.data) financialHealth = finHealthRes.data as FinancialHealth;
     // OP5 — ALMA evidence signals join on the entity UUID, so it runs once the
     // ABN→entity match resolves above.
     if (graphEntity?.id) {
@@ -668,6 +803,9 @@ export default async function SocialEnterpriseDetailPage({ params }: { params: P
               </div>
             </Section>
           )}
+
+          {/* Financial health — latest ACNC AIS signal (OP4) */}
+          {financialHealth && <FinancialHealthSection data={financialHealth} />}
 
           {/* Open funding matched on sector + place */}
           {matchedGrants.length > 0 && (

--- a/docs/leverage-map.md
+++ b/docs/leverage-map.md
@@ -72,10 +72,20 @@ All three are **evidence-depth** plays — the wedge's stated #1 tie-breaker ("e
   `5dcff2a`. Effort: M. Wedge: **green**. (Highest-volume best-quadrant find so far.)
 
 - **OP4 — Financial-health signal on justice-funded charities.** Datasets: `justice_funding` ×
-  `acnc_charities` / `mv_acnc_ais_yearly` via ABN. Serves: **G3**. Why valuable: **4,366 (12%)** justice
-  recipients are ACNC charities with AIS financials → flag which delivery orgs are financially fragile
-  (the resourced-vs-struggling question the dead ATO lead couldn't answer). Evidence: 4,366 ABN-matched.
-  State: **latent**, moderate coverage. Effort: M. Wedge: **supply-magnet / mission** (not direct revenue).
+  `acnc_ais` via ABN. Serves: **G3**. Why valuable: justice recipients that are ACNC charities with AIS
+  financials → flag which delivery orgs are financially fragile (the resourced-vs-struggling question the
+  dead ATO lead couldn't answer). State: **BUILT 2026-06-09** — `mv_justice_charity_financial_health`
+  (**3,996 rows**; migration `20260609000000`, cron-registered `20260609010000`). The 4,366 ACNC overlap
+  narrows to 3,996 charities that actually filed an AIS. Latest-AIS-per-ABN; computes 4 transparent
+  ratios (surplus margin, current ratio, reserves-runway months, govt-revenue share) + 5 raw flags, rolled
+  into a `fragility_tier` (**healthy 53% / watch 30% / fragile 13.5% / unknown 3%**). **Data-quality gate
+  was load-bearing:** balance-sheet split (current assets/liabs) is only filed by ~49% → `low_liquidity` is
+  NULL-when-unknown, never inferred false. And reserves-runway is the MASTER solvency signal so a weak
+  current ratio never alone flags an asset-rich org fragile (caught universities — 20+ months reserves,
+  sub-1 current ratio — being mislabelled; fixed). Surfaces as a **"Financial Health"** section on
+  `/social-enterprises/[id]`, framed as a supportive capacity signal (where multi-year/capacity support
+  may help), not a buyer warning; no search-results badge (Ben's call — avoids a scarlet-letter effect).
+  Effort: M. Wedge: **supply-magnet / mission** (not direct revenue).
 
 - **OP6 — Community-controlled orgs in funding deserts (the named list).** Datasets: `mv_funding_deserts`
   × `gs_entities(is_community_controlled)` via lga. Serves: **G5∩G4**. Why valuable: the worst-100 desert

--- a/scripts/refresh-views-v2.mjs
+++ b/scripts/refresh-views-v2.mjs
@@ -48,6 +48,7 @@ const VIEW_LIST = [
   'mv_triple_proof_suppliers',
   'mv_justice_proven_suppliers',
   'mv_indigenous_proven_suppliers',
+  'mv_justice_charity_financial_health',
   'mv_funding_by_postcode',
   'mv_funding_by_lga',
   'mv_funding_by_disadvantage',

--- a/supabase/migrations/20260609000000_op4_mv_justice_charity_financial_health.sql
+++ b/supabase/migrations/20260609000000_op4_mv_justice_charity_financial_health.sql
@@ -1,0 +1,118 @@
+-- OP4 — Financial-health signal on justice-funded ACNC charities.
+-- Joins justice_funding recipients to their latest ACNC Annual Information Statement (AIS)
+-- financials, computes a small set of transparent solvency/runway ratios, and assigns a
+-- fragility tier. Serves G3 (delivery orgs). Wedge: supply-magnet / mission.
+--
+-- DATA-QUALITY GATES (verified 2026-06-09 against the 3,996 justice-funded charities with AIS):
+--   * revenue / expenses / net-result / net-assets / govt-revenue ≈ 96–100% coverage.
+--   * balance-sheet split (current assets/liabilities) only ≈ 49% — cash-basis & small-charity
+--     filers report no balance sheet. So `current_ratio`/`low_liquidity` are NULL when the source
+--     fields are absent — NEVER inferred false. A charity is not "liquid" because it didn't file
+--     a balance sheet.
+--   * Each row carries `ais_year` so the UI can caveat stale filings (91% are 2023+).
+--
+-- One row per justice-funded ABN that has at least one AIS. Latest AIS year wins.
+
+DROP MATERIALIZED VIEW IF EXISTS mv_justice_charity_financial_health CASCADE;
+
+CREATE MATERIALIZED VIEW mv_justice_charity_financial_health AS
+WITH justice_abns AS (
+  SELECT DISTINCT recipient_abn AS abn
+  FROM justice_funding
+  WHERE recipient_abn IS NOT NULL AND recipient_abn <> ''
+),
+latest_ais AS (
+  SELECT DISTINCT ON (a.abn)
+    a.abn,
+    a.ais_year,
+    a.charity_name,
+    a.charity_size,
+    a.total_revenue,
+    a.total_expenses,
+    a.net_surplus_deficit,
+    a.total_current_assets,
+    a.total_current_liabilities,
+    a.net_assets_liabilities,
+    a.revenue_from_government
+  FROM acnc_ais a
+  JOIN justice_abns j ON j.abn = a.abn
+  ORDER BY a.abn, a.ais_year DESC, a.date_ais_received DESC NULLS LAST
+),
+computed AS (
+  SELECT
+    l.*,
+    -- Surplus margin: how much of income is retained (negative = running at a loss).
+    CASE WHEN l.total_revenue > 0
+      THEN round(l.net_surplus_deficit / l.total_revenue, 4) END AS operating_margin,
+    -- Current ratio: short-term assets vs short-term obligations (<1 = can't cover).
+    -- NULL when the filer reported no balance-sheet split (≈51% of cases).
+    CASE WHEN l.total_current_liabilities > 0
+      THEN round(l.total_current_assets / l.total_current_liabilities, 4) END AS current_ratio,
+    -- Reserves runway: months of total operating cost covered by net assets.
+    -- Only when net assets are non-negative (negative equity is its own fragile trigger).
+    CASE WHEN l.total_expenses > 0 AND l.net_assets_liabilities >= 0
+      THEN round(l.net_assets_liabilities / (l.total_expenses / 12.0), 2) END AS months_of_reserves,
+    -- Government-revenue concentration (these orgs are govt-funded by definition; tracked
+    -- as a separate concentration signal, NOT folded into the fragility tier).
+    CASE WHEN l.total_revenue > 0 AND l.revenue_from_government IS NOT NULL
+      THEN round(l.revenue_from_government / l.total_revenue, 4) END AS govt_revenue_share
+  FROM latest_ais l
+)
+SELECT
+  c.abn,
+  c.charity_name,
+  c.charity_size,
+  c.ais_year,
+  c.total_revenue,
+  c.total_expenses,
+  c.net_surplus_deficit,
+  c.total_current_assets,
+  c.total_current_liabilities,
+  c.net_assets_liabilities,
+  c.revenue_from_government,
+  c.operating_margin,
+  c.current_ratio,
+  c.months_of_reserves,
+  c.govt_revenue_share,
+  -- Risk flags. NULL = not assessable from filed data; never an inferred false.
+  (c.net_surplus_deficit < 0)                                          AS is_deficit,
+  (c.net_assets_liabilities < 0)                                       AS net_assets_negative,
+  CASE WHEN c.current_ratio IS NOT NULL
+    THEN c.current_ratio < 1.0 END                                     AS low_liquidity,
+  CASE WHEN c.months_of_reserves IS NOT NULL
+    THEN c.months_of_reserves < 3 END                                  AS low_reserves,
+  CASE WHEN c.govt_revenue_share IS NOT NULL
+    THEN c.govt_revenue_share > 0.75 END                               AS high_govt_dependency,
+  -- Fragility tier — a transparent rule where the RESERVES RUNWAY is the master solvency
+  -- signal (96% coverage) and liquidity only refines it. Strong reserves override a weak
+  -- current ratio: a large asset-rich org (e.g. a university) with 20+ months of reserves
+  -- but a sub-1 current ratio is a balance-sheet-structure artifact, NOT fragility. Each row
+  -- also exposes the raw flags so the UI can show WHY. 'unknown' = no usable income/expense.
+  CASE
+    WHEN c.total_revenue IS NULL OR c.total_revenue <= 0 THEN 'unknown'
+    -- Insolvency or no meaningful buffer at all.
+    WHEN c.net_assets_liabilities < 0 THEN 'fragile'
+    WHEN c.months_of_reserves IS NOT NULL AND c.months_of_reserves < 1 THEN 'fragile'
+    -- Thin buffer (<3 months) AND bleeding or illiquid.
+    WHEN c.months_of_reserves IS NOT NULL AND c.months_of_reserves < 3
+      AND (c.net_surplus_deficit < 0 OR c.current_ratio < 1.0) THEN 'fragile'
+    -- Reserves unknown but two independent red flags (deficit + illiquid).
+    WHEN c.months_of_reserves IS NULL AND c.net_surplus_deficit < 0
+      AND c.current_ratio IS NOT NULL AND c.current_ratio < 1.0 THEN 'fragile'
+    -- Single yellow flag, still-limited resilience → watch.
+    WHEN c.net_surplus_deficit < 0 THEN 'watch'
+    WHEN c.months_of_reserves IS NOT NULL AND c.months_of_reserves < 3 THEN 'watch'
+    WHEN c.current_ratio IS NOT NULL AND c.current_ratio < 1.0
+      AND (c.months_of_reserves IS NULL OR c.months_of_reserves < 6) THEN 'watch'
+    ELSE 'healthy'
+  END AS fragility_tier
+FROM computed c;
+
+-- Unique index on abn enables CONCURRENTLY refresh + fast per-profile lookup.
+CREATE UNIQUE INDEX mv_justice_charity_financial_health_abn_idx
+  ON mv_justice_charity_financial_health (abn);
+CREATE INDEX mv_justice_charity_financial_health_tier_idx
+  ON mv_justice_charity_financial_health (fragility_tier);
+
+COMMENT ON MATERIALIZED VIEW mv_justice_charity_financial_health IS
+  'OP4: latest ACNC AIS financial-health signal for justice-funded charities. Fragility tier + raw flags. Liquidity NULL when no balance sheet filed (never inferred). Supply-magnet/mission lens — capacity signal, not a buyer warning.';

--- a/supabase/migrations/20260609010000_cron_refresh_order_add_charity_financial_health.sql
+++ b/supabase/migrations/20260609010000_cron_refresh_order_add_charity_financial_health.sql
@@ -1,0 +1,123 @@
+-- OP4: register mv_justice_charity_financial_health in the nightly cron's refresh_order array.
+-- Re-dumped via pg_get_functiondef with one array line inserted after mv_indigenous_proven_suppliers.
+-- The cron fix (SET statement_timeout='0', SET search_path) is preserved verbatim.
+
+CREATE OR REPLACE FUNCTION public.refresh_civicgraph_mvs()
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_catalog'
+ SET statement_timeout TO '0'
+AS $function$
+DECLARE
+  v_started TIMESTAMPTZ;
+  v_finished TIMESTAMPTZ;
+  v_error TEXT;
+  v_mv TEXT;
+  -- MVs that need non-concurrent refresh (no unique index OR surrogate key issue
+  -- OR duplicate-key data quality issues in the MV definition).
+  -- 2026-04-27: funding_by_lga and funding_deserts have duplicates that block
+  -- a unique index until the underlying queries are deduped.
+  needs_non_concurrent TEXT[] := ARRAY[
+    'mv_funding_by_lga',
+    'mv_funding_deserts',
+    'mv_foundation_grantees',
+    'mv_donation_contract_timing'
+  ];
+  -- Refresh order — same as refresh-views-v2.mjs VIEW_LIST
+  refresh_order TEXT[] := ARRAY[
+    -- Tier 1
+    'mv_acnc_latest',
+    'mv_acnc_ais_yearly',
+    'v_grant_stats',
+    'v_grant_focus_areas',
+    'v_grant_provider_summary',
+    'mv_abr_name_lookup',
+    -- Tier 2
+    'mv_gs_entity_stats',
+    'mv_gs_donor_contractors',
+    'mv_donor_contract_crossref',
+    'mv_org_justice_signals',
+    'mv_triple_proof_suppliers',
+    'mv_justice_proven_suppliers',
+    'mv_indigenous_proven_suppliers',
+    'mv_justice_charity_financial_health',
+    'mv_funding_by_postcode',
+    'mv_funding_by_lga',
+    'mv_funding_by_disadvantage',
+    'mv_indigenous_funding_by_disadvantage',
+    -- Tier 3
+    'mv_entity_power_index',
+    'mv_funding_deserts',
+    'mv_revolving_door',
+    'mv_board_interlocks',
+    'mv_foundation_grantees',
+    'mv_donation_contract_timing',
+    -- Compounds (built today)
+    'mv_indigenous_procurement_score',
+    'mv_grant_contract_overlap',
+    'mv_lga_indigenous_proxy_score'
+  ];
+BEGIN
+  -- Ensure log table exists (refresh-views-v2.mjs also creates it)
+  CREATE TABLE IF NOT EXISTS mv_refresh_log (
+    id BIGSERIAL PRIMARY KEY,
+    mv_name TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    duration_ms INTEGER,
+    status TEXT NOT NULL,
+    used_concurrent BOOLEAN,
+    error_message TEXT,
+    triggered_by TEXT DEFAULT 'pg_cron'
+  );
+
+  -- Refresh each MV in order
+  FOREACH v_mv IN ARRAY refresh_order LOOP
+    v_started := now();
+    v_error := NULL;
+
+    BEGIN
+      IF v_mv = ANY(needs_non_concurrent) THEN
+        -- Non-concurrent path
+        EXECUTE format('REFRESH MATERIALIZED VIEW %I', v_mv);
+        v_finished := now();
+        INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, triggered_by)
+          VALUES (v_mv, v_started, v_finished,
+                  EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'success', false, 'pg_cron');
+      ELSE
+        -- CONCURRENTLY path — try first
+        BEGIN
+          EXECUTE format('REFRESH MATERIALIZED VIEW CONCURRENTLY %I', v_mv);
+          v_finished := now();
+          INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, triggered_by)
+            VALUES (v_mv, v_started, v_finished,
+                    EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'success', true, 'pg_cron');
+        EXCEPTION WHEN OTHERS THEN
+          -- Fallback to non-concurrent if CONCURRENTLY fails (no unique index, etc.)
+          v_started := now();  -- reset timer for non-concurrent attempt
+          BEGIN
+            EXECUTE format('REFRESH MATERIALIZED VIEW %I', v_mv);
+            v_finished := now();
+            INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, error_message, triggered_by)
+              VALUES (v_mv, v_started, v_finished,
+                      EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'success-fallback', false,
+                      'CONCURRENTLY failed, used non-concurrent', 'pg_cron');
+          EXCEPTION WHEN OTHERS THEN
+            v_finished := now();
+            v_error := SQLERRM;
+            INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, error_message, triggered_by)
+              VALUES (v_mv, v_started, v_finished,
+                      EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'failed', false, v_error, 'pg_cron');
+          END;
+        END;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      v_finished := now();
+      v_error := SQLERRM;
+      INSERT INTO mv_refresh_log (mv_name, started_at, finished_at, duration_ms, status, used_concurrent, error_message, triggered_by)
+        VALUES (v_mv, v_started, v_finished,
+                EXTRACT(EPOCH FROM (v_finished - v_started)) * 1000, 'failed', NULL, v_error, 'pg_cron');
+    END;
+  END LOOP;
+END;
+$function$


### PR DESCRIPTION
## OP4 — Financial-health signal on justice-funded ACNC charities

A **supply-magnet / mission** leverage play (not direct buyer revenue): surface each justice-funded ACNC charity's financial resilience from its latest **Annual Information Statement**, so a buyer or funder can see which delivery orgs may need multi-year or capacity support — the resourced-vs-struggling question the dead ATO-transparency lead couldn't answer (ATO covered only 0.5% of justice recipients; ACNC AIS covers 12%).

### The data asset
`mv_justice_charity_financial_health` — **3,996 rows** (the justice recipients that actually filed an AIS, narrowed from the 4,366 ACNC overlap). Latest-AIS-per-ABN → 4 transparent ratios (surplus margin, current ratio, reserves-runway months, govt-revenue share) + 5 raw flags → a `fragility_tier`:

| Tier | Count | % |
|---|---|---|
| healthy | 2,125 | 53.2% |
| watch | 1,197 | 30.0% |
| fragile | 541 | 13.5% |
| unknown | 133 | 3.3% |

### Two data-quality gates that were load-bearing
1. **Liquidity is NULL-when-unknown, never false** — only ~49% of these charities file a balance sheet (cash-basis / small-charity exempt). A charity isn't "liquid" because it filed no balance sheet.
2. **Reserves-runway is the master solvency signal.** The first cut flagged Monash/RMIT/Deakin as "fragile" purely on current-ratio <1 — but they hold 20+ months of reserves (universities run on non-current assets + deferred revenue). Fixed so strong reserves override a weak current ratio. QUT (0.02 months reserves) correctly stays fragile; Sydney/UQ/ANU are healthy.

### The surface
A **"Financial Health"** section on `/social-enterprises/[id]` — figures + tier + AIS-year citation, framed as a **supportive capacity signal** ("may benefit from multi-year or capacity support, not avoidance"), not a buyer warning. **No search-results badge** (deliberate — avoids a scarlet-letter effect on real community orgs).

### Verification
- `npx tsc --noEmit` clean · `npx vitest run` 221/221 pass
- MV refreshes `CONCURRENTLY` (unique abn index); registered in both refresh paths (`refresh-views-v2.mjs` Tier 2 + nightly cron `refresh_order`)
- Rendered live across all three tiers: St Vincent's (fragile), Ballarat Red Cross (healthy), CQU (watch) — figures correct and internally consistent ($1.0B income / +$6.2M surplus / 4.7mo reserves for Red Cross)

### Files
- `supabase/migrations/20260609000000_op4_mv_justice_charity_financial_health.sql` — MV + indexes
- `supabase/migrations/20260609010000_cron_refresh_order_add_charity_financial_health.sql` — cron registration
- `apps/web/src/app/social-enterprises/[id]/page.tsx` — Financial Health section
- `scripts/refresh-views-v2.mjs` — refresh registration
- `docs/leverage-map.md` — OP4 entry marked BUILT

🤖 Generated with [Claude Code](https://claude.com/claude-code)
