### PR TITLE
fix(agents): convert bridge write-paths to set-based psql; gate justice_funding

### DIFF
--- a/scripts/bridge-justice-to-graph.mjs
+++ b/scripts/bridge-justice-to-graph.mjs
@@ -1,239 +1,101 @@
 #!/usr/bin/env node
 
 /**
- * Bridge justice_funding → gs_relationships
+ * Bridge justice_funding → gs_relationships (grant edges: program → recipient).
  *
- * Creates program entities for distinct (program_name, state) pairs,
- * then creates funding relationships: program → recipient entity.
- * Uses source_record_id for dedup, so it's safe to run repeatedly.
+ * Set-based via direct psql, in two additive + idempotent steps:
+ *   1. Ensure a `program` entity exists for every (program_name, state) — JUSTICE_PROGRAM_ENSURE_SQL.
+ *   2. Insert program→recipient `grant` edges, guarded so only payments with NO existing justice
+ *      edge are written (JUSTICE_BUILD_GUARD) → re-runs add zero duplicates.
+ *
+ * The edge SELECT, prog_map prelude and the two write helpers live in
+ * scripts/lib/graph-edge-datasets.mjs — the single source of truth shared with build-entity-graph
+ * (which inserts) and check-graph-completeness (which counts). This agent is therefore equivalent to
+ * `build-entity-graph.mjs --phase=justice`, kept standalone so the data-pipeline can run it alone.
+ *
+ * History: the old REST `.upsert({onConflict:'…,source_record_id'})` path could not match the only
+ * dedup index (idx_gs_rel_dedup, on the COALESCE(source_record_id,'') EXPRESSION), so it errored on
+ * every batch (0 written). Set-based psql with `ON CONFLICT (<the expression>) DO NOTHING` is the fix.
  *
  * Usage:
- *   node --env-file=.env scripts/bridge-justice-to-graph.mjs [--dry-run] [--limit=100000]
+ *   node --env-file=.env scripts/bridge-justice-to-graph.mjs [--dry-run]
  */
 
-import { createClient } from '@supabase/supabase-js';
-import { createHash } from 'crypto';
+import { spawnSync } from 'node:child_process';
+import { resolveBin, withRetry } from './lib/agent-resilience.mjs';
+import { edgeDataset, JUSTICE_PROGRAM_ENSURE_SQL, JUSTICE_BUILD_GUARD } from './lib/graph-edge-datasets.mjs';
+import 'dotenv/config';
 
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const DRY_RUN = process.argv.includes('--dry-run');
-const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '100000');
 
-if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  process.exit(1);
-}
+const PG_PASSWORD = process.env.DATABASE_PASSWORD;
+const PSQL_BIN = resolveBin('psql');
+const PSQL_CONN = [
+  '-h', process.env.PGHOST || 'aws-0-ap-southeast-2.pooler.supabase.com',
+  '-p', process.env.PGPORT || '5432',
+  '-U', process.env.PGUSER || 'postgres.tednluwflfhxyucgwigh',
+  '-d', process.env.PGDATABASE || 'postgres',
+  '-X', '-A', '-t', '-v', 'ON_ERROR_STOP=1',
+];
 
-const db = createClient(SUPABASE_URL, SUPABASE_KEY);
+// Mirrors build-entity-graph's DEDUP_TARGET (the idx_gs_rel_dedup expression).
+const DEDUP_TARGET =
+  "(source_entity_id, target_entity_id, relationship_type, dataset, COALESCE(source_record_id, ''::text))";
 
 function log(msg) {
   console.log(`[${new Date().toISOString()}] ${msg}`);
 }
 
-function slugify(s) {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 60);
+/** Run one DML/SELECT via psql, retrying transient pooler failures. Returns stdout. */
+async function runDml(label, sql) {
+  if (!PG_PASSWORD) throw new Error('DATABASE_PASSWORD not set — the justice bridge requires direct psql');
+  const stdout = await withRetry(() => {
+    const res = spawnSync(PSQL_BIN, [...PSQL_CONN, '-c', `SET statement_timeout=0;\n${sql}`], {
+      env: { ...process.env, PGPASSWORD: PG_PASSWORD },
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (res.error) throw res.error;
+    if (res.status !== 0) throw new Error((res.stderr || res.stdout || `psql exit ${res.status}`).trim());
+    return res.stdout || '';
+  }, label);
+  return String(stdout);
 }
 
-/** Collision-resistant gs_id: slug-80 + 4-char hash of full name */
-function programGsId(name, state) {
-  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 80);
-  const hash = createHash('md5').update(name).digest('hex').slice(0, 4);
-  return `GS-PROG-${slug}-${hash}-${state.toLowerCase()}`;
+/** Parse the inserted-row count from psql's "INSERT 0 N" command tag. */
+function insertedCount(out) {
+  const m = String(out).match(/INSERT\s+\d+\s+(\d+)/);
+  return m ? m[1] : '0';
 }
 
 async function main() {
-  log(`=== Justice Funding → Graph Bridge ===`);
-  log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}, Limit: ${LIMIT}`);
+  const d = edgeDataset('justice_funding');
+  log(`=== Justice Funding → Graph Bridge (${DRY_RUN ? 'DRY RUN' : 'LIVE'}) ===`);
 
-  // Step 1: Get justice_funding records with ABNs (paginate past 1000 limit)
-  const records = [];
-  let page = 0;
-  const PAGE_SIZE = 1000;
-  while (records.length < LIMIT) {
-    const { data, error } = await db
-      .from('justice_funding')
-      .select('id, recipient_name, recipient_abn, program_name, amount_dollars, state, financial_year')
-      .not('recipient_abn', 'is', null)
-      .gt('amount_dollars', 0)
-      // Stable order by PK is REQUIRED for .range() pagination — without it PostgREST can return
-      // rows in inconsistent order across pages, silently overlapping/dropping ~35% (the #82 bug).
-      .order('id', { ascending: true })
-      .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
-
-    if (error) { log(`Error: ${error.message}`); process.exit(1); }
-    if (!data?.length) break;
-    records.push(...data);
-    page++;
-    if (data.length < PAGE_SIZE) break;
-  }
-  log(`Fetched ${records.length} justice_funding records with ABNs (${page} pages)`);
-
-  // Step 2: Get entity IDs for recipient ABNs
-  const uniqueAbns = [...new Set(records.map(r => r.recipient_abn))];
-  log(`Unique recipient ABNs: ${uniqueAbns.length}`);
-
-  const abnToEntity = new Map();
-  for (let i = 0; i < uniqueAbns.length; i += 500) {
-    const batch = uniqueAbns.slice(i, i + 500);
-    const { data: entities } = await db
-      .from('gs_entities')
-      .select('id, abn')
-      .in('abn', batch);
-    for (const e of (entities || [])) {
-      if (!abnToEntity.has(e.abn)) abnToEntity.set(e.abn, e.id);
-    }
-  }
-  log(`Matched ${abnToEntity.size} ABNs to entities`);
-
-  // Step 3: Find or create program entities for distinct (program_name, state) pairs
-  const programKeys = new Set();
-  for (const rec of records) {
-    programKeys.add(`${rec.program_name}|||${rec.state || 'NAT'}`);
-  }
-  log(`Unique programs: ${programKeys.size}`);
-
-  // Look up existing program entities
-  const programToEntity = new Map(); // key → uuid
-  const { data: existingPrograms } = await db
-    .from('gs_entities')
-    .select('id, gs_id, canonical_name, state')
-    .eq('entity_type', 'program');
-
-  // Build lookup from gs_id → entity id
-  const gsIdToEntity = new Map();
-  for (const ep of (existingPrograms || [])) {
-    gsIdToEntity.set(ep.gs_id, ep.id);
-  }
-  // Match program keys to existing entities (try new format, fall back to old)
-  for (const key of programKeys) {
-    const [name, state] = key.split('|||');
-    const newGsId = programGsId(name, state);
-    const oldGsId = `GS-PROG-${slugify(name)}-${state.toLowerCase()}`;
-    if (gsIdToEntity.has(newGsId)) {
-      programToEntity.set(key, gsIdToEntity.get(newGsId));
-    } else if (gsIdToEntity.has(oldGsId)) {
-      programToEntity.set(key, gsIdToEntity.get(oldGsId));
-    }
-  }
-  log(`Found ${programToEntity.size} existing program entities`);
-
-  // Create missing program entities
-  let programsCreated = 0;
-  for (const key of programKeys) {
-    if (programToEntity.has(key)) continue;
-    const [name, state] = key.split('|||');
-    const gsId = programGsId(name, state);
-
-    if (!DRY_RUN) {
-      const { data: inserted, error: insertErr } = await db
-        .from('gs_entities')
-        .insert({
-          gs_id: gsId,
-          canonical_name: name,
-          entity_type: 'program',
-          sector: 'government',
-          state: state === 'NAT' ? null : state,
-          confidence: 'inferred',
-        })
-        .select('id')
-        .single();
-
-      if (insertErr) {
-        if (insertErr.message.includes('duplicate')) {
-          // Already exists, look it up
-          const { data: existing } = await db
-            .from('gs_entities')
-            .select('id')
-            .eq('gs_id', gsId)
-            .single();
-          if (existing) programToEntity.set(key, existing.id);
-        } else {
-          log(`Program insert error for "${name}" (${state}): ${insertErr.message}`);
-        }
-        continue;
-      }
-      programToEntity.set(key, inserted.id);
-    }
-    programsCreated++;
-  }
-  log(`${DRY_RUN ? 'Would create' : 'Created'} ${programsCreated} program entities`);
-
-  // Step 4: Build relationships (program → recipient)
-  let created = 0;
-  let skipped = 0;
-  let errors = 0;
-  const BATCH_SIZE = 50;
-  let batch = [];
-
-  for (const rec of records) {
-    const targetId = abnToEntity.get(rec.recipient_abn);
-    if (!targetId) { skipped++; continue; }
-
-    const programKey = `${rec.program_name}|||${rec.state || 'NAT'}`;
-    const sourceId = programToEntity.get(programKey);
-    if (!sourceId) { skipped++; continue; }
-
-    batch.push({
-      source_entity_id: sourceId,
-      target_entity_id: targetId,
-      relationship_type: 'grant',
-      amount: rec.amount_dollars,
-      year: parseInt(rec.financial_year) || null,
-      dataset: 'justice_funding',
-      source_record_id: String(rec.id),
-      properties: { program: rec.program_name, state: rec.state, recipient: rec.recipient_name },
-    });
-
-    if (batch.length >= BATCH_SIZE) {
-      if (!DRY_RUN) {
-        const { data, error: insertErr } = await db
-          .from('gs_relationships')
-          .upsert(batch, {
-            onConflict: 'source_entity_id,target_entity_id,relationship_type,dataset,source_record_id',
-            ignoreDuplicates: true,
-            count: 'exact',
-          });
-        if (insertErr) {
-          if (errors < 3) log(`Upsert error: ${insertErr.message}`);
-          errors += batch.length;
-        } else {
-          created += batch.length;
-        }
-      } else {
-        created += batch.length;
-      }
-      batch = [];
-    }
+  if (DRY_RUN) {
+    // Count what the guarded write would insert against CURRENT program entities. (Program
+    // creation is skipped in dry-run, so brand-new programs' rows are not yet counted.)
+    const out = await runDml('justice dry-run',
+      `${d.prelude}\nSELECT count(*) FROM (${d.selectSql}${JUSTICE_BUILD_GUARD}) _q;`);
+    const n = out.trim().split('\n').pop() || '?';
+    log(`Would insert ~${n} grant edges (excludes payments whose program entity is not yet created)`);
+    log('=== DRY RUN COMPLETE ===');
+    return;
   }
 
-  // Flush remaining
-  if (batch.length) {
-    if (!DRY_RUN) {
-      const { error: insertErr } = await db
-        .from('gs_relationships')
-        .upsert(batch, {
-          onConflict: 'source_entity_id,target_entity_id,relationship_type,dataset,source_record_id',
-          ignoreDuplicates: true,
-        });
-      if (insertErr) {
-        if (errors < 3) log(`Upsert error (flush): ${insertErr.message}`);
-        errors += batch.length;
-      } else {
-        created += batch.length;
-      }
-    } else {
-      created += batch.length;
-    }
-  }
+  log('Step 1/2: ensuring program entities (additive)...');
+  const pe = await runDml('justice program entities', JUSTICE_PROGRAM_ENSURE_SQL);
+  log(`  Program entities created: ${insertedCount(pe)} (existing reused)`);
 
-  log(`=== COMPLETE ===`);
-  log(`Programs: ${programsCreated} created, ${programToEntity.size} total`);
-  log(`Relationships: ${created} created`);
-  log(`Skipped (no entity or duplicate): ${skipped}`);
-  log(`Errors: ${errors}`);
+  log('Step 2/2: inserting program→recipient grant edges (additive, guarded)...');
+  const ins = await runDml('justice edges',
+    `${d.prelude}\nINSERT INTO gs_relationships ${d.cols}\n${d.selectSql}${JUSTICE_BUILD_GUARD}\nON CONFLICT ${DEDUP_TARGET} DO NOTHING;`);
+  log(`  Grant edges inserted: ${insertedCount(ins)} (existing skipped via ON CONFLICT)`);
+
+  log('=== COMPLETE ===');
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Fatal:', err);
   process.exit(1);
 });

--- a/scripts/bridge-person-roles.mjs
+++ b/scripts/bridge-person-roles.mjs
@@ -1,238 +1,157 @@
 #!/usr/bin/env node
 /**
- * Bridge Person Roles → Graph
+ * Bridge person_roles → gs_relationships (directorship / member_of edges: person → company).
  *
- * 1. Match person_roles.company_abn → gs_entities to find company entities
- * 2. Create person entities in gs_entities for each unique person
- * 3. Create gs_relationships from person → company with role_type
- * 4. Backfill person_roles.entity_id and person_entity_id
+ * Set-based via direct psql, all three steps additive + idempotent:
+ *   1. Ensure a `person` entity exists for each distinct person (gs_id = GS-PERSON-<slug>, capped 80).
+ *   2. Insert person→company edges, one per (person, company, relationship_type). role_type maps
+ *      director/chair → directorship, everything else → member_of (mirrors the old ROLE_TO_REL
+ *      with its `|| 'member_of'` default).
+ *   3. Backfill person_roles.person_entity_id + entity_id with the resolved entity ids.
+ *
+ * History: the old path used REST `.insert()` with NO onConflict, so whole 1-person batches died on
+ * the dedup unique index (idx_gs_rel_dedup) whenever any edge already existed — the agent could not
+ * cleanly re-run. Set-based psql with `ON CONFLICT (<the dedup expression>) DO NOTHING` is the fix.
+ * Unlike the justice bridge, person entities use a single gs_id format, so the gs_id join lands on
+ * exactly the nodes existing edges use and a plain ON CONFLICT dedups them — no build-side guard needed.
  *
  * Usage:
- *   node --env-file=.env scripts/bridge-person-roles.mjs [--apply] [--limit=1000]
+ *   node --env-file=.env scripts/bridge-person-roles.mjs [--apply]   (default: DRY RUN)
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { spawnSync } from 'node:child_process';
+import { resolveBin, withRetry } from './lib/agent-resilience.mjs';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import 'dotenv/config';
+
+const APPLY = process.argv.includes('--apply');
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const PG_PASSWORD = process.env.DATABASE_PASSWORD;
+const PSQL_BIN = resolveBin('psql');
+const PSQL_CONN = [
+  '-h', process.env.PGHOST || 'aws-0-ap-southeast-2.pooler.supabase.com',
+  '-p', process.env.PGPORT || '5432',
+  '-U', process.env.PGUSER || 'postgres.tednluwflfhxyucgwigh',
+  '-d', process.env.PGDATABASE || 'postgres',
+  '-X', '-A', '-t', '-v', 'ON_ERROR_STOP=1',
+];
 
-if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  process.exit(1);
+const DEDUP_TARGET =
+  "(source_entity_id, target_entity_id, relationship_type, dataset, COALESCE(source_record_id, ''::text))";
+
+// Person identity, shared by every step so entities, edges and backfill agree:
+//   normname = person_name_normalised, else upper(trim(person_name))  (mirrors JS `a || b`)
+//   gs_id    = left('GS-PERSON-' || slug(normname), 80)               (mirrors personGsId())
+const NORMNAME = `coalesce(NULLIF(pr.person_name_normalised,''), upper(trim(pr.person_name)))`;
+const PERSON_GSID = (norm) =>
+  `left('GS-PERSON-' || regexp_replace(regexp_replace(lower(${norm}),'[^a-z0-9]+','-','g'),'(^-|-$)','','g'), 80)`;
+
+// Step 1 — person entities (additive). DISTINCT ON (gs_id) collapses slug collisions to one node.
+const PERSON_ENTITY_SQL = `
+  INSERT INTO gs_entities (gs_id, canonical_name, entity_type, source_count, confidence)
+  SELECT DISTINCT ON (gs_id) gs_id, initcap(lower(normname)), 'person', cnt, 'registry'
+  FROM (
+    SELECT coalesce(NULLIF(pr.person_name_normalised,''), upper(trim(pr.person_name))) AS normname,
+           count(*) AS cnt
+      FROM person_roles pr
+     WHERE pr.company_abn IS NOT NULL
+       AND coalesce(NULLIF(pr.person_name_normalised,''), upper(trim(pr.person_name))) IS NOT NULL
+     GROUP BY 1
+  ) p,
+  LATERAL (SELECT left('GS-PERSON-' || regexp_replace(regexp_replace(lower(p.normname),'[^a-z0-9]+','-','g'),'(^-|-$)','','g'), 80) AS gs_id) g
+  WHERE g.gs_id <> 'GS-PERSON-'
+  ORDER BY gs_id, cnt DESC
+  ON CONFLICT (gs_id) DO NOTHING;`;
+
+// Step 2 — edges (additive). One row per (person, company, relationship_type); on collapse keep the
+// earliest-appointed role's metadata (deterministic by appointment_date then id).
+const EDGE_SELECT = `
+  WITH role_edges AS (
+    SELECT pe.id AS source_entity_id, ce.id AS target_entity_id,
+           CASE WHEN pr.role_type IN ('director','chair') THEN 'directorship' ELSE 'member_of' END AS relationship_type,
+           pr.appointment_date AS start_date, pr.cessation_date AS end_date,
+           coalesce(pr.source,'acnc') AS src, pr.role_type AS original_role, pr.id AS rid
+      FROM person_roles pr
+      JOIN gs_entities ce ON ce.abn = pr.company_abn
+      JOIN gs_entities pe ON pe.gs_id = ${PERSON_GSID(NORMNAME)}
+     WHERE pr.company_abn IS NOT NULL
+  )
+  SELECT DISTINCT ON (source_entity_id, target_entity_id, relationship_type)
+         source_entity_id, target_entity_id, relationship_type, 'person_roles', 'registry',
+         start_date, end_date,
+         jsonb_build_object('source', src, 'original_role', original_role)
+    FROM role_edges
+   ORDER BY source_entity_id, target_entity_id, relationship_type, start_date NULLS LAST, rid`;
+const EDGE_COLS =
+  '(source_entity_id, target_entity_id, relationship_type, dataset, confidence, start_date, end_date, properties)';
+
+// Step 3 — backfill person_roles with the resolved entity ids (per-row company; idempotent guard).
+const BACKFILL_SQL = `
+  UPDATE person_roles pr
+     SET person_entity_id = pe.id, entity_id = ce.id
+    FROM gs_entities pe, gs_entities ce
+   WHERE pr.company_abn IS NOT NULL
+     AND ce.abn = pr.company_abn
+     AND pe.gs_id = ${PERSON_GSID(NORMNAME)}
+     AND (pr.person_entity_id IS DISTINCT FROM pe.id OR pr.entity_id IS DISTINCT FROM ce.id);`;
+
+function log(msg) { console.log(`[${new Date().toISOString()}] ${msg}`); }
+
+async function runDml(label, sql) {
+  if (!PG_PASSWORD) throw new Error('DATABASE_PASSWORD not set — the person bridge requires direct psql');
+  const stdout = await withRetry(() => {
+    const res = spawnSync(PSQL_BIN, [...PSQL_CONN, '-c', `SET statement_timeout=0;\n${sql}`], {
+      env: { ...process.env, PGPASSWORD: PG_PASSWORD },
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (res.error) throw res.error;
+    if (res.status !== 0) throw new Error((res.stderr || res.stdout || `psql exit ${res.status}`).trim());
+    return res.stdout || '';
+  }, label);
+  return String(stdout);
 }
 
-const APPLY = process.argv.includes('--apply');
-const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '0', 10);
-
-const db = createClient(SUPABASE_URL, SUPABASE_KEY);
-
-function titleCase(name) {
-  return name.split(' ').map(w =>
-    w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
-  ).join(' ');
-}
-
-// Map person_roles role_type → gs_relationships relationship_type
-const ROLE_TO_REL = {
-  director: 'directorship',
-  chair: 'directorship',
-  board_member: 'member_of',
-  secretary: 'member_of',
-  trustee: 'member_of',
-  officeholder: 'member_of',
-  public_officer: 'member_of',
-  other: 'member_of',
-};
-
-function personGsId(normName) {
-  const slug = normName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  return `GS-PERSON-${slug}`.slice(0, 80);
-}
+const tag = (out, re) => (String(out).match(re) || [])[1] ?? '0';
 
 async function main() {
-  const run = await logStart(db, 'bridge-person-roles', 'Bridge Person Roles');
+  const supabase = SUPABASE_URL && SUPABASE_KEY ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
+  const run = supabase ? await logStart(supabase, 'bridge-person-roles', 'Bridge Person Roles') : { id: null };
+  const runId = run?.id ?? null;
 
   try {
-    console.log('=== Bridge Person Roles → Graph ===');
-    console.log(`  Mode: ${APPLY ? 'APPLY' : 'DRY RUN'}`);
-    console.log();
+    log(`=== Bridge Person Roles → Graph (${APPLY ? 'APPLY' : 'DRY RUN'}) ===`);
 
-    // 1. Fetch all person_roles with company_abn
-    const allRoles = [];
-    let offset = 0;
-    const pageSize = 1000;
-
-    while (true) {
-      let query = db
-        .from('person_roles')
-        .select('id, person_name, person_name_normalised, role_type, company_name, company_abn, appointment_date, cessation_date, source')
-        .not('company_abn', 'is', null)
-        // Stable order by PK is REQUIRED for .range() pagination — without it PostgREST can return
-        // rows in inconsistent order across pages, silently overlapping/dropping ~35% (the #82 bug).
-        .order('id', { ascending: true })
-        .range(offset, offset + pageSize - 1);
-
-      const { data: page, error } = await query;
-      if (error) throw error;
-      if (!page || page.length === 0) break;
-      allRoles.push(...page);
-      if (page.length < pageSize) break;
-      offset += pageSize;
+    if (!APPLY) {
+      const out = await runDml('person edges dry-run', `SELECT count(*) FROM (${EDGE_SELECT}) _q;`);
+      const n = out.trim().split('\n').pop() || '?';
+      log(`Would insert ~${n} person→company edges (existing skipped via ON CONFLICT). Use --apply to write.`);
+      if (supabase && runId) await logComplete(supabase, runId, { items_found: Number(n) || 0, items_new: 0 });
+      return;
     }
 
-    console.log(`  ${allRoles.length} person roles with company ABN`);
+    log('Step 1/3: ensuring person entities (additive)...');
+    const pe = await runDml('person entities', PERSON_ENTITY_SQL);
+    log(`  Person entities created: ${tag(pe, /INSERT\s+\d+\s+(\d+)/)} (existing reused)`);
 
-    // 2. Build ABN → gs_entity map
-    const uniqueAbns = [...new Set(allRoles.map(r => r.company_abn))];
-    const abnToEntity = new Map();
+    log('Step 2/3: inserting person→company edges (additive)...');
+    const ins = await runDml('person edges',
+      `INSERT INTO gs_relationships ${EDGE_COLS}\n${EDGE_SELECT}\nON CONFLICT ${DEDUP_TARGET} DO NOTHING;`);
+    const relsCreated = Number(tag(ins, /INSERT\s+\d+\s+(\d+)/));
+    log(`  Edges inserted: ${relsCreated} (existing skipped via ON CONFLICT)`);
 
-    for (let i = 0; i < uniqueAbns.length; i += 100) {
-      const batch = uniqueAbns.slice(i, i + 100);
-      const { data: entities, error } = await db
-        .from('gs_entities')
-        .select('id, abn')
-        .in('abn', batch);
-      if (error) throw error;
-      for (const e of entities) abnToEntity.set(e.abn, e.id);
-    }
+    log('Step 3/3: backfilling person_roles entity references...');
+    const bf = await runDml('person_roles backfill', BACKFILL_SQL);
+    log(`  person_roles rows linked: ${tag(bf, /UPDATE\s+(\d+)/)}`);
 
-    console.log(`  ${abnToEntity.size}/${uniqueAbns.length} company ABNs matched to gs_entities`);
-
-    // 3. Group roles by person
-    const personMap = new Map(); // norm_name → { displayName, roles[] }
-    for (const role of allRoles) {
-      const key = role.person_name_normalised || role.person_name.toUpperCase().trim();
-      if (!personMap.has(key)) {
-        personMap.set(key, { displayName: titleCase(key), roles: [] });
-      }
-      personMap.get(key).roles.push(role);
-    }
-
-    console.log(`  ${personMap.size} unique persons`);
-
-    // 4. Process each person
-    let personsCreated = 0;
-    let relsCreated = 0;
-    let skipped = 0;
-    let errors = 0;
-
-    const entries = [...personMap.entries()];
-    const toProcess = LIMIT ? entries.slice(0, LIMIT) : entries;
-
-    for (let i = 0; i < toProcess.length; i++) {
-      const [normName, { displayName, roles }] = toProcess[i];
-
-      // Find distinct companies for this person
-      const companyEdges = new Map(); // entityId-relType → edge data
-      for (const role of roles) {
-        const companyEntityId = abnToEntity.get(role.company_abn);
-        if (!companyEntityId) continue;
-        const relType = ROLE_TO_REL[role.role_type] || 'member_of';
-        const key = `${companyEntityId}:${relType}`;
-        if (!companyEdges.has(key)) {
-          companyEdges.set(key, {
-            companyEntityId,
-            relType,
-            originalRole: role.role_type,
-            appointmentDate: role.appointment_date,
-            cessationDate: role.cessation_date,
-            source: role.source || 'acnc',
-          });
-        }
-      }
-
-      if (companyEdges.size === 0) {
-        skipped++;
-        continue;
-      }
-
-      if (!APPLY) {
-        personsCreated++;
-        relsCreated += companyEdges.size;
-        continue;
-      }
-
-      // Create person entity
-      const gsId = personGsId(normName);
-      const { data: personEntity, error: personError } = await db
-        .from('gs_entities')
-        .upsert({
-          gs_id: gsId,
-          canonical_name: displayName,
-          entity_type: 'person',
-          source_count: roles.length,
-          confidence: 'registry',
-        }, { onConflict: 'gs_id' })
-        .select('id')
-        .single();
-
-      if (personError) {
-        errors++;
-        if (errors <= 5) console.error(`  Error creating person ${displayName}: ${personError.message}`);
-        continue;
-      }
-
-      personsCreated++;
-      const personEntityId = personEntity.id;
-
-      // Create relationships
-      const relBatch = [];
-      for (const [, edge] of companyEdges) {
-        relBatch.push({
-          source_entity_id: personEntityId,
-          target_entity_id: edge.companyEntityId,
-          relationship_type: edge.relType,
-          dataset: 'person_roles',
-          confidence: 'registry',
-          start_date: edge.appointmentDate || null,
-          end_date: edge.cessationDate || null,
-          properties: { source: edge.source, original_role: edge.originalRole },
-        });
-      }
-
-      const { error: relError } = await db
-        .from('gs_relationships')
-        .insert(relBatch);
-
-      if (relError) {
-        errors++;
-        if (errors <= 5) console.error(`  Error creating relationships for ${displayName}: ${relError.message}`);
-      } else {
-        relsCreated += relBatch.length;
-      }
-
-      // Update person_roles with entity references
-      const roleIds = roles.filter(r => abnToEntity.has(r.company_abn)).map(r => r.id);
-      if (roleIds.length > 0) {
-        const firstCompanyId = abnToEntity.get(roles.find(r => abnToEntity.has(r.company_abn)).company_abn);
-        await db
-          .from('person_roles')
-          .update({ person_entity_id: personEntityId, entity_id: firstCompanyId })
-          .in('id', roleIds);
-      }
-
-      if ((i + 1) % 500 === 0) {
-        console.log(`  Progress: ${i + 1}/${toProcess.length} (${personsCreated} persons, ${relsCreated} relationships)`);
-      }
-    }
-
-    console.log(`\n=== Summary ===`);
-    console.log(`  Persons: ${personsCreated} created`);
-    console.log(`  Relationships: ${relsCreated} created`);
-    console.log(`  Skipped (no matching company): ${skipped}`);
-    console.log(`  Errors: ${errors}`);
-    if (!APPLY) console.log('  (DRY RUN — use --apply to write changes)');
-
-    await logComplete(db, run.id, {
-      items_found: toProcess.length,
-      items_new: personsCreated,
-      items_updated: relsCreated,
-    });
-
+    log('=== COMPLETE ===');
+    if (supabase && runId) await logComplete(supabase, runId, { items_found: relsCreated, items_new: relsCreated });
   } catch (err) {
     console.error('Fatal:', err);
-    await logFailed(db, run.id, err);
+    if (supabase && runId) await logFailed(supabase, runId, err);
     process.exit(1);
   }
 }

--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -11,6 +11,7 @@
  *   node scripts/build-entity-graph.mjs --phase=donations  # donations only
  *   node scripts/build-entity-graph.mjs --phase=contracts  # contracts only
  *   node scripts/build-entity-graph.mjs --phase=links      # cross-registry links
+ *   node scripts/build-entity-graph.mjs --phase=justice    # justice funding grant edges
  *   node scripts/build-entity-graph.mjs --phase=refresh    # refresh materialized views
  *   node scripts/build-entity-graph.mjs --dry-run          # count only, no writes
  */
@@ -18,7 +19,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { spawnSync } from 'node:child_process';
 import { resolveBin, withRetry } from './lib/agent-resilience.mjs';
-import { edgeDataset } from './lib/graph-edge-datasets.mjs';
+import { edgeDataset, JUSTICE_PROGRAM_ENSURE_SQL, JUSTICE_BUILD_GUARD } from './lib/graph-edge-datasets.mjs';
 import 'dotenv/config';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -699,6 +700,23 @@ async function buildCrossRegistryLinks() {
   await buildRelationshipsSetBased(d.label, d.cols, d.selectSql, d.prelude);
 }
 
+// ─── Phase 2d: Justice funding → relationships ──────────────────────────────
+
+async function buildJusticeRelationships() {
+  log('\nPhase 2d: Justice funding relationships...');
+  const d = edgeDataset('justice_funding');
+  // Program entities (entity_type='program') are derived from justice_funding itself, so create
+  // them here (additive, idempotent) before building the program→recipient grant edges.
+  if (!dryRun) {
+    const out = await runDml('justice program entities', JUSTICE_PROGRAM_ENSURE_SQL);
+    const m = out.match(/INSERT\s+\d+\s+(\d+)/);
+    log(`  Program entities: ${m ? m[1] : '0'} created (existing reused)`);
+  }
+  // WRITE appends the additive guard (only un-edged payments); the completeness gate uses the bare
+  // selectSql (full derivation), so expected can't drift from the canonical join.
+  await buildRelationshipsSetBased(d.label, d.cols, d.selectSql + JUSTICE_BUILD_GUARD, d.prelude);
+}
+
 // ─── Phase 3: Refresh materialised views ─────────────────────────────────────
 
 async function refreshViews() {
@@ -746,6 +764,10 @@ async function main() {
 
   if (phase === 'all' || phase === 'links') {
     await buildCrossRegistryLinks();
+  }
+
+  if (phase === 'all' || phase === 'justice') {
+    await buildJusticeRelationships();
   }
 
   if (phase === 'all' || phase === 'refresh') {

--- a/scripts/lib/graph-edge-datasets.mjs
+++ b/scripts/lib/graph-edge-datasets.mjs
@@ -133,7 +133,91 @@ export const GRAPH_EDGE_DATASETS = [
      WHERE f.parent_company IS NOT NULL AND f.acnc_abn IS NOT NULL
      ORDER BY f.acnc_abn, parent.id`,
   },
+  {
+    dataset: 'justice_funding',
+    relationshipType: 'grant',
+    label: 'Justice funding relationships',
+    sourceTable: 'justice_funding',
+    cols: '(source_entity_id, target_entity_id, relationship_type, amount, year, dataset, source_record_id, properties)',
+    // The program ENTITY layer (gs_entities entity_type='program') is created/refreshed by
+    // JUSTICE_PROGRAM_ENSURE_SQL (below), run by build-entity-graph's justice phase and the bridge
+    // BEFORE the edge insert. It is deliberately NOT in this prelude, so the completeness gate
+    // (which executes preludes to compute "expected") stays strictly read-only.
+    //
+    // Why prog_map + the build-side guard: the program layer accreted two gs_id formats
+    // (old GS-PROG-<slug60>-<state>, new GS-PROG-<slug80>-<md5x4>-<state>) plus slug collisions,
+    // so the ~56K pre-existing edges are split across nodes with NO single clean (name,state)→node
+    // mapping. prog_map collapses each program to ONE node (preferring the node that already carries
+    // justice edges, then old/hash-less format, then lowest id) so newly built edges stay coherent.
+    // The completeness gate measures this FULL derivation; the WRITE additionally appends
+    // JUSTICE_BUILD_GUARD so it only touches payments with no edge yet — making re-runs idempotent
+    // and adding ZERO duplicates regardless of which node a payment's prior edge happens to sit on.
+    prelude: `CREATE TEMP TABLE jf_prog_map AS
+       SELECT DISTINCT ON (canonical_name, norm_state) canonical_name, norm_state, id AS prog_id
+         FROM (
+           SELECT e.id, e.canonical_name,
+                  coalesce(NULLIF(trim(e.state),''),'NAT') AS norm_state,
+                  (e.gs_id ~ '-[0-9a-f]{4}-[a-z]{2,3}$') AS new_fmt,
+                  EXISTS (SELECT 1 FROM gs_relationships r
+                           WHERE r.source_entity_id = e.id
+                             AND r.dataset='justice_funding' AND r.relationship_type='grant') AS has_edges
+             FROM gs_entities e WHERE e.entity_type='program'
+         ) z
+        ORDER BY canonical_name, norm_state, has_edges DESC, new_fmt ASC, id ASC;
+       CREATE INDEX ON jf_prog_map(canonical_name, norm_state);
+       ANALYZE jf_prog_map;`,
+    // source = canonical program node (prog_map); target = recipient matched by exact ABN.
+    // year mirrors parseInt(financial_year): leading digits of e.g. '2016-17' / '2016-ongoing'.
+    selectSql: `SELECT
+       pm.prog_id AS source_entity_id, rec.id AS target_entity_id, 'grant' AS relationship_type,
+       jf.amount_dollars,
+       NULLIF(substring(jf.financial_year from '^[0-9]+'),'')::int,
+       'justice_funding', jf.id::text AS source_record_id,
+       jsonb_build_object('program', jf.program_name, 'state', jf.state, 'recipient', jf.recipient_name)
+     FROM justice_funding jf
+     JOIN gs_entities rec ON rec.abn = jf.recipient_abn
+     JOIN jf_prog_map pm ON pm.canonical_name = jf.program_name
+                        AND pm.norm_state    = coalesce(NULLIF(trim(jf.state),''),'NAT')
+     WHERE jf.recipient_abn IS NOT NULL AND jf.amount_dollars > 0`,
+  },
 ];
+
+/**
+ * Additive write-guard for the justice build: only emit edges for payments that have NO existing
+ * justice edge. Because the historical program-node layer is split across two gs_id formats, a
+ * payment's prior edge may sit on a different node than prog_map now picks; this guard ensures the
+ * write never creates a second (duplicate) edge for an already-edged payment — so re-runs add zero
+ * duplicates and are fully idempotent. The completeness gate measures the bare `selectSql` (the full
+ * derivation); ONLY the WRITE path appends this guard, right before `ON CONFLICT … DO NOTHING`.
+ */
+export const JUSTICE_BUILD_GUARD = `
+     AND NOT EXISTS (SELECT 1 FROM gs_relationships y
+                      WHERE y.dataset='justice_funding' AND y.relationship_type='grant'
+                        AND COALESCE(y.source_record_id,'') = jf.id::text)`;
+
+/**
+ * Ensure a program entity exists for every justice (program_name, state) that has none yet.
+ * Brand-new nodes get the collision-resistant new format (slug80 + md5[:4] + state, mirroring
+ * programGsId() in bridge-justice-to-graph.mjs); any existing node (either format) is reused via
+ * the NOT EXISTS guard. Idempotent (ON CONFLICT (gs_id) DO NOTHING). Run BEFORE the justice edge
+ * insert — NOT from the dataset prelude (keeps the gate read-only).
+ */
+export const JUSTICE_PROGRAM_ENSURE_SQL = `
+  INSERT INTO gs_entities (gs_id, canonical_name, entity_type, sector, state, confidence)
+  SELECT DISTINCT
+    'GS-PROG-'
+      || left(regexp_replace(regexp_replace(lower(jf.program_name),'[^a-z0-9]+','-','g'),'(^-|-$)','','g'),80)
+      || '-' || left(md5(jf.program_name),4)
+      || '-' || lower(coalesce(NULLIF(trim(jf.state),''),'NAT')),
+    jf.program_name, 'program', 'government', NULLIF(trim(jf.state),''), 'inferred'
+  FROM justice_funding jf
+  WHERE jf.recipient_abn IS NOT NULL AND jf.amount_dollars > 0
+    AND NOT EXISTS (
+      SELECT 1 FROM gs_entities e
+       WHERE e.entity_type='program'
+         AND e.canonical_name = jf.program_name
+         AND coalesce(NULLIF(trim(e.state),''),'NAT') = coalesce(NULLIF(trim(jf.state),''),'NAT'))
+  ON CONFLICT (gs_id) DO NOTHING;`;
 
 /** Look up one dataset definition by its `dataset` key; throws if unknown. */
 export function edgeDataset(dataset) {

--- a/thoughts/shared/handoffs/agent-health-resilience/current.md
+++ b/thoughts/shared/handoffs/agent-health-resilience/current.md
@@ -9,17 +9,20 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-06-18 (late) — THREE PRs shipped this session: **#86** (Phase 1d/1e/1i 1000-cap reads + supplier backfill), **#87** (completeness gate — roadmap Phase 2), **#88** (`.order('id')` on two bridge `.range()` reads). All merged. Graph: **603,572 entities · ~1.96M edges**.
+**Updated:** 2026-06-18 (later) — **BRIDGE WRITE-PATH REWRITE DONE (live, uncommitted on `main`).** Both bridges converted to set-based psql `INSERT…SELECT … ON CONFLICT (dedup-expr) DO NOTHING`, sharing the SoT. **justice +81,493 edges (56,630→138,123), gate now OK; person +329,896 edges (5,086→334,982), 333,836 person_roles backfilled.** Graph: **~605,900 entities · 2,370,061 edges** (+411,389 this run). NOT yet committed/PR'd — awaiting Ben's go. Earlier this session: **#86/#87/#88** all merged.
 **Goal:** Make the CivicGraph relationship graph correct, fast, and self-monitoring. Diagnose by REPRODUCTION (never assumption); every fix validated live before claiming done.
 **Branch:** `main` at `ee617a4`. **No open PRs** (#86/#87/#88 all squash-merged, branches deleted). CI green throughout.
 **Test:** `node --check scripts/build-entity-graph.mjs` · dry-run a phase (`--phase=X --dry-run`) · `node --env-file=.env scripts/check-graph-completeness.mjs` (the gate) · reproduce/validate live before claiming done.
 
-### Now — NEXT TASK (decided with Ben: fresh pass after /clear)
-[->] **Convert the two bridge agents' WRITE paths to set-based psql** so they're re-runnable and actually recover the dropped edges. PR #88 fixed their READS (`.order('id')`) but re-running revealed the writes are broken against the dedup index:
-- **`bridge-justice-to-graph.mjs`** — PostgREST `.upsert({onConflict:'…,source_record_id'})` can't match the only dedup index `idx_gs_rel_dedup` (on EXPRESSION `COALESCE(source_record_id,'')`) → **0 created, 99,999 errors** when run live (count still 56,630, no harm). The [[feedback_postgrest_partial_index_upsert]] failure mode.
-- **`bridge-person-roles.mjs`** — plain `.insert()` (no onConflict) fails whole batches on existing-edge unique violations → can't cleanly re-run.
-- **Fix:** rewrite both writes as `INSERT INTO gs_relationships … SELECT … ON CONFLICT (source_entity_id,target_entity_id,relationship_type,dataset,COALESCE(source_record_id,'')) DO NOTHING` via psql (the `buildRelationshipsSetBased` pattern in build-entity-graph). **Elegant bonus:** lift the justice_funding edge SELECT into `scripts/lib/graph-edge-datasets.mjs`, have build-entity-graph build it, and the completeness gate watches it for free (closes part of the gate coverage gap below). Expected recovery: ~20K justice grant edges + the person edges.
-- Validate the usual way: dry-run candidate count, then live, then `check-graph-completeness.mjs` should show justice OK.
+### Now — DONE this session (live, uncommitted). Next: commit + PR (Ben's go).
+[x] **Converted both bridge agents' WRITE paths to set-based psql** — re-runnable, additive, recovered the dropped edges. Files changed (uncommitted on `main`):
+- **`scripts/lib/graph-edge-datasets.mjs`** — added `justice_funding` dataset entry (read-only `jf_prog_map` prelude + canonical edge SELECT) and two write-side exports: `JUSTICE_PROGRAM_ENSURE_SQL` (creates missing `program` entities) + `JUSTICE_BUILD_GUARD` (`NOT EXISTS` additive guard, write-only).
+- **`scripts/build-entity-graph.mjs`** — new `--phase=justice` (program-ensure → guarded set-based edge insert). Included in `all`.
+- **`scripts/bridge-justice-to-graph.mjs`** — rewritten as a thin set-based psql agent sharing the SoT. `--dry-run` counts; live = program-ensure + guarded `INSERT…ON CONFLICT DO NOTHING`. (Old REST `.upsert` couldn't match the COALESCE-expr index → 0 written: the [[feedback_postgrest_partial_index_upsert]] mode.)
+- **`scripts/bridge-person-roles.mjs`** — rewritten set-based, 3 steps (person entities → edges → `person_roles` backfill), all `ON CONFLICT DO NOTHING` / idempotent UPDATE. `--apply` to write.
+- **Why the justice guard:** the program-node layer is historically split (old `GS-PROG-<slug60>-<state>` + new `<slug80>-<md5x4>-<state>` + slug collisions); 55,811 of 56,630 existing edges sit on OLD-format nodes, so NO clean (name,state)→node map matches them all. The `NOT EXISTS (payment already edged)` guard makes the WRITE touch only un-edged payments → 0 new dups, fully re-runnable. The gate measures the FULL derivation (bare selectSql); only the write appends the guard. Person needs no guard (single gs_id format → gs_id join lands on the existing nodes; `ON CONFLICT` dedups the 5,086).
+- **Results (live):** justice +81,493 (gate justice now **138,055 exp / 138,123 act / OK**); person +329,896 (dir 113,419 + member_of 221,563), 333,836 backfilled, 87 residual unlinked (empty-slug/unmatched-ABN). Total edges 2,370,061.
+- **Gate coverage:** justice_funding now watched (was on the gap list). Person NOT gated (would need 2 entries dir+member_of — follow-up). grant_opportunities/foundations still STALE (pre-existing legacy; separate clean-rebuild).
 
 ### Context for that task (verified this session)
 - Only dedup index: `idx_gs_rel_dedup UNIQUE (source_entity_id, target_entity_id, relationship_type, dataset, COALESCE(source_record_id,''::text))`. `gs_relationships_pkey` on `id`.

--- a/thoughts/shared/handoffs/agent-health-resilience/current.md
+++ b/thoughts/shared/handoffs/agent-health-resilience/current.md
@@ -1,0 +1,105 @@
+---
+date: 2026-06-18T00:00:00+10:00
+session_name: agent-health-resilience
+branch: main
+status: active
+---
+
+# Work Stream: entity-graph data health (was: agent-health-resilience)
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-06-18 (late) — THREE PRs shipped this session: **#86** (Phase 1d/1e/1i 1000-cap reads + supplier backfill), **#87** (completeness gate — roadmap Phase 2), **#88** (`.order('id')` on two bridge `.range()` reads). All merged. Graph: **603,572 entities · ~1.96M edges**.
+**Goal:** Make the CivicGraph relationship graph correct, fast, and self-monitoring. Diagnose by REPRODUCTION (never assumption); every fix validated live before claiming done.
+**Branch:** `main` at `ee617a4`. **No open PRs** (#86/#87/#88 all squash-merged, branches deleted). CI green throughout.
+**Test:** `node --check scripts/build-entity-graph.mjs` · dry-run a phase (`--phase=X --dry-run`) · `node --env-file=.env scripts/check-graph-completeness.mjs` (the gate) · reproduce/validate live before claiming done.
+
+### Now — NEXT TASK (decided with Ben: fresh pass after /clear)
+[->] **Convert the two bridge agents' WRITE paths to set-based psql** so they're re-runnable and actually recover the dropped edges. PR #88 fixed their READS (`.order('id')`) but re-running revealed the writes are broken against the dedup index:
+- **`bridge-justice-to-graph.mjs`** — PostgREST `.upsert({onConflict:'…,source_record_id'})` can't match the only dedup index `idx_gs_rel_dedup` (on EXPRESSION `COALESCE(source_record_id,'')`) → **0 created, 99,999 errors** when run live (count still 56,630, no harm). The [[feedback_postgrest_partial_index_upsert]] failure mode.
+- **`bridge-person-roles.mjs`** — plain `.insert()` (no onConflict) fails whole batches on existing-edge unique violations → can't cleanly re-run.
+- **Fix:** rewrite both writes as `INSERT INTO gs_relationships … SELECT … ON CONFLICT (source_entity_id,target_entity_id,relationship_type,dataset,COALESCE(source_record_id,'')) DO NOTHING` via psql (the `buildRelationshipsSetBased` pattern in build-entity-graph). **Elegant bonus:** lift the justice_funding edge SELECT into `scripts/lib/graph-edge-datasets.mjs`, have build-entity-graph build it, and the completeness gate watches it for free (closes part of the gate coverage gap below). Expected recovery: ~20K justice grant edges + the person edges.
+- Validate the usual way: dry-run candidate count, then live, then `check-graph-completeness.mjs` should show justice OK.
+
+### Context for that task (verified this session)
+- Only dedup index: `idx_gs_rel_dedup UNIQUE (source_entity_id, target_entity_id, relationship_type, dataset, COALESCE(source_record_id,''::text))`. `gs_relationships_pkey` on `id`.
+- justice agent program-entity creation DID work (2046 created); only the relationship write is broken.
+- `bridge-justice-to-graph` runs LIVE by default (`--dry-run` to suppress); `bridge-person-roles` needs `--apply`.
+
+**[history] Re-run surfaced a DEEPER write bug (the `.order()` fix is necessary-not-sufficient):** ran `bridge-justice-to-graph` live → **0 relationships created, 99,999 errors**, "no unique constraint matching ON CONFLICT". Root cause: PostgREST `.upsert({onConflict:'…,source_record_id'})` can't match the only dedup index `idx_gs_rel_dedup` which is on the EXPRESSION `COALESCE(source_record_id,'')` (the [[feedback_postgrest_partial_index_upsert]] failure mode). No data harmed (count still 56,630). `bridge-person-roles` has an analogous problem — plain `.insert()` (no onConflict) fails whole batches on existing-edge unique violations, so it can't cleanly re-run either (NOT run, deliberately). **Real fix = convert both write paths to set-based psql `INSERT…SELECT … ON CONFLICT (…COALESCE(source_record_id,'')…) DO NOTHING`** (the build-entity-graph pattern) — would recover ~20K justice + ~? person edges AND make both agents re-runnable. Natural to fold justice_funding into `graph-edge-datasets.mjs` + the gate at the same time. PR #88's `.order()` fixes still correct + mergeable (prerequisite for any recovery), just don't recover edges alone.
+
+**Gate coverage gap (noted):** the completeness gate watches only the 4 build-entity-graph datasets (~1.44M of ~2.0M edges). The ~25 agent-built datasets (directorship 322K, shared_director 95K, justice grants 56K, the other grant/* + lobbies_for/member_of/affiliated_with) are NOT watched. Extending the gate to set-based-expressible ones (e.g. justice_funding) is a roadmap follow-up.
+
+### Earlier today
+[->] **PR #87 MERGED** (squash `a90dfa6`) — completeness gate live + scheduled. The gate's first run flagged grant_opportunities (+1,122) & foundations (+20) as STALE (over-built legacy rows) and donations/austender as sub-threshold over-built (+30K/+31K) → roadmap Phase 1 **clean-rebuild per dataset** is the natural next data op. Also: audit other relationship agents (#3) for the 1000-cap class; build the `/health` UI surface (roadmap Phase 2 #3 — gate already emits `--json`).
+
+### Completeness gate (BUILT 2026-06-18, branch `feat/graph-completeness-gate`)
+- **`scripts/lib/graph-edge-datasets.mjs`** — single source of truth for the 4 edge SELECTs; imported by BOTH `build-entity-graph` (inserts) and the check (counts) → expected can't drift from actual. Build's 4 phase fns are now thin wrappers; validated by per-phase `--dry-run` (SQL semantically identical, only key-col aliases added).
+- **`scripts/check-graph-completeness.mjs`** — per dataset: EXPECTED (distinct edge-keys over the build SELECT) vs ACTUAL (`gs_relationships`). `expected>actual`→ALERT (under-built, exit 1); `actual>expected`→STALE (exit 0). Flags: `--threshold=` (default 0.05), `--json` (for /health).
+- **migration `…_gs_graph_completeness_log.sql`** — trend table (the roadmap's "coverage trend") + `service_role` grant + nightly `agent_schedules` row. All idempotent. Registered in agent-registry (`check-graph-completeness`, deps `build-entity-graph`).
+- **First live run** (±5%): donations 713,348/743,594 OK · austender 658,940/689,921 OK · grants 5,291/6,413 STALE · foundations 18/38 STALE · 0 ALERTs. Rows persisted.
+
+### This Session (2026-06-18 late — PR #86)
+- [x] **#86 OPEN (`41d8b6f`+`110c690`)** — paginate Phase 1d (gov bodies), 1e (suppliers), 1i (ASX). Unpaginated PostgREST reads → set-based `DISTINCT` via psql, parsed delimiter-safe through `row_to_json` + new `selectJsonRows` helper. **1e saw only ~1000 of 60,017 distinct supplier ABNs.** Also filtered 1e + the contracts join (kept in sync) to valid 11-digit ABNs (12 garbage values like `#N/A`/`Exempt-*` were collapsing 100s of suppliers into fake hubs `AU-ABN-#N/A` et al.).
+- [x] **selectJsonRows SET-tag crash found+fixed (`110c690`)** — `runDml` prepends `SET statement_timeout=0;` so psql echoes a `SET` line; `JSON.parse('SET')` threw fatal on the first call. Filter to `{`-prefixed lines. Routed 1f through the same hardened helper → also kills #85's latent bug minting a junk "SET" political_party (deleted the orphan: `DELETE 1`).
+- [x] **1i finding:** all 2,013 `asx_companies.abn` are NULL → 1i creates 0 entities regardless of pagination (separate upstream data gap; now logged explicitly).
+- [x] **Backfill run live** — entities phase (18min) created the missing suppliers (austender entities 55,638→57,408; **supplier ABN coverage 59,958/60,017**). Contracts re-run set-based, clean: **+4,385 edges** (685,536→689,921). Impact modest because most supplier ABNs already had entities via ACNC/ATO/ORIC (same `AU-ABN-*` gs_id); only ~1,770 were austender-only.
+- [x] **MV refresh** re-running live (`b6la5297f`).
+- [!] **Transient flake during entities run:** 1000 row writes failed with `TypeError: terminated` (shared-pooler saturation, NOT a code bug — see memory). Landed mostly in the JusticeHub phase (ran last) + 59 suppliers. Idempotent → recovered on any future `--phase=entities` run. NOT blocking.
+
+### Prior Session (2026-06-18 earlier)
+- [x] **#83 MERGED (`38f9bd8`)** — set-based rewrite of all 4 relationship phases (donations/contracts/grants/links). One server-side `INSERT…SELECT … ON CONFLICT DO NOTHING` each via psql; in-memory `loadEntityIndex` removed entirely. ~40× faster end-to-end (donations 63s vs ~45min). Validated phase-by-phase diff-to-zero. Recovered **+578,799** index-dropped edges live (donations +159,659, contracts +418,876, grants +257, links +7).
+- [x] **#84 MERGED** — `docs/strategy/data-health-roadmap.md` (5 phases; completeness gate = centerpiece).
+- [x] **#85 MERGED** — Phase 1f party creation read was unpaginated → PostgREST 1000-cap → only 66 of 2,437 parties. Set-based `SELECT DISTINCT` fix. Live: parties **66→2,438**, donation edges **368,365→743,594** (re-ran donations after).
+- [x] **MVs refreshed twice** — 38/38, 0 failed; final refresh (21.6 min) reflects the doubled donations + deduped contracts.
+- [x] **#1 contract dedup DONE (data op, no PR)** — removed 702,189 legacy dual-key dupes + stale rows; **preserved 29,193** would-be-lost contracts (safe set only). Contracts **1,387,725→685,536**. No recurrence (current code keys on `ocid`).
+
+### Next
+- [x] ~~Fix Phase 1d/1e/1i unpaginated reads~~ → **PR #86**, backfilled live.
+- [x] ~~Merge PR #86~~ → squash-merged `94a66a8`, CI green, branch deleted.
+- [ ] **Build the completeness gate** (roadmap Phase 2): nightly expected-vs-actual edge count per dataset, alert on drift. Would have caught all of #82/#83/#85/#86/#1 the morning after. **← now the top durable item.**
+- [ ] **#3 audit** other relationship agents (directorship 329K, shared_director 95K, grant 94K) for the same 1000-cap read class.
+- [ ] **ASX ABN data gap** — populate `asx_companies.abn` (all 2,013 NULL) upstream so Phase 1i actually creates entities. Separate ingest fix.
+- [ ] **Mop-up (low pri):** re-run `--phase=entities` once to recover the 1000 transient-failed rows + 59 missing suppliers (idempotent). Tonight's manual run or any future build clears it.
+
+### Decisions
+- **Additive-only writes** for the rewrite (Ben, 2026-06-17): recover dropped links, leave legacy rows; clean rebuild only as a deliberate separate step.
+- **#1 contract cleanup = safe delete** (Ben, 2026-06-18): delete only proven dupes+stale, preserve the 29,193 net-loss rows.
+- **Large DELETEs:** precompute doomed IDs into an indexed TEMP table set-based, then delete-by-pkey. Per-row `EXISTS` in a big DELETE = pathological (killed a 22-min runaway). Even safe, 702K×13-index deletes = ~21min IO on the throttled shared instance.
+
+### Open Questions
+- UNCONFIRMED: exact count the 29,193 shrinks to after Phase 1d/1e fix + contract re-run (expected to drop substantially, not necessarily to 0).
+- UNCONFIRMED: whether the frontend actually surfaces the now-complete graph + refreshed MVs (no app audit done — likely the biggest user-visible win; roadmap Phase 4 / a `/leverage` pass).
+
+### Workflow State
+pattern: diagnose-fix-validate-ship
+phase: 6
+total_phases: 8
+retries: 0
+max_retries: 3
+
+#### Resolved
+- goal: "make the entity graph correct, fast, self-monitoring; fix donation/contract data at source"
+- resource_allocation: balanced
+
+#### Unknowns
+- frontend_surfaces_the_data: UNKNOWN (no app audit)
+
+#### Last Failure
+(none — last destructive op, the contract dedup, completed clean: DELETE 702189, 29193 preserved)
+
+---
+
+## Context
+
+### Key facts for resume
+- **Supabase:** SELECT via `node --env-file=.env scripts/gsql.mjs "..."`; DML/heavy via direct psql (`PGPASSWORD=$DATABASE_PASSWORD psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U postgres.tednluwflfhxyucgwigh -d postgres -f file.sql`). `exec_sql` RPC is SELECT-only. Shared pooler intermittently saturates.
+- **Set-based phase helper:** `buildRelationshipsSetBased(label, cols, selectSql, prelude)` in `scripts/build-entity-graph.mjs` — shells to psql via `resolveBin`+`withRetry` (`scripts/lib/agent-resilience.mjs`); `ON CONFLICT (dedup index expr) DO NOTHING`. Prelude pre-materialises+indexes lookup tables (donor_map) so joins are index scans, not nested-loop-over-Materialize (~4B-op runaway otherwise).
+- **The recurring bug class:** silent read truncation — unpaginated REST `.select()` (PostgREST 1000-row cap) OR `.range()` without stable `.order()`. Caused #82 (entity index), #85 (66 parties), and the 29,193 unresolved contracts (Phase 1d/1e). The completeness gate is the durable fix.
+- **Memory:** `project_build_entity_graph_setbased` (full detail, corrected findings), `feedback_data_quality_before_scoring`.
+- **Roadmap:** `docs/strategy/data-health-roadmap.md`.
+
+### Prior sessions (history — see git/PRs/memory for detail)
+- 2026-06-17: #80 (build-entity-graph resilience + JusticeHub N+1), #81 (Vercel 45-min deploy hang), #82 (`loadEntityIndex` `.order('id')` — found the ⅓ drop). #76–#79 (shared `agent-resilience.mjs`, withRetry on logStart/Complete/Failed, trust-remediation unify, null-run_id snapshot fix).
+- 2026-06-16: #71–#75 (scraper-hang timeouts, enrich-se status accounting, YJ tracker pooler-retry, trust-remediation psql-PATH, Poll-Frontier 403 auto-disable).
+- DEFERRED: Notion sync (#71) re-enable needs per-run cap (full run = 1,480-page dump); agent is `enabled=false`.

--- a/thoughts/shared/handoffs/agent-health-resilience/next-session-prompts.md
+++ b/thoughts/shared/handoffs/agent-health-resilience/next-session-prompts.md
@@ -1,0 +1,66 @@
+# Next-session prompts — bridge write-path rewrite
+
+> Written 2026-06-18 end-of-session. Decided with Ben: do this as a **fresh pass after `/clear`**.
+> The SessionStart hook auto-reloads the ledger (`current.md`), so these prompts just point at the
+> task + set guardrails. Full context (broken writes, exact dedup index, fix pattern) is in the
+> ledger's **"Now — NEXT TASK"** section.
+
+State at handoff: `main` @ `ee617a4` · no open PRs · #86/#87/#88 all merged · graph 603,572 entities · ~1.96M edges.
+
+---
+
+## Primary kickoff prompt (both agents)
+
+```
+Resume the "Now — NEXT TASK" in the agent-health-resilience ledger: convert the two
+bridge agents' WRITE paths to set-based psql so they're re-runnable and actually recover
+the dropped edges.
+
+Scope:
+- bridge-justice-to-graph.mjs (justice_funding → grant edges) and bridge-person-roles.mjs
+  (person_roles → directorship/member_of edges).
+- Replace their per-row/REST relationship writes with INSERT INTO gs_relationships … SELECT …
+  ON CONFLICT (source_entity_id,target_entity_id,relationship_type,dataset,COALESCE(source_record_id,''))
+  DO NOTHING via psql — the buildRelationshipsSetBased pattern in build-entity-graph.mjs.
+- For justice: lift the justice_funding edge SELECT into scripts/lib/graph-edge-datasets.mjs,
+  have build-entity-graph build it, and add it to the completeness gate. Confirm the gate then
+  reports justice_funding.
+
+Constraints:
+- Additive only (ON CONFLICT DO NOTHING) — don't delete existing edges.
+- Verify the dedup index before writing SQL (idx_gs_rel_dedup, on the COALESCE expression).
+- Validate each: dry-run candidate count → live run → check-graph-completeness.mjs shows OK.
+- Don't run both write-heavy agents concurrently (shared pooler saturates — caused
+  TypeError: terminated last session). Sequential only.
+- Stop criteria: justice + person edges recovered AND the gate run is clean. If a write still
+  errors, diagnose by reproduction, don't guess.
+
+Tier reminders: live data writes + push/PR/merge need my explicit go (ask first). Use effort
+xhigh — this is a schema-contract + multi-file design task.
+```
+
+---
+
+## Faster scoped variant (justice only first — the bigger ~20K-edge win)
+
+```
+Resume the ledger NEXT TASK but JUST bridge-justice-to-graph.mjs first. Rewrite its broken
+relationship upsert (PostgREST can't match the COALESCE expression index) as a set-based psql
+INSERT…SELECT…ON CONFLICT DO NOTHING, lifting the justice_funding edge SELECT into
+graph-edge-datasets.mjs so build-entity-graph builds it and the completeness gate watches it.
+Validate with check-graph-completeness.mjs. Additive only, sequential, ask before live writes /
+PR. Effort xhigh. Leave bridge-person-roles for a follow-up.
+```
+
+---
+
+## Quick notes
+
+- Start with `/preflight` (DB/env/git/types) — confirms `main` @ `ee617a4` and the gate is present.
+- To see the gate's current verdict before changing anything:
+  `node --env-file=.env scripts/check-graph-completeness.mjs`
+  (shows the 4 gated datasets; justice_funding won't appear until the rewrite adds it.)
+- Verified facts for the task (don't re-derive):
+  - Only dedup index: `idx_gs_rel_dedup UNIQUE (source_entity_id, target_entity_id, relationship_type, dataset, COALESCE(source_record_id,''::text))`; pkey on `id`.
+  - justice agent's program-entity creation already works (2046 created); only the relationship write is broken.
+  - `bridge-justice-to-graph` runs LIVE by default (`--dry-run` to suppress); `bridge-person-roles` needs `--apply`.


### PR DESCRIPTION
## What

Both bridge agents wrote `gs_relationships` via the Supabase REST client, which **cannot match the only dedup index** `idx_gs_rel_dedup` (a UNIQUE index on the `COALESCE(source_record_id,'')` **expression**):

- `bridge-justice-to-graph.mjs` — `.upsert({onConflict:'…,source_record_id'})` → **0 written, 99,999 errors** on a live run.
- `bridge-person-roles.mjs` — plain `.insert()` (no onConflict) → whole per-person batches died on existing-edge unique violations.

Neither could re-run. This rewrites both write paths as server-side `INSERT … SELECT … ON CONFLICT (<the dedup expression>) DO NOTHING` via psql (the `buildRelationshipsSetBased` pattern). **Additive only** — no deletes.

## Changes

- **`scripts/lib/graph-edge-datasets.mjs`** — new `justice_funding` dataset (single source of truth): read-only `jf_prog_map` prelude + canonical edge SELECT, plus two write-side exports `JUSTICE_PROGRAM_ENSURE_SQL` and `JUSTICE_BUILD_GUARD`.
- **`scripts/build-entity-graph.mjs`** — new `--phase=justice` (program-ensure → guarded edge insert), included in `all`.
- **`scripts/bridge-justice-to-graph.mjs`** — thin set-based psql agent sharing the SoT.
- **`scripts/bridge-person-roles.mjs`** — set-based 3-step rewrite (person entities → edges → `person_roles` backfill), all idempotent.
- The completeness gate now **watches `justice_funding`** automatically (no gate code change).

## Design note

The justice program-node layer is historically split — old `GS-PROG-<slug60>-<state>` + new `<slug80>-<md5x4>-<state>` + slug collisions — so **55,811 of 56,630 existing edges sit on old-format nodes** and there is no clean `(name,state)→node` map that matches all of them. Rather than create ~20K duplicate edges chasing that, the **write appends a `NOT EXISTS (payment already edged)` guard** so it only touches genuinely-missing payments → **0 new duplicates, fully re-runnable**. The gate measures the full canonical derivation (bare `selectSql`); only the write appends the guard. Person needs no guard (single gs_id format → the gs_id join lands on the existing nodes, so plain `ON CONFLICT` dedups the prior 5,086 edges).

## Live results (additive, already applied)

| dataset | before | after | recovered |
|---|---|---|---|
| justice `grant` | 56,630 | 138,123 | **+81,493** |
| person `directorship` | 2,228 | 113,419 | — |
| person `member_of` | 2,858 | 221,563 | — |
| person total | 5,086 | 334,982 | **+329,896** |
| total `gs_relationships` | ~1.96M | **2,370,061** | **+411,389** |

Gate after run: `justice_funding` expected 138,055 / actual 138,123 / drift −0.05% / **OK**. `person_roles` backfilled 333,836 rows (87 residual unlinked = empty-slug/unmatched-ABN edge cases).

## Validation

- `node --check` on all 4 scripts; both bridges `--dry-run` count-checked; `EXPLAIN` confirmed the live INSERT/UPDATE plans (justice + person), incl. `Conflict Arbiter Indexes: idx_gs_rel_dedup`.
- Completeness gate run before (justice ALERT, expected) and after (justice OK).
- Sequential runs only (shared pooler); re-runnable (re-run inserts 0).

## Follow-ups (not in this PR)

- Extend the gate to person_roles (needs 2 entries: `directorship` + `member_of`).
- `grant_opportunities`/`foundations` STALE legacy rows — separate clean-rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
