### PR TITLE
fix(entity-graph): order loadEntityIndex pagination — stop silently dropping ~35% of entities

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -134,6 +134,7 @@ async function loadEntityIndex() {
     const { data, error } = await supabase
       .from('gs_entities')
       .select('id, gs_id')
+      .order('id', { ascending: true }) // stable order: range() pagination without it overlaps/skips pages → silently dropped ~35% of entities
       .range(offset, offset + 999);
     if (error) { log(`  ERROR loading index: ${error.message}`); break; }
     if (!data?.length) break;


### PR DESCRIPTION
## Problem

`loadEntityIndex()` paginates `gs_entities` with `.range(offset, offset+999)` and **no `.order()`**. PostgREST/Postgres gives no stable row order across separate range queries, so pages **overlap** (duplicate `gs_id`s, deduped away by the `Map`) and leave **gaps** (entities never fetched).

**Reproduced live** (exact replica of the function): it fetched all **599,503** rows across 600 pages, but the in-memory map held only **387,404 unique `gs_id`s — 212,099 (35.4%) missing.**

Every relationship phase (donations, contracts, grants, cross-registry) resolves entity UUIDs through this index, so any donation/contract whose donor/target entity fell in the missing 35% was **silently skipped**. The relationship graph has been under-built by up to a third, every run. (Surfaced while prototyping a set-based rewrite: the SQL version, joining the complete table, produced 338K donation links vs the 206K the JS run wrote — the gap is this bug.)

## Fix

Add `.order('id', { ascending: true })` — a stable total order over the PK so offset pagination partitions the table cleanly. One line; no behaviour change beyond completeness. Takes effect on the next scheduled `build-entity-graph` run.

## Follow-ups (not this PR)

- **Same pattern, ~10 other scans:** the `.range()`-without-stable-order bug also exists in the Phase 1 source-table loads and the donations/contracts relationship scans (lines 638/708). Line 405 orders by `report_year`, which isn't unique, so it's also unstable. Worth a dedicated sweep.
- **Durable fix:** rewrite the relationship phases as set-based `INSERT…SELECT` (~250× faster — measured ~45 min → ~11 s on Phase 2a), which sidesteps the in-memory index entirely.

## Test

`node --check` passes; pre-commit `tsc --noEmit` passes. Behaviour is validated by the live reproduction above (387K → will load all 599K with the order clause). The Vercel preview will now also build fast (the #81 build-config fix is already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)