### PR TITLE
feat(people): person-disambiguation gate + scoping (read-only, no migration)

### DIFF
--- a/scripts/person-disambig-probe.mjs
+++ b/scripts/person-disambig-probe.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * person-disambig-probe — VERIFICATION GATE for person disambiguation.
+ *
+ * READ-ONLY. Splits a name-keyed person megamerge into candidate distinct
+ * identities via a per-name co-director graph (+ geography), then reports
+ * cluster shape, nominee-block detection, and money attribution per cluster.
+ *
+ * This is the gate that must pass BEFORE building the clustering migration.
+ * It writes NOTHING to the database — pure SELECTs via exec_sql.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/person-disambig-probe.mjs                  # validation set
+ *   node --env-file=.env scripts/person-disambig-probe.mjs "JANE DOE" ...   # ad-hoc names
+ *
+ * Signals (verified 2026-06-19): company_abn/acn/entity_id ~100%;
+ * appointment_date ~0%, cessation_date 0% (temporal signal is DEAD).
+ * So: shared co-directors + geography only.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// ---- tunable thresholds (the disambiguation contract) ----
+const HIGH_DEGREE = 10;   // a co-director on >= this many of the target's boards = "block officer" → glues them all
+const MIN_SHARED = 2;     // mid-degree co-directors: a pair of boards needs >= this many shared co-directors to merge
+const NOMINEE_MIN = 20;   // a component >= this size with a dominant officer + postcode = trustee/nominee block
+const DOMINANCE = 0.5;    // officer/postcode must cover >= this fraction of the component to flag nominee
+
+const esc = (s) => s.replace(/'/g, "''");
+
+async function q(sql) {
+  const { data, error } = await supabase.rpc('exec_sql', { query: sql });
+  if (error) throw new Error(error.message + '\n--SQL--\n' + sql);
+  return data || [];
+}
+
+// exec_sql returns via PostgREST which caps at 1000 rows — page with an inner LIMIT/OFFSET.
+// buildSql(limit, offset) must emit a stably-ORDERed query.
+async function qPaged(buildSql) {
+  const page = 1000; let offset = 0; const all = [];
+  for (;;) {
+    const rows = await q(buildSql(page, offset));
+    all.push(...rows);
+    if (rows.length < page) break;
+    offset += page;
+  }
+  return all;
+}
+
+class UF {
+  constructor() { this.p = new Map(); }
+  add(x) { if (!this.p.has(x)) this.p.set(x, x); }
+  find(x) {
+    let r = x;
+    while (this.p.get(r) !== r) r = this.p.get(r);
+    while (this.p.get(x) !== r) { const n = this.p.get(x); this.p.set(x, r); x = n; }
+    return r;
+  }
+  union(a, b) { const ra = this.find(a), rb = this.find(b); if (ra !== rb) this.p.set(ra, rb); }
+}
+
+async function fetchName(name) {
+  const n = esc(name);
+  // roles + geography (entity_id ~100% populated)
+  const roles = await qPaged((lim, off) => `
+    SELECT pr.entity_id, pr.company_abn, e.canonical_name, e.entity_type, e.state, e.postcode
+    FROM person_roles pr
+    JOIN gs_entities e ON e.id = pr.entity_id
+    WHERE pr.person_name_normalised = '${n}'
+    ORDER BY pr.entity_id LIMIT ${lim} OFFSET ${off}`);
+  // co-directors on those boards (this is the big one — must paginate)
+  const codir = await qPaged((lim, off) => `
+    SELECT pr.entity_id, pr.person_name_normalised AS codir
+    FROM person_roles pr
+    WHERE pr.entity_id IN (SELECT entity_id FROM person_roles WHERE person_name_normalised = '${n}')
+      AND pr.person_name_normalised <> '${n}'
+    ORDER BY pr.entity_id, codir LIMIT ${lim} OFFSET ${off}`);
+  // money per entity (pre-aggregated in the MV; MAX to de-dup role rows)
+  const money = await qPaged((lim, off) => `
+    SELECT entity_id,
+           MAX(justice_dollars) AS justice, MAX(procurement_dollars) AS procurement, MAX(donation_dollars) AS donation
+    FROM mv_person_entity_network WHERE person_name_normalised = '${n}' GROUP BY entity_id
+    ORDER BY entity_id LIMIT ${lim} OFFSET ${off}`);
+  return { roles, codir, money };
+}
+
+function cluster(name, { roles, codir, money }) {
+  const geo = new Map();   // entity -> {name,abn,type,state,postcode}
+  for (const r of roles) geo.set(r.entity_id, r);
+  const mny = new Map();   // entity -> {justice,procurement,donation}
+  for (const m of money) mny.set(m.entity_id, m);
+
+  // codir name -> Set(entity) within this target's boards
+  const byCodir = new Map();
+  for (const { entity_id, codir: c } of codir) {
+    if (!byCodir.has(c)) byCodir.set(c, new Set());
+    byCodir.get(c).add(entity_id);
+  }
+
+  const uf = new UF();
+  for (const r of roles) uf.add(r.entity_id);
+
+  // 1) block officers (high degree) glue all their boards together
+  const blockOfficers = [];
+  for (const [c, set] of byCodir) {
+    if (set.size >= HIGH_DEGREE) {
+      blockOfficers.push({ name: c, degree: set.size });
+      const arr = [...set];
+      for (let i = 1; i < arr.length; i++) uf.union(arr[0], arr[i]);
+    }
+  }
+  // 2) mid-degree co-directors: pairs of boards merge only with >= MIN_SHARED corroborating co-directors
+  const pairCount = new Map();
+  for (const [, set] of byCodir) {
+    if (set.size >= HIGH_DEGREE || set.size < 2) continue;
+    const arr = [...set];
+    for (let i = 0; i < arr.length; i++)
+      for (let j = i + 1; j < arr.length; j++) {
+        const k = arr[i] < arr[j] ? arr[i] + '|' + arr[j] : arr[j] + '|' + arr[i];
+        pairCount.set(k, (pairCount.get(k) || 0) + 1);
+      }
+  }
+  for (const [k, c] of pairCount) if (c >= MIN_SHARED) { const [a, b] = k.split('|'); uf.union(a, b); }
+
+  // assemble components
+  const comps = new Map();
+  for (const r of roles) {
+    const root = uf.find(r.entity_id);
+    if (!comps.has(root)) comps.set(root, []);
+    comps.get(root).push(r.entity_id);
+  }
+
+  const out = [];
+  for (const [, ents] of comps) {
+    const size = ents.length;
+    let justice = 0, procurement = 0, donation = 0;
+    const pcCount = new Map(), stateCount = new Map();
+    for (const e of ents) {
+      const m = mny.get(e); if (m) { justice += +m.justice || 0; procurement += +m.procurement || 0; donation += +m.donation || 0; }
+      const g = geo.get(e);
+      if (g?.postcode) pcCount.set(g.postcode, (pcCount.get(g.postcode) || 0) + 1);
+      if (g?.state) stateCount.set(g.state, (stateCount.get(g.state) || 0) + 1);
+    }
+    // officers present on >=2 of this component's boards
+    const entSet = new Set(ents);
+    const officers = [];
+    for (const [c, set] of byCodir) {
+      let hits = 0; for (const e of set) if (entSet.has(e)) hits++;
+      if (hits >= 2) officers.push({ name: c, hits });
+    }
+    officers.sort((a, b) => b.hits - a.hits);
+    const topPc = [...pcCount.entries()].sort((a, b) => b[1] - a[1])[0];
+    const topOfficer = officers[0];
+    const pcWith = [...pcCount.values()].reduce((a, b) => a + b, 0);
+    const isNominee = size >= NOMINEE_MIN
+      && topOfficer && topOfficer.hits / size >= DOMINANCE
+      && topPc && pcWith > 0 && topPc[1] / size >= DOMINANCE;
+    const confidence = isNominee ? 'high' : size > 1 ? 'medium' : 'low';
+    out.push({ size, justice, procurement, donation, ents, officers, topPc, topState: [...stateCount.entries()].sort((a, b) => b[1] - a[1])[0], isNominee, confidence, geo });
+  }
+  out.sort((a, b) => b.size - a.size);
+  return { name, total: roles.length, comps: out, blockOfficers, geo, mny };
+}
+
+const fmt$ = (n) => n >= 1e6 ? `$${(n / 1e6).toFixed(2)}M` : n >= 1e3 ? `$${(n / 1e3).toFixed(0)}k` : n ? `$${n}` : '';
+
+function report(res) {
+  const { name, total, comps, blockOfficers } = res;
+  const nominees = comps.filter(c => c.isNominee);
+  console.log(`\n${'='.repeat(72)}\n${name} — ${total} roles → ${comps.length} identities (${nominees.length} nominee block${nominees.length !== 1 ? 's' : ''})`);
+  console.log(`  block officers (>=${HIGH_DEGREE} shared boards): ${blockOfficers.map(o => `${o.name}(${o.degree})`).join(', ') || 'none'}`);
+  const singles = comps.filter(c => c.size === 1).length;
+  console.log(`  largest=${comps[0]?.size}  multi-board identities=${comps.filter(c => c.size > 1).length}  singletons=${singles}`);
+  console.log(`  ── top identities ──`);
+  for (const c of comps.slice(0, 8)) {
+    const off = c.officers.slice(0, 3).map(o => `${o.name}×${o.hits}`).join(', ');
+    const m = [c.justice && `justice ${fmt$(c.justice)}`, c.procurement && `proc ${fmt$(c.procurement)}`, c.donation && `don ${fmt$(c.donation)}`].filter(Boolean).join(' ');
+    console.log(`   [${c.confidence}${c.isNominee ? '/NOMINEE' : ''}] n=${c.size} ${c.topState ? c.topState[0] : '?'}/${c.topPc ? c.topPc[0] : '?'}  ${m}`);
+    if (off) console.log(`        officers: ${off}`);
+    if (c.size <= 3) for (const e of c.ents) { const g = res.geo.get(e); const mm = res.mny.get(e); const mv = mm ? [mm.justice > 0 && fmt$(+mm.justice) + ' just', mm.procurement > 0 && fmt$(+mm.procurement) + ' proc'].filter(Boolean).join(' ') : ''; console.log(`          · ${g?.canonical_name?.slice(0, 60)} (${g?.state || '?'} ${g?.postcode || ''}) ${mv}`); }
+  }
+  return { name, total, n_ids: comps.length, n_nominee: nominees.length, comps };
+}
+
+// ---- assertions (the gate) ----
+function check(label, cond) { console.log(`   ${cond ? '✅ PASS' : '❌ FAIL'}  ${label}`); return !!cond; }
+
+function gate(name, r) {
+  console.log(`  ── assertions ──`);
+  let ok = true;
+  if (name === 'MARK SMITH') {
+    ok &= check(`massive collapse: ${r.n_ids} identities ≪ 714`, r.n_ids < 100);
+    const block = r.comps.find(c => c.isNominee && c.size > 500);
+    ok &= check(`one nominee block > 500 boards (got ${block?.size ?? 'none'})`, !!block);
+    // money split: SA Aboriginal D&A Council justice $3.45M must NOT be in the nominee block
+    const saReal = r.comps.find(c => c.ents.some(e => abnOf(c, e) === '27890475461'));
+    ok &= check(`SA justice $3.45M attributed to a NON-nominee identity`, saReal && !saReal.isNominee && saReal.justice > 3e6);
+    const gp = r.comps.find(c => c.ents.some(e => abnOf(c, e) === '83090533174'));
+    ok &= check(`Garnett Passe procurement sits IN the nominee block`, gp && gp.isNominee);
+  } else if (name === 'JODI KENNEDY') {
+    const block = r.comps.find(c => c.isNominee && c.size > 200);
+    ok &= check(`one nominee block > 200 boards (got ${block?.size ?? 'none'})`, !!block);
+  } else if (name === 'THARANI JEGATHEESWARAN') {
+    ok &= check(`rare-name control resolves to few identities (got ${r.n_ids}, expect ≤2)`, r.n_ids <= 2);
+    ok &= check(`control is NOT flagged nominee`, r.n_nominee === 0);
+  }
+  return !!ok;
+}
+// helpers to read an entity's abn within a component
+function abnOf(comp, entity_id) { const g = comp.geo.get(entity_id); return g?.company_abn ? String(g.company_abn) : null; }
+
+async function main() {
+  const names = process.argv.slice(2).length ? process.argv.slice(2) : ['MARK SMITH', 'JODI KENNEDY', 'THARANI JEGATHEESWARAN'];
+  console.log(`person-disambig-probe — READ-ONLY gate`);
+  console.log(`thresholds: HIGH_DEGREE=${HIGH_DEGREE} MIN_SHARED=${MIN_SHARED} NOMINEE_MIN=${NOMINEE_MIN} DOMINANCE=${DOMINANCE}`);
+  let allOk = true;
+  for (const name of names) {
+    const data = await fetchName(name);
+    const res = cluster(name, data);
+    // attach geo/mny to each comp for assertion helpers
+    for (const c of res.comps) { c.geo = res.geo; c.mny = res.mny; }
+    const summary = report(res);
+    allOk = gate(name, summary) && allOk;
+  }
+  console.log(`\n${allOk ? '✅ GATE PASSED' : '❌ GATE FAILED'}`);
+  process.exit(allOk ? 0 : 1);
+}
+
+main().catch(e => { console.error(e.message); process.exit(1); });

--- a/thoughts/shared/plans/person-disambiguation-scoping-2026-06-19.md
+++ b/thoughts/shared/plans/person-disambiguation-scoping-2026-06-19.md
@@ -1,0 +1,138 @@
+# Person Disambiguation — Scoping Report + Proposed Approach
+
+**Date:** 2026-06-19 · **Status:** SCOPING COMPLETE — awaiting Ben's go before any migration
+**Prior:** homonym guard (cap board_count ≤10) + leaderboard re-rank shipped #90/#91. Guard is a band-aid; this is the real fix.
+
+---
+
+## TL;DR
+
+The ranking-head "megamerges" are **not** hundreds of distinct homonyms merged together. They are dominated by **trustee-company nominee blocks** — one trustee firm whose officers are listed as "responsible persons" on hundreds of administered charitable trusts. Mark Smith's 714 boards = ~686 one nominee block + ~28 scattered real individuals.
+
+This is **good news for separability**: the nominee block is the *densest* co-occurrence cluster in the data, so co-occurrence clustering collapses it cleanly. The remaining tail is mostly board-singletons that correctly stay separate.
+
+The real probity fix has **two parts**, and the second matters more for leaderboard credibility than the first:
+1. **Split** homonym megamerges into distinct identities (co-director graph + geography).
+2. **Flag** nominee/trustee-administered blocks so a trustee-firm officer on 686 admin trusts is not ranked as a powerful individual board member.
+
+Temporal signal (appointment/cessation overlap) from the proposed approach is **dead** — see below.
+
+---
+
+## 1. Scale (verified)
+
+`mv_person_influence`: **237,340** distinct `person_name_normalised`.
+- 2–10 boards: 39,105 (the plausible serial-director mass — leave alone)
+- \>10 boards: **615** · >50 boards: **79** · max: **744** (Jodi Kennedy)
+
+`person_roles`: ~339,286 rows (ABN-keyed directorships).
+
+## 2. Signal coverage per role (verified, 5% sample + global existence checks)
+
+| Signal | Coverage | Usable? |
+|---|---|---|
+| `company_abn` | ~100% | ✅ primary entity key |
+| `company_acn` | 100% | ✅ |
+| `entity_id` → `gs_entities` | ~100% | ✅ unlocks state/postcode/sector/type |
+| `appointment_date` | **~0%** (true globally but 0 in 16K sample) | ❌ effectively dead |
+| `cessation_date` | **0%** (none exist) | ❌ dead |
+| `person_entity_id` | 100% but **name-keyed** — all 714 Mark Smith rows → 1 id | ❌ this IS the megamerge, not an identity key |
+
+**Consequence:** the "tenure temporal overlap" idea in the brief is not available. Disambiguation rests on **co-occurrence (shared co-directors)** + **geography** + **role/sector/source patterns**.
+
+## 3. Separability — proven on 2 megamerge names (by reproduction)
+
+### Mark Smith (714 boards)
+- 714 roles on **714 distinct entities** — no two share a board → direct shared-board signal is zero.
+- BUT 3 names co-occur on ~686 of them: **Phillip Blackmore (687), Andrew Baker (686), Adam Balsamo (686)**.
+- 669/714 in **NSW across only 12 postcodes**; the block clusters at **postcode 2034**.
+- Block entities are **"The Trustee For [X] Trust"** foundations → a single trustee company's responsible-persons list.
+- → Splits into **~1 nominee identity (~686) + ~28 scattered singletons** (QLD/VIC/SA/WA/NT).
+
+### Jodi Kennedy (744 boards) — same structure, different firm
+- Co-directors: **Johanna Platt (735), Michael O'Brien (439), Ian Westley (322)** → another trustee-officer block.
+
+### Money inflation is real and co-occurrence fixes it
+Mark Smith's $1.16M procurement + $3.6M justice = **three different real people**:
+| Funded entity | Money | Nominee block? | Real person |
+|---|---|---|---|
+| Aboriginal Drug & Alcohol Council (SA) Aboriginal Corp | $3.45M justice | No | SA Mark Smith |
+| Garnett Passe & Rodney Williams Foundation | $1.12M procurement | **Yes** | NSW trustee-officer |
+| Allora Show Society (QLD) | $155K justice | No | QLD Mark Smith |
+
+The board-count guard does **nothing** here — these people may each sit on 1–2 boards. Only identity-splitting re-attributes the money correctly.
+
+## 4. Bonus finding — name-normalisation also fragments identities
+Surname-first / middle-name variants split one person across keys:
+`MICHAEL O'BRIEN`(439) vs `O'BRIEN MICHAEL`(7); `IAN WESTLEY`(322) vs `WESTLEY IAN`(7); `MARTIN GEOFFREY WALSH`(15) vs `GEOFF WALSH`(4). A normalisation pass (sort tokens / strip middle names with confidence) is a cheap orthogonal win — but it can also over-merge, so treat as a *candidate-link* signal, not a hard merge.
+
+---
+
+## 5. What IS vs ISN'T separable
+
+**Separable cleanly:**
+- Nominee/trustee blocks — densest co-occurrence cluster → collapse + flag.
+- People who are board-linked to others via shared co-directors.
+- Money attribution when the funded entity sits in a distinguishable cluster (proven above).
+
+**Not separable (accept and stay conservative):**
+- Two genuinely distinct people with identical names, each on **one** board, no shared co-director, same region → indistinguishable. They remain separate singletons (safe: no false merge). We can't *prove* they're distinct, but we never fabricate a link.
+- One real person on 2 boards with no shared co-directors may **over-split** into 2 identities. Acceptable for probity: over-splitting under-counts (conservative), over-merging fabricates power (dangerous). **Bias toward over-split.**
+
+---
+
+## 6. Proposed approach (NOT yet committed — for Ben's review)
+
+**Model: connected-components over a per-name co-director graph.**
+
+For each `person_name_normalised` with >1 role:
+1. Nodes = that name's role-entities.
+2. Edge between two entities if they share ≥1 *other* co-director (another normalised name on both boards). Weight = count/rarity of shared co-directors.
+3. Connected components = candidate distinct persons. Singletons → own identity.
+4. Geography as secondary tie-breaker (same postcode/state strengthens; never the sole merge basis).
+5. **Nominee detection:** a component where one identity holds N boards with a small fixed co-officer set and concentrated postcode → tag `is_nominee_block` + `nominee_postcode`.
+
+**Output (additive, non-destructive):**
+- New table `person_identities` (or `person_role_clusters`): `role_id → identity_key`, `confidence`, `is_nominee_block`, `cluster_size`, `method`. Stable `identity_key` (hash of name + sorted member-ABN set, or name + component seed).
+- Re-point `mv_person_influence` / `mv_person_entity_network` to aggregate by `identity_key` instead of `person_name_normalised`. Keep the old column for rollback.
+- Leaderboard: rank by identity, **exclude/down-weight `is_nominee_block`** identities from individual-governance rankings.
+
+**Build order (verification gate FIRST — per house rule):**
+1. **Gate script** `scripts/person-disambig-probe.mjs`: for a given name, print role count, component count, largest-component size + co-officer signature + dominant postcode, money-per-component with funded entity names, singleton tail. Assert expected shapes on Mark Smith (~1 block + ~28), Jodi Kennedy (block), and a **clean control** (a rare name → exactly 1 component). This is the gate — must pass before any write.
+2. Only then: build the clustering job (set-based SQL in `scripts/`, chunked — no in-memory entity index; cf. `project_build_entity_graph_setbased`).
+3. Re-point MVs; validate leaderboards unchanged-or-better; never break the shipped guard.
+
+**Open questions for Ben:**
+- Nominee blocks: collapse-to-one-identity **and** flag-out of individual rankings? (recommended) Or keep visible as "trustee-administered"?
+- Identity-key stability across rebuilds — hash of sorted member-ABN set is stable unless membership changes; acceptable?
+- Scope of first migration run: all 615 >10-board names, or start with >50 (79 names) where payoff is highest?
+
+**Guardrails honoured:** additive only; verified by reproduction not assumption; gate before scoring; proven on 2 names first; no repo-wide migration without Ben's go.
+
+---
+
+## 7. VALIDATION RESULTS — gate PASSED (2026-06-19)
+
+Built `scripts/person-disambig-probe.mjs` (READ-ONLY; no DB writes). Decisions locked with Ben: **nominee blocks collapse to one identity + flagged `is_nominee_block` → excluded from individual rankings**; **build gate + clusterer, validate, no migration yet.**
+
+Algorithm as built: per-name co-director graph, union-find. Edge rules:
+- **Block officer** (a co-director on ≥`HIGH_DEGREE`=10 of the target's boards) glues all its boards → catches nominee blocks.
+- **Mid-degree corroboration** (co-director on 2–9 boards): a pair of boards merges only with ≥`MIN_SHARED`=2 shared co-directors → high precision on the tail, drops spurious single-common-name bridges.
+- **Nominee flag:** component ≥`NOMINEE_MIN`=20 with a dominant officer (≥50%) AND dominant postcode (≥50%).
+- Confidence: nominee→high, multi-board→medium, singleton→low. **Bias to over-split** (singletons stay separate; no false merges).
+
+| Name | Raw boards | → identities | Nominee block | Real-people tail |
+|---|---|---|---|---|
+| MARK SMITH | 714 | **24** | 689 (NSW/2034) | 23 (each ≤2 boards) |
+| JODI KENNEDY | 745 | **6** | 740 (VIC/3001) | 5 |
+| THARANI JEGATHEESWARAN (control) | 6 | **2** | none | 1×5-board real + 1 singleton |
+
+All assertions pass: massive collapse; one nominee block >500 (Mark)/>200 (Jodi); **SA justice $3.45M → non-nominee identity; Garnett Passe $1.12M → nominee block**; control resolves to ≤2, not flagged nominee.
+
+**Bug the gate caught:** `exec_sql` RPC silently caps at PostgREST's 1000-row limit → first run truncated co-director data, fragmenting Mark's block to 301. Fixed with `qPaged()` (inner LIMIT/OFFSET). Re-run → block restored to 689. (Same cap noted in memory re: `paginatedRpc`.)
+
+**Side-findings (out of scope, worth a ticket):**
+- `mv_person_entity_network` money columns attribute an entity's **full** procurement/justice/donation to **every** board member — so "personal money footprint" is itself over-attributed (e.g. control shows $1.14B procurement on a 5-board person). The disambiguation re-point should decide whether per-person money is `SUM` or needs a fairer split.
+- gs_entities has duplicate orgs ("Elston Giving Foundation" + "...LTD") — clustering correctly merged them via shared co-directors, but a dedup pass would help upstream.
+
+**Next step (NEEDS BEN'S GO — Tier 3 migration):** generalise the clusterer to a set-based job over all >50-board names (79) first, write `person_identities` (role_id → identity_key, confidence, is_nominee_block) additively, re-point `mv_person_influence`/`mv_person_entity_network` by identity_key, exclude nominee blocks from rankings, validate leaderboards unchanged-or-better. Do NOT touch the shipped board-count guard.


### PR DESCRIPTION
## What

Read-only **verification gate** + scoping plan for the real fix to people/probity leaderboards: splitting name-keyed person megamerges into distinct real identities. Follow-on to the homonym board-count guard (#90/#91), which is a band-aid that can't fix money inflation under 10 boards.

**This PR ships no migration and writes nothing to the DB.** It lands the validated approach + the gate that must pass before any migration.

## Key finding (the reframe)

The ranking-head megamerges are **not** hundreds of homonyms merged — they're **trustee-company nominee blocks**: one trustee firm's officers listed as "responsible persons" on hundreds of administered "The Trustee For X Trust" charities.

| Name | Raw boards | → identities | Nominee block | Real tail |
|---|---|---|---|---|
| Mark Smith | 714 | **24** | 689 (NSW/2034) | 23 (each ≤2 boards) |
| Jodi Kennedy | 745 | **6** | 740 (VIC/3001) | 5 |
| Tharani Jegatheeswaran (control) | 6 | **2** | none | 1 real 5-board + 1 singleton |

Money attribution is provably correct: Mark's $3.45M SA justice → a non-nominee real person; $1.12M Garnett Passe procurement → the nominee block.

## What's in `scripts/person-disambig-probe.mjs`

- Per-name co-director graph + union-find clustering
- Block-officer rule (co-director on ≥10 boards) collapses nominee blocks; mid-degree pairs merge only with ≥2 shared co-directors (bias to over-split — no false merges)
- Nominee detection (size ≥20 + dominant officer ≥50% + dominant postcode ≥50%)
- Money-per-cluster attribution + gate assertions on the 3 cases above
- `qPaged()` works around `exec_sql`'s silent 1000-row PostgREST cap (a bug the gate itself caught)

## Signal facts (verified)

- `appointment_date` ~0% populated, `cessation_date` 0 rows → **temporal-overlap signal is dead**
- `person_entity_id` is name-keyed (all 714 Mark Smith → 1 id) → it *is* the megamerge, not an identity key
- `company_abn`/`acn`/`entity_id`→gs_entities ~100% covered

## Decisions locked

Nominee blocks: collapse to one identity + flag `is_nominee_block` + **exclude from individual-governance rankings**.

## Out of scope (tickets to file)

- `mv_person_entity_network` attributes an entity's *full* money to *every* board member (per-person footprint over-attributed)
- gs_entities has duplicate orgs

## Next (separate PR, needs explicit go)

Set-based migration over the 79 names with >50 boards → additive `person_identities` table → re-point person MVs by identity → exclude nominees from rankings. Shipped guard untouched.

Full scoping + results: `thoughts/shared/plans/person-disambiguation-scoping-2026-06-19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)