### PR TITLE
refactor(agents): extract resolveBin + withRetry into shared resilience lib

### DIFF
--- a/scripts/lib/agent-resilience.mjs
+++ b/scripts/lib/agent-resilience.mjs
@@ -1,0 +1,77 @@
+/**
+ * agent-resilience.mjs — shared resilience helpers for pipeline agents.
+ *
+ * Two failure classes were being fixed agent-by-agent; this consolidates them:
+ *
+ *  1. resolveBin()       — scheduler/cron/pm2 contexts run with a minimal PATH, so both
+ *                          `which <bin>` AND a bare spawnSync('<bin>') fail with ENOENT.
+ *                          Probe an env override and known install locations, not just `which`.
+ *
+ *  2. withRetry()        — the shared Supabase pooler saturates during the nightly batch,
+ *     isTransientDbError()  so DB calls sporadically throw `fetch failed` / schema-cache
+ *                          errors. Retry the transient ones (network throws AND transient
+ *                          error values) with linear backoff; let real errors pass through.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+// Known absolute install locations, used as the minimal-PATH fallback for resolveBin.
+export const KNOWN_BIN_CANDIDATES = {
+  psql: [
+    '/opt/homebrew/bin/psql',
+    '/opt/homebrew/opt/postgresql@16/bin/psql',
+    '/usr/local/bin/psql',
+    '/Applications/Postgres.app/Contents/Versions/latest/bin/psql',
+  ],
+};
+
+/**
+ * Resolve an absolute binary path that works under a minimal PATH.
+ * Order: {NAME}_BIN env override -> validated `which` hit -> known candidates -> bare name.
+ */
+export function resolveBin(name, candidates = KNOWN_BIN_CANDIDATES[name] || []) {
+  const envOverride = process.env[`${name.toUpperCase()}_BIN`];
+  if (envOverride && existsSync(envOverride)) return envOverride;
+  try {
+    const found = execSync(`which ${name}`, { encoding: 'utf8' }).trim();
+    if (found && existsSync(found)) return found;
+  } catch {
+    // `which` unavailable or PATH too minimal — fall through to candidates.
+  }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return name;
+}
+
+/** True for transient pooler/connection failures that are worth retrying. */
+export function isTransientDbError(message) {
+  return /fetch failed|ECONNRESET|ETIMEDOUT|timeout|schema cache|EPIPE|socket hang up|503|terminating connection|too many (clients|connections)|Connection terminated|deadlock|ECONNREFUSED/i.test(String(message || ''));
+}
+
+/**
+ * Run a Supabase call with retry on transient connection failures. Handles both shapes
+ * the client produces: a thrown network error, or a returned `{ data, error }` whose
+ * error is transient. Non-transient errors pass straight through (returned or rethrown)
+ * so real bugs surface immediately and are NOT retried.
+ */
+export async function withRetry(fn, label, tries = 4, baseDelayMs = 1500) {
+  let lastResult;
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    try {
+      lastResult = await fn();
+      if (!(lastResult && lastResult.error && isTransientDbError(lastResult.error.message))) {
+        return lastResult;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!isTransientDbError(message) || attempt === tries) throw err;
+      lastResult = { data: null, error: { message } };
+    }
+    if (attempt === tries) return lastResult;
+    const delay = baseDelayMs * attempt;
+    console.error(`[retry] ${label}: transient DB failure (attempt ${attempt}/${tries}): ${lastResult?.error?.message} — retrying in ${delay}ms`);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  return lastResult;
+}

--- a/scripts/refresh-youth-justice-source-chain.mjs
+++ b/scripts/refresh-youth-justice-source-chain.mjs
@@ -1,16 +1,8 @@
 #!/usr/bin/env node
 import 'dotenv/config';
-import { spawnSync, execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import { resolveBin } from './lib/agent-resilience.mjs';
 
-// Resolve absolute binary paths at load time — cron/scheduler runs don't
-// have /usr/local/bin or nvm shim paths, so `psql` and `node` fail with ENOENT.
-function resolveBin(name) {
-  try {
-    return execSync(`which ${name}`, { encoding: 'utf8' }).trim() || name;
-  } catch {
-    return name;
-  }
-}
 const NODE_BIN = process.execPath;
 const PSQL_BIN = resolveBin('psql');
 import { createClient } from '@supabase/supabase-js';

--- a/scripts/run-bridge-fuzzy.mjs
+++ b/scripts/run-bridge-fuzzy.mjs
@@ -4,7 +4,9 @@
 // that pass p_min_similarity, returns (inserted, batch_size, last_id, done).
 
 import { spawnSync } from 'child_process';
+import { resolveBin } from './lib/agent-resilience.mjs';
 
+const PSQL_BIN = resolveBin('psql');
 const password = process.env.DATABASE_PASSWORD;
 if (!password) {
   console.error('DATABASE_PASSWORD not set');
@@ -31,7 +33,7 @@ function runBatch(cursor) {
     SELECT rows_inserted || '|' || batch_processed || '|' || COALESCE(last_id::text, '') || '|' || done
     FROM bridge_civicscope_to_act_fuzzy(${BATCH_LIMIT}, ${cursorArg}, ${MIN_SIM});`;
 
-  const res = spawnSync('psql', [...psqlArgs, '-c', sql], {
+  const res = spawnSync(PSQL_BIN, [...psqlArgs, '-c', sql], {
     env: { ...process.env, PGPASSWORD: password },
     encoding: 'utf8',
   });

--- a/scripts/run-tracker-refresh.mjs
+++ b/scripts/run-tracker-refresh.mjs
@@ -2,6 +2,7 @@
 import 'dotenv/config';
 import { spawnSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
+import { withRetry } from './lib/agent-resilience.mjs';
 
 const args = process.argv.slice(2);
 const argMap = new Map(
@@ -27,34 +28,6 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 }
 
 const db = createClient(SUPABASE_URL, SUPABASE_KEY);
-
-// Retry transient pooler/connection failures (the shared Supabase saturates during the
-// nightly batch). Retries network throws and transient error VALUES; non-transient
-// errors pass through to the caller's existing handling.
-function isTransientDbError(message) {
-  return /fetch failed|ECONNRESET|ETIMEDOUT|timeout|schema cache|EPIPE|socket hang up|503|terminating connection|too many (clients|connections)|Connection terminated|deadlock|ECONNREFUSED/i.test(String(message || ''));
-}
-
-async function withRetry(fn, label, tries = 4, baseDelayMs = 1500) {
-  let lastResult;
-  for (let attempt = 1; attempt <= tries; attempt++) {
-    try {
-      lastResult = await fn();
-      if (!(lastResult && lastResult.error && isTransientDbError(lastResult.error.message))) {
-        return lastResult;
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (!isTransientDbError(message) || attempt === tries) throw err;
-      lastResult = { data: null, error: { message } };
-    }
-    if (attempt === tries) return lastResult;
-    const delay = baseDelayMs * attempt;
-    console.error(`[run-tracker-refresh] ${label}: transient DB failure (attempt ${attempt}/${tries}): ${lastResult?.error?.message} — retrying in ${delay}ms`);
-    await new Promise((r) => setTimeout(r, delay));
-  }
-  return lastResult;
-}
 
 function runSync() {
   const result = spawnSync('node', ['--env-file=.env', 'scripts/sync-tracker-evidence.mjs'], {

--- a/scripts/sync-tracker-evidence.mjs
+++ b/scripts/sync-tracker-evidence.mjs
@@ -22,6 +22,7 @@ import os from 'node:os';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import { withRetry } from './lib/agent-resilience.mjs';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -280,36 +281,6 @@ async function fetchSourceMetadata(event) {
       fetched_at: new Date().toISOString(),
     };
   }
-}
-
-// The shared Supabase pooler saturates during the nightly orchestrator batch, so DB
-// calls sporadically throw `fetch failed` / schema-cache errors. Without resilience a
-// single hiccup killed the whole tracker chain (this agent read ~6% success while
-// running clean standalone). Retry transient connection failures — both network throws
-// and transient error VALUES — and let non-transient errors pass through unchanged.
-function isTransientDbError(message) {
-  return /fetch failed|ECONNRESET|ETIMEDOUT|timeout|schema cache|EPIPE|socket hang up|503|terminating connection|too many (clients|connections)|Connection terminated|deadlock|ECONNREFUSED/i.test(String(message || ''));
-}
-
-async function withRetry(fn, label, tries = 4, baseDelayMs = 1500) {
-  let lastResult;
-  for (let attempt = 1; attempt <= tries; attempt++) {
-    try {
-      lastResult = await fn();
-      if (!(lastResult && lastResult.error && isTransientDbError(lastResult.error.message))) {
-        return lastResult;
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (!isTransientDbError(message) || attempt === tries) throw err;
-      lastResult = { data: null, error: { message } };
-    }
-    if (attempt === tries) return lastResult;
-    const delay = baseDelayMs * attempt;
-    console.error(`[sync-tracker-evidence] ${label}: transient DB failure (attempt ${attempt}/${tries}): ${lastResult?.error?.message} — retrying in ${delay}ms`);
-    await new Promise((r) => setTimeout(r, delay));
-  }
-  return lastResult;
 }
 
 async function selectOne(query) {

--- a/scripts/trust-remediation-loop.mjs
+++ b/scripts/trust-remediation-loop.mjs
@@ -15,33 +15,10 @@
 
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
-import { spawnSync, execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { resolveBin } from './lib/agent-resilience.mjs';
 
-// Resolve absolute binary paths at load time. Scheduler/cron/pm2 contexts run with a
-// minimal PATH, so BOTH `which psql` and a bare `spawnSync('psql')` fail with ENOENT —
-// that was the actual failure leaving this loop at ~16% success. Probe an env override
-// and known install locations, not just `which`.
-function resolveBin(name, candidates = []) {
-  const envOverride = process.env[`${name.toUpperCase()}_BIN`];
-  if (envOverride && existsSync(envOverride)) return envOverride;
-  try {
-    const found = execSync(`which ${name}`, { encoding: 'utf8' }).trim();
-    if (found && existsSync(found)) return found;
-  } catch {
-    // `which` unavailable or PATH too minimal — fall through to candidates.
-  }
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return name;
-}
-const PSQL_BIN = resolveBin('psql', [
-  '/opt/homebrew/bin/psql',
-  '/opt/homebrew/opt/postgresql@16/bin/psql',
-  '/usr/local/bin/psql',
-  '/Applications/Postgres.app/Contents/Versions/latest/bin/psql',
-]);
+const PSQL_BIN = resolveBin('psql');
 const NODE_BIN = process.execPath; // always the absolute path of the running node
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
 


### PR DESCRIPTION
## What
The PATH-ENOENT fix (#74) and pooler-retry fix (#73) were both **generic** but had been applied agent-by-agent. This consolidates them into `scripts/lib/agent-resilience.mjs` so any agent gets them with a one-line import — "fix the class, not the instance."

### New lib
- **`resolveBin(name, candidates)`** — minimal-PATH-robust binary resolution: `{NAME}_BIN` env override → validated `which` hit → known install locations → bare name.
- **`withRetry(fn, label)` + `isTransientDbError(message)`** — retry transient pooler/connection failures (network throws *and* transient `{error}` values) with linear backoff; real errors pass straight through (not retried).

### Migrations
| File | Change |
|---|---|
| trust-remediation-loop | use shared `resolveBin` |
| refresh-youth-justice-source-chain | use shared `resolveBin` (was the vulnerable `which`-only version) |
| **run-bridge-fuzzy** | **new fix** — it spawned **bare `psql`** with no resolution, so it had the same cron/pm2 ENOENT bug; now resolved via the shared helper |
| sync-tracker-evidence | use shared `withRetry` / `isTransientDbError` |
| run-tracker-refresh | use shared `withRetry` / `isTransientDbError` |

Net **−8 lines** — the consolidation removes more than the lib adds.

## Verification
- Lib smoke test under a simulated minimal PATH (`/usr/bin:/bin`): `resolveBin('psql')` → `/opt/homebrew/bin/psql`; `isTransientDbError` correctly classifies `fetch failed` (true) vs `syntax error` (false); `withRetry` returns happy-path immediately and recovers a transient `schema cache` on retry.
- `sync-tracker-evidence` runs clean end-to-end via the **imported** helper (39 rows, 25s, exit 0).

Behaviour-neutral consolidation (the shared functions are identical to the inline ones) plus the run-bridge-fuzzy hardening.

## Follow-up (out of scope)
`trust-remediation-loop` has its own older `withRetry(label, fn)` with a different signature; left as-is to avoid churn, worth unifying later. Same for adding `withRetry` to `logStart` so every agent's run-logging survives pooler saturation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)