### PR TITLE
fix(yj-trackers): retry transient pooler failures in tracker refresh chain

### DIFF
--- a/scripts/run-tracker-refresh.mjs
+++ b/scripts/run-tracker-refresh.mjs
@@ -28,6 +28,34 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 
 const db = createClient(SUPABASE_URL, SUPABASE_KEY);
 
+// Retry transient pooler/connection failures (the shared Supabase saturates during the
+// nightly batch). Retries network throws and transient error VALUES; non-transient
+// errors pass through to the caller's existing handling.
+function isTransientDbError(message) {
+  return /fetch failed|ECONNRESET|ETIMEDOUT|timeout|schema cache|EPIPE|socket hang up|503|terminating connection|too many (clients|connections)|Connection terminated|deadlock|ECONNREFUSED/i.test(String(message || ''));
+}
+
+async function withRetry(fn, label, tries = 4, baseDelayMs = 1500) {
+  let lastResult;
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    try {
+      lastResult = await fn();
+      if (!(lastResult && lastResult.error && isTransientDbError(lastResult.error.message))) {
+        return lastResult;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!isTransientDbError(message) || attempt === tries) throw err;
+      lastResult = { data: null, error: { message } };
+    }
+    if (attempt === tries) return lastResult;
+    const delay = baseDelayMs * attempt;
+    console.error(`[run-tracker-refresh] ${label}: transient DB failure (attempt ${attempt}/${tries}): ${lastResult?.error?.message} — retrying in ${delay}ms`);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  return lastResult;
+}
+
 function runSync() {
   const result = spawnSync('node', ['--env-file=.env', 'scripts/sync-tracker-evidence.mjs'], {
     cwd: process.cwd(),
@@ -64,7 +92,7 @@ async function main() {
     ORDER BY jurisdiction, latest_event_date DESC NULLS LAST, tracker_key
   `;
 
-  const { data, error } = await db.rpc('exec_sql', { query });
+  const { data, error } = await withRetry(() => db.rpc('exec_sql', { query }), 'summary query');
   if (error) {
     console.error('[run-tracker-refresh] Summary query failed:', error.message);
     process.exit(1);
@@ -125,8 +153,8 @@ async function main() {
   `;
 
   const [{ data: siteRows, error: siteError }, { data: previousSnapshots, error: previousError }] = await Promise.all([
-    db.rpc('exec_sql', { query: siteQuery }),
-    db.rpc('exec_sql', { query: previousSnapshotQuery }),
+    withRetry(() => db.rpc('exec_sql', { query: siteQuery }), 'site query'),
+    withRetry(() => db.rpc('exec_sql', { query: previousSnapshotQuery }), 'previous snapshot query'),
   ]);
   if (siteError) {
     console.error('[run-tracker-refresh] Site summary query failed:', siteError.message);
@@ -170,7 +198,7 @@ async function main() {
   });
 
   if (snapshotRows.length > 0) {
-    const { error: insertError } = await db.from('tracker_site_snapshots').insert(snapshotRows);
+    const { error: insertError } = await withRetry(() => db.from('tracker_site_snapshots').insert(snapshotRows), 'snapshot insert');
     if (insertError) {
       console.error('[run-tracker-refresh] Snapshot insert failed:', insertError.message);
       process.exit(1);

--- a/scripts/sync-tracker-evidence.mjs
+++ b/scripts/sync-tracker-evidence.mjs
@@ -282,14 +282,44 @@ async function fetchSourceMetadata(event) {
   }
 }
 
+// The shared Supabase pooler saturates during the nightly orchestrator batch, so DB
+// calls sporadically throw `fetch failed` / schema-cache errors. Without resilience a
+// single hiccup killed the whole tracker chain (this agent read ~6% success while
+// running clean standalone). Retry transient connection failures — both network throws
+// and transient error VALUES — and let non-transient errors pass through unchanged.
+function isTransientDbError(message) {
+  return /fetch failed|ECONNRESET|ETIMEDOUT|timeout|schema cache|EPIPE|socket hang up|503|terminating connection|too many (clients|connections)|Connection terminated|deadlock|ECONNREFUSED/i.test(String(message || ''));
+}
+
+async function withRetry(fn, label, tries = 4, baseDelayMs = 1500) {
+  let lastResult;
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    try {
+      lastResult = await fn();
+      if (!(lastResult && lastResult.error && isTransientDbError(lastResult.error.message))) {
+        return lastResult;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!isTransientDbError(message) || attempt === tries) throw err;
+      lastResult = { data: null, error: { message } };
+    }
+    if (attempt === tries) return lastResult;
+    const delay = baseDelayMs * attempt;
+    console.error(`[sync-tracker-evidence] ${label}: transient DB failure (attempt ${attempt}/${tries}): ${lastResult?.error?.message} — retrying in ${delay}ms`);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  return lastResult;
+}
+
 async function selectOne(query) {
-  const { data, error } = await db.rpc('exec_sql', { query });
+  const { data, error } = await withRetry(() => db.rpc('exec_sql', { query }), 'selectOne');
   if (error) throw new Error(error.message);
   return data?.[0] ?? {};
 }
 
 async function selectRows(query) {
-  const { data, error } = await db.rpc('exec_sql', { query });
+  const { data, error } = await withRetry(() => db.rpc('exec_sql', { query }), 'selectRows');
   if (error) throw new Error(error.message);
   return data ?? [];
 }
@@ -844,19 +874,25 @@ async function syncConfig(config) {
     return { tracker: config.tracker_key, rows: payload.length, inserted: 0, updated: 0, payload };
   }
 
-  const { data: beforeRows } = await db
-    .from('tracker_evidence_events')
-    .select('id')
-    .eq('domain', config.domain)
-    .eq('jurisdiction', config.jurisdiction)
-    .eq('tracker_key', config.tracker_key);
+  const { data: beforeRows } = await withRetry(
+    () => db
+      .from('tracker_evidence_events')
+      .select('id')
+      .eq('domain', config.domain)
+      .eq('jurisdiction', config.jurisdiction)
+      .eq('tracker_key', config.tracker_key),
+    `beforeRows:${config.tracker_key}`,
+  );
   const before = beforeRows?.length || 0;
 
-  const { error } = await db
-    .from('tracker_evidence_events')
-    .upsert(payload, {
-      onConflict: 'domain,jurisdiction,tracker_key,stage,event_date,title',
-    });
+  const { error } = await withRetry(
+    () => db
+      .from('tracker_evidence_events')
+      .upsert(payload, {
+        onConflict: 'domain,jurisdiction,tracker_key,stage,event_date,title',
+      }),
+    `upsert:${config.tracker_key}`,
+  );
 
   if (error) throw new Error(error.message);
 


### PR DESCRIPTION
## What
Refresh Youth Justice Source Chain read **~6% success** in `/health` — but it runs **clean standalone** (29s, all 5 trackers updated). The failures are **environmental, not a code bug**.

## Root cause (verified in the act)
During the nightly orchestrator batch, the shared Supabase pooler saturates and DB calls sporadically throw `Could not query the database for the schema cache` / `fetch failed`. The chain had **no retry resilience**, so a single transient hiccup killed the whole 4-step chain → `exited with status 1`. It only "succeeded" when the pooler happened to be quiet.

This was confirmed live — a regression run hit the real error mid-run and recovered:
```
beforeRows:watchhouse-support: transient DB failure (attempt 1/4): Could not query the database for the schema cache. Retrying. — retrying in 1500ms
... attempt 2/4 ... attempt 3/4 ...
watchhouse-support: 9 row(s) processed   ← recovered on attempt 4
```

## Fix
`withRetry()` around the Supabase calls in both scripts:
- **sync-tracker-evidence.mjs** — `exec_sql` selects, the evidence upsert, the before-count select
- **run-tracker-refresh.mjs** — summary / site / previous-snapshot queries + the snapshot insert

Retries **transient** connection failures only (network throws *and* transient error values) with linear backoff, up to 4 attempts. Non-transient errors pass straight through to existing handling and are **not** retried — so real bugs still surface immediately (confirmed: a genuine FK/unique violation in testing was correctly *not* retried).

## Verification
- Standalone chain completes clean (5 trackers updated).
- Retry recovers from the real pooler error mid-run (above).
- DB constraints confirmed safe for production: `run_id` FKs `agent_runs(id)` (orchestrator passes the real run id); the `COALESCE(run_id, zero-uuid)` unique index only collides on null run_ids, which production never produces.

## Follow-up (out of scope)
If `logStart` itself fails under pooler load, the chain runs without a `--run-id` and the snapshot insert can collide on the zero-uuid unique index. Lower-probability; best fixed by adding the same retry to `logStart` (which would harden **all** agents). Noted for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)