### PR TITLE
fix: stop two failing /health agents (scraper hang + removed Notion property)

### DIFF
--- a/scripts/enrich-charities.mjs
+++ b/scripts/enrich-charities.mjs
@@ -44,6 +44,12 @@ const PREFERRED_PROVIDER = process.argv.find(a => a.startsWith('--provider='))?.
 const sizeArg = process.argv.find(a => a.startsWith('--size='));
 const SIZE_FILTER = sizeArg ? sizeArg.split('=')[1] : null;
 
+// Hard cap per-charity scrape: r.jina.ai can hang past the scraper's 15s-per-fetch
+// bound, and one unresponsive site otherwise consumes the whole 600s orchestrator run.
+const SCRAPE_TIMEOUT_MS = 30_000;
+// Stop launching new batches before the 600s SIGKILL so we can log a real completion.
+const RUN_BUDGET_MS = 540_000;
+
 if (!SUPABASE_URL || !SUPABASE_KEY) {
   console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
   process.exit(1);
@@ -298,6 +304,22 @@ async function getCharitiesToEnrichFallback() {
     .slice(0, LIMIT);
 }
 
+const EMPTY_SCRAPE = { websiteContent: null, aboutContent: null, programsContent: null, annualReportContent: null, scrapedUrls: [], errors: [] };
+
+// Race a scrape against a deadline; on timeout, return an empty scrape so the
+// caller's "insufficient content" path skips it gracefully instead of hanging.
+function withTimeout(promise, ms, onTimeout) {
+  let timer;
+  const guard = new Promise((resolve) => {
+    timer = setTimeout(() => resolve({ __timedOut: true }), ms);
+  });
+  promise.catch(() => {});
+  return Promise.race([promise, guard]).then((result) => {
+    clearTimeout(timer);
+    return (result && result.__timedOut) ? onTimeout() : result;
+  });
+}
+
 async function enrichOne(charity, scraper, index, total) {
   const name = charity.name;
   const website = charity.website;
@@ -311,7 +333,14 @@ async function enrichOne(charity, scraper, index, total) {
 
   try {
     // Step 1: Scrape website
-    const scraped = await scraper.scrapeFoundation(website);
+    const scraped = await withTimeout(
+      scraper.scrapeFoundation(website),
+      SCRAPE_TIMEOUT_MS,
+      () => {
+        log(`    Scrape timed out after ${SCRAPE_TIMEOUT_MS / 1000}s — skipping`);
+        return { ...EMPTY_SCRAPE };
+      }
+    );
     log(`    Scraped ${scraped.scrapedUrls.length} pages`);
 
     const webContent = [
@@ -421,8 +450,15 @@ async function main() {
   let errors = 0;
   let processed = 0;
 
-  // Process in parallel batches
+  // Process in parallel batches, stopping before the orchestrator timeout.
+  const t0 = Date.now();
+  let stoppedEarly = false;
   for (let i = 0; i < charities.length; i += CONCURRENCY) {
+    if (Date.now() - t0 > RUN_BUDGET_MS) {
+      stoppedEarly = true;
+      log(`  Time budget (${RUN_BUDGET_MS / 1000}s) reached — stopping after ${processed}/${charities.length}. Rest picked up next run.`);
+      break;
+    }
     const batch = charities.slice(i, i + CONCURRENCY);
     const results = await Promise.allSettled(
       batch.map((c, j) => enrichOne(c, scraper, i + j + 1, charities.length))
@@ -451,7 +487,10 @@ async function main() {
     errors: errors > 0 ? [`${errors} charity enrichment errors`] : [],
   });
 
-  log(`\nComplete: ${enriched} enriched, ${noContent} no content, ${noDescription} no description, ${errors} errors out of ${charities.length}`);
+  log(`\nComplete: ${enriched} enriched, ${noContent} no content, ${noDescription} no description, ${errors} errors out of ${processed}/${charities.length}${stoppedEarly ? ' (stopped at time budget)' : ''}`);
+
+  // Timed-out scrapes leave orphaned fetches pending; exit cleanly so the run ends.
+  process.exit(0);
 }
 
 main().catch(err => {

--- a/scripts/reprofile-missing-descriptions.mjs
+++ b/scripts/reprofile-missing-descriptions.mjs
@@ -35,6 +35,13 @@ const LIMIT = limitArg ? parseInt(limitArg.split('=')[1], 10) : 50;
 const concurrencyArg = process.argv.find(a => a.startsWith('--concurrency='));
 const CONCURRENCY = concurrencyArg ? parseInt(concurrencyArg.split('=')[1], 10) : 3;
 
+// Hard cap per-foundation scrape: r.jina.ai can hang well past the scraper's own
+// 15s-per-fetch bound (one unresponsive site otherwise consumes the whole run).
+const SCRAPE_TIMEOUT_MS = 30_000;
+// Stop launching new batches before the orchestrator's 600s SIGKILL so we can log
+// a real completion (the old behaviour was timed_out/duration_ms=0 on every run).
+const RUN_BUDGET_MS = 540_000;
+
 if (!SUPABASE_URL || !SUPABASE_KEY) {
   console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
   process.exit(1);
@@ -44,6 +51,22 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 function log(msg) {
   console.log(`[reprofile] ${msg}`);
+}
+
+const EMPTY_SCRAPE = { websiteContent: null, aboutContent: null, programsContent: null, annualReportContent: null, scrapedUrls: [], errors: [] };
+
+// Race a promise against a deadline; on timeout, call onTimeout() for a fallback
+// value instead of hanging. Swallows the loser's late settle to avoid noise.
+function withTimeout(promise, ms, onTimeout) {
+  let timer;
+  const guard = new Promise((resolve) => {
+    timer = setTimeout(() => resolve({ __timedOut: true }), ms);
+  });
+  promise.catch(() => {});
+  return Promise.race([promise, guard]).then((result) => {
+    clearTimeout(timer);
+    return (result && result.__timedOut) ? onTimeout() : result;
+  });
 }
 
 async function getFoundationsToReprofile() {
@@ -94,7 +117,14 @@ async function reprofileOne(foundation, scraper, profiler, index, total) {
       if (!website) log(`    No website — relying on LLM web search/knowledge`);
       else log(`    Skipping scrape — using LLM web search/knowledge only`);
     } else {
-      scraped = await scraper.scrapeFoundation(website);
+      scraped = await withTimeout(
+        scraper.scrapeFoundation(website),
+        SCRAPE_TIMEOUT_MS,
+        () => {
+          log(`    Scrape timed out after ${SCRAPE_TIMEOUT_MS / 1000}s — falling back to LLM-only`);
+          return { ...EMPTY_SCRAPE };
+        }
+      );
       log(`    Scraped ${scraped.scrapedUrls.length} pages`);
       if (scraped.errors.length > 0) {
         log(`    ${scraped.errors.length} scrape errors`);
@@ -201,8 +231,15 @@ async function main() {
   let errors = 0;
   let processed = 0;
 
-  // Process in parallel batches
+  // Process in parallel batches, stopping before the orchestrator timeout.
+  const t0 = Date.now();
+  let stoppedEarly = false;
   for (let i = 0; i < foundations.length; i += CONCURRENCY) {
+    if (Date.now() - t0 > RUN_BUDGET_MS) {
+      stoppedEarly = true;
+      log(`  Time budget (${RUN_BUDGET_MS / 1000}s) reached — stopping after ${processed}/${foundations.length}. Rest picked up next run.`);
+      break;
+    }
     const batch = foundations.slice(i, i + CONCURRENCY);
     const results = await Promise.allSettled(
       batch.map((f, j) => reprofileOne(f, scraper, profiler, i + j + 1, foundations.length))
@@ -228,7 +265,10 @@ async function main() {
     items_updated: 0,
   });
 
-  log(`\nComplete: ${profiled} profiled, ${noDescription} still no description, ${errors} errors out of ${foundations.length}`);
+  log(`\nComplete: ${profiled} profiled, ${noDescription} still no description, ${errors} errors out of ${processed}/${foundations.length}${stoppedEarly ? ' (stopped at time budget)' : ''}`);
+
+  // Timed-out scrapes leave orphaned fetches pending; exit cleanly so the run ends.
+  process.exit(0);
 }
 
 main().catch(err => {

--- a/scripts/sync-pipeline-to-notion.mjs
+++ b/scripts/sync-pipeline-to-notion.mjs
@@ -170,7 +170,8 @@ async function syncPipeline(userId) {
           'Amount': numberProp(grant.amount_max || grant.amount_min),
           'Deadline': dateProp(grant.closes_at),
           'Funder': textProp(grant.provider),
-          'Stars': numberProp(item.stars || 0),
+          // 'Stars' was removed from the Grant Pipeline Tracker schema; writing it
+          // 400s the whole sync. (Foundation Targets still has Stars — kept below.)
           'Notes': textProp(notesWithId),
           'Key Requirements': textProp(
             (grant.categories || []).concat(grant.focus_areas || []).join(', ')


### PR DESCRIPTION
Fixes two of the agents flagged as failing in the `/health` dashboard. Root-caused, fixed, and verified individually.

## 1. Enrichment scraper hang (`7170cca`)
`reprofile-missing-descriptions` (9% success) and `enrich-charities` (14% success) scrape via `FoundationScraper` over the `r.jina.ai` reader proxy, which can hang **past** the scraper's own 15s-per-fetch bound. With no per-site timeout, a single unresponsive website consumed the entire 600s orchestrator budget → SIGKILL before `logComplete` → `timed_out` / `duration_ms=0` on **every** run, 0 rows enriched. This was the mechanism behind the stalled description/website coverage backfill.

- **30s hard scrape timeout per site** (`Promise.race`). `reprofile` falls back to LLM-only profiling; `enrich-charities` skips via its existing insufficient-content path.
- **540s wall-clock budget** stops launching new batches before the 600s SIGKILL, so the run logs a real completion and resumes the backlog next run.
- **`process.exit(0)`** after `logComplete` so orphaned (timed-out) fetches don't keep node alive.

Verified: `reprofile` was hanging 180s+ on a single foundation → now **2 profiled with descriptions in 87s, 0 errors, clean exit**. (`r.jina.ai` is currently hanging for every site, so the LLM fallback is what's filling descriptions — the intended resilience.)

## 2. Notion sync removed-property 400 (`6248392`)
`sync-pipeline-to-notion` (0% success, 13 runs) wrote a `Stars` property to the **Grant Pipeline Tracker**, but that property was removed from the Notion schema → `400 "Stars is not a property that exists"` failed the whole sync.

- Verified against the **live Notion schema**: every other pipeline property exists; the nearest field (`Readiness Score`, a 0–100 %) is semantically distinct from a star rating, so `Stars` is **dropped**, not remapped.
- **Foundation Targets** still has a `Stars` property, so that block is unchanged.

### Not in this PR (follow-ups)
- The Notion agent is `enabled = false` in `agent_schedules`, so it won't auto-fire. Before it's run for real it needs a **per-run cap / active-stage filter** — a full sync would create ~1,480 pages (1,361 grants + 119 foundations), which isn't a curated pipeline.
- Still failing per `/health`: Poll Foundation Frontier (external 403/404 source rot), Enrich Social Enterprises (same scraper), Refresh Youth Justice Source Chain (child exit 1), Trust Remediation Loop (likely mislabeled `running`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)