### PR TITLE
fix(classify-acnc): repoint execute_sql RPC onto canonical exec_sql

### DIFF
--- a/scripts/classify-acnc-social-enterprises.mjs
+++ b/scripts/classify-acnc-social-enterprises.mjs
@@ -263,7 +263,7 @@ async function main() {
   try {
     // Fetch charities not already in social_enterprises
     const { data: charities, error: fetchErr } = await supabase
-      .rpc('execute_sql', {
+      .rpc('exec_sql', {
         query: `
           SELECT c.abn, c.name, c.purposes, c.beneficiaries, c.charity_size, c.state, c.postcode
           FROM acnc_charities c
@@ -280,7 +280,7 @@ async function main() {
         `,
       });
 
-    // Fallback: if execute_sql RPC doesn't exist, use supabase-js query
+    // Fallback: if exec_sql RPC errors, use supabase-js query
     let rows;
     if (fetchErr || !charities) {
       log(`RPC not available (${fetchErr?.message || 'no data'}), using supabase-js query`);


### PR DESCRIPTION
execute_sql(sql_query text) was dropped from the shared DB (ACT migration 20260616010000)
during arbitrary-SQL helper consolidation. This call passed param `query` (mismatched vs
`sql_query`) so it always errored and fell back anyway; repoint to exec_sql(query text)
(param-compatible, SETOF json -> row array) so it uses the fast server-side path. Behaviour-
neutral if it ever still falls back. Needs redeploy of the grantscope orchestrator.
