### PR TITLE
fix(trust-remediation): resolve psql by absolute path for cron/pm2 PATH

### DIFF
--- a/scripts/trust-remediation-loop.mjs
+++ b/scripts/trust-remediation-loop.mjs
@@ -16,17 +16,32 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { spawnSync, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 
-// Resolve absolute binary paths at load time — scheduler/cron contexts
-// often have minimal PATH so `psql` and `node` aren't found otherwise.
-function resolveBin(name) {
+// Resolve absolute binary paths at load time. Scheduler/cron/pm2 contexts run with a
+// minimal PATH, so BOTH `which psql` and a bare `spawnSync('psql')` fail with ENOENT —
+// that was the actual failure leaving this loop at ~16% success. Probe an env override
+// and known install locations, not just `which`.
+function resolveBin(name, candidates = []) {
+  const envOverride = process.env[`${name.toUpperCase()}_BIN`];
+  if (envOverride && existsSync(envOverride)) return envOverride;
   try {
-    return execSync(`which ${name}`, { encoding: 'utf8' }).trim() || name;
+    const found = execSync(`which ${name}`, { encoding: 'utf8' }).trim();
+    if (found && existsSync(found)) return found;
   } catch {
-    return name;
+    // `which` unavailable or PATH too minimal — fall through to candidates.
   }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return name;
 }
-const PSQL_BIN = resolveBin('psql');
+const PSQL_BIN = resolveBin('psql', [
+  '/opt/homebrew/bin/psql',
+  '/opt/homebrew/opt/postgresql@16/bin/psql',
+  '/usr/local/bin/psql',
+  '/Applications/Postgres.app/Contents/Versions/latest/bin/psql',
+]);
 const NODE_BIN = process.execPath; // always the absolute path of the running node
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
 


### PR DESCRIPTION
## What
Trust Remediation Loop failed **~75% of runs** (30 of the last 40) with `spawnSync psql ENOENT`. The 8 successes did real work (216K / 84K rows processed), so it's a clean deterministic bug, not an accounting artifact.

## Root cause
`resolveBin()` resolved psql via `which psql`. But the orchestrator (pm2/cron) runs with a **minimal PATH** that doesn't include the Postgres bin dir — so `which psql` *also* failed, and the catch fell back to the bare name `'psql'`, which then `ENOENT`s at `spawnSync`. `NODE_BIN` was unaffected (it uses `process.execPath`). The loop only succeeded when launched from a shell that already had psql on PATH.

## Fix
`resolveBin` now, in order:
1. honours a `{NAME}_BIN` env override,
2. validates the `which` hit with `existsSync`,
3. falls back to known absolute install locations (Homebrew, `postgresql@16`, `/usr/local`, Postgres.app),
4. bare name as last resort.

## Verification
Under a simulated minimal PATH (`/usr/bin:/bin`):
```
which psql  -> FAILED (ENOENT-equivalent)    <- old code spawned this -> ENOENT
resolveBin  -> /opt/homebrew/bin/psql        <- new code
```

## Note (out of scope)
`refresh-youth-justice-source-chain.mjs` has the same `which`-only `resolveBin`, but it never spawns psql (all its steps are `node`), so it's unaffected. Worth extracting this helper to a shared lib in a later pass so every agent gets PATH-robust binary resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)