### PR TITLE
fix(agents): paginate Phase 1f party-entity creation (66 → 2,438 parties)

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -372,20 +372,18 @@ async function buildEntities() {
   stats.suppliers = uniqueSuppliers.size;
   log(`  AusTender suppliers (unique ABNs): ${stats.suppliers}`);
 
-  // 1f. Political parties — batch upsert
+  // 1f. Political parties — one entity per distinct donation_to recipient.
+  // The old unpaginated REST select silently hit PostgREST's 1000-row cap, so only
+  // ~66 of 2,437 distinct recipients ever became party entities. Fetch the distinct
+  // set set-based (instant), and keep makeGsId so gs_ids stay consistent across runs
+  // (the donations phase joins parties by name, but a stable gs_id prevents dupes).
   log('  Loading political parties...');
-  const { data: parties } = await supabase
-    .from('political_donations')
-    .select('donation_to')
-    .not('donation_to', 'is', null);
-
-  const uniqueParties = new Set();
-  for (const p of (parties || [])) {
-    if (p.donation_to) uniqueParties.add(p.donation_to);
-  }
+  const partyOut = await runDml('political party recipients',
+    `SELECT DISTINCT donation_to FROM political_donations WHERE donation_to IS NOT NULL;`);
+  const uniqueParties = partyOut.split('\n').map((s) => s.trim()).filter(Boolean);
 
   if (!dryRun) {
-    const partyEntities = Array.from(uniqueParties).map(name => ({
+    const partyEntities = uniqueParties.map((name) => ({
       entity_type: 'political_party',
       canonical_name: name,
       gs_id: makeGsId({ name }),
@@ -399,7 +397,7 @@ async function buildEntities() {
       await upsertEntities(chunk, { onConflict: 'gs_id', ignoreDuplicates: true });
     }
   }
-  stats.parties = uniqueParties.size;
+  stats.parties = uniqueParties.length;
   log(`  Political parties: ${stats.parties}`);
 
   // 1g. Donors (from donor_entity_matches) — batch upsert


### PR DESCRIPTION
## Problem

`build-entity-graph` Phase 1f built political-party entities from an **unpaginated** `political_donations.donation_to` read, which silently hit PostgREST's 1,000-row cap. Result: only **66 of 2,437** distinct recipients ever became entities — capping the entire donation graph upstream no matter how complete the edges were.

Same silent-read-truncation bug class as #82/#83, in entity creation instead of relationship building.

## Fix

Set-based `SELECT DISTINCT donation_to` (instant, all 2,437), keeping `makeGsId` so gs_ids stay consistent across runs — the donations phase matches parties by name, but a stable gs_id prevents duplicate party rows on re-run.

## Live result (applied this session)

- `political_party` entities **66 → 2,438**
- donation edges **368,365 → 743,594** (+375,229 after re-running the donations phase) — the donation graph **more than doubled**
- 0 write failures

## Not fixed here (flagged for the audit)

The other unpaginated Phase-1 reads (1d government bodies, 1e suppliers, 1i ASX) hit the same cap, but those entities are topped up from ABN-shared sources (ACNC/ATO), so impact is lower. Tracked in `docs/strategy/data-health-roadmap.md` Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)