### PR TITLE
funding-deserts follow-ups: state backfill + OP6 label/copy polish

### DIFF
--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -29,6 +29,22 @@ function money(n: number): string {
 }
 function fmt(n: number): string { return n.toLocaleString(); }
 
+// Human-readable entity-type labels (raw values are lower_snake enums).
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  indigenous_corp: 'Indigenous Corporation',
+  social_enterprise: 'Social Enterprise',
+  charity: 'Charity',
+  foundation: 'Foundation',
+  company: 'Company',
+  nonprofit: 'Nonprofit',
+  cooperative: 'Cooperative',
+  government: 'Government',
+};
+function entityTypeLabel(t: string): string {
+  return ENTITY_TYPE_LABELS[t.toLowerCase()]
+    ?? t.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 interface DesertLGA {
   lga_name: string;
   state: string;
@@ -349,7 +365,7 @@ export default async function FundingDesertsReport() {
                           <span className="font-bold text-bauhaus-black">{o.canonical_name}</span>
                         )}
                         {o.entity_type && (
-                          <div className="text-[10px] text-bauhaus-muted uppercase tracking-widest mt-0.5">{o.entity_type}</div>
+                          <div className="text-[10px] text-bauhaus-muted tracking-wide mt-0.5">{entityTypeLabel(o.entity_type)}</div>
                         )}
                       </td>
                       <td className="p-3 align-top">

--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -311,7 +311,7 @@ export default async function FundingDesertsReport() {
           <p className="text-sm text-bauhaus-muted mb-6 max-w-2xl">
             The deepest deserts are not empty. Inside the 100 worst-scoring LGAs,{' '}
             <strong className="text-bauhaus-black">{fmt(d.communitySummary.cc_orgs)} community-controlled organisations</strong> &mdash;
-            locally governed, nearly all of them Aboriginal and Torres Strait Islander corporations &mdash; are already
+            locally governed, the overwhelming majority of them Aboriginal and Torres Strait Islander corporations &mdash; are already
             operating in the places the funding system reaches least. They make up{' '}
             <strong className="text-bauhaus-black">{d.communitySummary.cc_share}%</strong> of every indexed
             organisation in those LGAs, yet <strong className="text-bauhaus-red">{fmt(d.communitySummary.zero_funding_orgs)} of

--- a/docs/leverage-map.md
+++ b/docs/leverage-map.md
@@ -89,18 +89,23 @@ All three are **evidence-depth** plays — the wedge's stated #1 tie-breaker ("e
 
 - **OP6 — Community-controlled orgs in funding deserts (the named list).** Datasets: `mv_funding_deserts`
   × `mv_entity_power_index(is_community_controlled)` via (lga_name, state). Serves: **G5∩G4**. Why valuable:
-  the worst-100 desert LGAs hold **102 community-controlled orgs** (re-verified 2026-06-09; the original 108
-  was pre-snapshot) — **29% of the 355 indexed orgs there**, and **101 of the 102 (99%) are Aboriginal &
-  Torres Strait Islander corporations** serving the hardest-hit places. The MV had the *counts*; the named
-  list is now surfaced. **Data note:** the count is sourced from `mv_entity_power_index` (the same source
-  `mv_funding_deserts.community_controlled_entities` aggregates), so the named list reconciles **exactly**
-  with the displayed count (102 = 102). They cluster in just **12 of the worst-100 LGAs** (the other 88 are
-  empty of indexed orgs entirely), and **76 of the 102 run on zero tracked funding**. State: **BUILT
+  the worst-100 desert LGAs hold **565 community-controlled orgs** — **12% of the 4,672 indexed orgs there**,
+  **514 of 565 (91%) Aboriginal & Torres Strait Islander corporations**, across **56 LGAs**, and **314 of the
+  565 run on zero tracked funding** — the orgs serving the hardest-hit places. The MV had the *counts*; the
+  named list is now surfaced. **Data note:** the count is sourced from `mv_entity_power_index` (the same source
+  `mv_funding_deserts.community_controlled_entities` aggregates), so the named list reconciles **exactly** with
+  the displayed count (565 = 565). **Figures revised 2026-06-09 (was 102 / 29% / 12 LGAs):** the
+  `postcode_geo.state` backfill (migration `20260609020000`) filled 227 blank-state LGAs and collapsed the
+  phantom zero-entity splits that had padded the old worst-100 — the corrected worst-100 is now real desert
+  LGAs that actually have orgs, so the count rose and the share fell to the true 12%. State: **BUILT
   2026-06-09** — a "Who's Already There" section on `/reports/funding-deserts` (named, profile-linked via
   `/entity/{gs_id}`, with Charity/Contracts/Justice evidence tags + tracked-$ flow), and the list exposed on
   `/api/data/funding-deserts` as `communityControlledInDeserts` (the outreach/registry export the link
   promises). Shared SQL + mapper in `lib/funding-deserts.ts` keeps page and API in sync. No new MV/migration
-  (the data was latent in existing MVs). Effort: S. Wedge: **supply-magnet / mission**.
+  for OP6 itself (the data was latent in existing MVs). Effort: S. Wedge: **supply-magnet / mission**.
+  **Known residual:** ~130 border-LGA state contradictions (e.g. Laverton entities coded NT vs lga_code WA)
+  remain — fixing them safely needs a coordinated `gs_entities.state` fix (~7K rows) + `mv_entity_power_index`
+  refresh (deferred — app-wide state blast radius).
 
 - **OP5 — ALMA evidence signals on supplier/entity profiles.** Datasets: `alma_interventions` (inline
   `evidence_strength_signal` + `portfolio_score` + `verification_status`) × `gs_entities` via gs_entity_id.

--- a/supabase/migrations/20260609020000_backfill_postcode_geo_state_nulls.sql
+++ b/supabase/migrations/20260609020000_backfill_postcode_geo_state_nulls.sql
@@ -1,0 +1,37 @@
+-- Backfill postcode_geo.state from the authoritative ABS lga_code (first digit = state)
+-- for rows where state is currently NULL/empty.
+--
+-- Why: the funding-deserts report showed 227 LGAs (39% of rows) as state "Unknown".
+-- All 227 are zero-entity LGAs whose state comes only from postcode_geo, where state
+-- was null for ~9% of postcodes. The ABS lga_code first digit encodes the state and is
+-- 99.97% populated and reliable, so it is the correct source of truth.
+--
+-- Effect: fills the 227 "Unknown" desert rows and collapses the blank-state phantom
+-- splits (e.g. a ghost "Barkly / blank / 0 entities / score 190" merges into the real
+-- "Barkly / NT / 33 entities" row), correcting the worst-deserts ranking.
+--
+-- Scope: NULLs only, lga_codes 1-8 (NSW VIC QLD SA WA TAS NT ACT). Deliberately NOT
+-- touching rows where state is already populated. Border-LGA contradiction corrections
+-- (e.g. Laverton coded NT but lga_code 54970 = WA) are deferred: correcting them safely
+-- also requires a coordinated gs_entities.state fix (~7K rows) + an mv_entity_power_index
+-- refresh, or the FULL JOIN in mv_funding_deserts would create new phantom rows. Tracked
+-- as a separate follow-up.
+
+UPDATE postcode_geo
+SET state = CASE LEFT(lga_code, 1)
+    WHEN '1' THEN 'NSW'
+    WHEN '2' THEN 'VIC'
+    WHEN '3' THEN 'QLD'
+    WHEN '4' THEN 'SA'
+    WHEN '5' THEN 'WA'
+    WHEN '6' THEN 'TAS'
+    WHEN '7' THEN 'NT'
+    WHEN '8' THEN 'ACT'
+  END
+WHERE (state IS NULL OR state = '')
+  AND lga_code ~ '^[1-8]';
+
+-- Refresh the two MVs that read postcode_geo (non-concurrent: mv_funding_deserts has
+-- known duplicate-key constraints and must refresh non-concurrently).
+REFRESH MATERIALIZED VIEW mv_funding_by_postcode;
+REFRESH MATERIALIZED VIEW mv_funding_deserts;


### PR DESCRIPTION
Follow-ups to OP6 (PR #63), all on the `/reports/funding-deserts` surface.

### 1. `postcode_geo.state` backfill (the "Unknown" bug)
The report showed **227 LGAs (39%) as state "Unknown"** and a phantom #1 desert (a blank-state "Barkly / 0 entities" ghost outranking the real "Barkly / NT / 33 entities"). Root cause: the MV keyed LGAs on `postcode_geo.state`, which was null for ~9% of postcodes. Fix: backfill `state` from the authoritative ABS `lga_code` (first digit = state, 99.97% populated).
- Migration `20260609020000`: UPDATE 1,071 null rows (codes 1-8) + refresh `mv_funding_by_postcode` + `mv_funding_deserts`.
- **Result (verified live):** 227 Unknowns → **0**; phantom splits collapsed; worst-deserts ranking corrected (all real LGAs/states).

### 2. OP6 figures corrected (knock-on)
The corrected worst-100 is now real desert LGAs, not phantoms, so OP6's headline moves **102/29% → 565/12%** (565 community-controlled orgs, 91% Indigenous, 314 on zero funding). Page computes live; copy softened **"nearly all" → "the overwhelming majority"** (accurate at 91%). leverage-map OP6 updated.

### 3. Entity-type label polish
Title-cased the type subtitle (`Indigenous Corporation` / `Social Enterprise` / …) instead of the raw `lower_snake` enum.

### Deferred (flagged, not done)
~130 border-LGA **state contradictions** (e.g. Laverton entities coded NT vs lga_code WA) need a coordinated `gs_entities.state` fix (~7K rows) + `mv_entity_power_index` refresh — app-wide state blast radius, so left for a separate scoped decision.

`tsc` clean · 221/221 tests (unchanged) · verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
