### PR TITLE
feat(data-health): nightly graph-completeness gate (roadmap Phase 2)

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -18,6 +18,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { spawnSync } from 'node:child_process';
 import { resolveBin, withRetry } from './lib/agent-resilience.mjs';
+import { edgeDataset } from './lib/graph-edge-datasets.mjs';
 import 'dotenv/config';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -663,99 +664,30 @@ async function buildEntities() {
 
 // ─── Phase 2a: Political donations → relationships ──────────────────────────
 
+// NB: the SQL for these 4 phases lives in scripts/lib/graph-edge-datasets.mjs — the
+// single source of truth shared with check-graph-completeness.mjs, so the gate's
+// "expected" count can never drift from what we actually insert. Edit the SQL there.
+
 async function buildDonationRelationships() {
   log('\nPhase 2a: Political donation relationships...');
-  // donor ABN: real column first, else donor_entity_matches name→ABN (one ABN per name key,
-  // mirroring the old last-write-wins JS Map). party: the political_party entity whose name
-  // equals donation_to — equivalent to the old AU-NAME-<hash> lookup minus hash collisions
-  // (a name-equality join can never resolve to a wrongly-collided party, the JS path could).
-  await buildRelationshipsSetBased(
-    'Donation relationships',
-    '(source_entity_id, target_entity_id, relationship_type, amount, year, dataset, source_record_id, confidence, properties)',
-    `SELECT
-       donor.id, party.id, 'donation', d.amount,
-       NULLIF(split_part(d.financial_year, '-', 1), '')::int,
-       'aec_donations', d.id::text, 'registry',
-       jsonb_build_object(
-         'financial_year', d.financial_year,
-         'return_type',    d.return_type,
-         'receipt_type',   d.receipt_type,
-         'donation_date',  d.donation_date)
-     FROM political_donations d
-     LEFT JOIN donor_map dm ON dm.key = upper(trim(d.donor_name))
-     JOIN gs_entities donor
-       ON donor.gs_id = 'AU-ABN-' || regexp_replace(coalesce(NULLIF(trim(d.donor_abn), ''), dm.matched_abn), '\\s', '', 'g')
-     JOIN gs_entities party
-       ON party.entity_type = 'political_party'
-      AND upper(trim(party.canonical_name)) = upper(trim(d.donation_to))`,
-    // prelude: materialise + index the donor name→ABN map so the join above is an index scan,
-    // not a nested loop over an unindexed Materialize node (~4B ops → runaway).
-    `CREATE TEMP TABLE donor_map AS
-       SELECT DISTINCT ON (key) key, matched_abn FROM (
-         SELECT upper(trim(donor_name)) AS key, matched_abn
-           FROM donor_entity_matches WHERE matched_abn IS NOT NULL
-         UNION ALL
-         SELECT upper(trim(donor_name_normalized)), matched_abn
-           FROM donor_entity_matches
-           WHERE donor_name_normalized IS NOT NULL AND matched_abn IS NOT NULL
-       ) z ORDER BY key;
-     CREATE INDEX ON donor_map(key);
-     ANALYZE donor_map;`,
-  );
+  const d = edgeDataset('aec_donations');
+  await buildRelationshipsSetBased(d.label, d.cols, d.selectSql, d.prelude);
 }
 
 // ─── Phase 2b: AusTender contracts → relationships ──────────────────────────
 
 async function buildContractRelationships() {
   log('\nPhase 2b: Contract relationships...');
-  // buyer: AU-GOV-<buyer_id> (falls back to buyer_name, matching makeGsId({buyer_id: id||name})).
-  // supplier: AU-ABN-<abn>. source_record_id mirrors `c.ocid || c.id` (every row has an ocid).
-  await buildRelationshipsSetBased(
-    'Contract relationships',
-    '(source_entity_id, target_entity_id, relationship_type, amount, year, start_date, end_date, dataset, source_record_id, confidence, properties)',
-    `SELECT
-       buyer.id, supplier.id, 'contract', c.contract_value,
-       coalesce(extract(year FROM c.contract_start)::int, extract(year FROM c.date_published)::int),
-       c.contract_start, c.contract_end,
-       'austender', coalesce(NULLIF(c.ocid, ''), c.id::text), 'registry',
-       jsonb_build_object(
-         'category',           c.category,
-         'procurement_method', c.procurement_method,
-         'buyer_name',         c.buyer_name,
-         'supplier_name',      c.supplier_name)
-     FROM austender_contracts c
-     JOIN gs_entities buyer
-       ON buyer.gs_id = 'AU-GOV-' || coalesce(NULLIF(c.buyer_id, ''), c.buyer_name)
-     JOIN gs_entities supplier
-       ON supplier.gs_id = 'AU-ABN-' || regexp_replace(c.supplier_abn, '\\s', '', 'g')
-     WHERE c.supplier_abn IS NOT NULL
-       AND regexp_replace(c.supplier_abn, '\\s', '', 'g') ~ '^[0-9]{11}$'`,
-  );
+  const d = edgeDataset('austender');
+  await buildRelationshipsSetBased(d.label, d.cols, d.selectSql, d.prelude);
 }
 
 // ─── Phase 2b2: Grant opportunities → relationships ─────────────────────────
 
 async function buildGrantRelationships() {
   log('\nPhase 2b2: Grant relationships...');
-  // self-ref edge on the foundation entity (foundation offers grant); amount = max || min.
-  await buildRelationshipsSetBased(
-    'Grant relationships',
-    '(source_entity_id, target_entity_id, relationship_type, amount, dataset, source_record_id, confidence, properties)',
-    `SELECT
-       f_ent.id, f_ent.id, 'grant', coalesce(g.amount_max, g.amount_min),
-       'grant_opportunities', g.id::text, 'registry',
-       jsonb_build_object(
-         'grant_name', g.name,
-         'categories', array_to_string(g.categories, ', '),
-         'closes_at',  g.closes_at,
-         'provider',   g.provider)
-     FROM grant_opportunities g
-     JOIN foundations f
-       ON f.id = g.foundation_id AND f.acnc_abn IS NOT NULL
-     JOIN gs_entities f_ent
-       ON f_ent.gs_id = 'AU-ABN-' || regexp_replace(f.acnc_abn, '\\s', '', 'g')
-     WHERE g.foundation_id IS NOT NULL`,
-  );
+  const d = edgeDataset('grant_opportunities');
+  await buildRelationshipsSetBased(d.label, d.cols, d.selectSql, d.prelude);
 }
 
 // ─── Phase 2c: Cross-registry links ──────────────────────────────────────────
@@ -763,23 +695,8 @@ async function buildGrantRelationships() {
 async function buildCrossRegistryLinks() {
   log('\nPhase 2c: Cross-registry links...');
   log('  Building foundation → parent company links...');
-  // parent matched by exact (case-insensitive) canonical_name = parent_company, mirroring the
-  // old nameIdMap.get(parent_company.toUpperCase()). DISTINCT ON keeps one parent per foundation
-  // (the JS map held a single id per name) — deterministic by parent.id.
-  await buildRelationshipsSetBased(
-    'Cross-registry links',
-    '(source_entity_id, target_entity_id, relationship_type, dataset, source_record_id, confidence, properties)',
-    `SELECT DISTINCT ON (f.acnc_abn)
-       parent.id, f_ent.id, 'subsidiary_of', 'foundations', f.acnc_abn, 'reported',
-       jsonb_build_object('parent_company', f.parent_company)
-     FROM foundations f
-     JOIN gs_entities f_ent
-       ON f_ent.gs_id = 'AU-ABN-' || regexp_replace(f.acnc_abn, '\\s', '', 'g')
-     JOIN gs_entities parent
-       ON upper(parent.canonical_name) = upper(f.parent_company)
-     WHERE f.parent_company IS NOT NULL AND f.acnc_abn IS NOT NULL
-     ORDER BY f.acnc_abn, parent.id`,
-  );
+  const d = edgeDataset('foundations');
+  await buildRelationshipsSetBased(d.label, d.cols, d.selectSql, d.prelude);
 }
 
 // ─── Phase 3: Refresh materialised views ─────────────────────────────────────

--- a/scripts/check-graph-completeness.mjs
+++ b/scripts/check-graph-completeness.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Graph completeness gate — data-health roadmap Phase 2 (the centerpiece).
+ *
+ * For each relationship dataset, compute the EXPECTED edge count set-based (the same
+ * INSERT…SELECT shape the build uses, minus the insert — distinct edge-keys) and compare
+ * it to the ACTUAL count in gs_relationships. The edge SQL is imported from the single
+ * source of truth (scripts/lib/graph-edge-datasets.mjs), so "expected" can never drift
+ * from what build-entity-graph actually inserts.
+ *
+ *   expected > actual  → ALERT: edges silently went missing (the #82/#83 bug class).
+ *   actual   > expected → STALE: gs_relationships carries rows the current build no longer
+ *                         produces (legacy/dead-code dupes, deleted source rows). Informational.
+ *
+ * Writes one row per dataset to gs_graph_completeness_log (the roadmap's "coverage trend")
+ * and an agent_runs row. Exits non-zero ONLY on ALERT (under-built) — the actionable bug
+ * direction — so a scheduler / CI surfaces it. STALE and OK exit 0.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/check-graph-completeness.mjs
+ *   node --env-file=.env scripts/check-graph-completeness.mjs --threshold=0.03
+ *   node --env-file=.env scripts/check-graph-completeness.mjs --json   # machine-readable (for /health)
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { spawnSync } from 'node:child_process';
+import { resolveBin, withRetry } from './lib/agent-resilience.mjs';
+import { GRAPH_EDGE_DATASETS, EDGE_KEY_COLS } from './lib/graph-edge-datasets.mjs';
+import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import 'dotenv/config';
+
+const AGENT_ID = 'check-graph-completeness';
+const AGENT_NAME = 'Check Graph Completeness';
+
+const args = process.argv.slice(2);
+const jsonOut = args.includes('--json');
+const thresholdArg = args.find((a) => a.startsWith('--threshold='))?.split('=')[1];
+// Drift tolerance: a dataset is ALERT only if it's under-built by MORE than this fraction.
+// Default 5% — comfortably catches the 35% #82 drop while tolerating source rows that have
+// arrived since the last build-entity-graph run (new data not yet built into edges).
+const THRESHOLD = Number(thresholdArg ?? process.env.GRAPH_COMPLETENESS_THRESHOLD ?? 0.05);
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const PG_PASSWORD = process.env.DATABASE_PASSWORD;
+const PSQL_BIN = resolveBin('psql');
+const PSQL_CONN = [
+  '-h', process.env.PGHOST || 'aws-0-ap-southeast-2.pooler.supabase.com',
+  '-p', process.env.PGPORT || '5432',
+  '-U', process.env.PGUSER || 'postgres.tednluwflfhxyucgwigh',
+  '-d', process.env.PGDATABASE || 'postgres',
+  '-X', '-A', '-t', '-v', 'ON_ERROR_STOP=1',
+];
+
+// Only the gate's own output (the table + alerts) should reach stdout in --json mode; route
+// progress chatter to stderr so `--json` produces a clean parseable document.
+const log = (msg) => process.stderr.write(`[graph-completeness] ${msg}\n`);
+
+/** Run a SELECT via psql and return the first cell of the last row as a string. */
+function psqlScalar(label, sql) {
+  if (!PG_PASSWORD) throw new Error('DATABASE_PASSWORD not set — graph-completeness check requires direct psql');
+  return withRetry(() => {
+    const res = spawnSync(PSQL_BIN, [...PSQL_CONN, '-c', `SET statement_timeout=0;\n${sql}`], {
+      env: { ...process.env, PGPASSWORD: PG_PASSWORD },
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (res.error) throw res.error;
+    if (res.status !== 0) throw new Error((res.stderr || res.stdout || `psql exit ${res.status}`).trim());
+    // -A -t output: psql echoes the "SET" command tag first, then the rows. Take the last
+    // non-empty line and its first |-field.
+    const lines = String(res.stdout || '').split('\n').map((s) => s.trim()).filter(Boolean);
+    const last = lines[lines.length - 1] || '';
+    return last.split('|')[0];
+  }, label);
+}
+
+async function checkDataset(def) {
+  const t0 = Date.now();
+  // EXPECTED: distinct edge-keys the current build SELECT would produce. Prelude (if any) runs
+  // in the SAME psql session so the SELECT can see its temp tables.
+  const pre = def.prelude ? `${def.prelude.trim()}\n` : '';
+  const expected = Number(await psqlScalar(`expected:${def.dataset}`,
+    `${pre}SELECT count(*) FROM (SELECT DISTINCT ${EDGE_KEY_COLS} FROM (${def.selectSql}) _q) _d;`));
+
+  // ACTUAL: edges currently in gs_relationships for this dataset + type.
+  const actual = Number(await psqlScalar(`actual:${def.dataset}`,
+    `SELECT count(*) FROM gs_relationships WHERE dataset = '${def.dataset}' AND relationship_type = '${def.relationshipType}';`));
+
+  // SOURCE rows: coverage denominator (the trend line).
+  const sourceRows = Number(await psqlScalar(`source:${def.dataset}`,
+    `SELECT count(*) FROM ${def.sourceTable};`));
+
+  const driftPct = expected > 0 ? (expected - actual) / expected : null;       // >0 = under-built
+  const coveragePct = sourceRows > 0 ? (actual / sourceRows) * 100 : null;
+  let status;
+  if (expected === 0) status = 'EMPTY';
+  else if (driftPct > THRESHOLD) status = 'ALERT';                             // under-built (the bug)
+  else if (-driftPct > THRESHOLD) status = 'STALE';                            // over-built (legacy/stale)
+  else status = 'OK';
+
+  return {
+    dataset: def.dataset,
+    relationship_type: def.relationshipType,
+    expected_edges: expected,
+    actual_edges: actual,
+    source_rows: sourceRows,
+    drift_pct: driftPct === null ? null : Number(driftPct.toFixed(5)),
+    coverage_pct: coveragePct === null ? null : Number(coveragePct.toFixed(2)),
+    status,
+    threshold: THRESHOLD,
+    duration_ms: Date.now() - t0,
+  };
+}
+
+function printTable(results) {
+  const pct = (n) => (n === null || n === undefined ? '   —  ' : `${(n * 100).toFixed(2)}%`.padStart(7));
+  const num = (n) => Number(n).toLocaleString('en-US').padStart(11);
+  log('');
+  log(`Graph completeness  (threshold ±${(THRESHOLD * 100).toFixed(1)}%)`);
+  log('─'.repeat(86));
+  log(`${'dataset'.padEnd(20)}${'expected'.padStart(11)}${'actual'.padStart(11)}  ${'drift'.padStart(8)}  ${'coverage'.padStart(8)}  status`);
+  log('─'.repeat(86));
+  for (const r of results) {
+    log(`${r.dataset.padEnd(20)}${num(r.expected_edges)}${num(r.actual_edges)}  ${pct(r.drift_pct)}  ${r.coverage_pct === null ? '   —  ' : (r.coverage_pct.toFixed(1) + '%').padStart(7)}  ${r.status}`);
+  }
+  log('─'.repeat(86));
+}
+
+async function main() {
+  const supabase = SUPABASE_URL && SUPABASE_KEY
+    ? createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } })
+    : null;
+  const run = supabase ? await logStart(supabase, AGENT_ID, AGENT_NAME) : { id: null };
+  const runId = run?.id ?? null;
+
+  const results = [];
+  try {
+    for (const def of GRAPH_EDGE_DATASETS) {
+      const r = await checkDataset(def);
+      results.push(r);
+      log(`  ${def.dataset}: expected ${r.expected_edges.toLocaleString()} · actual ${r.actual_edges.toLocaleString()} · ${r.status}`);
+    }
+  } catch (err) {
+    if (supabase && runId) await logFailed(supabase, runId, err);
+    console.error('[graph-completeness] Fatal error:', err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+
+  printTable(results);
+
+  // Persist the trend rows (best-effort — never let a logging hiccup mask the gate verdict).
+  if (supabase) {
+    const { error } = await supabase.from('gs_graph_completeness_log').insert(
+      results.map((r) => ({ ...r, run_id: runId })),
+    );
+    if (error) log(`WARN: could not write gs_graph_completeness_log: ${error.message}`);
+  }
+
+  const alerts = results.filter((r) => r.status === 'ALERT');
+  const stale = results.filter((r) => r.status === 'STALE');
+
+  if (supabase && runId) {
+    await logComplete(supabase, runId, {
+      items_found: results.reduce((s, r) => s + r.expected_edges, 0),
+      items_new: results.reduce((s, r) => s + r.actual_edges, 0),
+      status: alerts.length ? 'partial' : 'success',
+      errors: alerts.map((r) => `${r.dataset} under-built: expected ${r.expected_edges}, actual ${r.actual_edges} (drift ${(r.drift_pct * 100).toFixed(1)}%)`),
+    });
+  }
+
+  if (jsonOut) process.stdout.write(JSON.stringify({ threshold: THRESHOLD, results }, null, 2) + '\n');
+
+  if (alerts.length) {
+    log('');
+    for (const r of alerts) {
+      log(`✗ ALERT ${r.dataset}: ${(r.drift_pct * 100).toFixed(1)}% of expected edges are MISSING (expected ${r.expected_edges.toLocaleString()}, actual ${r.actual_edges.toLocaleString()}). Re-run build-entity-graph --phase=<…> and investigate.`);
+    }
+    process.exit(1);  // actionable: edges silently went missing
+  }
+  if (stale.length) {
+    log('');
+    for (const r of stale) {
+      log(`• STALE ${r.dataset}: ${(-r.drift_pct * 100).toFixed(1)}% more edges than the current build produces (${(r.actual_edges - r.expected_edges).toLocaleString()} legacy/stale rows). A clean rebuild of this dataset would reconcile it.`);
+    }
+  }
+  log('✓ No under-built datasets.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[graph-completeness] Fatal error:', err);
+  process.exit(2);
+});

--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -673,6 +673,14 @@ export const AGENTS = {
     timeoutMs: 3_600_000,
     dependencies: [],
   },
+  'check-graph-completeness': {
+    command: ['node', '--env-file=.env', 'scripts/check-graph-completeness.mjs'],
+    displayName: 'Check Graph Completeness',
+    category: 'graph',
+    defaultPriority: 4, // run after build-entity-graph (priority 3)
+    timeoutMs: 300_000,
+    dependencies: ['build-entity-graph'],
+  },
   'resolve-donor-entities': {
     command: ['node', '--env-file=.env', 'scripts/resolve-donor-entities.mjs'],
     displayName: 'Resolve Donor Entities',

--- a/scripts/lib/graph-edge-datasets.mjs
+++ b/scripts/lib/graph-edge-datasets.mjs
@@ -1,0 +1,143 @@
+/**
+ * Graph edge datasets — the single source of truth for how each relationship
+ * dataset in `gs_relationships` is derived from source tables.
+ *
+ * Both consumers import this array so they can NEVER drift apart:
+ *   - `build-entity-graph.mjs` runs `INSERT INTO gs_relationships <cols> <selectSql>`
+ *     (column aliases below are ignored — INSERT maps by position).
+ *   - `check-graph-completeness.mjs` runs `count(DISTINCT <key>)` over the SAME
+ *     `selectSql` to compute the EXPECTED edge count, and compares to ACTUAL.
+ *     The key-column aliases (source_entity_id / target_entity_id /
+ *     relationship_type / source_record_id) are what let the check count
+ *     distinct edge-keys without re-deriving the joins.
+ *
+ * The dedup key mirrors build-entity-graph's DEDUP_TARGET:
+ *   (source_entity_id, target_entity_id, relationship_type, dataset, COALESCE(source_record_id,''))
+ * Within one dataset, `dataset` is a constant literal, so the per-dataset
+ * distinct key reduces to (source_entity_id, target_entity_id, relationship_type,
+ * COALESCE(source_record_id,'')) — see EDGE_KEY_COLS below.
+ *
+ * If you change a join/filter here, the completeness check's "expected" moves with
+ * it automatically — that is the whole point. Do not copy these SELECTs anywhere else.
+ */
+
+/** Dedup-key columns for a single dataset (dataset literal is constant within each). */
+export const EDGE_KEY_COLS = "source_entity_id, target_entity_id, relationship_type, COALESCE(source_record_id, '')";
+
+export const GRAPH_EDGE_DATASETS = [
+  {
+    dataset: 'aec_donations',
+    relationshipType: 'donation',
+    label: 'Donation relationships',
+    sourceTable: 'political_donations',
+    cols: '(source_entity_id, target_entity_id, relationship_type, amount, year, dataset, source_record_id, confidence, properties)',
+    // prelude: materialise + index the donor name→ABN map so the join below is an index scan,
+    // not a nested loop over an unindexed Materialize node (~4B ops → runaway).
+    prelude: `CREATE TEMP TABLE donor_map AS
+       SELECT DISTINCT ON (key) key, matched_abn FROM (
+         SELECT upper(trim(donor_name)) AS key, matched_abn
+           FROM donor_entity_matches WHERE matched_abn IS NOT NULL
+         UNION ALL
+         SELECT upper(trim(donor_name_normalized)), matched_abn
+           FROM donor_entity_matches
+           WHERE donor_name_normalized IS NOT NULL AND matched_abn IS NOT NULL
+       ) z ORDER BY key;
+     CREATE INDEX ON donor_map(key);
+     ANALYZE donor_map;`,
+    selectSql: `SELECT
+       donor.id AS source_entity_id, party.id AS target_entity_id, 'donation' AS relationship_type, d.amount,
+       NULLIF(split_part(d.financial_year, '-', 1), '')::int,
+       'aec_donations', d.id::text AS source_record_id, 'registry',
+       jsonb_build_object(
+         'financial_year', d.financial_year,
+         'return_type',    d.return_type,
+         'receipt_type',   d.receipt_type,
+         'donation_date',  d.donation_date)
+     FROM political_donations d
+     LEFT JOIN donor_map dm ON dm.key = upper(trim(d.donor_name))
+     JOIN gs_entities donor
+       ON donor.gs_id = 'AU-ABN-' || regexp_replace(coalesce(NULLIF(trim(d.donor_abn), ''), dm.matched_abn), '\\s', '', 'g')
+     JOIN gs_entities party
+       ON party.entity_type = 'political_party'
+      AND upper(trim(party.canonical_name)) = upper(trim(d.donation_to))`,
+  },
+  {
+    dataset: 'austender',
+    relationshipType: 'contract',
+    label: 'Contract relationships',
+    sourceTable: 'austender_contracts',
+    cols: '(source_entity_id, target_entity_id, relationship_type, amount, year, start_date, end_date, dataset, source_record_id, confidence, properties)',
+    prelude: '',
+    // buyer: AU-GOV-<buyer_id> (falls back to buyer_name, matching makeGsId({buyer_id: id||name})).
+    // supplier: AU-ABN-<abn>. source_record_id mirrors `c.ocid || c.id` (every row has an ocid).
+    // supplier_abn filtered to valid 11-digit ABNs (kept in sync with Phase 1e entity creation).
+    selectSql: `SELECT
+       buyer.id AS source_entity_id, supplier.id AS target_entity_id, 'contract' AS relationship_type, c.contract_value,
+       coalesce(extract(year FROM c.contract_start)::int, extract(year FROM c.date_published)::int),
+       c.contract_start, c.contract_end,
+       'austender', coalesce(NULLIF(c.ocid, ''), c.id::text) AS source_record_id, 'registry',
+       jsonb_build_object(
+         'category',           c.category,
+         'procurement_method', c.procurement_method,
+         'buyer_name',         c.buyer_name,
+         'supplier_name',      c.supplier_name)
+     FROM austender_contracts c
+     JOIN gs_entities buyer
+       ON buyer.gs_id = 'AU-GOV-' || coalesce(NULLIF(c.buyer_id, ''), c.buyer_name)
+     JOIN gs_entities supplier
+       ON supplier.gs_id = 'AU-ABN-' || regexp_replace(c.supplier_abn, '\\s', '', 'g')
+     WHERE c.supplier_abn IS NOT NULL
+       AND regexp_replace(c.supplier_abn, '\\s', '', 'g') ~ '^[0-9]{11}$'`,
+  },
+  {
+    dataset: 'grant_opportunities',
+    relationshipType: 'grant',
+    label: 'Grant relationships',
+    sourceTable: 'grant_opportunities',
+    cols: '(source_entity_id, target_entity_id, relationship_type, amount, dataset, source_record_id, confidence, properties)',
+    prelude: '',
+    // self-ref edge on the foundation entity (foundation offers grant); amount = max || min.
+    selectSql: `SELECT
+       f_ent.id AS source_entity_id, f_ent.id AS target_entity_id, 'grant' AS relationship_type, coalesce(g.amount_max, g.amount_min),
+       'grant_opportunities', g.id::text AS source_record_id, 'registry',
+       jsonb_build_object(
+         'grant_name', g.name,
+         'categories', array_to_string(g.categories, ', '),
+         'closes_at',  g.closes_at,
+         'provider',   g.provider)
+     FROM grant_opportunities g
+     JOIN foundations f
+       ON f.id = g.foundation_id AND f.acnc_abn IS NOT NULL
+     JOIN gs_entities f_ent
+       ON f_ent.gs_id = 'AU-ABN-' || regexp_replace(f.acnc_abn, '\\s', '', 'g')
+     WHERE g.foundation_id IS NOT NULL`,
+  },
+  {
+    dataset: 'foundations',
+    relationshipType: 'subsidiary_of',
+    label: 'Cross-registry links',
+    sourceTable: 'foundations',
+    cols: '(source_entity_id, target_entity_id, relationship_type, dataset, source_record_id, confidence, properties)',
+    prelude: '',
+    // parent matched by exact (case-insensitive) canonical_name = parent_company, mirroring the
+    // old nameIdMap.get(parent_company.toUpperCase()). DISTINCT ON keeps one parent per foundation
+    // (the JS map held a single id per name) — deterministic by parent.id.
+    selectSql: `SELECT DISTINCT ON (f.acnc_abn)
+       parent.id AS source_entity_id, f_ent.id AS target_entity_id, 'subsidiary_of' AS relationship_type, 'foundations', f.acnc_abn AS source_record_id, 'reported',
+       jsonb_build_object('parent_company', f.parent_company)
+     FROM foundations f
+     JOIN gs_entities f_ent
+       ON f_ent.gs_id = 'AU-ABN-' || regexp_replace(f.acnc_abn, '\\s', '', 'g')
+     JOIN gs_entities parent
+       ON upper(parent.canonical_name) = upper(f.parent_company)
+     WHERE f.parent_company IS NOT NULL AND f.acnc_abn IS NOT NULL
+     ORDER BY f.acnc_abn, parent.id`,
+  },
+];
+
+/** Look up one dataset definition by its `dataset` key; throws if unknown. */
+export function edgeDataset(dataset) {
+  const def = GRAPH_EDGE_DATASETS.find((d) => d.dataset === dataset);
+  if (!def) throw new Error(`No graph edge dataset definition for '${dataset}'`);
+  return def;
+}

--- a/supabase/migrations/20260618120000_gs_graph_completeness_log.sql
+++ b/supabase/migrations/20260618120000_gs_graph_completeness_log.sql
@@ -1,0 +1,48 @@
+-- Graph completeness gate — data-health roadmap Phase 2 (the centerpiece).
+--
+-- Per-dataset expected-vs-actual edge counts, one row per relationship dataset per run.
+-- Written by scripts/check-graph-completeness.mjs (nightly agent, after build-entity-graph).
+--
+-- This table IS the roadmap's "coverage trend": query it over time to see whether each
+-- dataset's edge coverage is holding, rising (genuinely capturing more), or silently
+-- regressing. status='ALERT' means edges went missing relative to what the source data +
+-- current build code support — the exact #82/#83 bug class that hid for months because
+-- nothing was watching graph completeness.
+
+CREATE TABLE IF NOT EXISTS gs_graph_completeness_log (
+  id                 bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  checked_at         timestamptz NOT NULL DEFAULT now(),
+  dataset            text        NOT NULL,   -- gs_relationships.dataset (e.g. aec_donations, austender)
+  relationship_type  text,                   -- the edge type this dataset produces
+  expected_edges     bigint      NOT NULL,   -- distinct edge-keys the current build SELECT would produce
+  actual_edges       bigint      NOT NULL,   -- edges currently in gs_relationships for this dataset
+  source_rows        bigint,                 -- rows in the base source table (coverage denominator)
+  drift_pct          numeric,                -- (expected - actual) / expected  (signed; >0 = under-built)
+  coverage_pct       numeric,                -- actual / source_rows  (the trend line, %)
+  status             text        NOT NULL,   -- OK | ALERT (under-built) | STALE (over-built) | EMPTY
+  threshold          numeric     NOT NULL,   -- drift tolerance used for this run (fraction, e.g. 0.05)
+  duration_ms        integer,
+  run_id             uuid                    -- agent_runs.id for this check (nullable under pooler stress)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gs_graph_completeness_log_dataset_time
+  ON gs_graph_completeness_log (dataset, checked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gs_graph_completeness_log_status
+  ON gs_graph_completeness_log (status, checked_at DESC)
+  WHERE status <> 'OK';
+
+-- Access: the nightly agent writes via the service_role key (PostgREST). New tables created
+-- through psql don't inherit API-role grants, so grant explicitly. Not exposed to anon/
+-- authenticated — /health reads this server-side via the service key, keeping it off the
+-- public PostgREST surface (no RLS-disabled-but-exposed advisory).
+GRANT SELECT, INSERT ON gs_graph_completeness_log TO service_role;
+
+COMMENT ON TABLE gs_graph_completeness_log IS
+  'Nightly graph-completeness gate (data-health roadmap Phase 2). Expected vs actual edge counts per relationship dataset. status=ALERT => edges silently went missing (the #82/#83 bug class).';
+
+-- Register the nightly check (runs after build-entity-graph via the orchestrator dependency).
+-- Idempotent so re-applying the migration is safe; agent metadata lives in scripts/lib/agent-registry.mjs.
+INSERT INTO agent_schedules (agent_id, interval_hours, enabled, priority)
+VALUES ('check-graph-completeness', 24, true, 4)
+ON CONFLICT (agent_id) DO NOTHING;


### PR DESCRIPTION
## Why

The durable fix for the **#82 / #83 / #85 / #86** bug class. Those were all *silent* graph under-builds — edges that should have existed in `gs_relationships` simply weren't there, and nothing noticed for months because nothing was watching completeness. This makes "is the graph *right*?" something the platform checks itself, nightly. (Data-health roadmap **Phase 2** — the centerpiece / highest-leverage item.)

## What it does

For each relationship dataset, compute the **expected** edge count set-based (the same `INSERT…SELECT` shape the build uses, minus the insert — counting *distinct edge-keys*) and compare to **actual** in `gs_relationships`:

| condition | status | meaning | exit |
|---|---|---|---|
| `expected > actual` beyond threshold | **ALERT** | edges silently went missing — the bug class | **1** |
| `actual > expected` beyond threshold | **STALE** | legacy / dead-code / deleted-source rows | 0 |
| within ±threshold | **OK** | — | 0 |

Threshold defaults to ±5% (catches the 35% #82 drop comfortably while tolerating source rows that arrived since the last build). Configurable via `--threshold=` / `GRAPH_COMPLETENESS_THRESHOLD`.

## No-drift guarantee (the key design point)

A gate that re-states the build's SQL would rot the moment someone edits one and not the other. So the 4 edge `SELECT`s move into **one source of truth** — `scripts/lib/graph-edge-datasets.mjs` — imported by **both** `build-entity-graph.mjs` (which `INSERT`s them) and the new check (which `count`s them). Edit the join there and the gate's "expected" moves with it automatically.

`build-entity-graph`'s 4 relationship phase functions are now thin wrappers over the shared defs. Validated by per-phase `--dry-run` candidate counts: the SQL is semantically identical — only key-column aliases (`source_entity_id` etc.) were added, which the positional `INSERT` ignores but the check's distinct-count needs.

## Pieces

- `scripts/lib/graph-edge-datasets.mjs` — shared edge definitions (source of truth)
- `scripts/check-graph-completeness.mjs` — the gate (`--threshold`, `--json` for `/health`)
- `supabase/migrations/…_gs_graph_completeness_log.sql` — trend table (the roadmap's "coverage trend") + `service_role` grant + nightly `agent_schedules` row (all idempotent)
- `scripts/lib/agent-registry.mjs` — register `check-graph-completeness` (depends on `build-entity-graph`, runs after it)

## First live run (±5%)

```
dataset                expected     actual     drift  coverage  status
aec_donations           713,348    743,594   -4.24%    44.2%   OK
austender               658,940    689,921   -4.70%    84.8%   OK
grant_opportunities       5,291      6,413  -21.21%    25.2%   STALE
foundations                  18         38 -111.11%     0.3%   STALE
```

Zero under-built ALERTs (correct — the graph isn't missing edges; it carries stale extras). The STALE rows are legacy edges a clean rebuild would reconcile (roadmap Phase 1). Trend rows persist to `gs_graph_completeness_log`.

## Follow-ups (not in this PR)

- `/health` UI surface for the gate (roadmap Phase 2 #3) — the check already emits `--json`.
- Clean-rebuild the STALE datasets to reconcile the over-build (roadmap Phase 1).
- Audit the other relationship agents (directorship/shared_director/grant) for the same 1000-cap class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)