### PR TITLE
fix(app): restore read-only exec_sql — un-break 99 stranded data routes

### DIFF
--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -4,7 +4,31 @@ function getUrl() {
   return process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
 }
 
-const blockedSqlRpcNames = new Set(['exec_sql', 'exec', 'execute_sql', 'exec_agent_sql']);
+// Arbitrary-SQL agent RPCs that must never run from the app runtime — they bypass RLS and
+// accept writes. `exec_sql` is handled separately: it is the read path the data routes depend
+// on, so SELECT/WITH reads are allowed through (the DB function is itself SELECT-wrapped) while
+// any write shape is rejected. See commit 02213dd.
+const fullyBlockedSqlRpcNames = new Set(['exec', 'execute_sql', 'exec_agent_sql']);
+
+/**
+ * exec_sql read-only guard (defense-in-depth). Allows a single SELECT/WITH read; rejects
+ * non-reads, stacked statements, and data-modifying CTEs. The DB function additionally wraps
+ * input as `SELECT row_to_json(t) FROM (<query>) t`, so writes fail there too.
+ */
+function isReadOnlyExecSql(query: string | undefined): boolean {
+  if (typeof query !== 'string') return false;
+  const stripped = query
+    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+    .replace(/--[^\n]*/g, ' ') // line comments
+    .trim();
+  if (!stripped) return false;
+  if (!/^(select|with)\b/i.test(stripped)) return false; // top-level read only
+  if (/;\s*\S/.test(stripped.replace(/;\s*$/, ''))) return false; // no stacked statements
+  if (/\b(insert\s+into|update\s+[\w".]+\s+set|delete\s+from|merge\s+into)\b/i.test(stripped)) {
+    return false; // no data-modifying CTE
+  }
+  return true;
+}
 
 /** Client-side Supabase (anon key, RLS enforced) */
 let _supabase: SupabaseClient | null = null;
@@ -74,14 +98,34 @@ function createBlockedSqlRpcBuilder(functionName: string): EmptyQueryBuilder {
   });
 }
 
+function createReadOnlyViolationBuilder(): EmptyQueryBuilder {
+  return createStaticQueryBuilder({
+    data: null,
+    error: {
+      message: 'exec_sql only accepts read-only (SELECT/WITH) queries from the app runtime.',
+      code: 'SQL_RPC_READONLY',
+      details: null,
+      hint: 'Use a typed Supabase read or a dedicated write RPC for mutations.',
+    },
+    count: null,
+  });
+}
+
 function createRuntimeSupabaseClient(client: SupabaseClient): SupabaseClient {
   return new Proxy(client, {
     get(target, prop, receiver) {
       if (prop === 'rpc') {
         const rpc = Reflect.get(target, prop, receiver) as (...args: unknown[]) => unknown;
         return (functionName: string, ...args: unknown[]) => {
-          if (blockedSqlRpcNames.has(functionName)) {
+          if (fullyBlockedSqlRpcNames.has(functionName)) {
             return createBlockedSqlRpcBuilder(functionName);
+          }
+          if (functionName === 'exec_sql') {
+            const params = args[0] as { query?: unknown } | undefined;
+            const query = typeof params?.query === 'string' ? params.query : undefined;
+            if (!isReadOnlyExecSql(query)) {
+              return createReadOnlyViolationBuilder();
+            }
           }
           return rpc.apply(target, [functionName, ...args]);
         };


### PR DESCRIPTION
## Problem
Commit `02213dd` ("stop unsafe Supabase SQL RPC load", 2026-06-16) added an app-side proxy that blocks **every** `.rpc('exec_sql')` call, but only migrated ~5 of ~104 routes off it. The other **99 routes were stranded** and have returned **500 in production since 06-16**:
`/person`, `/power`, all `/reports/*`, most `/api/data/*`, `/foundations/*`, `/entity/*`.

The DB function itself is fine — service-role `exec_sql` still returns 200. This was purely the app-side block.

## Fix (read-only restore — "restore reads fast", agreed)
Narrow the runtime block in `apps/web/src/lib/supabase.ts`:
- `exec_sql` is allowed through **only** for read-only `SELECT`/`WITH` queries.
- Non-reads, stacked statements, and data-modifying CTEs are rejected (`SQL_RPC_READONLY`).
- `exec` / `execute_sql` / `exec_agent_sql` stay **fully blocked** (the app calls none of them).
- The DB function also wraps input as `SELECT row_to_json(t) FROM (<query>) t`, so writes fail there too — this is defense-in-depth.

## Security note
This re-opens the read path `02213dd` deliberately closed. The remaining posture: service-role reads built from `esc()`-escaped string SQL (RLS-bypassing reads of public data). Writes cannot pass the guard. The **proper long-term fix is migrating routes off string-SQL `exec_sql` to typed Supabase reads / safe RPCs** — tracked as follow-up, too large for this hotfix.

## Verification
- `/person`, `/power`, `/rankings`, `/power-index`, `/who-runs-australia`, `/sector` → back to **200** (were 500).
- 17/17 read-only predicate tests (allows SELECT/WITH; blocks UPDATE/DELETE/DROP/TRUNCATE/GRANT/stacked/CTE-writes).
- `tsc --noEmit` clean.

Independent of #90 (different files, no conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)