### PR TITLE
docs(goods-qbe): QBE $400K match strategy pack + GHL opp-fix scripts

### DIFF
--- a/scripts/create-sefa-ghl-opp.mjs
+++ b/scripts/create-sefa-ghl-opp.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * create-sefa-ghl-opp.mjs
+ *
+ * Re-create the SEFA repayable-debt opportunity in GoHighLevel. The old bundled
+ * "Snow Foundation / SEFA — Impact Investment Loan" opp vanished from live GHL
+ * (the CivicGraph mirror was stale), leaving SEFA — the highest-match-value (repayable)
+ * lever for the QBE match — with NO tracked opportunity. This re-creates a clean one
+ * in the Goods funder pipeline.
+ *
+ * Pipeline : Goods Supporter Journey  (the funder pipeline; Snow/Minderoo/Centrecorp live here)
+ * Stage    : Cultivating               (honest for reopening a dormant-but-real relationship)
+ * Contact  : Joel Bird (joel.bird@sefa.com.au)
+ * Value    : AU$300,000                (documented senior concessional-debt target)
+ *
+ * IDEMPOTENT: searches for an existing SEFA opp first and refuses to create a duplicate.
+ *
+ * Run (dry-run, read-only, default): node --env-file=.env scripts/create-sefa-ghl-opp.mjs
+ * Apply:                             node --env-file=.env scripts/create-sefa-ghl-opp.mjs --apply
+ */
+const GHL_BASE = 'https://services.leadconnectorhq.com';
+const GHL_API_KEY = process.env.GHL_API_KEY;
+const GHL_LOCATION_ID = process.env.GHL_LOCATION_ID;
+const APPLY = process.argv.slice(2).includes('--apply');
+
+const PIPELINE_ID = 'JvBFYpVpyKsw899lkFgj';            // Goods Supporter Journey
+const STAGE_ID = '524aca71-287d-4eeb-a53a-66ff3a7aede5'; // Cultivating
+// Other stages if you want to change it: Identified cf8d31d2-73be-4119-b56b-7b0334254197 | Ask made a23b26b4-ace3-4199-8a14-b65ed888aa52
+const CONTACT_ID = 'QP8M4iLfBOfs66V81jiX';            // Joel Bird (SEFA)
+
+const OPP = {
+  locationId: GHL_LOCATION_ID,
+  name: 'SEFA - Impact Investment Loan (Goods on Country)',
+  pipelineId: PIPELINE_ID,
+  pipelineStageId: STAGE_ID,
+  status: 'open',
+  monetaryValue: 300000,
+  contactId: CONTACT_ID,
+};
+
+async function ghl(endpoint, options = {}) {
+  if (!GHL_API_KEY) throw new Error('GHL_API_KEY not set');
+  const res = await fetch(`${GHL_BASE}${endpoint}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${GHL_API_KEY}`,
+      'Content-Type': 'application/json',
+      Version: '2021-07-28',
+      ...options.headers,
+    },
+  });
+  if (!res.ok) throw new Error(`GHL ${res.status} on ${endpoint}: ${await res.text()}`);
+  return res.json();
+}
+
+console.log(`\n=== create-sefa-ghl-opp.mjs  [${APPLY ? 'APPLY' : 'DRY-RUN (read-only)'}] ===\n`);
+
+// Idempotency guard: is there already a SEFA opp anywhere in this location?
+const found = await ghl(`/opportunities/search?location_id=${GHL_LOCATION_ID}&q=SEFA`);
+const existing = (found.opportunities || []).filter(o => /sefa/i.test(o.name || ''));
+if (existing.length) {
+  console.log('A SEFA opportunity already exists — NOT creating a duplicate:');
+  existing.forEach(o => console.log(`  ${o.id}  ${JSON.stringify(o.name)}  [pipeline ${o.pipelineId}]`));
+  console.log('\nIf this is the wrong pipeline/stage, edit it in GHL rather than creating a new one.\n');
+  process.exit(0);
+}
+console.log('No existing SEFA opportunity found (confirmed gap).');
+console.log('WILL CREATE:');
+console.log(`  name:    ${OPP.name}`);
+console.log(`  pipeline:${OPP.pipelineId}  (Goods Supporter Journey)`);
+console.log(`  stage:   ${OPP.pipelineStageId}  (Cultivating)`);
+console.log(`  value:   AU$${OPP.monetaryValue.toLocaleString()}`);
+console.log(`  contact: ${OPP.contactId}  (Joel Bird, SEFA)`);
+console.log(`  status:  ${OPP.status}\n`);
+
+if (!APPLY) {
+  console.log('Dry-run — nothing created. Re-run with --apply to create it.\n');
+  process.exit(0);
+}
+
+const res = await ghl('/opportunities/', { method: 'POST', body: JSON.stringify(OPP) });
+console.log(`CREATED -> id ${res?.opportunity?.id || '(see response)'}  name ${JSON.stringify(res?.opportunity?.name || OPP.name)}`);
+console.log('Done. Next GHL->CivicGraph sync (<=12h) will mirror it into ghl_opportunities.\n');

--- a/scripts/fix-goods-ghl-opps.mjs
+++ b/scripts/fix-goods-ghl-opps.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * fix-goods-ghl-opps.mjs
+ *
+ * One-off CRM hygiene: rename two Goods opportunities in GoHighLevel so the
+ * funder pipeline tells the truth (surfaced by the QBE capital-strategy alignment, 2026-06-19).
+ *
+ *  1. "Snow Foundation / SEFA — Impact Investment Loan (Goods on Country)"  ($250K, Grants pipeline)
+ *     -> "SEFA — Impact Investment Loan (Goods on Country)"
+ *     Reason: Snow already has its OWN opp ($402,930, Supporter Journey). The "Snow Foundation /"
+ *     prefix conflates a grant with a repayable loan; SEFA is the highest-match-value (repayable) line
+ *     and must be trackable on its own.
+ *
+ *  2. "Paul Ramsay Foundation"  ($0, "Ask made", Goods Supporter Journey)
+ *     -> "Paul Ramsay Foundation (Goods: no active ask — PRF relationship via JusticeHub)"
+ *     Reason: $0 phantom opp reads as a warm Goods money front; the real PRF money is two JusticeHub lines.
+ *
+ * RENAME ONLY. No new opps, no deletes, no pipeline/stage moves (left to a human — there is no debt pipeline).
+ * All other fields are preserved by reading the opp first and writing it back with only `name` changed.
+ *
+ * Run (dry-run, read-only, default): node --env-file=.env scripts/fix-goods-ghl-opps.mjs
+ * Apply:                             node --env-file=.env scripts/fix-goods-ghl-opps.mjs --apply
+ */
+const GHL_BASE = 'https://services.leadconnectorhq.com';
+const GHL_API_KEY = process.env.GHL_API_KEY;
+const APPLY = process.argv.slice(2).includes('--apply');
+
+const TARGETS = [
+  {
+    id: 'jKKxyTLE2NHbr44uNiEj',
+    newName: 'SEFA — Impact Investment Loan (Goods on Country)',
+    reason: 'split SEFA repayable line out of the Snow-bundled grant row',
+  },
+  {
+    id: 'nsSkwDuMlfulSzwticWu',
+    newName: 'Paul Ramsay Foundation (no active Goods ask; PRF via JusticeHub)',
+    reason: 'flag the $0 phantom Goods opp so it stops reading as a warm money front',
+  },
+];
+
+async function ghl(endpoint, options = {}) {
+  if (!GHL_API_KEY) throw new Error('GHL_API_KEY not set');
+  const res = await fetch(`${GHL_BASE}${endpoint}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${GHL_API_KEY}`,
+      'Content-Type': 'application/json',
+      Version: '2021-07-28',
+      ...options.headers,
+    },
+  });
+  if (!res.ok) throw new Error(`GHL ${res.status} on ${endpoint}: ${await res.text()}`);
+  return res.json();
+}
+
+console.log(`\n=== fix-goods-ghl-opps.mjs  [${APPLY ? 'APPLY' : 'DRY-RUN (read-only)'}] ===\n`);
+
+for (const t of TARGETS) {
+  let o;
+  try {
+    ({ opportunity: o } = await ghl(`/opportunities/${t.id}`));
+  } catch (e) {
+    console.log(`Opp ${t.id}  (${t.reason})`);
+    console.log(`  NOT FOUND in live GHL (mirror stale / opp removed) — skipping. [${String(e.message).slice(0, 80)}]\n`);
+    continue;
+  }
+  console.log(`Opp ${t.id}  (${t.reason})`);
+  console.log(`  pipeline/stage: ${o.pipelineId} / ${o.pipelineStageId}   value: ${o.monetaryValue}   status: ${o.status}`);
+  console.log(`  BEFORE: ${JSON.stringify(o.name)}`);
+  console.log(`  AFTER:  ${JSON.stringify(t.newName)}`);
+  if (o.name === t.newName) { console.log('  (already correct — skipping)\n'); continue; }
+  if (!APPLY) { console.log('  (dry-run — no write)\n'); continue; }
+
+  // Preserve all other fields; change name only.
+  const payload = {
+    pipelineId: o.pipelineId,
+    name: t.newName,
+    pipelineStageId: o.pipelineStageId,
+    status: o.status,
+    monetaryValue: o.monetaryValue ?? 0,
+  };
+  if (o.contactId) payload.contactId = o.contactId;
+  if (o.assignedTo) payload.assignedTo = o.assignedTo;
+  const upd = await ghl(`/opportunities/${t.id}`, { method: 'PUT', body: JSON.stringify(payload) });
+  console.log(`  APPLIED -> name now: ${JSON.stringify(upd?.opportunity?.name ?? t.newName)}\n`);
+}
+
+console.log(APPLY ? 'Done. Next GHL->CivicGraph sync (<=12h) will mirror the new names.\n' : 'Dry-run complete. Re-run with --apply to write.\n');

--- a/thoughts/shared/strategy/goods-funder-relationship-history.md
+++ b/thoughts/shared/strategy/goods-funder-relationship-history.md
@@ -1,0 +1,83 @@
+# Goods funder relationship history — alignment substrate
+
+> Compiled 2026-06-19 from Goods Notion (QBE operating plan, populated Investor Alignment Tool, Tier-1 funder letters, Area 10 Investors) + live CivicGraph CRM tables. This is the alignment layer for `goods-qbe-power-capital-strategy.md`: every funder move must reconcile to the real stage/contact/history here, and obey the claim guardrails. Background workflow agents could not authenticate to Notion, so this file carries the Notion-only facts; the live state is in the DB tables named below.
+
+## The keystone (unchanged)
+- Goods is 1 of 10 enterprises in **Catalysing Impact** (Social Impact Hub × QBE Foundation), sharing a $1M pool.
+- **Stage 2 prize:** up to AU$400K ($150K floor), discretionary, **must be at least 1:1 matched by external commitments**, **prefers repayable finance over grants**, verified at the **Sept 2026** application, decided **Nov 2026**.
+- **Goal:** close the first **~AU$400K of SIGNED, match-eligible commitments by 31 Aug 2026**. **0 signed today** — "a conversation problem, not a discovery problem."
+- **SIH pipeline model:** Prospect → EOI → LOI → Term Sheet → Funding Agreement. Signed LOI+ counts as match.
+- SIH contact for funder verification: **Jay Boolkin** (jay@socialimpacthub.org). Attach SIH "Letter to Funders" (Adam Long, 1 Apr 2026). Cost model advisory: **Matt** (lead) + **Mal** (QA).
+
+## The capital stack (reconciled 2026-06-13) — AU$900K–1M blended, non-equity
+| Layer | Target | Source | Notes |
+|---|---|---|---|
+| Junior — grants | ~$500K | Snow R4/R5, Centrecorp next round, VFFF (+ Butterfly/DGR upside FY2026-27) | de-risks the debt |
+| Catalytic — QBE match | up to $400K | QBE (contingent, 1:1) | output of match raised, NOT an input |
+| Senior — concessional debt | ~$300K | SEFA | gated on financial model + independent-majority board + revenue covenant |
+| **First use of funds** | **$60–80K** | (from the above) | **50-bed in-source production run** — turns the $425.74 unit-cost claim from MODELLED to MEASURED. 0 beds assembled in-house so far. |
+
+## Warmest-first shortlist (proximity to a signed, match-eligible commitment)
+
+### Tier 1 — push now (warm, knockout-pass, full fit score)
+| Funder | Contact | Stage / history | Capital | The specific ask (letter already drafted) |
+|---|---|---|---|---|
+| **Snow Foundation** | Georgina + team | Stewarding, deepest relationship (~$403K hist), R4/R5 in flight | Grant (ask loan-first / recoverable) | Formalise R4/R5 as a **signed multi-year LOI before end Aug** we can present as match. The first-mover signal everyone else reads. |
+| **SEFA** | (named contact in CRM) | **Advanced discussion** | **Repayable working-capital ~$300K** | **THE single highest-value move:** advance to a **term sheet** now. Repayable = highest match value. Use of funds: inventory + next on-Country run. |
+| **Centrecorp Foundation** | Randle | Stewarding + **live 130-bed board (June)**; already approved/paid 107 beds (Utopia) | Grant | At June board, a **grant commitment kept SEPARATE from the bed order** (order = revenue, not match). Central Australian Aboriginal foundation = real weight. |
+| **Minderoo Foundation** | Lucy | **Ask made (~$200K)** | Grant | A decision inside the Sept window — a **signed LOI now, disbursement later**. Remote-Australia thesis. |
+| **Vincent Fairfax Family Foundation (VFFF)** | El | Stewarding (~$50K), repeat funder | Grant | Renew with a **signed commitment to aggregate into the blended round**. |
+
+### Tier 2 — ask in, convert before September
+Paul Ramsay · Ian Potter · Tim Fairfax Family Foundation · Bryan Foundation · Brian M Davis · **Eloise Hall** (impact investor) · Dusseldorp Forum · The Funding Network · FRRR · Rotary.
+
+### Tier 3 — net-new repayable (THE MATCH GAP — mostly cold, this is where the strategy adds most)
+- **First Australians Capital** — highest-fit Indigenous-led repayable capital, **open now** (full fit score, fails knockout on TIMING only → right for next cycle unless it can move fast).
+- **IBA** (Indigenous Business Australia) · **SVA / SEDIF** · **Conscious Investment** (debt side only).
+- **QLD Partnering for Impact: CLOSED for 2026** (min $500K, 20% cap, EOI closed 15 Mar) — NOT a Sept match source; watch future round.
+
+### Excluded from the match math (note, do NOT count)
+QBE Foundation (cannot match itself) · DEWR / REAL Innovation Fund (separate vehicle) · equity VCs incl. Giant Leap (fail no-equity knockout) · the **buyer pipeline** (WHSAC, Northern Land Council, health corporations, govt re-tenders) = **revenue, not match capital**.
+
+## Cautions from the relationship history (do not break these)
+- **FRRR / VFFF**: the $50K is **one joint "Backing the Future" stream** — do NOT count as two separate $50K grants.
+- **Centrecorp**: keep the **grant (match) cleanly separate from the 130-bed order (revenue)**.
+- **PICC (Palm Island Community Company)**: contact **Rachel Atkinson**; PICC is a partner-relationship not just a funder; flagged as the **biggest revival opportunity** across the funder pipeline.
+- **"El" vs Eloise Hall**: VFFF letter is to "El"; "Eloise Hall" is also listed separately as a Tier-2 impact investor (TABOO co-founder, outgoing Butterfly board). Confirm whether these are the same person before personalising.
+
+## Hard claim guardrails (apply to ALL funder-facing output — Area 10)
+1. Do **not** present active pipeline as committed capital.
+2. Do **not** present the GHL pipeline value as committed (it is prospects, not signatures).
+3. Do **not** say the QBE match is unlocked.
+4. Do **not** present QBE's $400K as secured (**0 signed commitments today**).
+5. Do **not** use DGR/entity language without legal/accounting confirmation (entity migration in progress; MinterEllison advising).
+6. Do **not** imply community-owned manufacturing is complete (0 beds assembled in-house).
+7. Do **not** quote a precise revenue figure — **hold AU$741,111 publicly until accountant-signed**; Goods-only carve-out ~AU$713,827; corrected reconciliation ~$907,569 still pending sign-off.
+8. **Lead with verified proof only:** 496 beds · 9 communities · every bed QR-tracked · ~20kg recycled plastic/bed. (133 Stretch + 363 Basket; 107 to Utopia May 2026, 2.14t plastic diverted.)
+
+## Live relationship data IN the CivicGraph DB (agents query these directly)
+- **`fundraising_pipeline`** (14 rows) — curated funder pipeline: `funder, type, amount, status, probability, expected_date, actual_date, project_codes, contact_id, requirements, deadline, notes`. THE hand-curated truth.
+- **`ghl_opportunities`** (975) — live GoHighLevel CRM: `name, pipeline_name, stage_name, status, monetary_value, project_code, pile, last_stage_change_at, last_status_change_at, assigned_to`. Filter `project_code` to Goods (ACT-GD) + the Goods funder pipeline_name. Synced every 12h.
+- **`ghl_pipelines`** (17) — pipeline definitions (`name, stages`). Find the Goods funder pipeline + the dedicated "Match Campaign" pipeline.
+- **`funder_briefs`** (2) — already-structured: `asks_from_them, ask_amount_aud, ask_status, ask_submitted_at, ask_decision_due, strategy_their_priorities, strategy_our_claims, next_move, next_move_owner, next_move_due, last_feedback_summary, notion_hq_url`. The template to extend.
+- **`funder_profiles`** (3) · **`funder_portfolios`** / **`funder_portfolio_entities`** · **`funder_context_snapshot`** · **`funder_nudge_log`** · **`funder_allowlist`** / **`funder_blocklist`**.
+- **Proof points:** `goods_communities`, `goods_deployment_batches`, `goods_asset_lifecycle`, `goods_procurement_entities`, `goods_procurement_signals`, `goods_governance_readiness`.
+- `contact_intelligence` / `contact_intelligence_scores` / `contact_cadence_metrics` — engagement scoring per contact.
+
+## Notion relationship pages (reference; agents cannot auth — facts above are extracted)
+- QBE operating plan (warmest-first shortlist): `380ebcf981cf819cac62f51dd9532e84`
+- Investor alignment tool, populated: `380ebcf981cf814ca724c12a01016467`
+- Tier-1 funder letters (drafts): `380ebcf981cf81cfa9d1e21327880348`
+- Area 10 — Investors & Capital Raising: `36eebcf981cf81329a11e33e2d121bf9`
+- 19 GHL investor pipeline (match-readiness pipeline design): `380ebcf981cf81169eb0cc62f939e049`
+- Capital And Funder Register: `355ebcf981cf81f085cfe0dcf26ea6d4`
+- Per-project pipelines — Goods/Harvest/JusticeHub (tag scheme: goods-state-{nt|qld}, goods-communitycontrolled, goods-stage-{prospect|active|customer}, warmth goods-{hot|steady|cooling|cold}): `36debcf981cf817c90e5da6c150ab3b3`
+- Goods on Country: the funding and demand system: `36debcf981cf81a48f9bd56727137d84`
+- 10. Investors and Capital Raising (cautions incl. FRRR/VFFF double-count): `355ebcf981cf81bca45ce9a81a9c10e3`
+- PICC Reporting (Rachel Atkinson, revival opportunity): `367ebcf981cf81c2b037f003a93c73f8`
+
+## How the strategy must use this
+1. **Reconcile** every workflow-discovered candidate against this shortlist + `fundraising_pipeline`/`ghl_opportunities` — do not re-pitch a Tier-1 as a cold lead; advance it from its real stage. Drop anything on the excluded list.
+2. **Align** each Tier-1 brief to the drafted letter + named contact + the live stage; the brief's "opening move" is the *next* step on the SIH path (e.g. Snow LOI, SEFA term sheet), not an intro.
+3. **Concentrate net-new discovery on Tier 3** — repayable/catalytic capital to fill the match gap (First Australians Capital, SVA/SEDIF, Conscious Investment + DB-surfaced peers). This is the scarce, highest-leverage search.
+4. **Obey the 8 guardrails** in every funder-facing line.

--- a/thoughts/shared/strategy/goods-qbe-artifact-map.md
+++ b/thoughts/shared/strategy/goods-qbe-artifact-map.md
@@ -1,0 +1,392 @@
+# Goods x QBE - Diagnostic Artifact Map
+
+This is the reviewer-navigable index of the QBE Foundation Catalysing Impact diagnostic for Goods on Country (A Curious Tractor, with Social Impact Hub). The diagnostic has 12 areas. Each area below is an "artifact" a reviewer can navigate: the claim or decision being made, the evidence (every figure labelled verified / modelled / target / future), the live website proof, any consent-cleared story, the gap and next build, and a public-copy risk line.
+
+How to use it: read "The verified proof spine" first so you carry the same safe figures and guardrails into every area. Then use "At a glance" to jump to the area you need. "P0 priority gaps" is the worklist backwards-planned from 31 August. Every figure is provenance-tagged; nothing modelled or future is dressed as fact. No revenue figure is quoted as confirmed, no match is presented as secured, and entity/DGR language is held as in-progress throughout.
+
+## At a glance
+
+| Area | Status | Priority | Owner | Primary gap | Key live link |
+|------|--------|----------|-------|-------------|---------------|
+| 01 Vision & Ambition | Strength | P1 | Ben/Nic | Founder/legal sign-off on entity + community-ownership wording; reconcile present-tense site copy | [/partner](https://www.goodsoncountry.com/partner) |
+| 02 Social Objective & Impact | Priority gap | P0 | Ben | No partner-validated health-outcomes method (pathway is modelled/future) | [/impact](https://www.goodsoncountry.com/impact) |
+| 03 Business Model | Priority gap | P0 | Nic/Ben | Buyer pipeline not reconciled to Xero; no signed commitments | [/shop/stretch-bed-single](https://www.goodsoncountry.com/shop/stretch-bed-single) |
+| 04 Financial Management | Priority gap | P0 | Ben / accountant | Management data only, not audited; whole-org Xero not carved to Goods-only | [/partner](https://www.goodsoncountry.com/partner) |
+| 05 Strategic Planning & Risk | Priority gap | P0 | Ben/Nic | No scored risk register with owners; no public-vs-internal language call | [/partner](https://www.goodsoncountry.com/partner) |
+| 06 Process & Technology | Strength | P1 | Ben | External-account Drive access test still outstanding | [/bed/GB0-156-96](https://www.goodsoncountry.com/bed/GB0-156-96) |
+| 07 Governance, Data & Reporting | Priority gap | P0 | Ben / Nic / legal | No sign-off matrix for evidence / story-consent / finance / entity language | [/impact](https://www.goodsoncountry.com/impact) |
+| 08 People & Organisation | Partial | P1 | Ben/Nic | No 12-month role map or founder-dependency mitigation plan | [/about](https://www.goodsoncountry.com/about) |
+| 09 Legal Structure | Partial | P0 | Ben / Nic / legal | No founder/accountant/legal-signed final entity-wording block | [/partner](https://www.goodsoncountry.com/partner) |
+| 10 Investors & Capital Raising | Partial | P0 | Ben/Nic | No signed/eligible capital, no confirmed QBE match rules, no approved ask | [/partner](https://www.goodsoncountry.com/partner) |
+| 11 Cost Model v6 | Partial | P0 | Ben / Nic / accountant / SIH | Container + On-Country facility capex modelled, not vendor-quoted | [/cost-story](https://www.goodsoncountry.com/cost-story) |
+| 12 Investor Alignment Tool | Partial | P0 | Ben/Nic | QBE match-rule confirmation + written commitments (register holds fit-scores only) | [/partner](https://www.goodsoncountry.com/partner) |
+
+## The verified proof spine
+
+Safe to use anywhere, exactly as written:
+
+- **496 deployed beds** across Australia [verified]
+- **9 served communities** [verified] (NT, QLD, WA - e.g. Maningrida, Ampilatwatja, Palm Island, Tennant Creek)
+- **Every bed QR-tracked** to a public, scannable per-asset record [verified]
+- **Bed price AUD 750** [verified] (live shop, Stripe checkout)
+- **~20kg recycled HDPE per Stretch bed**; **~2,660kg Stretch-only diversion** to date [modelled]
+- **Marginal cost ~AUD 426 in-house / ~AUD 685 buy-kit** [modelled]
+- **Breakeven ~338 beds/yr in-house** [modelled]
+
+### Global guardrails (apply to every area, no exceptions)
+
+- **0 signed match commitments today.** Never present pipeline as committed, and never say the QBE match is unlocked, secured, or booked.
+- **Do not quote a precise revenue figure as confirmed.** Hold ~AU$741,111 (canonical-received) and ~AU$713,827 (Goods-only carve-out) as **UNSIGNED** management data until accountant-signed.
+- **Do not claim community-owned manufacturing is complete** - 0 beds assembled in-house yet. It is the direction of travel, not a delivered fact.
+- **Do not use settled DGR / entity language** - entity migration is in progress. DGR runs only through The Butterfly Movement Ltd.
+- **Always separate the three tiers:** verified physical assets, modelled outcomes/economics, future/health indicators. Make no clinical-outcome claim without partner evidence.
+
+### Live-site copy flag to fix before review
+
+The public site is mixed on the community-ownership point. The homepage already carries one guardrail-compliant future-tense line ("Beds now. Washing machines next. Community-owned production over time"), but two lines read as already-achieved on-country making and must be reconciled: **"Manufactured On-Country"** (/impact) and **"Beds being made by the people who'll sleep on them"** (/). The /process page also reads operationally present-tense (young people "drill the holes and fit the screws"), which brushes the "0 beds assembled in-house" guardrail. Reconciling these specific lines is the real Area 01/03 next build - scope it to those lines, not a wholesale rewrite.
+
+Two headline figures also drift across the public site and should be reconciled before sending to a reviewer who clicks through: **/impact** headlines 496 beds / 9 communities, while **/communities** shows 493 beds / 7 places. Pick one source of truth.
+
+## The 12 artifacts
+
+### Area 01 - Vision & Ambition
+
+**Status:** Strength | **Priority:** P1 | **Owner:** Ben/Nic | **Timing:** Ongoing
+
+**The claim (decision artifact).** Goods on Country makes essential health hardware *with* remote First Nations communities, not just *for* them - the ambition is to make the making belong on Country, moving toward community-owned production. The founder-approved framing for external materials is: proven product and place today (496 beds, 9 communities), with community ownership of manufacturing as the stated direction of travel, not a completed transfer.
+
+**Evidence.**
+- 496 deployed beds across Australia [verified] (also shown live on homepage + impact page).
+- 9 served communities [verified] (NT, QLD, WA - e.g. Maningrida, Ampilatwatja, Palm Island, Tennant Creek).
+- ~2,660kg Stretch-only plastic diversion (~20kg recycled HDPE per Stretch bed) [modelled].
+- Ambition: "make the making belong on Country," toward community-owned production [target]. Direction of travel, not current state.
+- Community-owned, in-house manufacturing [future]. 0 beds assembled in-house to date.
+
+**Live proof (website).**
+- **/** (homepage) - proof spine front-and-centre: "496 beds across Australia," "9 communities," "20kg plastic diverted per bed," plus the ambition line "Beds being made by the people who'll sleep on them" (present-tense - keep the QBE narrative careful here). The homepage also carries the compliant future-tense line "Beds now. Washing machines next. Community-owned production over time." https://www.goodsoncountry.com/
+- **/impact** - same verified metrics (496 / 9 / 20kg) under "Community-designed health hardware. Manufactured On-Country." Present-tense "Manufactured On-Country" overstates current in-house assembly. https://www.goodsoncountry.com/impact
+- **/partner** - clearest articulation of the *ambition-as-direction*: blended-capital ask framed as "Capital for beds now, washing machines next, and production moving to Country." https://www.goodsoncountry.com/partner
+- **/pitch** - gated investor cockpit (password-protected); not fetched.
+
+**Stories.** No direct consent-cleared story fits this area cleanly. Published rows with named storytellers in `goods_content_library` did not match the vision/Country/community-ownership themes; on-theme articles carry no storyteller attribution and are on non-public URLs. **Recommend: source/clear one founder or community-voice story on "making belongs on Country" before this area's artifact ships to QBE** - currently evidence-strong but narrative-thin.
+
+**The gap + next build.** Gap: founder/legal confirmation of entity wording and the community-ownership pathway *language*. Next action: Ben/Nic sign off one canonical ambition + entity sentence, then reconcile the website's present-tense "Manufactured On-Country" / "made by the people who'll sleep on them" copy so the public site matches the guardrail before the QBE review.
+
+**Public-copy risk.** Use 496 beds / 9 communities / 2,660kg Stretch-only diversion. Do NOT claim community-owned manufacturing is already transferred (0 beds assembled in-house yet) - and note the live site currently leans aspirational-present on exactly this point.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf8187b43cdb663f3dcbf9 - Strategy: `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` line 36 (vision/proof-spine paragraph).
+
+### Area 02 - Social Objective & Impact
+
+**Status:** Priority gap | **Priority:** P0 | **Owner:** Ben | **Timing:** 6-12 months
+
+**The claim (decision artifact).** Goods on Country measures impact through one disciplined method that separates three tiers: **verified physical assets** (beds deployed, communities served), **modelled environmental/cost outcomes** (HDPE diverted, unit economics), and **future health indicators** (the bedding to infection to RHD pathway). No health outcome is asserted as achieved without partner clinical evidence.
+
+**Evidence.**
+- 496 beds deployed across 9 communities; every bed QR-tracked for provenance (e.g. bed GB0-156-40 to Utopia Homelands) [verified].
+- 2,660 kg Stretch-only HDPE diversion (~20 kg recycled HDPE per Stretch bed) [modelled].
+- Unit economics: AUD 750 bed price; marginal cost ~AUD 426 in-house / ~685 buy-kit; breakeven ~338 beds/yr in-house [modelled].
+- Health pathway - unwashable bedding to scabies / Strep A to Rheumatic Heart Disease [future]. Plausible mechanism only; cannot be claimed as an outcome without clinical partner data (Miwatj / ACCHOs).
+- Consent-cleared story list expanded to 32 (2026-06-17) [target].
+
+**Live proof (website).**
+- **/impact** - three headline metrics: "496 beds across Australia", "9 communities", "20kg plastic diverted per bed". https://www.goodsoncountry.com/impact
+- **/communities** - lists 7 communities with bed counts (Tennant Creek 159, Utopia Homelands 147, Palm Island 131, Kalgoorlie 20, Maningrida 18, Alice Springs 16, Mount Isa 2). Note: public page shows 7 places / 493 beds, vs the "9 communities / 496 beds" headline on /impact - reconcile before review. https://www.goodsoncountry.com/communities
+- **/bed/GB0-156-40** - QR page for one Stretch bed: model ID, Utopia Homelands location, recycled-material composition. https://www.goodsoncountry.com/bed/GB0-156-40
+- **/stories** - 22 named storytellers across 8 communities on housing, dignity and health, each retaining data sovereignty. https://www.goodsoncountry.com/stories
+
+**Stories.** No consent-cleared story carries a public goodsoncountry URL tagged to this area's health/impact theme in `goods_content_library` (matching rows resolve to `localhost:3030`). The live **/stories** page is itself the consent-cleared surface (22 named, data-sovereignty-controlled storytellers) and is the correct evidence link until the 32-story list is wired into the public library.
+
+**The gap + next build.** Gap: no partner-validated outcomes method - the health pathway is modelled/future only. Next action: sign a clinical/data partner (Miwatj or an ACCHO) to co-define and validate the bedding to infection to RHD measurement method before any health-outcome claim is made public.
+
+**Public-copy risk.** Always separate verified asset metrics from modelled outcomes from future health indicators - make NO clinical-outcome claim without partner evidence. Note the live site is internally inconsistent on bed/community totals (496/9 vs 493/7).
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf8100bff8f866fa0b8820 - Strategy: `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` (verified-proof-spine / claims-discipline section).
+
+### Area 03 - Business Model
+
+**Status:** Priority gap | **Priority:** P0 | **Owner:** Nic/Ben | **Timing:** 0-3 months
+
+**The claim (decision artifact).** Goods on Country runs a product business with one direct-sale product today - the **Stretch Bed** (washing-machine line is prototype/register-interest; Basket archived). The model sells beds at a fixed price with a known marginal cost, and a founder-approved buyer pathway routes institutional and philanthropic capital through a blended stack rather than a single grant.
+
+**Evidence.**
+- Stretch Bed sells at **AUD 750** [verified] (live shop page, Stripe checkout, Australia-wide delivery).
+- **496 beds deployed across 9 communities**, every bed QR-tracked [verified].
+- Marginal cost **~AUD 426 in-house / ~AUD 685 buy-kit**; fixed-cost block **~AUD 109,500/yr**; **breakeven ~338 beds/yr** in-house [modelled]. Not yet reconciled to Xero.
+- **~20kg recycled HDPE diverted per Stretch bed**; ~2,660kg Stretch-only diversion to date [modelled].
+- Buyer pathway = blended capital stack (grants, DGR giving via Butterfly, recoverable grants, patient working capital, procurement-backed revenue) [target]. **0 signed match commitments today.**
+- Community-owned on-country manufacturing (container factory) [future]. **Designed and described, 0 beds assembled in-house yet.**
+
+**Live proof (website).**
+- **/stretch-bed** - product page: flat-pack bed (recycled plastic + galvanised steel + canvas, 5-min tool-free assembly, 200kg capacity, 20kg plastic diverted per bed); links out to the shop. https://www.goodsoncountry.com/stretch-bed
+- **/shop/stretch-bed-single** - working shop/checkout: **AUD 750** shown, Stripe secure checkout, sponsor-a-bed option. The only direct-sale product. https://www.goodsoncountry.com/shop/stretch-bed-single
+- **/partner** - five-pathway blended capital stack; reads as an *invitation* to fund the on-country production bridge, not closed deals. https://www.goodsoncountry.com/partner
+- **/process** - manufacturing walkthrough (collect to shred to heat-press to CNC-cut to finish to assemble) inside a two-container mobile factory. Note: the page reads operationally present-tense (young people from Oonchiumpa "drill the holes and fit the screws") - against the "0 beds assembled in-house" guardrail, this overstates current state and is part of the copy reconcile. The publicly reachable washing-machine page (/shop/washing-machine) shows no price - prototype/register-interest only. https://www.goodsoncountry.com/process
+
+**Stories.** No direct story - this is a finance/product/business-model area. The consent-cleared library holds youth-justice and place narratives on `localhost:3030`; the nearest matches describe *programs*, not Goods' bed business model, so linking them would mislead a reviewer. Use the live shop + process + partner pages instead.
+
+**The gap + next build.** Primary gap: buyer pipeline is not reconciled against Xero and there are no signed commitments, so demand cannot be presented as revenue. Next action: reconcile the buyer/sales pipeline line-by-line against Xero and separate (a) cash actually received, (b) modelled cost/breakeven, (c) unsigned pipeline - producing one founder-approved business-model + pricing/cost sheet.
+
+**Public-copy risk.** Stretch Bed is the only direct-sale product - never quote the demand pipeline as committed, and never present the blended capital stack or QBE match as secured/booked revenue. Reconcile /process present-tense in-house-making copy against the "0 beds assembled in-house" guardrail.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf81fb8aa8de54f38bdeb4 - Strategy: `thoughts/shared/strategy/goods-qbe-capital-action-plan.md` (capital stack + buyer-pathway sequencing); revenue carve-out guardrails in `goods-qbe-power-capital-strategy.md` (hold ~AU$741,111 canonical / ~$713,827 Goods-only, both UNSIGNED).
+
+### Area 04 - Financial Management
+
+**Status:** Priority gap | **Priority:** P0 | **Owner:** Ben / accountant | **Timing:** 0-2 months
+
+**The claim (decision artifact).** Goods asserts a founder/accountant-approved finance summary that states the capital-ask basis, treats payable matching-gaps as bookkeeper clean-up (not public debt), and holds the revenue figure as management data until accountant-signed. The open founder decision is gross-vs-net capital ask, pending a bookkeeper/accountant review of the matching gaps.
+
+**Evidence.**
+- ACT-GD receivables: AUD 733,410.79 raised / 650,910.79 paid / 82,500 due (management data, not audited, snapshot 1 Jun 2026). Whole-org Xero, not Goods-only [modelled].
+- Goods-only carve-out ~AU$713,827 [modelled] - **UNSIGNED**, hold until accountant-signed.
+- Unit economics: bed price AUD 750; marginal cost ~AUD 426 in-house / ~AUD 685 buy-kit; breakeven ~338 beds/yr in-house [modelled].
+- Deployment base underpinning the receivables story: 496 deployed beds, 9 served communities, every bed QR-tracked [verified].
+- Match position: **AU$0 signed match-eligible today** [modelled]; the ~$400K match gap is fully open.
+
+**Live proof (website).** `/investors?skin=mc` - gated investor cockpit (password-protected); not fetched. This is the only route attached to this area; there is no public finance page on https://www.goodsoncountry.com to review for Area 04.
+
+**Stories.** No direct story (asset/finance/legal area). The consent-cleared library has no story whose themes map to financial management.
+
+**The gap + next build.** Primary gap: management data only, not audited - whole-org Xero is not carved to Goods-only, and AP gaps are unreviewed. Next action: bookkeeper/accountant review of the matching gaps, producing an accountant-signed Goods-only finance summary that resolves the founder's gross-vs-net capital-ask decision.
+
+**Public-copy risk.** Management data only, not audited - the whole-org Xero figure is not Goods-only and AP gaps are bookkeeper clean-up, not public debt; **hold the revenue figure (do not quote ~$713,827 or ~$741,111 as confirmed) until accountant-signed.**
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf8167884fc3d5ecda0e32 - Strategy: `thoughts/shared/strategy/goods-qbe-capital-action-plan.md` ("Match math - what is genuinely in play vs the gap" and "The match gap: net-new repayable capital").
+
+### Area 05 - Strategic Planning & Risk
+
+**Status:** Priority gap | **Priority:** P0 | **Owner:** Ben/Nic | **Timing:** 0-3 months
+
+**The claim (decision artifact).** Goods on Country plans against a scored, owner-assigned risk register, with founder-approved language governing what risk we will and won't say in public. The decision artifact is that register plus an explicit shareability call on each external risk line, built on verified asset and cost metrics rather than narrative.
+
+**Evidence.**
+- 496 beds deployed across 9 served communities, every bed QR-tracked [verified] - the asset base the risk model is anchored to.
+- Bed price AUD 750 [verified] - the live commercial reference point for finance-risk framing.
+- Marginal cost ~AUD 426 in-house vs ~AUD 685 buy-kit; breakeven ~338 beds/yr in-house [modelled] (not yet realised; 0 beds assembled in-house).
+- ~2,660kg Stretch-only recycled-HDPE diversion (~20kg per Stretch bed) [modelled] - sustainability claim, not a measured plant output.
+- Closing the register inside a ~12-week window: QBE match gate (Sept), freshest Utopia proof, free program support ends Aug, warm funders waiting [target] - the "why-now".
+- Founder-approved external risk language for the unresolved items (entity migration, QBE match, capital decision, community-owned production) [future] - to be ratified, not yet settled.
+
+**Live proof (website).**
+- **/impact** - the verified proof spine rendered publicly: 496 beds, 9 communities, ~20kg plastic diverted per bed, with foundation backing (incl. QBE) listed. https://www.goodsoncountry.com/impact
+- **/partner** ("Back the Work") - the scale-risk narrative made explicit: capital sought to bridge from product proof to on-country manufacturing/community ownership, with the entity split (ACT Pty trades, Butterfly handles DGR giving) stated. The page surfaces a ~$3M blended-capital ambition, explicitly framed on-page as "a blended-finance target, not committed capital" - treat as aspiration, NOT a committed raise. https://www.goodsoncountry.com/partner
+
+**Stories.** No direct story (asset/finance/legal-governance area). The consent-cleared library has no named, on-topic story for strategic planning or risk.
+
+**The gap + next build.** Gap: a scored risk register with named owners and mitigations does not yet exist, and there is no founder-approved decision on which risks are shareable externally. Next action: Ben/Nic run one working session to score the top risks (entity migration, QBE match dependency, capital/production bridge, single-customer/funder concentration), assign an owner + mitigation to each, and ratify the public-vs-internal language line for each.
+
+**Public-copy risk.** Do NOT present unresolved entity migration, the QBE match, capital decisions, or community-owned production as settled - frame each as in-progress/unsigned, and never let the /partner ~$3M figure read as committed.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf8143a283efd1eb5260d7 - Strategy: `thoughts/shared/strategy/goods-qbe-capital-action-plan.md` (12-week window, QBE match gate, program-support-ends-Aug sequencing) and `goods-qbe-power-capital-strategy.md` (capital decision + entity-risk framing).
+
+### Area 06 - Process & Technology
+
+**Status:** Strength | **Priority:** P1 | **Owner:** Ben | **Timing:** Ongoing
+
+**The claim (decision artifact).** Goods runs a single operating-system owner map across five lanes - money, pipeline, assets, stories, and public copy - so every claim a funder reads traces back to a system of record. Each physical bed is QR-tracked to a public record, and CivicGraph syncs the pipeline and hosts the Match Campaign commitment register on a scheduled (not real-time) cadence.
+
+**Evidence.**
+- Every bed is QR-tracked to a public, scannable record (e.g. bed GB0-156-96 to Utopia Homelands, full bill-of-materials and local supplier chain shown) [verified].
+- 496 beds deployed across 9 communities, each with its own traceable asset record [verified].
+- HighLevel (GHL) API connection verified 10 Jun 2026; reauth resolved [verified].
+- CivicGraph syncs 3 Goods pipelines every 12h and hosts the Match Campaign commitment register (scheduled batch, not live automation) [verified].
+- ~20kg recycled HDPE diverted per Stretch bed (2,660kg Stretch-only diversion) [modelled].
+
+**Live proof (website).**
+- **/impact** - the headline proof spine: "496 beds across Australia", "9 communities", "20kg plastic diverted per bed". Detailed traceability lives on individual bed records. https://www.goodsoncountry.com/impact
+- **/bed/GB0-156-96** - a working per-asset QR record: bed personalised to its recipient ("this is your bed"), deployed to Utopia Homelands, full materials (Australian canvas, galvanised steel, recycled HDPE legs by Defy Manufacturing) and named local suppliers (DNA Steel Direct, Centre Canvas, Coastal Fasteners - all Alice Springs / Mparntwe). The single best live demonstration of bed-level traceability. https://www.goodsoncountry.com/bed/GB0-156-96
+
+**Stories.** No direct story - asset/systems/infrastructure area. The consent-cleared library holds no story themed to QR-tracking, traceability, or operating-systems; the live /bed/GB0-156-96 record is the human-facing proof instead.
+
+**The gap + next build.** Gap: external-account Drive access test still outstanding (HighLevel reauth is resolved, verified 10 Jun 2026). Next action: run and document the external-account Drive access test to close the last owner-map verification gap.
+
+**Public-copy risk.** Do NOT claim full automation - CivicGraph syncs on a 12-hour batch cadence, not in real time.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf81659f6afab915672b57 - Strategy: `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` (operating-system / proof-infrastructure thread - QR-tracked beds + CivicGraph commitment register as the verifiable backbone).
+
+### Area 07 - Governance, Data & Reporting
+
+**Status:** Priority gap | **Priority:** P0 | **Owner:** Ben / Nic / legal | **Timing:** 0-6 months
+
+**The claim (decision artifact).** Goods on Country is standing up an approved governance path for how evidence, stories, finance claims, and entity wording get used - defining roles for who can sign off on each, with consent and data-sharing guardrails baked in. It does **not** yet have audited accounts or a formal board; advisory relationships and management reports are named as exactly that.
+
+**Evidence.**
+- Every one of the 496 deployed beds is QR-tracked, giving a per-bed audit trail underneath the impact numbers (496 beds, 9 communities) [verified].
+- Stories are used **only when consent-cleared** - operationalised in the DB as `published_at IS NOT NULL` on `goods_content_library`; unpublished/unconsented rows are excluded by query design [verified].
+- Finance figures (marginal cost ~AUD 426 in-house / ~685 buy-kit, breakeven ~338 beds/yr in-house, 2,660kg Stretch-only HDPE diversion) are management estimates, **not audited** [modelled].
+- A single approved sign-off matrix covering evidence use, story consent, finance-claim language, and entity wording (0-6 months) [target].
+- Independent audit of accounts and a formally constituted board (advisory relationships today are advisory, not a board) [future].
+
+**Live proof (website).** **/impact** - the headline proof spine (496 beds, 9 communities, 20kg plastic diverted per bed). The page does **not** publicly describe the QR audit trail, consent framework, or that finance figures are management (unaudited) estimates - that governance/verification layer is currently internal, which is exactly the gap this area names. (The page shows the three aggregate figures only; per-community bed breakdowns live on /communities, not /impact.) https://www.goodsoncountry.com/impact
+
+**Stories.** No direct story (governance / data / legal area). Two targeted queries against `goods_content_library` (consent-cleared only) returned no public story themed to governance, consent, data, trust, transparency, or accountability - fitting, since this is an internal-process area.
+
+**The gap + next build.** Gap: no formal approval path for who can authorise evidence claims, story use, finance language, and entity wording. Next action: draft and ratify the one-page sign-off matrix (who approves what, across evidence / story-consent / finance-claim / entity-language), with Ben, Nic, and legal as named roles.
+
+**Public-copy risk.** Do **not** publish household or story data without consent, do **not** call advisory relationships a board, and do **not** treat management reports as audited.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf813e9b6fc95d4e5a703a - Strategy: `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` (governance / evidence-credibility and entity-language sections).
+
+### Area 08 - People & Organisation
+
+**Status:** Partial | **Priority:** P1 | **Owner:** Ben/Nic | **Timing:** 0-6 months
+
+**The claim (decision artifact).** Goods on Country is founder-led by Ben Knight and Nicholas Marchesi (co-founders of A Curious Tractor), with community and advisory capacity drawn from named partners. The committed deliverable is a **12-month role map plus a founder-dependency mitigation plan** - making explicit who does what, where founder labour sits in the economics, and how the org reduces single-points-of-failure as it scales.
+
+**Evidence.**
+- Two named founders: Ben Knight + Nicholas Marchesi, operating under A Curious Tractor as parent [verified]. Both visible on the live /about page.
+- Named external capacity, presented as partners/advisors (NOT owned headcount): Oonchiumpa Consultancy (community partner, on /partner) and Utopia / Warumungu community partners including Dianne Stokes (Warumungu Elder, on /about) [verified].
+- Founder labour is held *inside* the unit economics: marginal cost ~AUD 426/bed in-house (vs ~685 buy-kit), bed price AUD 750, breakeven ~338 beds/yr in-house [modelled] - a founder-rate cost model, not a hire-dependent one.
+- Operating footprint the small team covers today: 496 deployed beds across 9 served communities, every bed QR-tracked [verified].
+- A 12-month role map + founder-dependency mitigation plan (the area's decision) [target] - drafted within the 0-6 month window, owned by Ben/Nic.
+
+**Live proof (website).**
+- **/about** - the two founders named (Ben Knight, Nicholas Marchesi), a small team described as "designers, engineers, and community members across Brisbane, Tennant Creek, and the Top End," and Elder Dianne Stokes featured as a community voice. Frames "Elders and community partners shape every product" rather than listing staff - consistent with not implying hires that don't exist. https://www.goodsoncountry.com/about
+- **/partner** - funding partners (Snow, Centrecorp, The Funding Network, FRRR, AMP, QBE) and Oonchiumpa Consultancy named as a community partner. These are relationships/backers, not owned operating capacity. https://www.goodsoncountry.com/partner
+
+**Stories.** No direct story (org/capacity area). No consent-cleared row in `goods_content_library` maps to People & Organisation themes - nearest matches are untitled community-media assets with no storyteller. The human proof lives on the live /about and /partner pages.
+
+**The gap + next build.** Gap: role clarity, funded capacity, and founder-dependency mitigation are undocumented - the org runs on two founders with no written map of what happens as volume grows. Next action: draft the **12-month role map + founder-dependency mitigation plan** (Ben/Nic, 0-6 months), explicitly showing where founder labour sits in the bed economics and which roles convert from founder-held to funded/partner-held first.
+
+**Public-copy risk.** Do NOT imply future hires already exist, do NOT remove founder labour from the unit economics, and do NOT present partners/advisors (Oonchiumpa, Utopia/Warumungu) as owned operating capacity - they are relationships, not staff.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf813cbfbbca1709600971 - Strategy: `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` line 30 (the rationale for funding capacity and de-risking founder dependency).
+
+### Area 09 - Legal Structure
+
+**Status:** Partial | **Priority:** P0 | **Owner:** Ben / Nic / legal | **Timing:** 0-6 months
+
+**The claim (decision artifact).** Goods on Country uses a deliberately separated, approved entity structure: **A Curious Tractor Pty Ltd** is the trading/contracting company, and **The Butterfly Movement Ltd** is the charity that holds DGR and is the only tax-deductible giving pathway. This wording block is the single approved language for public pages, grants, contracts, and investment material - it is not yet a settled end-state.
+
+**Evidence.**
+- Live Xero org since 1 Jun 2026 trades as **Nicholas Marchesi sole trader, ABN 21 591 780 066** - the current operating entity today [verified].
+- **The Butterfly Movement Ltd** (ABN 22 155 132 684) is an ACNC-registered charity holding **Item 1 DGR + PBI since 2012** - the existing, real DGR home [verified]. Goods on Country itself is **not** DGR-endorsed.
+- Migration of trading to **A Curious Tractor Pty Ltd** (ABN 36 697 347 676), with Butterfly as the DGR/receipting home for FY2026-27 [target]. In progress, not complete.
+- **Supply Nation 51% First Nations ownership gate tightens 1 Jul 2026** [target] - confirming ACT Pty meets the 51% test is a P0 prerequisite (also gates First Australians Capital and IBA capital pathways).
+- **MinterEllison advising** on the entity/migration structure; founder/accountant/legal sign-off on the final wording block is still outstanding [future].
+- Proof spine the structure carries: 496 deployed beds across 9 communities, every bed QR-tracked [verified].
+
+**Live proof (website).** **/partner** - the entity wording block live: A Curious Tractor Pty Ltd named as the trading company, The Butterfly Movement Ltd named as the ACNC-registered charity and DGR pathway for eligible giving, an explicit note that "Goods on Country and A Curious Tractor Pty Ltd are not themselves DGR-endorsed," and an ABN-lookup verification link. The public face of the decision artifact, consistent with the guardrails. https://www.goodsoncountry.com/partner
+
+**Stories.** No direct story (legal/entity/finance area - entity structure is not a consent-cleared lived-experience story, and no published `goods_content_library` row fits this theme).
+
+**The gap + next build.** Gap: no founder/accountant/legal-confirmed final wording block yet - sole-trader / company / charity roles must be locked so public, grant, and contract language can't blur. Next action: get MinterEllison + Standard Ledger sign-off on the approved entity-wording block AND confirm the Supply Nation 51% First Nations ownership test is met before 1 Jul 2026; then freeze that wording across all surfaces.
+
+**Public-copy risk.** Do NOT say Goods is already DGR, blur the sole-trader / company / charity roles, or present the community-ownership transfer as complete - all three are in progress, not done.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf8106b398d52438170718 - Strategy: `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` ("DGR mechanic for foundation lenders", line 120): recoverable grants route through The Butterfly Movement (Item 1 DGR + PBI); straight commercial debt to ACT Pty t/a Goods on Country.
+
+### Area 10 - Investors & Capital Raising
+
+**Status:** Partial | **Priority:** P0 | **Owner:** Ben/Nic | **Timing:** 0-3 months
+
+**The claim (decision artifact).** Goods on Country is raising a blended, non-equity capital stack of roughly AU$900K-1M to scale community-built health hardware: junior grant capital, the QBE catalytic match (contingent), and senior SEFA-style debt. The decision being made is a founder-approved investor story, use-of-funds budget, confirmed QBE match rules, and a register of signed/eligible commitments.
+
+**Evidence.**
+- Capital ask **AU$900K-1M blended, non-equity**: ~$500K grants (junior) + up to **$400K QBE match (catalytic, contingent on external capital raised)** + ~$300K SEFA debt (senior) [target].
+- First **~AU$400K signed match-eligible by 31 Aug 2026** [target] - a milestone, not a commitment.
+- **0 signed match commitments today** [verified]. Nothing in the stack is secured.
+- Operating proof spine the ask rests on: **496 deployed beds across 9 communities, every bed QR-tracked**, bed price **AUD 750** [verified].
+- Unit economics underpinning use-of-funds: marginal cost ~AUD 426 in-house / ~AUD 685 buy-kit, breakeven ~338 beds/yr in-house, ~2,660kg Stretch-only recycled-HDPE diversion (~20kg/bed) [modelled].
+
+**Live proof (website).**
+- **/partner** - a "Back the Work" funder page presenting the ~$3M blended-capital framing (grants, DGR giving via Butterfly, recoverable grants, patient working capital) and the QBE line worded correctly as "up to $400,000, at least matched by external capital raised," with the explicit caveat that DGR runs only through The Butterfly Movement Ltd and is being formalised for FY2026-27. https://www.goodsoncountry.com/partner
+- **/press** - a press/brand kit (wordmark, palette, typography, community quotes). Press-coverage/photos/videos sections read "No coverage listed yet" - functional brand hub, no media coverage yet. https://www.goodsoncountry.com/press
+- **/investors?skin=mc** - gated investor cockpit (password-protected); not fetched.
+
+Reconcile flag: the public /partner copy headlines a ~$3M total-vision figure while this diagnostic's ask is the ~$900K-1M near-term stack. The mismatch is magnitude, not framing (the page already labels $3M "raising, not committed") - align the two numbers before sending to QBE.
+
+**Stories.** No direct story (finance/legal/capital area). No consent-cleared story in `goods_content_library` carries capital/investment/enterprise themes on a public `goodsoncountry.com` URL - theme-adjacent matches are youth-justice articles on `localhost:3030`.
+
+**The gap + next build.** Gap: signed/eligible capital evidence, QBE match-rule confirmation, and a founder-approved capital ask. Next action: lock founder sign-off on the investor story + use-of-funds budget and stand up the signed/eligible commitment register, so the ~AU$400K match-eligible milestone has a verifiable source by 31 Aug 2026.
+
+**Public-copy risk.** Do NOT present pipeline as committed, claim the QBE match is unlocked/secured, quote the AUD 400K cap as secured, or use unsettled entity/DGR language - the match is contingent, 0 is signed today, and the entity/DGR migration is in progress.
+
+**Links.** Notion: https://app.notion.com/p/36eebcf981cf81329a11e33e2d121bf9 - Strategy: `thoughts/shared/strategy/goods-qbe-capital-action-plan.md` (capital-stack design + match-eligibility milestones); supporting context in `goods-qbe-power-capital-strategy.md`.
+
+### Area 11 - Cost Model v6 (reconfigured)
+
+**Status:** Partial | **Priority:** P0 | **Owner:** Ben / Nic / accountant / SIH | **Timing:** 0-2 months
+
+**The claim (decision artifact).** Goods on Country has a founder/accountant-approved cost-model basis: a Stretch bed sells for AUD 750 against a verified bed-level bill of materials, and bringing leg manufacturing in-house drops the marginal cost from ~AUD 685 (buy-kit) to ~AUD 426 - the wedge that funds fixed operations and underwrites the capital ask. Factory and On-Country facility capex are modelled, not yet vendor-quoted.
+
+**Evidence.**
+- Bed price AUD 750; bed-level BOM mostly verified. Stretch bed uses ~20kg recycled HDPE per bed [verified].
+- 8.6x markup confirmed on bought-in HDPE legs - the cost line that in-sourcing collapses [verified].
+- Marginal cost ~AUD 426 in-house vs ~AUD 685 buy-kit; breakeven ~338 beds/yr in-house; ~AUD 109,500 annual fixed operating expenses covered by contribution [modelled].
+- Factory capex AUD 112K-222K gross, of which **AUD 110,046 already invested** (verified-spent); On-Country site capex AUD 100K-150K/site is **UNVERIFIED**, pending vendor quotes [modelled].
+- First use of funds: a AUD 60-80K, 50-bed in-source production run that converts the AUD 426 marginal cost from *modelled* to *measured* [target].
+
+**Live proof (website).**
+- **/cost-story** - public transparent cost breakdown: the AUD 750 sell price, AUD 685 current marginal cost dropping to AUD 426 once legs are made in-house, and the contribution funding ~AUD 109,500/yr fixed costs. Reads exactly as the claim above. https://www.goodsoncountry.com/cost-story
+- **/cost-model-diagram.png** - valid PNG, cost-model visual. https://www.goodsoncountry.com/cost-model-diagram.png
+- **/goods-marginal-vs-fixed.png** - valid PNG, marginal-vs-fixed-cost diagram. https://www.goodsoncountry.com/goods-marginal-vs-fixed.png
+- **/goods-cost-down.png** - cost-down trajectory diagram (sibling asset on the same path pattern). https://www.goodsoncountry.com/goods-cost-down.png
+- **/investors?skin=mc** - gated investor cockpit (password-protected); not fetched.
+
+**Stories.** No direct story (asset/finance/legal area). The consent-cleared library has no item whose themes fit unit economics / cost model - closest matches are youth-program and social-enterprise narratives, not cost evidence.
+
+**The gap + next build.** Primary gap: the container-factory and On-Country facility capex are modelled, not vendor-quoted, and the external-account evidence-pack access test is unrun. Single next action: commission the vendor-quoted equipment/build list for the container + On-Country facility, and run the 50-bed in-source production run to measure the AUD 426 marginal cost.
+
+**Public-copy risk.** Do NOT present container/On-Country facility capex as fully actual or quoted - bed-level BOM is mostly verified, but facility capex is modelled. Global guardrails also apply (0 signed match commitments; no pipeline-as-committed; QBE match not "secured").
+
+**Links.** Notion: https://app.notion.com/p/36febcf981cf8146a55de05050e956e9 - Strategy: `thoughts/shared/strategy/goods-qbe-capital-action-plan.md` ("Match math - what is genuinely in play vs the gap" and "The match gap: net-new repayable capital").
+
+### Area 12 - Investor Alignment Tool (populated)
+
+**Status:** Partial | **Priority:** P0 | **Owner:** Ben/Nic | **Timing:** 0-3 months
+
+**The claim (decision artifact).** Goods has a structured investor-alignment process - an 8-knockout + 14-fit-criteria checklist (Social Impact Hub tool), populated warmest-first - and a live funder pipeline ("Goods Supporter Journey", 49 opportunities) that ranks capital sources by fit. The artifact a reviewer should be able to inspect is the checklist plus a commitment register that separates *eligible/fit-scored* prospects from *signed* commitments.
+
+**Evidence.**
+- The Social Impact Hub tool exists and is populated: 8 knockout criteria + 14 fit criteria, scored warmest-first [verified]. Tier-1 prospects (Snow / SEFA / Centrecorp / Minderoo / VFFF) pass; FAC + IBA are full-fit but **fail the timing knockout**.
+- Live funder pipeline = "Goods Supporter Journey" with 49 opportunities in CRM [verified].
+- Pipeline value ~AU$5.18M total, but ~$4.0M (77%) is two EXCLUDED lines (REAL/DEWR ~$2.0M + QBE match ~$2.0M); non-excluded ~$1.18M, and that still overstates match-readiness (planning figure, not committed) [modelled].
+- QBE Catalysing Impact match of up to AU$400,000 is an *output* contingent on external capital being raised first - a blended-finance target, not committed capital, unverified until ~Sept 2026 [target].
+- **0 signed match commitments today** [future]. Highest-match-value repayable instruments (e.g. SEFA ~$300K) are aspirational - a bundled earliest-stage grant row, not an indicative term sheet.
+
+**Live proof (website).**
+- **/investors?skin=mc** - gated investor cockpit (password-protected); not fetched. https://www.goodsoncountry.com/investors?skin=mc
+- **/partner** - a blended-capital invitation ("Start the capital conversation" form, capital-type selector) plus a backers row including Snow, Centrecorp and QBE Foundation. QBE is correctly framed: "QBE Catalysing Impact 2026 creates a timely match opportunity of up to $400,000, at least matched by external capital we raise first... a blended-finance target, not committed capital." The dual-entity structure (A Curious Tractor Pty Ltd trading / The Butterfly Movement Ltd for DGR giving) is shown. https://www.goodsoncountry.com/partner
+
+**Stories.** No direct story (asset/finance/legal area). The only thematically-adjacent consent-cleared content (economic-empowerment changemaker pieces) carries `localhost:3030` URLs, so it is not a publishable public link and does not evidence investor alignment.
+
+**The gap + next build.** Gap: QBE match-rule confirmation and *written* commitments - the register today holds fit-scores and pipeline, not signed eligible capital. Next action: split SEFA out of the bundled "Snow / SEFA" grant line into its own debt-pipeline opportunity and advance it from "advanced discussion" to an **indicative term sheet** (~$300K concessional repayable to ACT Pty Ltd) - the first line that can move the register from "fit-scored" to "eligible commitment".
+
+**Public-copy risk.** Pipeline is not committed capital; the QBE match is contingent and fit scores are planning tools, not investor confirmation - never present any of the 49 opps, the ~$400K match, or a fit-score as secured/committed.
+
+**Links.** Notion: https://app.notion.com/p/36febcf981cf81f5ad6dee375364d032 - Strategy: `goods-qbe-capital-action-plan.md` lines 40-57 (pipeline-vs-committed reality, SEFA mis-categorisation, knockouts) and line 147 ("Do not say the QBE match is unlocked"); `goods-qbe-power-capital-strategy.md` line 116 ("The $400K QBE match plan").
+
+## P0 priority gaps (close these first)
+
+Nine of the twelve areas are P0. Backwards-planned from the **31 August** match-eligibility milestone, the critical path is: lock the legal/finance foundations first (everything else cites them), then the risk + governance language, then the capital instruments that produce signed/eligible commitments.
+
+| # | Area | Next build | Owner | Timing |
+|---|------|-----------|-------|--------|
+| 1 | 09 Legal Structure | MinterEllison + Standard Ledger sign-off on the entity-wording block; confirm Supply Nation 51% before 1 Jul 2026; freeze wording across all surfaces | Ben / Nic / legal | 0-6 mo (51% test by **1 Jul**) |
+| 2 | 04 Financial Management | Bookkeeper/accountant review of matching gaps; accountant-signed Goods-only finance summary; resolve gross-vs-net ask | Ben / accountant | 0-2 mo |
+| 3 | 11 Cost Model v6 | Commission vendor-quoted equipment/build list for container + On-Country facility; run the 50-bed in-source run to measure the AUD 426 marginal cost | Ben / Nic / accountant / SIH | 0-2 mo |
+| 4 | 03 Business Model | Reconcile buyer pipeline line-by-line against Xero; separate cash-received / modelled-cost / unsigned-pipeline into one founder-approved sheet | Nic / Ben | 0-3 mo |
+| 5 | 05 Strategic Planning & Risk | One working session to score top risks, assign owner + mitigation, ratify public-vs-internal language per risk line | Ben / Nic | 0-3 mo |
+| 6 | 07 Governance, Data & Reporting | Draft + ratify the one-page sign-off matrix (evidence / story-consent / finance / entity language) | Ben / Nic / legal | 0-6 mo |
+| 7 | 10 Investors & Capital Raising | Founder sign-off on investor story + use-of-funds budget; stand up the signed/eligible commitment register with a verifiable source for the ~AU$400K milestone | Ben / Nic | 0-3 mo (milestone **31 Aug**) |
+| 8 | 12 Investor Alignment Tool | Split SEFA into its own debt-pipeline line; advance from "advanced discussion" to an indicative term sheet (~$300K concessional repayable to ACT Pty) | Ben / Nic | 0-3 mo |
+| 9 | 02 Social Objective & Impact | Sign a clinical/data partner (Miwatj or an ACCHO) to co-define and validate the bedding to infection to RHD measurement method | Ben | 6-12 mo |
+
+P1 areas in good shape (01 Vision, 06 Process & Technology, 08 People) need lighter touches: 01 + 03 share the live-site copy reconcile (the "Manufactured On-Country" / "made by the people who'll sleep on them" / /process present-tense lines), 06 needs the external-account Drive access test run, and 08 needs the 12-month role map drafted.
+
+## Cross-reference
+
+**Strategy docs.**
+- `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md` - vision/proof-spine, governance + evidence-credibility, entity-language, DGR mechanic, power/capital framing.
+- `thoughts/shared/strategy/goods-qbe-capital-action-plan.md` - capital-stack design, match-math (in-play vs gap), match-eligibility milestones, SEFA mis-categorisation, knockouts, "Do not say the QBE match is unlocked".
+- `thoughts/shared/strategy/goods-funder-relationship-history.md` - funder relationship history (QBE, Snow, Centrecorp and the wider Tier-1 cohort).
+
+**Live surfaces (start here).**
+- Public funder page / entity-wording block: https://www.goodsoncountry.com/partner
+- Impact proof spine: https://www.goodsoncountry.com/impact
+- Bed-level traceability (best single live proof): https://www.goodsoncountry.com/bed/GB0-156-96
+- Transparent cost model: https://www.goodsoncountry.com/cost-story
+- Consent-cleared stories surface: https://www.goodsoncountry.com/stories
+- Gated investor cockpit (password-protected): https://www.goodsoncountry.com/investors?skin=mc

--- a/thoughts/shared/strategy/goods-qbe-capital-action-plan.md
+++ b/thoughts/shared/strategy/goods-qbe-capital-action-plan.md
@@ -1,0 +1,164 @@
+# Goods x QBE — Live-Aligned Capital Action Plan
+
+**Prepared 19 June 2026 · The operating document Ben acts from. Reconciled to live CRM (`ghl_opportunities`, `ghl_contacts`, `fundraising_pipeline`, `funder_briefs`) on 2026-06-19.**
+*Deep intelligence (power-mapping, foundation universe, per-target briefs) lives in `goods-qbe-power-capital-strategy.md`. The relationship substrate lives in `goods-funder-relationship-history.md`. This file does not duplicate them; it tells you what to do next, in order.*
+*Credit line on every funder-facing line: "Catalysing Impact, powered by Social Impact Hub, in partnership with QBE Foundation."*
+
+There are **0 signed, match-eligible commitments today.** That is the whole problem, and it is a conversation problem, not a discovery problem. The QBE Stage 2 prize is up to AU$400K (AU$150K floor), discretionary, contingent on at least 1:1 external match, verified at the September 2026 application and decided November 2026. The job is to close roughly **AU$400K of SIGNED match-eligible commitments by 31 August 2026.** Every "big number" in the pipeline today is an ask, a stewarding state, or an unentered $0 line — none of it is a signature. The three moves that actually move the needle: **(1)** stand up and advance a **SEFA repayable term sheet (~$300K)** — repayable carries the highest match value; **(2)** convert the warm **Snow** in-review ask into a **signed recoverable LOI (~$120K–$400K)** — the deepest relationship and the first-mover signal everyone else reads; **(3)** convert **Minderoo's $200K ask-made into a signed LOI** in the September window. Snow + Minderoo alone clear the floor and approach the ceiling; SEFA is the highest-value addition and the biggest execution risk.
+
+---
+
+## The reconciled funder ledger
+
+On-match-track = can count toward the QBE ~$400K. Lane separation is enforced: revenue, receivables, Harvest/JusticeHub grants, and QBE/DEWR are OFF the match ledger.
+
+| Funder | Tier | Match? | Live stage (verified) | Contact | Capital type | Next step | Flags |
+|---|---|---|---|---|---|---|---|
+| **Snow Foundation** | 1 | Yes | Stewarding + live $120K ask `in-review` (submitted 2026-02-15) | Primary **UNVERIFIED** — 3 real contacts: Sally Grimsley-Ballard (brief reviewer), Georgina Byron (CEO), Carolyn Ludovici | Grant, ask loan-first/recoverable | Close Feb feedback + reconcile bed count, then convert to **signed multi-year LOI** | Bed numbers NOT reconciled (alignment WARN); do not assert "closed out". Bridge to PRF (Ben Smith) + FRRR (David Hardie). EL sub $14,988 is separate |
+| **SEFA** | 1 | Yes | One earliest-stage row only: "Snow / SEFA" **Grants** pipeline, $250K, bundled, open. No standalone debt opp | Hanna Ebeling (CEO, UNVERIFIED-confirm). 4 SEFA contacts DO exist in CRM (Chelsea Baker, Joel Bird, Leigh Brezler, info@) | Senior concessional **repayable** debt ~$300K to ACT Pty | **Split into its own debt opp**, then advance to **term sheet** | Highest match value + biggest execution risk. Covenants unmet: financial model, independent-majority board, revenue covenant. Confirm Supply Nation 51% pre-1 Jul |
+| **Centrecorp Foundation** | 1 | Yes | Stewarding $123,332 (warm anchor) | Randle Walker (randle@centrecorp.com.au, VERIFIED) | Grant to Butterfly DGR, $40–60K safe band | At **June board**, secure grant commitment **separate from the 130-bed order** | Grant (match) ≠ 130-bed order ($106,150, revenue) ≠ $84,700 production-plant draft. Walker's Foundation title unconfirmed (email safe) |
+| **Minderoo Foundation** | 1 | Yes | Ask made, $200,000, open (2026-05-31) | Lucy Stronach (lstronach@minderoo.org, VERIFIED) | Grant (recoverable loan only if they raise it) | Convert $200K ask-made to **signed LOI**, disbursement later | Doc ranked it cold lender #11 — OVERRIDDEN: live shows warm $200K grant ask. Prefer live |
+| **VFFF** | 1 | Yes | Stewarding $50,000, open; prior $50K won 2025-11-29 | El Schwanke (elschwanke@vfff.org.au, VERIFIED) | Grant | **Signed LOI** aggregating into blended round | **VFFF + FRRR = ONE joint $50K. Count once.** El ≠ Eloise Hall (distinct records) |
+| **FRRR** | 1 | Yes | Stewarding $50,000, open (joint with VFFF) | Steph Pearson (s.pearson@frrr.org.au, VERIFIED) | Grant (holds DGR) | **Sign joint Backing-the-Future LOI** with VFFF | Count $50K ONCE. Two lanes: match (Backing the Future) + Harvest (climate R4) — never merge dollars. David Hardie = Snow↔FRRR bridge |
+| **Paul Ramsay Foundation** | 2 | Conditional | **No verified Goods opp.** Only record: JusticeHub $200K @ 0.25, ACT-JH, expected ~Sept | William Frazer (wfrazer@paulramsayfoundation.org.au, VERIFIED) | Grant in CRM; doc proposes recoverable loan, co-invest with SEFA | **Disambiguate**: is the ask a Goods match instrument or a JH grant? If match, advance to EOI/LOI | The "live Goods Ask-made" thread is UNVERIFIED — do NOT present as a warm Goods front. $200K is JH, not Goods match. Slow committee |
+| **The Funding Network** | 2 | Yes | Stewarding $130,000, open (2026-05-27) | Kristen Lark (kristen.lark@thefundingnetwork.com.au, VERIFIED) | Grant | Ask if a **named tranche** can be signed as match-eligible LOI | $130K = pipeline value, not match. Prior "Bupa Pitch" $146,973 won is a separate ACT-CA event |
+| **The Ian Potter Foundation** | 2 | Yes | Ask made, $0 entered (amount not entered) | Alberto Furlan (alberto.furlan@ianpotter.org.au, VERIFIED) | Grant | Enter amount, advance ask-made → LOI | $0 = amount not entered, NOT no ask |
+| **Brian M Davis Charitable Foundation** | 2 | Yes | Ask made, $0 entered | Sarah Bartak (sarah.bartak@brianmdavis.org.au, VERIFIED) | Grant | Enter amount, advance ask-made → LOI | $0 = amount not entered |
+| **Rotary Global Grant (washers/beds)** | 2 | Yes | Ask made, $0 entered | Pene Curtis (pene.curtis@bigpond.com, VERIFIED) | Grant | Confirm Global Grant amount/stage; advance to LOI if in-window | Do NOT confuse with Rotary Eclub receivable (excluded) |
+| **Eloise Hall — Impact Investor** | 2 | Yes | Cultivating, $0 | Eloise Hall (eloisebernadette@gmail.com / eloise@tabooau.co, VERIFIED) | Impact investor (repayable) | Move Cultivating → concrete repayable EOI | DISTINCT from El Schwanke (VFFF). Repayable = high match value |
+| **First Australians Capital (CIF)** | 3 | Yes | ABSENT from CRM (0 rows) | UNVERIFIED — Adrian Appo OAM (MD), Brian Wyborn (Managing Partner) per web; route info@firstaustralianscapital.org | First Nations patient/recoverable debt $100K–$2M | Net-new: create opp, request IM/EOI now | TIMING risk: may miss Sept window. Gated on ACT Pty meeting 50%+ Indigenous-ownership test |
+| **Social Enterprise Loan Fund (SELF / White Box)** | 3 | Yes | ABSENT (net-new, not in DB) | UNVERIFIED — route whiteboxenterprises.com.au/innovate/self/ | Concessional loan $100K–$500K, from 6.5%, to 7yr | Net-new: enquire now. **Strongest 31-Aug-feasible repayable** | Standing fund, not a closing round. Priority cohorts incl. First Nations + regional. Don't name Luke Terry without confirming |
+| **IBA (+ Indigenous Business Guarantee)** | 3 | Yes | ABSENT (0 rows) | UNVERIFIED — 1800 107 107 / iba.gov.au | Concessional loan to ~$150K + Guarantee up to 50%/$1M | Net-new: intake now; use Guarantee to de-risk a larger SELF/FAC ticket | Govt cycle slow — second-tranche realistic. Gated on 50%+ Indigenous-ownership |
+| **Lord Mayor's Charitable Foundation (Naarm)** | 3 | Yes | ABSENT (0 rows) | UNVERIFIED | Below-market loan to Butterfly $100K–$250K | Net-new: sequence AFTER SEFA term sheet so it stacks | DISTINCT from LMCF **Trust** (Brisbane). Dependent on SEFA structure existing first |
+| **Foresters Community Finance** | 3 | Yes | ABSENT (0 rows) | UNVERIFIED — 07 3851 8000 / foresters.org.au | Flexible repayable loan (smaller tickets) | Net-new fallback: quick low-ceremony option for a modest amount | QLD-based CDFI, emerging-SE focus. Fallback if SEFA/FAC stall |
+| **Many Rivers / Bank Australia / SVA-SEDIF / CIM / Macdoch / Suncorp-FRRR / NAB Foundation / QBE Local Grant** | 3 | Mixed | ABSENT (0 rows, doc-only) | UNVERIFIED | Repayable or grant fallbacks | Hold as secondary; act only if primary debt stalls | SVA DIF **CLOSED** to new investments. CIM = institutional asset-backed only (ticket mismatch). See match-gap section |
+| **Dusseldorp · TFFF · Bryan · Regional Arts · LMCF Trust (Brisbane)** | 2/3 | **No** | Cultivating / Ask made (warm) but Harvest/JusticeHub lane | Per ledger (mostly VERIFIED) | Relational / grant (non-match) | Advance on **Harvest/JH lanes**, off the $400K ledger | Warmer in CRM than doc's "cold", but non-match lanes |
+
+### Match math — what is genuinely in play vs the gap
+
+- **Signed, match-eligible today: AU$0.** Every advanced opp is an ask or a stewarding state, not a signature.
+- **Live Goods Supporter Journey pipeline = 49 opps, ~AU$5.18M total** — but ~$4.0M (77%) is the two EXCLUDED lines (REAL/DEWR $2.0M + QBE $2.0M). Strip those → ~$1.18M non-excluded, and even that overstates match-readiness.
+- **Warm Tier-1 grant ASKS that could be signed as match (none signed): ~$540–600K** — Snow ($120K in-review of a ~$403K relationship), Minderoo ($200K ask made), VFFF+FRRR (ONE joint $50K), Centrecorp (~$40–60K safe band, separate from the bed order), The Funding Network ($130K stewarding).
+- **Highest-value repayable instruments are aspirational, not pipeline:** SEFA (~$300K) sits only as a bundled earliest-stage grant row; the entire Tier-3 lender cohort (FAC, IBA, SELF, LMCF-Naarm, Foresters, Many Rivers, Bank Australia) has effectively zero CRM footprint, and several fail the timing knockout.
+- **Gap to ~$400K: the full ~$400K is open.** Realistic close: convert 2–4 warm Tier-1 asks into signed LOIs. **Snow LOI (~$120K) + Minderoo LOI (~$200K) clear the floor and approach the ceiling; Centrecorp ($40–60K) + VFFF/FRRR ($50K once) top it up.** SEFA's ~$300K repayable is the single highest-value addition but must first be split into CRM and pass its covenants.
+
+### Excluded from the match math (note, do NOT count)
+
+QBE Catalysing-Impact match ($2.0M ask — cannot match itself; the $400K is the OUTPUT) · REAL/DEWR ($2.0M — separate government vehicle) · equity VCs incl. Giant Leap (fail no-equity knockout) · buyer/revenue pipeline · **Centrecorp 130-bed order** (revenue, keep separate from the grant) · **Rotary Eclub Outback INV-0222** ($82.5K, ~291d overdue — recovery, not match; CLAUDE.md Rule 3) · Just Reinvest NSW (~$27.5K overdue + endorsement connector, not capital) · Social Impact Hub Foundation (~$21.78K overdue) · PICC (partner + EL sub, revenue/partner track) · Homeland ($44K, delivery) · Karrkad-Kanjdji (governance reference model, not a funder) · EL subscriptions (Snow $14,988, Orange Sky, SNAICC, Oonchiumpa, Palm Island) · Harvest/JusticeHub lanes (Regional Arts, TFFF, Bryan, Dusseldorp, LMCF Trust Brisbane).
+
+---
+
+## Tier-1: advance these from where they actually are
+
+These are NEXT steps, not cold intros. Best-first. Full per-funder briefs (opening line, attach pack, timing) are held against each funder; this section is the decision-grade summary.
+
+### 1. SEFA — repayable term sheet (the single highest-value move)
+
+The doc's #1 move, and the biggest execution risk. **First fix the CRM:** SEFA currently appears only as a bundled earliest-stage "Snow / SEFA" line in the **Grants** pipeline ($250K) — that mis-categorises the highest-match-value instrument as a grant. Split it into its own opportunity in a **debt** pipeline. Then advance the off-system "advanced discussion" to an **indicative term sheet** for a senior concessional **repayable** loan (~$300K) into **ACT Pty Ltd (ABN 36 697 347 676)** — lead with the commercial loan to the Pty, not a DGR grant. Why it leads: QBE prefers repayable over grants, and a First Nations on-Country producer borrowing from a First-Nations-majority-owned lender is the cleanest structural fit in the field. **Knockouts not yet met:** financial model sized to the tranche, independent-majority board on ACT Pty, revenue covenant — plus confirm Supply Nation 51% First Nations ownership before 1 July (this also gates FAC and IBA). A warm internal route already exists: 4 SEFA contacts are in `ghl_contacts`.
+
+### 2. Snow Foundation — recoverable LOI (deepest relationship, first-mover signal)
+
+**Do the reconciliation before you paper anything.** The live brief flag is real: the bed numbers are NOT reconciled (alignment WARN: 369 deployed vs 389 tracked vs 140+ field deployments) and the resubmission has not been delivered (ask still `in-review`). Sequence: **(a)** close the Feb feedback loop — deliver the revised submission (risks expanded, Deadly Heart Trek dropped, Alice Springs strategy in, **bed count reconciled**); **(b)** then ask Snow to formalise the $120K (or a tranche) as a **signed multi-year recoverable LOI to The Butterfly Movement**, band AU$150K–$400K, with a path to community equity. Loan-first carries the highest match value, and a below-market loan from a PAF/PuAF to a DGR may count toward that fund's distribution obligation — present that as "worth your finance team confirming," never as settled fact. **Primary contact is UNVERIFIED** between Sally (the live brief reviewer), Georgina (CEO, the drafted history letter is to her), and Carolyn — do not address a single name as "the primary" until Nic/Ben confirm. Once the signature is in train, trigger the Snow → Ben Smith (PRF) and Snow/David Hardie → FRRR intros. Highest-probability first signature in the portfolio — pull this lever first among grants.
+
+### 3. Minderoo Foundation — convert $200K ask-made to signed LOI
+
+Verified live: "Ask made", $200,000, open, last moved 2026-05-31. The doc ranks Minderoo a cold lender #11 — **overridden**: the live state is a warm $200K grant ask already on the table. The one step: ask Lucy whether Minderoo can issue a **signed LOI now for a later-dated disbursement**, on the remote-Australia thesis. What the match needs is the signature before 31 Aug, not the cash. Lead with the grant LOI; offer a recoverable structure only as an advice-first option if she opens the door.
+
+### 4. Centrecorp Foundation — June-board grant, kept separate from the beds
+
+Warm anchor at Stewarding $123,332. The big-dollar Centrecorp lines (130 Stretch Beds $106,150; Production Plant $84,700 draft) sit in the **buyer pipeline = revenue** and stay there. The move is to create a **new grant line on the match track** — a deployment-tied grant ($40–60K safe band, routed through Butterfly DGR once accounting-confirmed) secured at the **June board**. A signed grant from an Aboriginal-controlled Central Australian foundation is high-signal cultural legitimacy other funders read. Walker's email is verified and safe to use; do not assert his Foundation title.
+
+### 5. VFFF + FRRR — one joint LOI, counted once
+
+Both at Stewarding $50,000, open. This is **ONE joint "Backing the Future" $50K stream** — do not double-count. The artifact is a short joint LOI naming FRRR + VFFF backing the same $50K stream, aggregating into the blended round before 31 Aug. Lowest-friction signatures on the board: two warm repeat funders already mid-steward. Keep FRRR's Harvest climate round (Community Led Climate Solutions R4) on a wholly separate non-match track — never merge the dollars.
+
+### 6. The Funding Network — name a tranche as match-eligible
+
+Stewarding $130,000, open. Ride the stewardship report already owed: ask Kristen whether a **named tranche** (propose $50K–$130K) can be signed, in writing, as a match-eligible commitment for the window. No committee gate on a relationship already in stewarding, so it can move fast. Speed/validation play, not the cornerstone.
+
+### 7. Paul Ramsay Foundation — disambiguate before advancing
+
+**There is no verified Goods-side PRF opportunity.** The only PRF record is JusticeHub ($200K @ 0.25, ACT-JH, ~Sept) — that is JusticeHub money and would not count toward the Goods match unless re-scoped. The one move: a note to William Frazer that **splits the relationship into two asks** (Goods match instrument vs JH platform grant), and in parallel requests the Snow → Ben Smith warm intro for the Goods catalytic conversation. If PRF's appetite is a Goods recoverable tranche co-invested alongside SEFA, advance to a soft EOI/LOI before 31 Aug. Committee-driven and slow — anchor signal, not the gate on the deadline. Keep DGR-routing-to-Butterfly **advisory-only**, not directive.
+
+---
+
+## The match gap: net-new repayable capital
+
+The `foundations` table is structurally thin on repayable capital — it is overwhelmingly grant-making ancillary funds. The genuine repayable intermediaries are not in the DB and must be created as net-new opps. Ranked by ability to sign a match-eligible repayable commitment **before 31 Aug**. Recoverable grants route through **The Butterfly Movement (Item 1 DGR + PBI)**; straight commercial debt goes to **ACT Pty t/a Goods on Country**. **Every contact below is UNVERIFIED unless flagged — confirm from the funder's own site before any outreach; do not reuse a prior-workflow name.**
+
+| Rank | Vehicle | Instrument | Realistic structure | Confidence to sign by 31 Aug |
+|---|---|---|---|---|
+| 1 | **Social Enterprise Loan Fund (SELF / White Box)** | Concessional loan $100K–$500K, from 6.5%, to 7yr | Loan into ACT Pty, framed as WISE + First Nations + regional (its stated priority cohorts) | **High** — standing fund, the strongest net-new find, most likely to clear committee in-window |
+| 2 | **First Australians Capital (CIF)** | First Nations patient debt $100K–$2M | Loan into ACT Pty (NOT Butterfly), conditional on 50%+ Indigenous-ownership test | **High fit / ambitious timing** — own diligence + IC. MD Adrian Appo OAM, Brian Wyborn (web-verified) |
+| 3 | **IBA + Indigenous Business Guarantee** | Loan to ~$150K + Guarantee up to 50% / $1M | IBA loan, OR Guarantee stacked behind a SELF/FAC ticket to de-risk a larger amount | **Medium** — govt cycle slow; best as a stacking instrument. Gated on 50%+ Indigenous-ownership |
+| 4 | **Foresters Community Finance** | Flexible repayable loan, smaller tickets | Asset/equipment/working-capital loan into ACT Pty, QLD-aligned | **Medium** — quick low-ceremony fallback for a modest amount |
+| 5 | **Lord Mayor's Charitable Foundation (Naarm)** | Below-market loan to Butterfly $100K–$250K | Co-structured to stack on the SEFA structure | **Low** — sequence after SEFA term sheet exists |
+| — | **CIM / SVA-SEDIF / Many Rivers / Bank Australia / Macdoch** | Various | — | **Knockouts/fallbacks**: SVA DIF CLOSED to new investments; CIM institutional asset-backed only (ticket mismatch); rest are tertiary fallbacks if SEFA/FAC/SELF stall |
+
+**Before any net-new outreach:** (a) confirm ACT Pty's actual Indigenous-ownership % — it gates FAC and IBA; (b) confirm with QBE/SIH which instruments (concessional loan vs recoverable grant vs PRI) count toward the ~$400K match and at what ratio; (c) a DGR-requiring recoverable grant routes through Butterfly, never ACT Pty.
+
+---
+
+## Sequenced actions (backwards-planned from 31 Aug)
+
+Advice-first openers throughout. Every funder-facing send carries the SIH credit line and the Jay Boolkin (jay@socialimpacthub.org) verification offer. Lead every opener with verified proof only: **496 beds · 9 communities · every bed QR-tracked · ~20kg recycled plastic/bed.** No em-dashes in sent copy. **Receivables recovery (Rotary Eclub INV-0222) stays OFF the match track — finance/collections only.**
+
+### This week (w/c 23 Jun)
+
+| Funder | Advice-first opener (gist) | What to send | Owner |
+|---|---|---|---|
+| **SEFA** | "We named SEFA as lead loan partner in our QBE submission — 20 min on how to structure growth capital against a production-ramp decision." | Impact + unit-economics sheet (label MODELLED, 0 beds in-house); QBE one-pager; term-sheet skeleton flagging cl 7.3 (IP) + cl 5.3 (SIH 3yr co-invest) | Ben / Nic |
+| **SEFA (CRM)** | — | **Split SEFA out of the "Snow / SEFA" grant row into its own debt-pipeline opp.** | Ben |
+| **Snow** | "We're structuring the next stage and Snow is the relationship we want to build it on first — your read on recoverable vs one-off grant." | **First reconcile the bed count + close Feb feedback.** Then: revised submission, recoverable-loan outline (distribution note "for your finance team to confirm"), Butterfly DGR/PBI evidence | Nic |
+| **Minderoo** | "Our $200K conversation sits inside a blended round — could Minderoo put a signed LOI behind it now, disbursement timed to our production ramp later?" | Traction one-pager; QBE one-pager; LOI skeleton (signature-now/disbursement-later) | Ben |
+| **Centrecorp** | "Before the June board, your read — a separate deployment-tied grant alongside the bed order, kept cleanly apart from it." | Deployment sheet; QBE one-pager; scoped-grant outline; Butterfly DGR evidence (once accounting-confirmed) | Ben |
+| **VFFF + FRRR** | "We're aggregating Backing the Future into a blended round — carry FRRR + VFFF's joint commitment as a single signed line." | Traction one-pager; joint LOI skeleton ("one $50K stream, counts once") | Ben |
+| **SELF (White Box)** | Net-new enquiry: WISE + First Nations + regional fit. | SELF enquiry via whiteboxenterprises.com.au/innovate/self/ | Ben |
+
+### By mid-Jul — advisory workshop + LOI drafting
+
+- **SEFA**: advice call by ~30 Jun → **indicative term sheet mid-Jul**. Run the cost-model advisory with Matt (lead) + Mal (QA) to satisfy the financial-model covenant. Confirm Supply Nation 51% before 1 Jul.
+- **Snow**: verbal "yes in principle" on a recoverable structure; loop Craig Betts (CIO) for instrument mechanics; LOI drafted in July.
+- **Minderoo / VFFF / FRRR / Centrecorp / TFN**: LOI scope agreed; circulate skeletons; reconcile VFFF+FRRR as one stream on their side.
+- **FAC**: request the Investment Memorandum; confirm ACT Pty ownership test. **IBA**: open intake; scope the Guarantee as a stacking instrument.
+- **PRF**: warm intro to Ben Smith via Snow; disambiguate Goods-match vs JH.
+
+### By end-Jul
+
+- **Confirm Butterfly signing authority is settled through the ~end-July stewardship handover before papering any DGR-routed instrument.**
+- SEFA term sheet in hand or in final exchange; Snow LOI drafted; Minderoo LOI scope locked; Centrecorp board commitment minuted.
+- Net-new debt: SELF and/or FAC at EOI/term-sheet stage; IBA Guarantee path scoped.
+
+### By 31 Aug (keystone, with mid-Aug buffer)
+
+- **Banked as signed, match-eligible**: SEFA term sheet + Snow recoverable LOI + Minderoo LOI + VFFF/FRRR joint $50K (once) + Centrecorp grant + any TFN tranche. Target ~AU$400K signed.
+- Snow + Minderoo alone clear the AU$150K floor and approach the AU$400K ceiling; SEFA is the highest-value addition.
+- **Sept 2026**: cite the signed commitments in the QBE Stage 2 application; verify via Jay Boolkin. **Nov 2026**: QBE decision.
+- PRF, FAC, IBA, LMCF-Naarm, Foresters ride in parallel as the **post-31-Aug follow-on round** if they cannot move in time — they do not gate the keystone.
+
+---
+
+## Guardrails honoured
+
+Every funder-facing line in this plan and its source briefs is held to these 8:
+
+1. **Do not present pipeline as committed capital** — all GHL/pipeline figures are labelled asks/stewarding/unentered, never signatures.
+2. **Do not present GHL value as committed** — $123,332 / $200K / $130K / $50K are relationship/ask scale, not money in hand.
+3. **Do not say the QBE match is unlocked** — it is contingent and unverified until Sept 2026.
+4. **Do not present QBE's $400K as secured** — 0 signed today; the $400K is the OUTPUT of the raise.
+5. **No DGR/entity language without legal/accounting confirmation** — Butterfly DGR routing is strategy, not asserted fact; entity migration in progress.
+6. **Do not imply community-owned manufacturing is complete** — 0 beds assembled in-house; unit cost is MODELLED, not measured.
+7. **Do not quote a precise revenue figure** — hold AU$741,111 until accountant-signed (Goods-only carve-out ~AU$713,827).
+8. **Lead with verified proof only** — 496 beds · 9 communities · every bed QR-tracked · ~20kg recycled plastic/bed.
+
+### Flagged breaches and their fixes (must be applied before any send)
+
+- **Snow — HARD (guardrail 8 + verification).** The drafted opening line asserts "we have closed out your February notes (... the bed numbers reconciled)" as done. The live DB contradicts it: alignment WARN, bed count NOT reconciled, resubmission not delivered. **FIX: remove the "reconciled / closed out" claim from any sent copy until the bed count is actually reconciled and the resubmission delivered.** The brief body already says to reconcile first — make the opener match the body. **Ben must personally check this line before it goes to Snow.**
+- **SEFA — false VERIFIED claim (not funder-facing, but operationally material).** A prior brief stated "no SEFA contact exists in the CRM (VERIFIED — 0 rows)." **FIX: 4 SEFA contacts DO exist** (Chelsea Baker, Joel Bird, Leigh Brezler, info@) — a warm internal route already exists; use it rather than a cold start. Also: `fundraising_pipeline` has 14 rows total (0 are SEFA), not an empty table.
+- **PRF — unverified figure stated as fact (load-bearing).** A prior brief presented a "live Goods Ask-made" PRF opportunity as verified. **FIX: no such Goods opp exists in `ghl_opportunities`** — the only PRF record is the JH $200K line. Do not present a warm Goods-side PRF front; disambiguate first. Keep DGR-to-Butterfly advisory-only.
+- **Minor (verify, do not assert):** Centrecorp — Walker's *Foundation* title is unconfirmed (email is safe); FRRR/VFFF — the ACT-GD/ACT-FP project-code labels were not confirmable (stage/value/status ARE verified); attachment specifics "107 to Utopia, 2.14t diverted" trace to the strategy docs but were not independently re-verified this pass — the safe verified floor is 496 / 9 / QR / ~20kg.
+- **Carry-over to verify before send:** Jay Boolkin (jay@socialimpacthub.org), the "~$900K–1M blended round", the 31 Aug window, and QBE's $150K floor / Sept judging all trace to the strategy/history docs — confirmed there, but reconfirm against SIH before quoting externally.
+
+---
+
+*Cross-references: deep power-mapping intelligence and full per-target briefs → `thoughts/shared/strategy/goods-qbe-power-capital-strategy.md`. Relationship substrate, capital stack, and the 8 guardrails in full → `thoughts/shared/strategy/goods-funder-relationship-history.md`.*

--- a/thoughts/shared/strategy/goods-qbe-power-capital-strategy.md
+++ b/thoughts/shared/strategy/goods-qbe-power-capital-strategy.md
@@ -1,0 +1,354 @@
+# Goods x QBE — Power-Mapped Capital Strategy
+
+**Prepared 19 June 2026 · Operating document, not an essay.**
+*Credit line required on all investor-facing materials: "Catalysing Impact, powered by Social Impact Hub, in partnership with QBE Foundation."*
+
+---
+
+## Executive summary
+
+The keystone is one signature. By 31 August 2026, Goods on Country must close roughly AUD 400,000 in signed, match-eligible catalytic capital. That commitment is the match the QBE Foundation Stage 2 grant (up to AUD 400K, AUD 150K floor, submitted September 2026) is judged on, through the Catalysing Impact program powered by Social Impact Hub. Repayable and recoverable structures carry the highest match value, so the raise leads with instruments built to lend, not only to give.
+
+The approach is power-mapping. CivicGraph now resolves, for any of Australia's ~11,000 foundations, the actual people who run it and who in Goods' existing network sits one or two links from a decision-maker. That turns a stack of funder names into a sequenced, evidenced approach. The top three moves: (1) reopen SEFA — already named as Goods' lead loan partner in the QBE application, and an Aboriginal-controlled lender, so the cultural and structural fit is the cleanest in the field; (2) convert the warm Snow Foundation relationship from grant into a recoverable instrument, the highest-probability first signature; (3) use Snow as the one-hop bridge to the Paul Ramsay Foundation impact team. Land any one first mover and every later conversation gets easier.
+
+---
+
+## The thesis: legibility as leverage
+
+### The platform makes Australian money and power legible
+
+Most capital in this country moves through relationships that only one side can see. A foundation knows its board, its other grantees, its giving history and its decision-makers. The community-led enterprise that needs its money knows almost none of that. It walks into the room blind, pitches into a fog, and waits to be chosen. That asymmetry is not an accident of philanthropy. It is the operating condition of it.
+
+CivicGraph exists to remove that fog. The platform maps how money and power actually move in Australia: who funds whom, who sits on which boards, which people pull the levers behind the institutions that hold the capital. It is built on 11,075 foundations, 10,159 of them with giving figures, 10,329 with named board members, and 241,260 disambiguated person identities, joined across donations, contracts, lobbying and grants. The board-interlock, revolving-door and power-index layers turn that into a picture of who is connected to whom. A single verified join path closes the last gap: a foundation's ABN links to the responsible persons who run it, so the question stops being "which foundation might fund us" and becomes "who decides, what have they funded before, and who do we already know who can open the door."
+
+This is not muck-raking. It is the opposite. Muck-raking treats power as something to expose and embarrass. Legibility treats power as something to navigate deliberately, so that a partnership can be built on equal footing. The data is public. What has been missing is the connective tissue that lets a small First Nations enterprise read it as fluently as a wealth manager reads a cap table.
+
+### Legibility flips the asymmetry
+
+The disruption is mechanical, not rhetorical. When Goods on Country approaches a funder, it can now know, before the first conversation: who chairs the board and what else they chair; the foundation's real average grant size and giving range, not the figure in the brochure; the themes and geographies it actually funds, drawn from its grant history; whether it holds DGR and how it prefers to give; and whether anyone in Goods' existing network sits one or two links away from a decision-maker. The warm path is found before the cold ask is sent.
+
+That changes the shape of the encounter. A funder is used to controlling the terms of a relationship it can see and the grantee cannot. When the grantee arrives already understanding the funder's portfolio, its constraints and its people, the conversation moves from supplication to fit. The ask is precise. It speaks to what this funder demonstrably backs, structured the way this funder can actually move money. The same intelligence tells Goods which doors not to knock on, which saves the scarcest resource a small team has, which is time and the credibility you spend on every approach.
+
+None of this is adversarial. A funder is better served by a grantee who understands them. Legibility makes both sides legible to each other faster, and that is what lets a partnership form on equal terms rather than on the funder's terms alone.
+
+### Why this matters for Goods
+
+Goods on Country presses recycled-plastic beds and remote-grade washing machines on Country, so that community owns the production, not just consumes the output. 496 beds across nine communities, 16 washers, 2,660kg of plastic kept out of landfill, AUD 741,111 received to date. The next move is the one that locks ownership in: by 31 August 2026, close the first roughly AUD 400,000 in signed, match-eligible catalytic capital. That commitment is the match QBE Foundation's Stage 2 grant is judged on, through the Catalysing Impact program powered by Social Impact Hub. Repayable and recoverable structures carry the highest match value, which is why the warmest first-movers are the ones built to lend, not only to give: SEFA, Snow Foundation, Centrecorp, and a PAF pathway where a below-market loan to The Butterfly Movement, the DGR home, can satisfy a fund's own distribution obligation while it backs Goods.
+
+Power-mapping is how a nine-person enterprise marshals that raise without a development office. It tells Goods which of its already-warm relationships sit closest to a catalytic structure, who on each funder's board has backed community-owned or First Nations work before, and where the second-order introductions live. The playbook says we drive the raise; mentors and SIH introduce but cannot raise for us. Legibility is what lets us drive it. It turns a stack of names into a sequenced, evidenced approach, so the first signature lands on time and every conversation after it starts from a position of knowing, rather than hoping to be known.
+
+---
+
+## What the data work unlocked
+
+The person-disambiguation and graph-clearing work turned CivicGraph from "a name is a node" into "a name resolves to a distinct real person." That is the difference between a poisoned leaderboard and a usable power map. Concretely, the cleared data makes the following queryable end-to-end:
+
+- **Who runs a foundation.** For any of the ~11,000 foundations, name the actual humans who run it by joining `foundations.acnc_abn` to `person_roles.company_abn`, returning person name and role (chair / director / trustee / secretary). Verified live: World Vision Australia resolves to chair Peter Trent plus board members including Andrew Scipione and Kate Harrison Brennan.
+- **Rank real people by cross-system influence.** `mv_person_identity_influence` holds 241,260 identities with the 142 trustee-nominee blocks flagged and excluded, so the people surfaced are genuine serial directors, not name-collision megamerges. Filter `WHERE NOT is_nominee_block`.
+- **Who sits on multiple boards, and what money runs through those orgs.** `mv_board_interlocks` gives each person's organisations, role types, an interlock score, and per-person procurement / justice / donation rollups. Verified live: Allan James Myers bridges Minderoo Foundation to the Ian Potter Foundation, George Alexander Foundation and Ian Potter Cultural Trust.
+- **Per-name disambiguation for intro targeting.** `mv_person_identity_network` backs the `/person/[name]` picker, so Goods opens the right "David Smith" rather than a 63-way merge.
+- **Map a warm funder to its people and their other boards.** Take a warm funder's ABN (Snow, Centrecorp, Just Reinvest's network), join `person_roles` for its directors, then run `mv_board_interlocks` to find who else those directors sit with. Those other orgs are the warm doorways.
+
+The one load-bearing caveat: person-level dollar columns over-attribute each org's whole money to every board member, so read them as "scale of orgs this person governs," never "money this person personally controls." (Full caveat list in Verification & gaps.)
+
+---
+
+## The clearest view of Australia's foundations
+
+The clearest view is built from one base table joined out to people and interlocks. All four steps run from repo root with `node --env-file=.env scripts/gsql.mjs "SELECT ... LIMIT n"`, one heavy query at a time on the shared pooler.
+
+**1. Enumerate the universe.** The `foundations` table has 11,075 rows with rich, populated columns: name, acnc_abn (11,054 populated), type, total_giving_annual (10,159), thematic_focus[] (10,957), geographic_focus[] (10,954), board_members (10,329), has_dgr (only 551 true), avg_grant_size, grant_range_min/max, wealth_source, giving_philosophy, application_tips, notable_grants, gs_entity_id, and an embedding vector for semantic search. Arrays must be filtered with `array_to_string(thematic_focus,' ') ILIKE '%term%'`, never a bare ILIKE on the array.
+
+**2. Segment in one pass** with FILTER aggregates; vehicle split via `GROUP BY type`; geography via `GROUP BY array_to_string(geographic_focus,'|')`.
+
+**3. Resolve who runs them** via the verified join: `foundations f JOIN person_roles pr ON pr.company_abn = f.acnc_abn`, giving person name plus role_type. This resolves named people for roughly 10,750 of the ~11,054 ABN-bearing foundations (about 97 percent). The `board_members` text column is a fallback; `person_roles` is the structured source.
+
+**4. Connect** via the repeatable warm-path method below.
+
+### Top givers (verified against the live `foundations` table)
+
+| Foundation | Annual giving | DGR | Type | Focus (excerpt) |
+|---|---|---|---|---|
+| World Vision Australia | $514.1M | yes | service_delivery | education, health, community, indigenous |
+| The University of Sydney | $340.7M | yes | university | education, research, community, indigenous |
+| Catholic Education Centre | $281.5M | no | religious_organisation | education, indigenous |
+| Monash University | $273.7M | yes | university | education, research, health, indigenous |
+| Australian Red Cross Society | $265.7M | yes | service_delivery | human_rights, community, emergency, aged_care |
+| Geoffrey Cumming Foundation | $250.0M | no | private_ancillary_fund | health, education, community |
+| Ecumenical Schools Australia | $245.4M | no | religious_organisation | education |
+| Lutheran Education SA/NT/WA | $211.4M | yes | religious_organisation | education |
+| Minderoo Pictures Limited | $210.0M | no | grantmaker | arts, indigenous, health, education, environment |
+| Headspace National Youth Mental Health Foundation | $209.2M | no | corporate_foundation | health, indigenous, youth |
+| BHP Foundation | $195.1M | no | corporate_foundation | indigenous, community, environment, education |
+| Latter-day Saint Charities Australia | $185.2M | no | religious_organisation | community, health, education |
+| Rio Tinto Foundation | $153.7M | no | corporate_foundation | indigenous, community, cultural_heritage |
+| The Smith Family | $144.6M | no | service_delivery | education, youth, employment, poverty_reduction |
+| Coles Group Foundation | $132.7M | no | corporate_foundation | community |
+| Australian National University | $124.0M | yes | university | education, research, environment, indigenous |
+| Royal Flying Doctor Service | $111.0M | no | service_delivery | health, community, research |
+
+### Who runs them (verified via person_roles)
+
+- **World Vision Australia** (ABN 28004778081): Peter Trent (chair), Jonathan Seeley, Andrew Scipione, Kate Harrison Brennan, Charles Badenoch, Darryl Gardiner.
+- **Minderoo Foundation**: Andrew Forrest AO, Allan James Myers, Nicola Forrest, Anthony Grist, Prof Fiona Stanley AC (trustee), Suzanne Montandon (secretary).
+- **The Smith Family** (ABN 28000030179): Nicholas Moore (chair), Doug Taylor, Lisa Paul, Mark Ryan, Caroline Fishpool, Peter Radoll, Rosheen Garnon.
+- **Royal Flying Doctor Service** (ABN 74438059643): Tracey Hayes / John O'Donnell (chairs), Peter de Cure, Saranne Cooke, Kieran Chilcott, Robert Slocombe.
+- **The Ian Potter Foundation**: Allan James Myers (chair) — the same person chairs Minderoo Foundation, George Alexander Foundation and Ian Potter Cultural Trust (7 boards). This interlock is the canonical warm-path example.
+
+### Segmentation that matters for Goods (verified)
+
+- **DGR is the receipting gate.** Only 551 of 11,075 foundations have `has_dgr=true`. Within First Nations-themed foundations, 130 hold DGR.
+- **By theme** (array ILIKE counts): First Nations / Indigenous / Aboriginal = 2,060; Health = 1,834; Children/Youth = 262; Housing/Homeless = 49; Remote/Rural/Regional = 56.
+- **By geography:** AU-National 4,236; NSW 1,810; VIC 1,749; QLD 812; WA 567; SA 483; TAS 149; **NT 77** (the thinnest single-state pool, and the most relevant to Goods' remote footprint); ACT 71.
+- **By vehicle:** corporate_foundation 6,537; trust 3,194; grantmaker 288; service_delivery 131; **PAF 54; PuAF 40** (the catalytic-loan lane); religious_organisation 94; indigenous_organisation 14.
+- **The priority slice:** First-Nations-themed AND DGR = 130 foundations (highest-fit for the Butterfly receipting pathway). First-Nations-themed AND (NT geo or remote) = 166. Cross-reference these against the 94 PAF/PuAF vehicles to find the catalytic-loan-capable, on-Country-aligned subset.
+
+### The repeatable warm-path method
+
+1. **Resolve the target's people:** `SELECT pr.person_name, pr.role_type FROM foundations f JOIN person_roles pr ON pr.company_abn = f.acnc_abn WHERE f.name ILIKE '%<target>%'`.
+2. **Find the bridge people:** query `mv_board_interlocks` for anyone on the target's board who also sits on other boards. Those other orgs are warm doorways. (Verified: an Ian Potter or George Alexander relationship is a one-hop path to Minderoo via Allan James Myers.)
+3. **Score the bridge person** with `mv_person_identity_network` / `mv_person_influence` — keep `WHERE is_nominee_block = false`.
+4. **Shared-grantee path:** find funders that already back the same recipients Goods touches, joining on grantee with a tight WHERE (never an unfiltered scan).
+5. **Anchor to existing warm relationships:** run step 2 on each current funder (Snow, Centrecorp, Just Reinvest, Regional Arts) to surface bridge people on a target funder's board. **Fallback:** if no interlock row exists, report "no board-interlock path found; nearest is shared-geography/shared-theme cohort" rather than inventing a connection.
+
+---
+
+## The $400K QBE match plan
+
+**What counts as match-eligible:** the QBE eligibility test is "actively seeking investment or repayable finance in 2026." The Stage 2 grant is unlocked by matching funds, and a signed repayable / co-investment commitment is the highest-value form. Grants count, but rank below repayable instruments. The match is what triggers QBE's money.
+
+**The DGR mechanic for foundation lenders:** a below-market or recoverable loan from a PAF/PuAF to a DGR (The Butterfly Movement, ABN 22 155 132 684, Item 1 DGR + PBI since 2012) counts toward that fund's required annual distribution. So a PAF can lend to Goods-via-Butterfly and satisfy its own distribution obligation at the same time. (Tax/trust-deed-dependent — confirm against the specific fund's vehicle; see Verification & gaps.)
+
+**Clauses to clear before any signature:** cl 7.3 (IP — license Goods' own cost model back at own cost) and cl 5.3 (SIH 3-year co-invest right). Surface both early so they are not a surprise at term-sheet stage.
+
+### Ranked candidates by lane
+
+| # | Candidate | Lane | Vehicle | Match | Warmth | Lead ask |
+|---|---|---|---|---|---|---|
+| 1 | **SEFA** | Repayable / catalytic lender | repayable | high | high | Signed term-sheet, growth impact loan to ACT Pty |
+| 2 | **Snow Foundation** | Warm PAF / recoverable | PAF loan to Butterfly DGR | high | high | Convert pending ~$200K into a recoverable instrument |
+| 3 | **Paul Ramsay Foundation** | PAF / evergreen impact fund | sub-commercial loan to Butterfly | high | medium | Sub-commercial recoverable tranche, co-invest with SEFA |
+| 4 | **Lord Mayor's Charitable Foundation (Naarm)** | PAF / impact-investing book | below-market loan to Butterfly | high | medium | SEFA-co-structured recoverable tranche |
+| 5 | **First Australians Capital — Catalytic Impact Fund** | First Nations capital | patient/recoverable debt | high | medium | $100K–$400K patient debt to ACT Pty |
+| 6 | **Centrecorp Foundation** | Warm, deepen | grant (to Butterfly DGR) | medium | high | Deployment-tied grant; convert the ~$84.7K draft |
+| 7 | **Indigenous Business Australia (NAB-IBA guarantee)** | Repayable / statutory | guaranteed bank facility | high | low | NAB-IBA-guaranteed term facility to ACT Pty |
+| 8 | **Many Rivers Microfinance** | Repayable | recoverable loan | high | low | Secondary working-capital tranche |
+| 9 | **Bank Australia — Impact Finance** | Repayable | term facility | high | low | For-purpose facility; best fit for Harvest works |
+| 10 | **Foresters Community Finance** | Repayable (fallback) | recoverable loan | high | low | Fallback CDFI if SEFA/FAC stall |
+| 11 | **Minderoo Foundation** | PAF / Indigenous | PAF loan to Butterfly | high | low | Below-market recoverable loan, advice-first |
+| 12 | **Suncorp / FRRR Rebuilding Futures** | Corporate / QBE-adjacent | grant (to Butterfly DGR) | medium | medium | Disaster-resilience washer grant, via Snow→FRRR |
+| 13 | **NAB Foundation** | Corporate / QBE-adjacent | grant (to Butterfly DGR) | medium | medium | Community-resilience grant via NAB banker |
+| 14 | **QBE Foundation Local Grants** | Corporate / QBE-adjacent | grant | low | high | $50K Local Grant as parallel traction, not self-match |
+
+**Sequencing logic:** lead with repayable/catalytic and warmest (1–3). Land any one first mover early; one committed backer de-risks every later conversation. Run the slower, higher-value catalytic targets (FAC, PRF, IBA) in parallel as anchors, never as the gate on the deadline, since their investment-committee cycles may not close by 31 August. The playbook in every conversation: ask for advice not money, keep the pack send-ready so it goes the same day, and remember we drive the raise — SIH and mentors introduce, they cannot raise for us.
+
+---
+
+### Brief 1 — SEFA (Social Enterprise Finance Australia) · repayable · match HIGH · warmth HIGH
+
+**Who they are.** Australia's longest-running impact lender (since 2011). NSW Aboriginal Land Council became its majority shareholder in November 2021. The giving arm, SEFA Partnerships Ltd, runs roughly $1.08M annual giving. (See Verification: the "Aboriginal-controlled and governed" framing and the named loan streams are the brief's own inference, not a confirmed SEFA-site fact — lead with the verified NSWALC-majority-shareholder fact, not the stronger characterisation.)
+
+**Who runs it.** CEO Hanna Ebeling (since 2019) is the term-sheet conversation. SEFA Partnerships chair David Rickards and director Vedran Drakulic are independently corroborated. The remaining roster names and the specific NSWALC-nominated SEFA Ltd directors are unverified — confirm at sefa.com.au/board before naming anyone in the room.
+
+**Why Goods fits.** A First Nations on-Country producer borrowing from a First-Nations-majority-owned lender is the cleanest cultural-and-structural match in the field. Bed unit economics are loan-serviceable: price $750, marginal cost ~$421–426, break-even ~338 beds/yr. That is a real cash-flow line a lender can size against.
+
+**The warm path.** This is a re-engagement, not a cold start: SEFA is already named as Goods' lead loan partner in the QBE application. Second route: Goods' live Just Reinvest NSW relationship sits inside the same NSW Aboriginal land/justice network as SEFA's majority owner — use it as cultural-credibility framing, but confirm the named person-to-person bridge before claiming it in writing. Fallback intro: SIH / QBE.
+
+**The ask.** Signed term sheet, SEFA growth impact loan into ACT Pty (ABN 36 697 347 676) for production-facility plus working capital, sized to a tranche toward the ~$400K match, first drawdown timed to the production ramp. Lead with the commercial loan to ACT Pty — do not mis-frame a SEFA loan as a DGR grant; hold the Butterfly-DGR recoverable structure for the PAF conversations.
+
+**The opening move.** Advice-first note to Hanna Ebeling: "We named SEFA as our lead loan partner in our QBE Catalysing Impact submission. We've a production-ramp decision to make and would value 20 minutes of your read on how to structure growth capital against it, before we firm anything up." Send-same-day pack: one-page impact + unit-economics sheet, the QBE one-pager with the credit line, a one-page term-sheet skeleton flagging cl 7.3 / cl 5.3, and the entity/ownership note.
+
+**Timing.** Advice call by ~30 Jun; indicative term sheet mid-Jul; entity/ownership confirmed past the 1 Jul Supply Nation threshold; signed mid-Aug; counted by 31 Aug. Landing SEFA first makes every later conversation easier.
+
+---
+
+### Brief 2 — Snow Foundation · PAF recoverable loan to Butterfly · match HIGH · warmth HIGH (warmest)
+
+**Who they are.** A corporate/family foundation (ABN 49 411 415 493). Wealth source: the Snow family (Capital Airports Group / Canberra Airport). Four pillars — Our Place, Our Country, Our Sector, Our Family. Themes health, community, Indigenous; geography ACT and NSW. Crucially, Snow runs a live social-impact-investment portfolio using repayable capital: $26.2M across 38 investments as at December 2025, 12 percent of corpus, target 20 percent, catalytic capital 32 percent of active commitments (web-verified, snowfoundation.org.au). They can write the repayable instrument the match needs, not just a grant.
+
+**Who runs it.** Georgina Byron AM, CEO since 2006 (web-confirmed), is the decision-maker. Craig Betts is Chief Investment Officer (not "Executive Director" — see Verification) and the technical counterpart for a debt instrument. Adjunct Professor Maree Meredith is a First Nations advisor and a useful internal-champion angle. (The per-theme First Nations and Homelessness dollar figures circulating in the raise docs are not stated allocations on the live page — see Verification; do not quote them.)
+
+**Why Goods fits.** Snow's notable grants already cover scabies and rheumatic-heart-disease elimination in remote Aboriginal communities, and a Good360 "matching goods to communities" partnership. Goods is the production-side answer: beds and washers on Country cut the overcrowding and hygiene drivers behind those diseases, and Goods is the upstream community-owned manufacturer of exactly the goods Good360 distributes.
+
+**The warm path.** Warm, not cold — Snow already funds ACT/Goods and has floated a social-impact-loan path. Go direct to Georgina Byron; loop in Craig Betts for instrument mechanics; name-check Maree Meredith for internal advocacy. No intro broker needed.
+
+**The ask.** Convert the pending Snow proposal (or a tranche) into a recoverable grant / below-market loan to The Butterfly Movement, 3-year, converting into community equity. Amount band $150K–$400K. The catalytic mechanic does double duty on Snow's side: a PAF/PuAF below-market loan to a DGR counts toward the fund's required annual distribution, so Snow gets distribution-credit and principal recovery.
+
+**The opening move.** Advice-first to Georgina Byron, referencing the loan path she floated. Send-same-day pack: traction one-pager, recoverable-loan term outline with the distribution-credit note, the QBE credit line, and Butterfly DGR/PBI evidence so their finance team can confirm distribution-eligibility same day.
+
+**Timing.** Highest-probability first signature. Advice call this fortnight; term sheet within days; counter-sign by mid-Aug for buffer. Confirm Butterfly's signing authority is settled through the ~end-Jul stewardship handover before papering, so a board-in-transition doesn't stall the signature.
+
+---
+
+### Brief 3 — Paul Ramsay Foundation · sub-commercial loan to Butterfly · match HIGH · warmth MEDIUM
+
+**Who they are.** Australia's largest philanthropic foundation (ABN 32 623 132 472). Scale figures ($1.513B distributed, $180M impact investments, 253 partners) are web-confirmed against the PRF About page. The piece that matters: PRF has committed $60M to an evergreen impact-investing fund that accepts concessionary returns, plus a separate commitment of 10 percent of liquid corpus to impact investing. (Note: "sub-commercial / recycled back into the fund / unprecedented" framing and a Kristy Muir quote in earlier drafts are not supported by the cited sources — see Verification. Use "concessionary returns" and the verified $60M figure.)
+
+**Who runs it.** Chair Michael Traill AM (founder figure in Australian social finance); CEO Prof Kristy Muir (since Aug 2022); director Natalie Walker (First Nations leader; publicly Chair of PRF's First Nations Advisory Council). Ben Smith leads PRF's impact-investing activity and is the target — confirm his exact title (sources vary between "Head of Impact Investing" and the title used in earlier drafts).
+
+**Why Goods fits.** PRF prioritises community-led, evidence-backed, investable work. Goods is community-owned production, not service delivery; the unit economics are built; and PRF's whole evergreen-fund thesis is concessionary capital that recycles on repayment — the rare ask their impact team can say yes to as an investment.
+
+**The warm path.** One warm hop via Snow. Ben Smith and Georgina Byron are peers in Australia's small catalytic-capital circle, and Snow is a committed Goods backer. Ask Snow for a warm intro to Ben Smith. (The claim that Smith and Byron co-presented is unverified — do not state it as fact; lead with the verified peer-network fact.) Backup: SIH/QBE cohort framing, or Conscious Investment Management / Australian Communities Foundation, both named PRF partners.
+
+**The ask.** A concessionary / recoverable loan from PRF's evergreen fund into The Butterfly Movement, $150K–$400K, framed as co-investment alongside SEFA — PRF takes a patient tranche that de-risks SEFA's loan.
+
+**Timing.** Cold-ish and committee-driven; unlikely to sign by 31 Aug from a standing start. Run as the lead anchor signal (advice → soft commitment → term sheet in train) while SEFA or a Snow top-up provides the signed match by the deadline. A PRF expression of interest before 31 Aug still strengthens the Stage 2 narrative.
+
+---
+
+### Brief 4 — Lord Mayor's Charitable Foundation (Naarm / Melbourne) · below-market loan to Butterfly · match HIGH · warmth MEDIUM
+
+**Who they are.** Australia's largest community foundation. Holds 1.5–2.5 percent of corpus in social-impact investing and positions itself as early risk capital. The proof point: in 2015 LMCF and SEFA jointly established an Affordable Housing Loan Fund, LMCF investing $3M. First Nations track record: $1.26M in grants to First-Nations-led organisations. (Note: the org has rebranded toward "Greater Melbourne Foundation"; check current naming before send. The "$2M Habitat loan" precedent is a conflation — do not state as fact; see Verification.)
+
+**Who runs it.** Verify the current board against the live greatermelbournefoundation.org.au page before naming anyone — the DB roster is stale. Do NOT name "Mong Do" (the real current member is Linh Do) and do NOT build the pitch around Raphael Arndt, who is a former, not current, board member. (See Verification.)
+
+**Why Goods fits.** LMCF's pillars are housing justice, economic justice and First Nations — Goods sits at the intersection. Beds and washers are the fit-out and dignity layer of remote housing, one rung closer to the household than LMCF's flagship housing-finance move.
+
+**The warm path.** One warm hop via SEFA, which already co-runs LMCF's $3M housing fund. Ask SEFA to co-structure the Goods tranche and walk it into LMCF's impact-investing team as a stacked deal. Do not cold-email the chair.
+
+**The ask.** A below-market / recoverable loan from LMCF's impact-investing allocation into The Butterfly Movement, co-structured with SEFA, $100K–$250K, anchored against their existing housing-loan precedent.
+
+**Timing.** Likely a strong match-stacking second mover, not the first signature. Start the SEFA conversation now; let SEFA pre-qualify the deal before it reaches an LMCF committee.
+
+---
+
+### Brief 5 — First Australians Capital (FAC), Catalytic Impact Fund · patient debt · match HIGH · warmth MEDIUM-LOW
+
+**Who they are.** Australia's First-Nations-led national impact fund (ABN 14 615 225 182). The Catalytic Impact Fund provides patient debt of $100K–$2M to Indigenous-led businesses; a separate Seed Capital Fund offers lower-rate or grant capital. **Key finding: QBE Foundation already funds FAC directly ($500K, April 2024) — so the SIH→QBE→FAC introduction runs along an existing relationship and is the fastest verified door in.** Co-investors include Paul Ramsay Foundation, Block ($3M), Visa Foundation ($2M). (Fund-size figures vary between a ~$20M first close and a ~$30M target — reconcile before quoting; see Verification.)
+
+**Who runs it.** Operating contact for anything QBE-adjacent is Managing Partner Brian Wyborn (named on the QBE-FAC partnership). The Catalytic Impact Fund Investment Committee — chaired by Jahna Cedar, with Tim Barber and Dan Porter — decides loans, distinct from the FAC board (Jocelyn King, Adrian Appo OAM, Abhilash Mudaliar, Craig North). Confirm current titles before send.
+
+**Why Goods fits.** A clean archetype: First Nations on-Country production, measurable environmental impact (2,660kg plastic diverted), and a real unit economy FAC can lend against.
+
+**The warm path.** Best: SIH/QBE warm intro to FAC (QBE already funds them). Front door if no intro lands: the First Nations Business Acceleration Program (confirm exact current name). Connector in reserve: FAC director Abhilash Mudaliar interlocks to Myriad Australia.
+
+**The ask.** Recoverable debt from the Catalytic Impact Fund, $100K–$400K, to ACT Pty (FAC lends to businesses, so the Pty is the counterparty, not Butterfly). The make-or-break gate: confirm Goods clears Supply Nation's 51 percent First Nations ownership before pitching.
+
+**Timing.** Best structural fit in the lane but slowest to clear because of the ownership gate (1 Jul tightening vs ~end-Jul Butterfly board install). Run in parallel; a signed term sheet or letter of intent may carry match weight even if drawdown lands later — confirm acceptable evidence with SIH. If the gate can't be evidenced in time, FAC converts cleanly into the post-QBE follow-on round.
+
+---
+
+### Brief 6 — Centrecorp Foundation · grant to Butterfly DGR · match MEDIUM · warmth HIGH
+
+**Who they are.** A corporate foundation (ABN 31 136 052 796) with DGR, stated annual giving ~$100K, themes community and indigenous, practical footprint in remote Central Australia. (DB figures could not be re-verified this session — see Verification.)
+
+**Why Goods fits.** Near-identical activity, not thematic adjacency: Centrecorp's parent already donates washing machines to these exact Central Australian communities (figure unverified this session — do not quote to the funder until re-sourced). Goods presses the remote-grade Pakkimjalki Kari washers for the same communities. The one-line fit: you already buy these; Goods lets the community build them, on Country.
+
+**The warm path.** Two levers. (a) The live ~$84.7K draft receivable — open from inside that thread. (b) Secretary Randle Walker's board interlock into adjacent Central Australian Aboriginal trusts — useful directional intelligence for co-funders, though the exact board count and Walker's Centrecorp role are unverified (he is CEO of the distinct Centrecorp Aboriginal Investment Corporation; see Verification).
+
+**The ask.** A deployment-tied community grant ($40K–$100K, safe band $40–60K) routed through Butterfly DGR, anchored on converting the draft receivable into a confirmed scoped grant. Set match expectations honestly: a grant counts but ranks below repayable capital, so Centrecorp is a fast corroborating signature and funder-validation, not the catalytic cornerstone. Do not force a recoverable structure on them.
+
+**Timing.** One of the quickest signatures available; run in parallel with the catalytic conversations.
+
+---
+
+### Briefs 7–14 (condensed)
+
+- **IBA / NAB-IBA guarantee** (repayable, statutory; warmth low). The 1 Jun 2026 Indigenous Business Guarantee supports lending up to $1M per First Nations business, IBA guaranteeing up to 50 percent. Eligibility is 50 percent First Nations ownership plus active management (distinct from Supply Nation's 51 percent). Fastest door is NAB's First Nations business desk; the deal is originated bank-side. Slower than a grant — run as the larger second tranche. (Chair is Darren Godwell; Havnen is Deputy Chair, not a second chair — see Verification.)
+- **Minderoo Foundation** (PAF loan to Butterfly; warmth low). One verified hop: an Ian Potter or George Alexander relationship reaches Minderoo via Allan James Myers. Advice-first to the impact-investing arm. Otherwise needs an SIH/mentor intro.
+- **Suncorp / FRRR Rebuilding Futures** (grant; warmth medium). One verified hop: David Hardie sits on both the Snow board and FRRR. Apply to Rebuilding Futures and ask Snow contacts to flag Goods to Hardie/FRRR.
+- **NAB Foundation** (grant; warmth medium). Start with Goods' NAB relationship manager and ask for an internal intro to the NAB Foundation, framed as NAB backing its own customer's QBE match.
+- **Many Rivers Microfinance, Bank Australia Impact Finance, Foresters Community Finance** (repayable; warmth low). Secondary/fallback CDFI options to SEFA/FAC. Verify current product ceilings and that each is still actively lending before approaching.
+- **QBE Foundation Local Grants** (grant; warmth high). A $50K Local Grant likely cannot self-match the same funder's Stage 2 — confirm with SIH and frame as parallel traction, not the match. Watch cl 5.3 / cl 7.3 before stacking a second QBE instrument.
+
+---
+
+## Existing relationships: which levers to pull
+
+These are people who already pay or fund ACT/Goods. Pull them in this order.
+
+1. **Snow Foundation (~$132K live).** Warmest catalytic lever. Ask: convert the pending tranche into a recoverable instrument (Brief 2). Also the bridge to PRF (via Ben Smith peer-network) and to FRRR/Suncorp (via David Hardie). Pull first.
+2. **Centrecorp (~$84.7K draft).** Ask: convert the draft into a scoped deployment-tied grant (Brief 6), and mine the Randle Walker network for adjacent Central Australian trusts.
+3. **Just Reinvest NSW (~$27.5K live).** Ask: advice-and-endorsement, not money. Have them co-sign the community-ownership model and introduce their First Nations justice funders. Use as the cultural-credibility framing into SEFA's NSWALC-aligned network and into the Dusseldorp/place-based circle for The Harvest.
+4. **Regional Arts (~$33K live).** Ask: re-engage as a Harvest-track partner (Regional Arts Fund, via the QLD administrator) — not the QBE match. Keep cleanly separate from the $400K ledger.
+5. **PICC (~$113.3K), Rotary (~$82.5K, INV-0222 a slow-recovery problem), BG Fit, Aleisha Keating, Homeland (~$5K), SMART Recovery.** PICC and Rotary are receivables-recovery, not fresh raise targets — keep them on the finance track, not the match track. **Homeland is a warm one-hop bridge to Dusseldorp Forum and Karrkad-Kanjdji via Teya Dusseldorp** — pull it for The Harvest, not the QBE match.
+
+Rule of order: warm catalytic first (Snow), then warm grant (Centrecorp), then warm endorsement/network (Just Reinvest), then Harvest-track (Regional Arts, Homeland). Receivables recovery (PICC, Rotary) stays off the match track.
+
+---
+
+## The Harvest support track
+
+The Harvest is a separate, smaller track from the $400K match. It does not need signed match-eligible catalytic capital, so match-value is mostly low here (grants are the realistic instrument) and timing is independent of the 31 Aug keystone. The fit is place-based / regional-QLD / regenerative-ag / community-ownership-transition / First Nations land partnership (Witta, Jinibara country). Because Grant Luff may sell the asset, favour funders that explicitly back community-ownership *transition* and long-horizon place commitments over capital improvements to a private asset. Where DGR receipting is needed, route through Butterfly. Most figures below are foundation scale (total giving / corpus), not commitments — treat as scale, not promises.
+
+- **Tim Fairfax Family Foundation (TFFF)** — best geographic + thematic fit. Funds rural/regional/remote QLD and NT exclusively; prefers multi-year general operating support, ideal for a venue building toward Year-3 community ownership. The Connectedness stream is delivered through FRRR, which is the application doorway. Cold to TFFF directly; lead via FRRR. Ask: multi-year operating support framed around Connectedness/Leadership, emphasising transition-to-community-ownership and Jinibara engagement.
+- **Dusseldorp Forum** — thematic bullseye (place-based, community-led systems change, lighthouse partnerships). **Warm one-hop via the live Homeland receivable: Teya Dusseldorp sits on both Dusseldorp Forum and Homeland School.** Ask: advice-first conversation positioning The Harvest as a candidate lighthouse place-based partner — multi-year relational backing of the community-governance build, not a capital grant.
+- **FRRR (Foundation for Rural & Regional Renewal)** — the application-open doorway, holds DGR, funds regenerative ag and community asset-ownership. Community Led Climate Solutions Round 4 has $400K nationally, plus a First Nations-led stream. **Warm one-hop via Snow (David Hardie on both boards).** Lowest-friction cold path of the set. Also the channel for TFFF's Connectedness funding — one application surface reaches two funders.
+- **Karrkad-Kanjdji Trust** — not a Harvest funder (NT geography) but the proven Indigenous-led land-trust model and a warm bridge via the same Teya Dusseldorp interlock. Use as a governance/design reference to strengthen the Jinibara community-ownership story in TFFF/FRRR/Dusseldorp applications.
+- **The Bryan Foundation** (Brisbane) — co-funder of Dusseldorp's PLACE infrastructure; fits the JusticeHub vocational-training angle. Cold; nearest path is a follow-on intro if a Dusseldorp/PLACE relationship lands first.
+- **Lord Mayor's Charitable Trust (Brisbane)** — small local civic grantmaker; Witta sits outside Brisbane City LGA, so a weaker geographic fit. Treat as a top-up, not a lead.
+- **Just Reinvest NSW** — warm connector (live receivable). Run the warm-intro play: ask Beetson/Vumbaca for intros into the justice-reinvestment funder circle that overlaps Dusseldorp's systems-change network.
+
+Internal rule: Harvest money funds the Harvest's arts/place program; the QBE $400K match comes from Snow / SEFA / Centrecorp / a catalytic PAF-to-Butterfly loan. Do not blur the two ledgers.
+
+---
+
+## Verification & gaps
+
+Nothing below may be stated as fact in funder-facing copy until re-verified. Many DB reads failed this session (Cloudflare 522 / pooler timeouts), so DB-cited claims are last-known, not confirmed-now. Re-query before quoting.
+
+### Data-platform caveats (capability gaps)
+
+- **Money over-attribution (load-bearing).** Person-level dollar columns in `mv_board_interlocks` and `mv_person_entity_network` attribute each org's full money to every board member (e.g. Claire Rogers shows $7.65B "procurement" = combined revenue of three orgs). Read as "scale of orgs this person governs," never "money this person personally moves."
+- **Residual nominee blocks.** 158 non-nominee identities still have board_count >10 (including a 325-board cluster). The MAX_PLAUSIBLE_BOARDS cap stays on the ranked leaderboards; do not trust the high-board-count tail as single real people until nominee detection is tuned.
+- **Dead temporal signal.** `person_roles.appointment_date` is ~0 percent populated and cessation_date is 0 percent, so "is this person CURRENTLY on the board" cannot be verified from the DB. A name resolving to a foundation may be a former director — confirm current decision-makers via the funder's own site before outreach.
+- **Name-keyed re-poisoning.** `mv_board_interlocks` is still name-keyed, so its head can re-poison on common names. Only the identity-keyed `mv_person_identity_influence` is clean.
+- **Partial foundation→person coverage.** The join resolves people only for foundations whose acnc_abn matches a person_roles record; per-funder coverage is unverified.
+- **MV staleness.** All counts are point-in-time; re-query before quoting.
+
+### Per-target unverified claims
+
+**SEFA:** "Aboriginal-controlled and governed" is the brief's inference, not a SEFA-site fact (only NSWALC majority-shareholder since Nov 2021 is confirmed). The three named loan streams (incl. "Aboriginal Community Enterprises") could not be confirmed on the live site. The $1.08M giving figure, the seven-name board roster, and the SEFA Partnerships ABN were not readable this session — only David Rickards (chair) and Vedran Drakulic are independently corroborated. Linda Carseldine's "secretary" title is contradicted by web (COO/CFO). "Longest-running impact lender" is an unverified superlative. The "$45M / 60 deals" stat is stale (site now says $50M+ / 75+ deals). **Earlier draft fabrication: "Ben Gales" as CEO is false — the CEO is Hanna Ebeling. The Ben Gales→PRF bridge is built on that phantom and must be dropped.**
+
+**Snow Foundation:** Craig Betts is CIO + Director, NOT "Executive Director." The First Nations "$2.85M" and Homelessness "$2.75M" theme allocations are not stated allocations on the live page (derived/incorrect sums) — do not quote. ABN, themes, geography, philosophy, wealth source, full director roster, and the two notable_grants quotes were DB-cited but not re-verifiable this session. The ~$132K receivable and ~$193,785-received figures are internal-ledger only (and internally inconsistent with the $741,111 "to date") — do not quote externally. The $218.2M corpus is unverified. Maree Meredith's exact title and "warm champion" framing are inferences. The PAF-loan-to-DGR-counts-as-distribution mechanic is stated as fact with no source — material and trust-deed-dependent; confirm.
+
+**Paul Ramsay Foundation:** The Kristy Muir "unprecedented in Australia" quote is fabricated — cut it. "Sub-commercial / recycled back into the fund" overstates the verified "concessionary returns" language. "Only evergreen fund of its kind" is an unsourced superlative. "10% at commercial return" overstates (the framing is risk-adjusted, not all-commercial). Ben Smith's exact title is unverified (sources say "Head of Impact Investing"). Natalie Walker is on the board / Chairs the First Nations Advisory Council ("Director" is plausible, not confirmed). The $1.513B / $180M / 253 figures are sound (web-confirmed) but should cite the PRF website, not person_roles (DB was down). The Smith–Byron co-presentation claim is unverified.
+
+**Lord Mayor's Charitable Foundation:** Do NOT send "Mong Do" (real member is Linh Do). Do NOT build the pitch around Raphael Arndt (former, not current, board member). The org has rebranded toward "Greater Melbourne Foundation" — check current naming. The "$2M Habitat loan" precedent is a conflation; the "regional Victoria" extension is unsupported (Greater Melbourne only). The $1.26M First Nations figure, themes, application tips, and the ABN twin-record reconciliation are DB-only and unverifiable this session. Wei Sue and Mary Nega are current members per the live page despite being absent from the stale DB roster.
+
+**Centrecorp:** All DB-cited claims (the $100K giving, has_dgr, the 10-name roster, notable_grants, themes, philosophy) could not be re-confirmed this session. The official board page lists only 7 directors — Darryl Fitz, Nicholas Williams and Randle Walker do not appear and read as stale. Randle Walker is CEO of the distinct Centrecorp Aboriginal Investment Corporation, not the Foundation's secretary. His 9-board interlock list contains a duplicate trust, so the count is inflated. The "2,500 washing machines" hook (the load-bearing fit) is unverifiable this session and conflates the parent company with the Foundation — do not quote to the funder until re-sourced. Steven Satour's Yankunytjatjara/Muṯitjulu identity is web-asserted, unconfirmed.
+
+**First Australians Capital:** Fund size is internally inconsistent ($20M first close vs $30M target) — reconcile before quoting. The $13M Impact Enterprise Fund and the VIC state attribution (sources say NSW/Sydney-founded) are unverified. All DB director claims and the "4 of 5 names matched" note could not be re-verified (pooler down). Jocelyn King as current Chair, Adrian Appo as current MD Partnerships, and the Business Acceleration Program's current name are unverified. The QBE→FAC $500K (April 2024) and Brian Wyborn / Investment Committee facts ARE web-verified.
+
+**Indigenous Business Australia:** Olga Havnen is Deputy Chair, not a second chair — the "chair transition in progress" is a fabricated rationalisation of a DB read-error; Godwell is Chair. Directors Leah Cameron and Claire Woodley are DB-only and unconfirmed against any 2025/26 source. The Godwell→Many Rivers/Numbulwar interlock (the warm-path route) is single-sourced to a DB view that could not be re-confirmed. The guarantee terms ($1M cap, 50 percent guarantee, 50 percent ownership gate) are web-verified; the NAB "$1B / 5,200 businesses" and IBA "$5B–$7B" figures are not.
+
+**Regional Arts Australia:** All giving figures and director names are DB-cited but not re-verifiable this session. Ros Abercrombie's exec title and the two RAA-WA chair records are unconfirmed. The QLD Regional Program Administrator (likely Flying Arts Alliance), the "July 2026 round opens" date, and the $20K–$60K grant band are all unconfirmed.
+
+**Cross-cutting (every brief):** Goods traction figures (496 beds, 9 communities, 16 washers, 2,660kg plastic, $741,111 to date), bed unit economics ($750 / ~$421–426 / ~338 break-even), the QBE Stage 2 parameters ($400K/$150K, Sep 2026, judged on matched funding, 31 Aug deadline), the "repayable carries highest match value" scoring claim, the clauses cl 7.3 / cl 5.3, and the Supply Nation 51 percent / 1 Jul 2026 tightening are all from internal/program inputs, not independently re-verified. Confirm against the Goods source-of-truth and the actual QBE/SIH agreement before relying on them.
+
+---
+
+## Next actions (sequenced)
+
+Backwards-planned from the 31 August 2026 keystone (signed ~$400K match-eligible) → September 2026 QBE Stage 2 submission.
+
+**This week (w/c 23 Jun) — open the two warm catalytic doors and confirm the gate**
+
+1. **Confirm Goods clears Supply Nation 51 percent First Nations ownership before 1 Jul.** This gates SEFA, FAC and IBA. Do this first; it is the single biggest cross-target risk.
+2. **SEFA — advice-first to Hanna Ebeling.** Reopen on the QBE-application mention. Opener: ask for 20 minutes on structuring growth capital against the production ramp, "not asking for a commitment yet, asking for your eye on the structure." Attach the send-same-day pack (impact + unit-economics sheet, QBE one-pager with credit line, term-sheet skeleton flagging cl 7.3/5.3, entity note).
+3. **Snow — advice-first to Georgina Byron.** Reference the loan path she floated; loop Craig Betts for mechanics. Attach traction one-pager, recoverable-loan term outline with the distribution-credit note, QBE credit line, Butterfly DGR/PBI evidence.
+4. **Verify before naming anyone:** SEFA board (sefa.com.au/board), Snow Craig Betts title, LMCF current board (greatermelbournefoundation.org.au), Centrecorp board, FAC current titles. Do not send any name flagged in Verification.
+
+**By ~30 Jun — first movers in motion**
+
+5. **Centrecorp — advice-first to Steven Satour**, from inside the draft-receivable thread. Re-source the washing-machine fit fact before using it.
+6. **Request the Snow → Ben Smith intro to PRF** ("we'd value Ben's read on structuring recyclable catalytic capital").
+7. **Request the SIH → QBE → FAC warm intro** (QBE already funds FAC). Target Brian Wyborn / the Investment Committee.
+
+**July — term sheets and the entity window**
+
+8. Clear cl 7.3 and cl 5.3 internally, in parallel not in series.
+9. Confirm Butterfly signing authority is settled through the ~end-Jul stewardship handover before papering any DGR-routed instrument.
+10. SEFA indicative term sheet; Snow recoverable instrument drafted. Open the LMCF conversation via SEFA. Open the IBA/NAB advice conversation so the credit case is in motion.
+
+**August — close the keystone**
+
+11. Counter-sign the first signature (Snow or SEFA) by **mid-Aug** for buffer. Land one first mover and cite the momentum to every later conversation.
+12. Stack: bank Centrecorp's grant as corroborating signed match; carry PRF/FAC/IBA as anchor signals (LOI or term-sheet-in-train) into the Stage 2 narrative even if they ink in Sep/Oct.
+13. **By 31 Aug:** ~$400K signed, match-eligible commitment closed.
+
+**September — submit**
+
+14. Submit the QBE Stage 2 grant application (up to $400K, $150K floor), evidenced by the signed match, carrying the credit line on every page.
+
+**Single highest-leverage next action:** send the advice-first note to Snow Foundation's Georgina Byron this week to convert the pending tranche into a recoverable instrument — Snow is the warmest, most structurally-ready lever, the highest-probability first signature, and the bridge to both PRF and FRRR.

--- a/thoughts/shared/strategy/goods-qbe-tier1-outreach-notes.md
+++ b/thoughts/shared/strategy/goods-qbe-tier1-outreach-notes.md
@@ -1,0 +1,95 @@
+# Goods x QBE — Tier-1 advice-first outreach notes (drafts to personalise and send)
+
+> Drafted 2026-06-19. Nothing here is sent. Each note advances ONE warm relationship one step along the SIH path (EOI to LOI to Term Sheet to Funding Agreement) so the commitment can count as matched capital for the September application. Contacts pulled from the live `ghl_contacts` CRM. Hold to the rails below.
+
+## Rails for every note
+- Acknowledge "Catalysing Impact, powered by Social Impact Hub in partnership with the QBE Foundation". (No QBE logo without written consent.)
+- Lead with verified proof only: 496 beds, 9 communities, every bed QR-tracked, about 20kg of recycled plastic diverted per bed.
+- Be specific about the ask and the timing: a signed commitment (LOI or beyond) before the end of August.
+- Do NOT quote a precise revenue figure (it is unsigned). Do NOT say the QBE match is unlocked or secured. Do NOT use DGR or entity language without confirmation. Do NOT imply community-owned manufacturing is complete.
+- Attach the SIH "Letter to Funders" (Adam Long, 1 April 2026). Offer Jay Boolkin (jay@socialimpacthub.org) as the SIH contact to verify the program.
+- Open with advice, not money. Send order: Snow first (the signal everyone reads), SEFA in parallel (longest diligence, highest match value), then Centrecorp timed to the board, then Minderoo.
+
+## Confirm before sending (do not skip)
+- **Snow recipient:** the live CRM shows **Alexandra Lagelee Kean** (personal-vip, contacted Apr 2026) as the active relationship contact; **Georgina Byron** is Snow's CEO. Decide who the note goes to (or address Alexandra and copy Georgina). The draft below is addressed to Alexandra.
+- **Snow bed claim removed:** the earlier draft asserted the bed numbers were reconciled / closed out. The live DB does not support that, so this draft makes NO Snow-specific bed claim and uses only the verified program-wide figures. Do not add a Snow-specific bed count until it is genuinely reconciled.
+- **SEFA stage:** the CRM shows SEFA in `nurture`, last contacted Sept 2025 (dormant), and the opp is mis-filed in the Grants pipeline at the earliest stage. If you have had a more recent live conversation off-CRM, warm the tone accordingly. The draft is honest about reopening.
+- **SEFA admin fix:** split the bundled "Snow Foundation / SEFA — Impact Investment Loan" row into its own debt-pipeline opportunity so the repayable line is tracked correctly.
+
+---
+
+## 1. Snow Foundation
+*To: Alexandra Lagelee Kean (a.lageleekean@snowfoundation.org.au) — confirm vs Georgina Byron. Ask: formalise Round 4/5 as a signed commitment we can present as match, structured as recoverable capital where it works.*
+
+> **Subject:** A way to make Snow's next backing of Goods go further
+>
+> Hi Alexandra,
+>
+> A genuine update first. With Snow behind it, Goods on Country has now reached 496 beds across 9 communities, every one QR-tracked so anyone can scan it and see where it lives and how it is holding up. Snow has been with this work longer than anyone, and it shows.
+>
+> I am writing because there is a way to make Snow's next backing go further. Goods is one of only 10 enterprises selected for Catalysing Impact, powered by Social Impact Hub in partnership with the QBE Foundation. The program offers up to $400,000 from a shared pool, decided in November, but only as a match against external commitments we secure first, and it especially welcomes repayable or patient finance.
+>
+> Before I ask anything, I would value your read. Would a signed multi-year commitment, even a short Letter of Intent we can show alongside the QBE application, fit where Snow is at with Round 4 and 5? It would not need to disburse early. What unlocks the match is the signature, not the cash flow, and structured as recoverable capital where that suits Snow it carries even more weight. Your commitment, more than any other, is the one the rest of the field reads.
+>
+> Social Impact Hub has written a short context letter I can forward, and their manager Jay Boolkin is happy to speak with you directly to verify the program. Could we find twenty minutes in the next fortnight?
+>
+> With thanks,
+> Ben
+
+---
+
+## 2. SEFA
+*To: Joel Bird (joel.bird@sefa.com.au) and Leigh Brezler (leigh.brezler@sefapartnerships.org.au). Ask: reopen the concessional working-capital conversation and move toward a term sheet, because repayable is exactly what the program wants matched.*
+
+> **Subject:** Reopening our working-capital conversation, with timing on our side
+>
+> Hi Joel and Leigh,
+>
+> It has been a little while, and I wanted to reconnect on the concessional working-capital line we discussed for Goods on Country, because the timing has become genuinely useful on our side.
+>
+> Goods is one of 10 enterprises in Catalysing Impact, powered by Social Impact Hub in partnership with the QBE Foundation. The program offers up to $400,000, decided in November, but only as a match against external commitments, and it explicitly prefers repayable finance over grants. A SEFA facility is therefore the single most valuable commitment we can put forward.
+>
+> I would value your advice before anything else: what would SEFA need to see to move from an early conversation toward a term sheet over the next couple of months, with a view to a signed commitment before the end of August? The use of funds is clear, inventory we can hold rather than wait on each funded batch, and working capital for the next on-Country production run. We have a live cost model and a reconciliation underway to support your diligence.
+>
+> Social Impact Hub can provide a context letter and a direct contact to verify the program. I would really value getting this moving again.
+>
+> Thanks,
+> Ben
+
+---
+
+## 3. Centrecorp Foundation
+*To: Randle Walker (randle@centrecorp.com.au). Ask: at the board, alongside the 130-bed order, consider a grant commitment we can present as match, kept distinct from the order.*
+
+> **Subject:** Two things for the board, kept separate on purpose
+>
+> Hi Randle,
+>
+> Thank you for shepherding the 130-bed order toward the board. That order matters in its own right, and I want to keep it cleanly separate from a second, smaller idea so the two never get tangled.
+>
+> Goods on Country is one of 10 enterprises in Catalysing Impact, powered by Social Impact Hub in partnership with the QBE Foundation. The program offers up to $400,000, decided in November, but only as a match against external commitments we secure first. A grant commitment from Centrecorp, distinct from the bed order, would count toward that match, and coming from a Central Australian Aboriginal foundation it would carry real weight with the program.
+>
+> If the board is open to it, even a Letter of Intent before the end of August would help. I am happy to provide whatever the board needs to consider it, and Social Impact Hub can send a short context letter and a contact to verify.
+>
+> Grateful for your backing on both fronts,
+> Ben
+
+---
+
+## 4. Minderoo Foundation
+*To: Lucy Stronach (lstronach@minderoo.org). Ask: a decision inside the September window, ideally a signed LOI now even if disbursement is later (the ~$200K ask is already made).*
+
+> **Subject:** A timing note on our proposal, so the same commitment can do more
+>
+> Hi Lucy,
+>
+> Thank you for considering our proposal. I am writing with a timing thought that could let the same commitment achieve more.
+>
+> Goods on Country is one of 10 enterprises selected for Catalysing Impact, powered by Social Impact Hub in partnership with the QBE Foundation. The program offers up to $400,000 from a shared pool, decided in November, but only as a match against external commitments confirmed before our September application.
+>
+> So if Minderoo is minded to support Goods, a decision inside that window, even a Letter of Intent now with disbursement later, would let your commitment unlock additional matched capital rather than standing alone. The work it backs is a de-risking round: holding inventory, the next on-Country production run, and the first community operators on payroll. The proof to date is 496 beds across 9 communities, every one QR-tracked, with about 20kg of recycled plastic diverted per bed.
+>
+> I would welcome a short call on timing if that helps, and Social Impact Hub can send a context letter and a contact to verify the program.
+>
+> Grateful,
+> Ben


### PR DESCRIPTION
## What

Commits the output of the Goods on Country **$400K QBE match** capital-strategy session: five strategy docs plus the two idempotent GHL scripts that were run live during the session.

## Files

**Strategy docs** (`thoughts/shared/strategy/`)
- `goods-qbe-power-capital-strategy.md` - "legibility as leverage" thesis, all-foundations power map, 14 ranked funders + briefs, Harvest track.
- `goods-funder-relationship-history.md` - warmest-first tiers, named contacts, drafted-letter asks, capital stack, 8 guardrails.
- `goods-qbe-capital-action-plan.md` - reconciled funder ledger, Tier-1 next-moves, sequenced actions to 31 Aug.
- `goods-qbe-tier1-outreach-notes.md` - 4 send-ready advice-first notes (Snow, SEFA, Centrecorp, Minderoo).
- `goods-qbe-artifact-map.md` - 12 QBE diagnostic areas, each with claim / evidence / live website / stories / gap / public-copy guardrail + P0 worklist.

**Scripts** (`scripts/`)
- `fix-goods-ghl-opps.mjs` - renamed the PRF Goods opp; dry-run-first, idempotent.
- `create-sefa-ghl-opp.mjs` - re-created the SEFA debt opp; dry-run-first, idempotent.

## Notes

Docs and helper scripts only. No app code, no schema, no migrations. The GHL writes these scripts perform were already applied live during the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
