### PR TITLE
feat(reports): named community-controlled orgs in the deepest funding deserts (OP6)

### DIFF
--- a/apps/web/src/app/api/data/funding-deserts/route.ts
+++ b/apps/web/src/app/api/data/funding-deserts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/supabase';
+import { DESERT_COMMUNITY_ORGS_SQL, mapDesertCommunityOrgs } from '@/lib/funding-deserts';
 
 export const dynamic = 'force-dynamic';
 
@@ -7,7 +8,7 @@ export async function GET() {
   try {
     const supabase = getServiceSupabase();
 
-    const [worstResult, bestResult, remotenessResult, stateResult, summaryResult] = await Promise.all([
+    const [worstResult, bestResult, remotenessResult, stateResult, summaryResult, communityOrgsResult] = await Promise.all([
       // Worst 30 funding deserts (deduplicated by LGA)
       supabase.rpc('exec_sql', {
         query: `SELECT DISTINCT ON (lga_name, state) lga_name, state, remoteness, avg_irsd_decile, avg_irsd_score, indexed_entities, community_controlled_entities, total_funding_all_sources, desert_score FROM mv_funding_deserts WHERE desert_score IS NOT NULL ORDER BY lga_name, state, desert_score DESC`,
@@ -28,6 +29,8 @@ export async function GET() {
       supabase.rpc('exec_sql', {
         query: `WITH deduped AS (SELECT DISTINCT ON (lga_name, state) lga_name, state, remoteness, avg_irsd_decile, indexed_entities, total_funding_all_sources, desert_score FROM mv_funding_deserts WHERE desert_score IS NOT NULL ORDER BY lga_name, state, desert_score DESC) SELECT COUNT(*) as total_lgas, COUNT(CASE WHEN desert_score > 100 THEN 1 END) as severe_deserts, ROUND(AVG(desert_score)::numeric,1) as avg_desert_score, ROUND(MAX(total_funding_all_sources)::numeric,0) as max_funding, ROUND(MIN(CASE WHEN total_funding_all_sources > 0 THEN total_funding_all_sources END)::numeric,0) as min_funding FROM deduped`,
       }),
+      // OP6 — named community-controlled orgs operating in the 100 worst deserts
+      supabase.rpc('exec_sql', { query: DESERT_COMMUNITY_ORGS_SQL }),
     ]);
 
     // Sort worst/best after DISTINCT ON
@@ -44,6 +47,7 @@ export async function GET() {
       byRemoteness: remotenessResult.data || [],
       byState: stateResult.data || [],
       summary: (summaryResult.data as Record<string, unknown>[])?.[0] || {},
+      communityControlledInDeserts: mapDesertCommunityOrgs(communityOrgsResult.data),
     });
   } catch (error) {
     console.error('Funding deserts API error:', error);

--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
+import { DESERT_COMMUNITY_ORGS_SQL, mapDesertCommunityOrgs } from '@/lib/funding-deserts';
 
 export const dynamic = 'force-dynamic';
 
@@ -66,10 +67,11 @@ interface Summary {
   min_funding: number;
 }
 
+
 async function getData() {
   const supabase = getServiceSupabase();
 
-  const [worstResult, bestResult, remotenessResult, stateResult, summaryResult] = await Promise.all([
+  const [worstResult, bestResult, remotenessResult, stateResult, summaryResult, communityOrgsResult, communitySummaryResult] = await Promise.all([
     supabase.rpc('exec_sql', {
       query: `SELECT DISTINCT ON (lga_name, state) lga_name, state, remoteness, avg_irsd_decile, avg_irsd_score, indexed_entities, community_controlled_entities, total_funding_all_sources, desert_score FROM mv_funding_deserts WHERE desert_score IS NOT NULL ORDER BY lga_name, state, desert_score DESC`,
     }),
@@ -84,6 +86,12 @@ async function getData() {
     }),
     supabase.rpc('exec_sql', {
       query: `WITH deduped AS (SELECT DISTINCT ON (lga_name, state) lga_name, state, remoteness, avg_irsd_decile, indexed_entities, total_funding_all_sources, desert_score FROM mv_funding_deserts WHERE desert_score IS NOT NULL ORDER BY lga_name, state, desert_score DESC) SELECT COUNT(*) as total_lgas, COUNT(CASE WHEN desert_score > 100 THEN 1 END) as severe_deserts, ROUND(AVG(desert_score)::numeric,1) as avg_desert_score, ROUND(MAX(total_funding_all_sources)::numeric,0) as max_funding, ROUND(MIN(CASE WHEN total_funding_all_sources > 0 THEN total_funding_all_sources END)::numeric,0) as min_funding FROM deduped`,
+    }),
+    // OP6 — named community-controlled orgs in the 100 worst deserts
+    supabase.rpc('exec_sql', { query: DESERT_COMMUNITY_ORGS_SQL }),
+    // OP6 — coverage summary across the same worst-100 LGAs
+    supabase.rpc('exec_sql', {
+      query: `WITH deserts AS (SELECT DISTINCT ON (lga_name, state) lga_name, state, desert_score, indexed_entities, community_controlled_entities FROM mv_funding_deserts WHERE desert_score IS NOT NULL ORDER BY lga_name, state, desert_score DESC), worst AS (SELECT lga_name, state, desert_score, indexed_entities, community_controlled_entities FROM deserts ORDER BY desert_score DESC LIMIT 100) SELECT SUM(community_controlled_entities) as cc_orgs, COUNT(*) FILTER (WHERE community_controlled_entities > 0) as lgas_with_cc, SUM(indexed_entities) as total_indexed, ROUND(100.0 * SUM(community_controlled_entities) / NULLIF(SUM(indexed_entities), 0), 0) as cc_share FROM worst`,
     }),
   ]);
 
@@ -114,7 +122,17 @@ async function getData() {
     min_funding: Number(summaryRaw.min_funding) || 0,
   };
 
-  return { worst30, best10, worst10, byRemoteness, byState, summary };
+  const communityOrgs = mapDesertCommunityOrgs(communityOrgsResult.data);
+
+  const csRaw = (communitySummaryResult.data as Record<string, unknown>[])?.[0] || {};
+  const communitySummary = {
+    cc_orgs: Number(csRaw.cc_orgs) || communityOrgs.length,
+    lgas_with_cc: Number(csRaw.lgas_with_cc) || 0,
+    cc_share: Number(csRaw.cc_share) || 0,
+    zero_funding_orgs: communityOrgs.filter((o) => o.total_dollar_flow === 0).length,
+  };
+
+  return { worst30, best10, worst10, byRemoteness, byState, summary, communityOrgs, communitySummary };
 }
 
 const REMOTENESS_COLORS: Record<string, string> = {
@@ -266,6 +284,115 @@ export default async function FundingDesertsReport() {
           </a>
         </div>
       </section>
+
+      {/* Section 1b: Community-controlled orgs already in the deepest deserts (OP6) */}
+      {d.communityOrgs.length > 0 && (
+        <section className="mb-12">
+          <div className="text-xs font-black text-bauhaus-red mb-1 uppercase tracking-widest">Community-Controlled Delivery Partners</div>
+          <h2 className="text-xl font-black text-bauhaus-black mb-2 uppercase tracking-widest">
+            Who&apos;s Already There
+          </h2>
+          <p className="text-sm text-bauhaus-muted mb-6 max-w-2xl">
+            The deepest deserts are not empty. Inside the 100 worst-scoring LGAs,{' '}
+            <strong className="text-bauhaus-black">{fmt(d.communitySummary.cc_orgs)} community-controlled organisations</strong> &mdash;
+            locally governed, nearly all of them Aboriginal and Torres Strait Islander corporations &mdash; are already
+            operating in the places the funding system reaches least. They make up{' '}
+            <strong className="text-bauhaus-black">{d.communitySummary.cc_share}%</strong> of every indexed
+            organisation in those LGAs, yet <strong className="text-bauhaus-red">{fmt(d.communitySummary.zero_funding_orgs)} of
+            them run on zero tracked funding</strong>. These are the natural delivery partners for any investment
+            aimed at the hardest-hit communities.
+          </p>
+
+          <div className="grid grid-cols-3 gap-0 mb-6">
+            <div className="border-4 border-bauhaus-black p-5 bg-bauhaus-black text-white">
+              <div className="text-3xl sm:text-4xl font-black">{fmt(d.communitySummary.cc_orgs)}</div>
+              <div className="text-white/60 text-[11px] font-black uppercase tracking-widest mt-2">Community-controlled orgs</div>
+            </div>
+            <div className="border-4 border-l-0 border-bauhaus-black p-5 bg-bauhaus-yellow text-bauhaus-black">
+              <div className="text-3xl sm:text-4xl font-black">{d.communitySummary.cc_share}%</div>
+              <div className="text-bauhaus-black/60 text-[11px] font-black uppercase tracking-widest mt-2">of indexed orgs in these deserts</div>
+            </div>
+            <div className="border-4 border-l-0 border-bauhaus-black p-5 bg-bauhaus-red text-white">
+              <div className="text-3xl sm:text-4xl font-black">{fmt(d.communitySummary.zero_funding_orgs)}</div>
+              <div className="text-white/60 text-[11px] font-black uppercase tracking-widest mt-2">on $0 tracked funding</div>
+            </div>
+          </div>
+
+          <div className="border-4 border-bauhaus-black bg-white overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-bauhaus-black text-white">
+                  <th className="text-left p-3 font-black uppercase tracking-widest text-xs w-8">#</th>
+                  <th className="text-left p-3 font-black uppercase tracking-widest text-xs">Organisation</th>
+                  <th className="text-left p-3 font-black uppercase tracking-widest text-xs">Place</th>
+                  <th className="text-left p-3 font-black uppercase tracking-widest text-xs hidden md:table-cell">Known From</th>
+                  <th className="text-right p-3 font-black uppercase tracking-widest text-xs hidden sm:table-cell">Desert Score</th>
+                  <th className="text-right p-3 font-black uppercase tracking-widest text-xs">Tracked Funding</th>
+                </tr>
+              </thead>
+              <tbody>
+                {d.communityOrgs.map((o, i) => {
+                  const tags = [
+                    o.in_charity_registry ? 'Charity' : null,
+                    o.in_procurement ? 'Contracts' : null,
+                    o.in_justice_funding ? 'Justice' : null,
+                  ].filter(Boolean) as string[];
+                  return (
+                    <tr key={`${o.gs_id ?? o.canonical_name}-${i}`} className={i % 2 === 0 ? 'bg-white' : 'bg-red-50/30'}>
+                      <td className="p-3 font-black text-bauhaus-muted align-top">{i + 1}</td>
+                      <td className="p-3 align-top">
+                        {o.gs_id ? (
+                          <a href={`/entity/${o.gs_id}`} className="font-bold text-bauhaus-black hover:text-bauhaus-blue underline decoration-2 underline-offset-2 decoration-bauhaus-blue/30">
+                            {o.canonical_name}
+                          </a>
+                        ) : (
+                          <span className="font-bold text-bauhaus-black">{o.canonical_name}</span>
+                        )}
+                        {o.entity_type && (
+                          <div className="text-[10px] text-bauhaus-muted uppercase tracking-widest mt-0.5">{o.entity_type}</div>
+                        )}
+                      </td>
+                      <td className="p-3 align-top">
+                        <div className="font-bold text-bauhaus-black text-xs">{o.lga_name}</div>
+                        <div className="text-[10px] text-bauhaus-muted">
+                          {o.state || '—'}{o.remoteness ? ` · ${REMOTENESS_SHORT[o.remoteness] || o.remoteness}` : ''}
+                        </div>
+                      </td>
+                      <td className="p-3 align-top hidden md:table-cell">
+                        {tags.length === 0 ? (
+                          <span className="text-[10px] text-bauhaus-muted font-bold">Registry only</span>
+                        ) : (
+                          <div className="flex flex-wrap gap-1">
+                            {tags.map((t) => (
+                              <span key={t} className="text-[10px] font-black uppercase tracking-widest border-2 border-bauhaus-black px-1.5 py-0.5 bg-bauhaus-canvas">{t}</span>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                      <td className="p-3 text-right font-mono font-black text-bauhaus-red align-top hidden sm:table-cell">
+                        {o.desert_score.toFixed(0)}
+                      </td>
+                      <td className="p-3 text-right font-mono whitespace-nowrap align-top">
+                        {o.total_dollar_flow === 0
+                          ? <span className="text-bauhaus-red font-black">$0</span>
+                          : money(o.total_dollar_flow)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 flex justify-between items-center flex-wrap gap-2">
+            <p className="text-xs text-bauhaus-muted font-bold">
+              Source: CivicGraph Entity Power Index &times; Funding Desert Index. Community-controlled flag from the entity registry.
+            </p>
+            <a href="/api/data/funding-deserts" className="text-xs font-black text-bauhaus-blue uppercase tracking-widest hover:text-bauhaus-red">
+              Full Data (API) &rarr;
+            </a>
+          </div>
+        </section>
+      )}
 
       <ReportCTA reportSlug="funding-deserts" reportTitle="Funding Deserts Geographic Analysis" variant="inline" />
 

--- a/apps/web/src/lib/funding-deserts.ts
+++ b/apps/web/src/lib/funding-deserts.ts
@@ -1,0 +1,55 @@
+// OP6 — the named list of community-controlled orgs operating in the deepest deserts.
+// Shared by /reports/funding-deserts (page) and /api/data/funding-deserts (route) so the
+// two never drift. Sourced from mv_entity_power_index (the same source mv_funding_deserts
+// counts), so this named list reconciles exactly with community_controlled_entities.
+// Joined to the 100 worst-desert LGAs by (lga_name, state).
+
+export interface DesertCommunityOrg {
+  gs_id: string | null;
+  canonical_name: string;
+  entity_type: string | null;
+  abn: string | null;
+  lga_name: string;
+  state: string;
+  remoteness: string;
+  desert_score: number;
+  system_count: number;
+  total_dollar_flow: number;
+  in_procurement: number;
+  in_justice_funding: number;
+  in_charity_registry: number;
+}
+
+export const DESERT_COMMUNITY_ORGS_SQL = `WITH deserts AS (
+  SELECT DISTINCT ON (lga_name, state) lga_name, state, remoteness, desert_score
+  FROM mv_funding_deserts WHERE desert_score IS NOT NULL
+  ORDER BY lga_name, state, desert_score DESC
+), worst AS (
+  SELECT lga_name, state, remoteness, desert_score
+  FROM deserts ORDER BY desert_score DESC LIMIT 100
+)
+SELECT e.gs_id, e.canonical_name, e.entity_type, e.abn, e.lga_name, e.state,
+  w.remoteness, w.desert_score, e.system_count, e.total_dollar_flow,
+  e.in_procurement, e.in_justice_funding, e.in_charity_registry
+FROM mv_entity_power_index e
+JOIN worst w ON e.lga_name = w.lga_name AND e.state = w.state
+WHERE e.is_community_controlled
+ORDER BY w.desert_score DESC, e.total_dollar_flow DESC, e.canonical_name`;
+
+export function mapDesertCommunityOrgs(rows: unknown): DesertCommunityOrg[] {
+  return ((rows || []) as Record<string, unknown>[]).map((o) => ({
+    gs_id: (o.gs_id as string) ?? null,
+    canonical_name: String(o.canonical_name ?? ''),
+    entity_type: (o.entity_type as string) ?? null,
+    abn: (o.abn as string) ?? null,
+    lga_name: String(o.lga_name ?? ''),
+    state: String(o.state ?? ''),
+    remoteness: String(o.remoteness ?? ''),
+    desert_score: Number(o.desert_score) || 0,
+    system_count: Number(o.system_count) || 0,
+    total_dollar_flow: Number(o.total_dollar_flow) || 0,
+    in_procurement: Number(o.in_procurement) || 0,
+    in_justice_funding: Number(o.in_justice_funding) || 0,
+    in_charity_registry: Number(o.in_charity_registry) || 0,
+  }));
+}

--- a/docs/leverage-map.md
+++ b/docs/leverage-map.md
@@ -88,11 +88,19 @@ All three are **evidence-depth** plays — the wedge's stated #1 tie-breaker ("e
   Effort: M. Wedge: **supply-magnet / mission** (not direct revenue).
 
 - **OP6 — Community-controlled orgs in funding deserts (the named list).** Datasets: `mv_funding_deserts`
-  × `gs_entities(is_community_controlled)` via lga. Serves: **G5∩G4**. Why valuable: the worst-100 desert
-  LGAs hold **108 community-controlled orgs** (27% of the 401 indexed orgs there) — the orgs serving the
-  hardest-hit places. The MV has the *counts*; the named-org list for outreach/registry is latent.
-  Evidence: 108 in worst-100 LGAs. State: **partially-built** (counts exist, list latent). Effort: S.
-  Wedge: **supply-magnet / mission**.
+  × `mv_entity_power_index(is_community_controlled)` via (lga_name, state). Serves: **G5∩G4**. Why valuable:
+  the worst-100 desert LGAs hold **102 community-controlled orgs** (re-verified 2026-06-09; the original 108
+  was pre-snapshot) — **29% of the 355 indexed orgs there**, and **101 of the 102 (99%) are Aboriginal &
+  Torres Strait Islander corporations** serving the hardest-hit places. The MV had the *counts*; the named
+  list is now surfaced. **Data note:** the count is sourced from `mv_entity_power_index` (the same source
+  `mv_funding_deserts.community_controlled_entities` aggregates), so the named list reconciles **exactly**
+  with the displayed count (102 = 102). They cluster in just **12 of the worst-100 LGAs** (the other 88 are
+  empty of indexed orgs entirely), and **76 of the 102 run on zero tracked funding**. State: **BUILT
+  2026-06-09** — a "Who's Already There" section on `/reports/funding-deserts` (named, profile-linked via
+  `/entity/{gs_id}`, with Charity/Contracts/Justice evidence tags + tracked-$ flow), and the list exposed on
+  `/api/data/funding-deserts` as `communityControlledInDeserts` (the outreach/registry export the link
+  promises). Shared SQL + mapper in `lib/funding-deserts.ts` keeps page and API in sync. No new MV/migration
+  (the data was latent in existing MVs). Effort: S. Wedge: **supply-magnet / mission**.
 
 - **OP5 — ALMA evidence signals on supplier/entity profiles.** Datasets: `alma_interventions` (inline
   `evidence_strength_signal` + `portfolio_score` + `verification_status`) × `gs_entities` via gs_entity_id.

--- a/thoughts/shared/handoffs/giving-data-commons/current.md
+++ b/thoughts/shared/handoffs/giving-data-commons/current.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-08T19:50:00+10:00
+date: 2026-06-09T06:09:58+10:00
 session_name: giving-data-commons
 branch: main
 status: active
@@ -9,13 +9,25 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-06-08T19:50:00+10:00
+**Updated:** 2026-06-09T06:09:58+10:00
 **Goal:** Buyer wedge: "free open registry for everyone; paid evidence + tender tools for buyers" (`docs/strategy/buyer-wedge.md`). Run `/wedge` before building SE/procurement/giving. Evidence-depth plays are the active focus (widening paused).
-**Branch:** **main** (clean) — PRs #57 (buyer-flow), #58 (OP5), #59 (OP3), #60 (OP1), #61 (OP8) all **MERGED**. HEAD `dd7a687`. Working tree clean except 2 pre-existing untracked data leftovers (`data/grant-eligibility-cache.jsonl`, `data/state-tenders/`). Merged remote branch `feat/op8-indigenous-triple-proof` still on origin (delete = Tier-3).
+**Branch:** **main** (clean) — PRs #57 (buyer-flow), #58 (OP5), #59 (OP3), #60 (OP1), #61 (OP8), #62 (OP4) all **MERGED**. HEAD `37470de`. Working tree clean except 2 pre-existing untracked data leftovers (`data/grant-eligibility-cache.jsonl`, `data/state-tenders/`). OP4 branch deleted (local+remote, ref pruned). Merged remote branch `feat/op8-indigenous-triple-proof` still on origin (delete = Tier-3).
 **Test:** cd apps/web && npx tsc --noEmit && npx vitest run
 
 ### Now
-[->] **Green-wedge premium tier COMPLETE** — both governance-deepened premium plays now shipped: **OP7** (justice triple-proof) + **OP8** (Indigenous triple-proof), on top of the Top-3 (OP3 + OP5 + OP1). Nothing in flight. The buyer-revenue/evidence-depth lane of the leverage map is now exhausted at the top tier. **Remaining candidates are both mission/supply-magnet** (wedge ranks them below the buyer plays just shipped): **OP4** — financial-health signal on the 4,366 justice-funded ACNC charities (flag fragile delivery orgs). **OP6** — funding-desert community-controlled named list (108 orgs in worst-100 LGAs). Plus OP7 follow-up (browsable list for the 558 non-SE triple-proof orgs). Re-run `/leverage` only after new state lands (a refresh of existing MVs doesn't count).
+[->] **OP4 shipped — buyer-revenue lane AND the first mission play now done.** Top-3 (OP3+OP5+OP1) + premium tier (OP7+OP8) + **OP4** (financial-health signal) all merged. Nothing in flight. **Remaining leverage candidates (both mission/supply-magnet):** **OP6** — funding-desert community-controlled named list (108 orgs in worst-100 LGAs; `mv_funding_deserts` has the counts, the named list is latent — effort S). Plus **OP7 follow-up** (browsable list for the 558 non-SE triple-proof orgs). Re-run `/leverage` only after new state lands (a refresh of existing MVs doesn't count).
+
+### This Session (2026-06-09, day) — OP4 shipped & merged (PR #62)
+Ben picked **OP4** (financial-health signal on justice-funded ACNC charities) from the OP4/OP6 remaining fork. Built end-to-end (verify data quality FIRST → build MV → correct a real false-positive → wire UI → verify live across all 3 tiers → ship → merge), Ben merging with an explicit "merge" verb.
+- [x] **OP4 BUILT + MERGED** (PR #62, merge `37470de`) — `mv_justice_charity_financial_health` (**3,996 rows** = the justice recipients that actually filed an ACNC AIS, narrowed from the 4,366 ACNC overlap). Latest-AIS-per-ABN → 4 transparent ratios (surplus margin, current ratio, reserves-runway months, govt-revenue share) + 5 raw flags → `fragility_tier`: **healthy 53% / watch 30% / fragile 13.5% / unknown 3%**. Migrations `20260609000000` (MV + unique abn index, CONCURRENTLY-capable) + `20260609010000` (cron `refresh_order` re-dump) **applied live**; registered in `refresh-views-v2.mjs` Tier 2. Surfaces as a **"Financial Health"** section on `/social-enterprises/[id]`, framed as a supportive **capacity** signal (where multi-year/capacity support may help), **not** a buyer warning. **No search-results badge** (Ben's call via AskUserQuestion — avoids a scarlet-letter effect on real community orgs).
+- **Two data-quality gates were load-bearing** (the "verify before scoring" discipline earned its keep): (1) only **~49%** of these charities file a balance sheet (cash-basis / small-charity exempt) → `low_liquidity` is **NULL-when-unknown, never inferred false**. (2) **Reserves-runway is the master solvency signal** — the first cut flagged Monash/RMIT/Deakin as "fragile" purely on current-ratio <1, but they hold **20+ months of reserves** (unis run on non-current assets + deferred revenue). Fixed so strong reserves override a weak current ratio; QUT (0.02 months reserves) correctly stays fragile, Sydney/UQ/ANU are healthy.
+- Verified live across all 3 tiers: St Vincent's (fragile), Ballarat Red Cross / Australian Red Cross Society (healthy — $1.0B income / +$6.2M surplus / 4.7mo reserves, internally consistent), CQU (watch). Gates green throughout (tsc 0, **221/221 tests**). Commit `163acaf`. Leverage map: OP4 marked BUILT.
+
+### This Session (2026-06-09, cross-repo) — JusticeHub Civic Scope detour (NO grantscope change)
+This session ran entirely in **`/Users/benknight/Code/JusticeHub`**, not grantscope. **grantscope state is unchanged** — main still at `dd7a687`, tree clean except the 2 pre-existing untracked data leftovers, tsc 0. Nothing in the buyer-wedge/leverage-map plan moved. Logged here only so the next grantscope session doesn't mistake a clean tree for skipped work.
+- [x] **JusticeHub SA Civic Scope loop run + applied.** Ran the read-only report loop (Adelaide launch queue, civic data backlog) + the SA Tier-1 curation dry-run (11 candidates, 1 strong). Ben applied `propose-sa-tier1-curation-candidates.mjs --apply --yes-production` himself via `!` → **10 proposal rows upserted into JusticeHub's `civic_org_classifications`** (1 existing skipped). Verified persisted (dry-run rerun: existing rows 1 → 11; idempotent). `type-check:search-and-chat` clean. Rows are review candidates only — Tier-1 confirmation still happens by hand in JusticeHub `/admin/civic/tier-1-curation`.
+- [x] **Handed back to JusticeHub** for the "Contained" remand-tour launch (branch `codex/remand-contained-live`, 23-file dirty tree). Handoff: `JusticeHub/thoughts/shared/handoffs/general/2026-06-09... ` → actual file `2026-06-08_20-06_contained-launch-handback-claude-code.yaml` (uncommitted in JusticeHub). It flags the undocumented intent behind the dirty tree + 3 questions for Ben (which Contained surface is the launch priority; commit-as-is vs WIP-reset; is the +268-line `alma/data-sprint` cron change even part of Contained).
+- **Caveat carried forward:** JusticeHub has **no `/resume_handoff` slash command** — its handoffs are read directly. (Does not affect grantscope.)
 
 ### This Session (2026-06-08, night cont.2) — OP8 shipped & merged (PR #61)
 Ben picked OP8 (Indigenous triple-proof) from the OP4/OP6/OP8 fork — the most wedge-aligned (green/buyer-revenue, lowest effort, composes onto the OP1 work just shipped). Built end-to-end (build → apply live → verify all 3 surfaces → ship → CI-green → merge), Ben merging with an explicit "merge" verb.
@@ -86,12 +98,11 @@ Executed `thoughts/shared/plans/buyer-flow-ux-audit.md`. Found the prior session
 - [x] All work committed + pushed: `b9bcb38` enrich-fix · `015365c` health-backlog · `75eb951` leverage skill · `b0330a1` health iter6 · `ed8a767` CLAUDE fix · `33c1e2d` leverage map.
 
 ### Next on resume (priority order)
-> All Top-3 + both premium plays now merged: **OP3 ✅ OP5 ✅ OP1 ✅ OP7 ✅ OP8 ✅.** The green-wedge/evidence-depth top tier is exhausted. Tree clean on `main`. Remaining leverage candidates are mission/supply-magnet (wedge ranks below the buyer plays). **Re-run `/leverage` only after new state lands.**
-1. (Backlog) **OP4** — financial-health signal on justice-funded charities (4,366 ACNC/AIS matches; flag financially-fragile delivery orgs). Supply-magnet/mission, not direct revenue. M. New MV + new surface (NOT just a badge). See `docs/leverage-map.md`.
-2. (Backlog) **OP6** — funding-desert community-controlled named list (108 orgs in worst-100 desert LGAs; counts exist in `mv_funding_deserts`, named list latent). Mission. S. · **OP7 follow-up** — browsable buyer list for the 558 non-SE triple-proof orgs.
-3. (Backlog) Enrichment-fleet timeout fixes (`docs/health-backlog.md`) — several agents at single-digit success.
-4. (Housekeeping, Tier-3) Delete merged remote branch `feat/op8-indigenous-triple-proof` (still on origin) — and sweep for any other stale merged branches.
-5. (Housekeeping) Decide on the 2 untracked data leftovers (`data/grant-eligibility-cache.jsonl`, `data/state-tenders/`) — gitignore, commit, or bin.
+> Top-3 + both premium plays + the first mission play now merged: **OP3 ✅ OP5 ✅ OP1 ✅ OP7 ✅ OP8 ✅ OP4 ✅.** The green-wedge/evidence-depth top tier is exhausted. Tree clean on `main`. Remaining leverage candidates are mission/supply-magnet (wedge ranks below the buyer plays). **Re-run `/leverage` only after new state lands.**
+1. (Backlog) **OP6** — funding-desert community-controlled named list (108 orgs in worst-100 desert LGAs; counts exist in `mv_funding_deserts`, named list latent). Mission. S. · **OP7 follow-up** — browsable buyer list for the 558 non-SE triple-proof orgs.
+2. (Backlog) Enrichment-fleet timeout fixes (`docs/health-backlog.md`) — several agents at single-digit success.
+3. (Housekeeping, Tier-3) Delete merged remote branch `feat/op8-indigenous-triple-proof` (still on origin) — and sweep for any other stale merged branches.
+4. (Housekeeping) Decide on the 2 untracked data leftovers (`data/grant-eligibility-cache.jsonl`, `data/state-tenders/`) — gitignore, commit, or bin.
 
 ### PRIOR SESSION (loop infrastructure — context, still valid)
 


### PR DESCRIPTION
## OP6 — Community-controlled orgs in the deepest funding deserts (the named list)

The last open leverage candidate. A **supply-magnet / mission** play: turn the latent *count* of community-controlled orgs in the worst funding deserts into a **named, profile-linked, exportable list** — the orgs already serving the hardest-hit places, the natural delivery partners for any investment aimed there.

### What it surfaces (all re-verified live 2026-06-09)
- The **worst-100 desert LGAs hold 102 community-controlled orgs** — **29% of the 355 indexed orgs** there (more than 1 in 4).
- **101 of the 102 (99%)** are Aboriginal & Torres Strait Islander corporations.
- They cluster in just **12 of the worst-100 LGAs** (the other 88 are empty of indexed orgs entirely).
- **76 of the 102 run on zero tracked funding.**

### How it's built
- **No new MV/migration** — the data was latent in existing views.
- Sourced from `mv_entity_power_index`, the **same source** `mv_funding_deserts.community_controlled_entities` aggregates, so the named list reconciles **exactly** with the displayed count (102 = 102). Joined to the worst-100 LGAs by `(lga_name, state)`.

### Changes
- **`lib/funding-deserts.ts`** (new): shared `DESERT_COMMUNITY_ORGS_SQL` + mapper so the page and API never drift.
- **`/reports/funding-deserts`**: new "Who's Already There" section — 3 stat cards (102 / 29% / 76) + named table (profile link via `/entity/{gs_id}`, Charity/Contracts/Justice evidence tags, tracked-$ flow with `$0` in red).
- **`/api/data/funding-deserts`**: list exposed as `communityControlledInDeserts` (the outreach/registry export the "Full Data (API)" link promises).
- **`docs/leverage-map.md`**: OP6 → BUILT (figures re-verified live; original 108 was pre-snapshot, now 102).

### Verification
- `npx tsc --noEmit` clean · `npx vitest run` **221/221** pass
- Live page section renders (heading, stat cards, 102 named rows, evidence tags); profile links resolve (HTTP 200)
- Live API returns all 102 with full fields
- All figures reconcile against the live DB

> With OP6 shipped, the leverage estate is mined out — all OPs (OP1–OP10) now built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
