### PR TITLE
fix(agents): stop null-run_id snapshot collision failing YJ tracker chain

### DIFF
--- a/scripts/run-tracker-refresh.mjs
+++ b/scripts/run-tracker-refresh.mjs
@@ -170,11 +170,23 @@ async function main() {
     };
   });
 
-  if (snapshotRows.length > 0) {
+  // Snapshot persistence is a non-critical analytics artifact: the scrape + tracker
+  // refresh above are this agent's real work. A snapshot hiccup must NOT abort the
+  // source chain (matches enrich-se / poll-frontier resilience). Two guards:
+  //  1. Skip when run_id is null. idx_tracker_site_snapshots_run_site is UNIQUE on
+  //     (COALESCE(run_id, '0000…'), domain, jurisdiction, site_name), so every
+  //     null-run_id batch buckets to the same zero-uuid and the second one onward
+  //     hits a duplicate-key violation — the deterministic cause of the 0/8 failures.
+  //     A null run_id means logStart never returned an id, so there is no run to
+  //     attach the snapshot to anyway.
+  //  2. On any insert error, warn and continue rather than process.exit(1), so a
+  //     productive run is never marked failed over a snapshot write.
+  if (!runId) {
+    console.warn('[run-tracker-refresh] No run-id; skipping snapshot insert (avoids orphaned null-run_id rows).');
+  } else if (snapshotRows.length > 0) {
     const { error: insertError } = await withRetry(() => db.from('tracker_site_snapshots').insert(snapshotRows), 'snapshot insert');
     if (insertError) {
-      console.error('[run-tracker-refresh] Snapshot insert failed:', insertError.message);
-      process.exit(1);
+      console.warn('[run-tracker-refresh] Snapshot insert skipped (non-fatal):', insertError.message);
     }
   }
 


### PR DESCRIPTION
## Problem

`refresh-youth-justice-trackers` was **0 success / 8 failures over 7 days** — surfaced by `/health`. The ledger's #73 hypothesis (transient pooler saturation) was wrong.

## Root cause (reproduced)

The agent is a 4-step source chain (3 scrapers + `run-tracker-refresh.mjs`). The 3 scrapers and the tracker computation all succeed; **step 4's snapshot insert dies deterministically** on `duplicate key value violates unique constraint "idx_tracker_site_snapshots_run_site"`, then `process.exit(1)` aborts the whole chain and marks the agent `failed`.

That index is `UNIQUE (COALESCE(run_id, '0000…'), domain, jurisdiction, site_name)`. Under batch-time pooler stress, `logStart`'s insert commits but its `.select().single()` response is lost → returns `{id:null}` → the chain omits `--run-id` → step 4 inserts `run_id=NULL`. All nulls bucket to the same zero-uuid, so the first null run leaves orphans and **every subsequent null run collides**. Last successful snapshot batch was 04-10.

## Fix

Two guards in `run-tracker-refresh.mjs` (same resilience pattern as enrich-se #72 / poll-frontier #75):

1. **Skip the snapshot insert when `run_id` is null** — a null run_id has no run to attach to and only ever creates colliding orphans.
2. **Downgrade an insert error from `process.exit(1)` to a non-fatal warning** — a productive scrape+refresh run is never marked `failed` over an analytics write.

Genuinely-fatal exits (summary / site / previous-snapshot query failures) are left intact.

## Validation

Full chain run end-to-end → logged **`success`** (39 rows, 11 mirrored, 28 gaps, 650s). **18 fresh snapshot rows landed under a real run_id with no skip-warning** — confirming the time-series still grows (guard #2 is a safety net, not a mask). First success since 04-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)