### PR TITLE
fix(agents): add stable .order('id') to bridge .range() reads (#82 bug class)

### DIFF
--- a/scripts/bridge-justice-to-graph.mjs
+++ b/scripts/bridge-justice-to-graph.mjs
@@ -55,6 +55,9 @@ async function main() {
       .select('id, recipient_name, recipient_abn, program_name, amount_dollars, state, financial_year')
       .not('recipient_abn', 'is', null)
       .gt('amount_dollars', 0)
+      // Stable order by PK is REQUIRED for .range() pagination — without it PostgREST can return
+      // rows in inconsistent order across pages, silently overlapping/dropping ~35% (the #82 bug).
+      .order('id', { ascending: true })
       .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
 
     if (error) { log(`Error: ${error.message}`); process.exit(1); }

--- a/scripts/bridge-person-roles.mjs
+++ b/scripts/bridge-person-roles.mjs
@@ -68,6 +68,9 @@ async function main() {
         .from('person_roles')
         .select('id, person_name, person_name_normalised, role_type, company_name, company_abn, appointment_date, cessation_date, source')
         .not('company_abn', 'is', null)
+        // Stable order by PK is REQUIRED for .range() pagination — without it PostgREST can return
+        // rows in inconsistent order across pages, silently overlapping/dropping ~35% (the #82 bug).
+        .order('id', { ascending: true })
         .range(offset, offset + pageSize - 1);
 
       const { data: page, error } = await query;


### PR DESCRIPTION
## Why

Follow-up audit (the ledger's "#3") swept the relationship-producing agents the new completeness gate (#87) does **not** cover, hunting the same 1000-cap / unstable-pagination class as #82/#85/#86. It found **two** paginated reads missing a stable `ORDER BY` — the exact #82 bug, where PostgREST returns rows in inconsistent order across `.range()` pages and silently overlaps/drops ~35%.

## Fixed

| script | dataset / type | edges | impact |
|---|---|---|---|
| `bridge-justice-to-graph.mjs` | justice_funding → `grant` | 56,630 | **the bigger one — ~20K edges likely missing per run** |
| `bridge-person-roles.mjs` | person_roles → `directorship`/`member_of` | ~5,000 | smaller |

Fix is the #82 remedy: `.order('id', { ascending: true })` before `.range()`. `LIMIT` defaults in both are safe (justice 100K > 71K rows; person-roles 0 = no cap).

## Audit cleared the big ungated datasets

- `directorship` / `acnc_register` (**322K**) — built per-ABN via the ACNC HTTP API in `sync-charity-board.mjs`, no paginated table read → **SAFE**.
- `shared_director` / `person_roles_crossmatch` (**95K**) — set-based via psql in `link-entities-mega.mjs` → **SAFE**.
- `build-person-network.mjs`'s top-2000 read is an intentional `--limit` default, not the silent bug → left as-is.

## Realizing the fix

Both fixed agents are being re-run live (additive upserts) to recover the dropped edges (~25K).

## Noted follow-up (not here)

The completeness gate watches only the 4 build-entity-graph datasets (~1.44M of ~2.0M edges). The ~25 agent-built datasets (incl. these two) aren't watched yet — extending the gate to the set-based-expressible ones (e.g. justice_funding) is a roadmap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)