### PR TITLE
feat(goods): cross-system power + SEIFA disadvantage overlays

### DIFF
--- a/apps/web/src/app/org/[slug]/goods/_components/goods-funding-chip.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-funding-chip.tsx
@@ -1,0 +1,60 @@
+import { moneyShort } from '@/lib/services/goods-engagement-shared';
+import {
+  fundingDirection,
+  fundingHeadline,
+  type RelationshipFunding,
+} from '@/lib/services/goods-relationship-funding';
+
+/**
+ * Funding-history chip — what a counterpart actually funds (foundation giving +
+ * political) vs what they've received (justice + procurement), from the data we
+ * already hold. Grantmakers read as a yellow "Funds $X/yr" (someone we ask);
+ * pure recipients read muted (a peer we might co-apply with). Full breakdown on
+ * hover. Renders nothing when the relationship carries no funding signal — so it
+ * degrades silently for the name-only registry rows that have no entity match.
+ */
+export function FundingChip({ funding }: { funding: RelationshipFunding | null }) {
+  if (!funding) return null;
+  const headline = fundingHeadline(funding);
+  if (!headline) return null;
+
+  const dir = fundingDirection(funding);
+  const tone =
+    funding.foundationGivingAnnual > 0
+      ? 'bg-bauhaus-yellow text-bauhaus-black' // registered grantmaker — the asks
+      : dir === 'grantmaker'
+        ? 'bg-bauhaus-blue text-white' // gives (political only)
+        : 'bg-bauhaus-canvas text-bauhaus-muted'; // recipient only
+
+  const label =
+    headline.label === 'funds'
+      ? `Funds ${moneyShort(headline.amount)}/yr`
+      : `${headline.label} ${moneyShort(headline.amount)}`;
+
+  // Detail breakdown — every direction we actually matched, in plain language.
+  const parts: string[] = [];
+  if (funding.foundationGivingAnnual > 0) {
+    let f = `Grantmaker: ${moneyShort(funding.foundationGivingAnnual)}/yr`;
+    if (funding.foundationAvgGrant > 0) f += `, avg grant ${moneyShort(funding.foundationAvgGrant)}`;
+    if (funding.foundationThemes.length > 0) f += ` · ${funding.foundationThemes.slice(0, 3).join(', ')}`;
+    parts.push(f);
+  }
+  if (funding.politicalTotal > 0) {
+    parts.push(`Political giving: ${moneyShort(funding.politicalTotal)} (${funding.politicalCount})`);
+  }
+  if (funding.justiceTotal > 0) {
+    parts.push(`Justice funding received: ${moneyShort(funding.justiceTotal)} (${funding.justiceProgramCount} programs)`);
+  }
+  if (funding.austenderTotal > 0) {
+    parts.push(`Procurement won: ${moneyShort(funding.austenderTotal)} (${funding.austenderContractCount} contracts)`);
+  }
+
+  return (
+    <span
+      className={`px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest ${tone}`}
+      title={parts.join('  ·  ') || 'Funding footprint'}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/app/org/[slug]/goods/communities/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/communities/page.tsx
@@ -26,7 +26,7 @@ export default async function GoodsCommunitiesHubPage({
   searchParams,
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ scope?: string; state?: string; q?: string }>;
+  searchParams: Promise<{ scope?: string; state?: string; q?: string; sort?: string }>;
 }) {
   const { slug } = await params;
   const sp = await searchParams;
@@ -36,11 +36,25 @@ export default async function GoodsCommunitiesHubPage({
   if (!profile) notFound();
 
   const scope = (sp.scope as 'active' | 'lead' | 'all' | 'with_deployments') || 'active';
+  const sort = (sp.sort as 'priority' | 'serve_next') || 'priority';
   const { communities, summary } = await getGoodsCommunitiesHub({
     scope,
     state: sp.state,
     search: sp.q,
+    sort,
   });
+
+  // Sort toggle hrefs that preserve scope / state / search.
+  const baseParams = new URLSearchParams();
+  if (scope !== 'active') baseParams.set('scope', scope);
+  if (sp.state) baseParams.set('state', sp.state);
+  if (sp.q) baseParams.set('q', sp.q);
+  const sortHref = (s: 'priority' | 'serve_next') => {
+    const p = new URLSearchParams(baseParams);
+    if (s !== 'priority') p.set('sort', s);
+    const qs = p.toString();
+    return `/org/${slug}/goods/communities${qs ? `?${qs}` : ''}`;
+  };
 
   return (
     <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
@@ -64,9 +78,9 @@ export default async function GoodsCommunitiesHubPage({
         {/* Summary cells */}
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
           <Cell label="Communities" value={summary.total} accent />
+          <Cell label="Most disadvantaged (≤D3)" value={summary.high_disadvantage} />
           <Cell label="With deployments" value={summary.with_deployments} />
           <Cell label="With open signals" value={summary.with_open_signals} />
-          <Cell label="With GHL contacts" value={summary.with_ghl} />
           <Cell label="Beds demanded" value={summary.total_beds_demanded} />
           <Cell label="Beds deployed" value={summary.total_beds_deployed} />
         </div>
@@ -91,6 +105,13 @@ export default async function GoodsCommunitiesHubPage({
           ))}
         </div>
 
+        {/* Sort */}
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="font-black uppercase tracking-wider">Sort:</span>
+          <Pill href={sortHref('priority')} active={sort === 'priority'} label="Priority" />
+          <Pill href={sortHref('serve_next')} active={sort === 'serve_next'} label="Serve next (SEIFA × unmet beds)" />
+        </div>
+
         {/* Table */}
         <div className="border-4 border-bauhaus-black bg-white overflow-x-auto">
           <table className="w-full text-xs">
@@ -100,6 +121,7 @@ export default async function GoodsCommunitiesHubPage({
                 <Th>State</Th>
                 <Th>Region / LC</Th>
                 <Th>Priority</Th>
+                <Th>Disadv. / Serve</Th>
                 <Th align="right">Beds (D / Demand)</Th>
                 <Th align="right">Washers (D / Demand)</Th>
                 <Th align="right">Open signals</Th>
@@ -109,7 +131,7 @@ export default async function GoodsCommunitiesHubPage({
             </thead>
             <tbody>
               {communities.length === 0 ? (
-                <tr><td colSpan={9} className="px-3 py-6 text-center text-gray-500">No communities match this filter.</td></tr>
+                <tr><td colSpan={10} className="px-3 py-6 text-center text-gray-500">No communities match this filter.</td></tr>
               ) : (
                 communities.map((c, i) => <Row key={c.id} c={c} alt={i % 2 === 1} orgSlug={slug} />)
               )}
@@ -160,6 +182,11 @@ function Row({ c, alt, orgSlug }: { c: CommunityHubRow; alt: boolean; orgSlug: s
     c.priority === 'active' ? 'bg-bauhaus-yellow' :
     c.priority === 'warm' ? 'bg-bauhaus-canvas' : 'bg-gray-200';
   const deploymentGapBg = c.demand_beds > 0 && c.assets_deployed === 0 ? 'bg-bauhaus-red text-white' : '';
+  const d = c.seifa_irsd_decile;
+  const disadvantageBg = d == null ? '' :
+    d <= 3 ? 'bg-bauhaus-red text-white' :
+    d <= 7 ? 'bg-bauhaus-yellow text-bauhaus-black' :
+    'bg-bauhaus-canvas text-bauhaus-black';
 
   return (
     <tr className={alt ? 'bg-bauhaus-canvas' : ''}>
@@ -176,6 +203,21 @@ function Row({ c, alt, orgSlug }: { c: CommunityHubRow; alt: boolean; orgSlug: s
       </td>
       <td className="border-b border-gray-300 px-2 py-1.5 align-top">
         <span className={`${pBg} px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-wider`}>{c.priority}</span>
+      </td>
+      <td className="border-b border-gray-300 px-2 py-1.5 align-top">
+        {c.seifa_irsd_decile == null ? (
+          <span className="text-gray-400">—</span>
+        ) : (
+          <span
+            className={`${disadvantageBg} px-1.5 py-0.5 font-mono text-[10px] font-black`}
+            title={`SEIFA IRSD decile ${c.seifa_irsd_decile}/10 (1 = most disadvantaged)`}
+          >
+            D{c.seifa_irsd_decile}
+          </span>
+        )}
+        {c.serve_next_score > 0 && (
+          <div className="mt-0.5 text-[10px] text-gray-600">serve {c.serve_next_score}</div>
+        )}
       </td>
       <td className={`border-b border-gray-300 px-2 py-1.5 align-top text-right ${deploymentGapBg}`}>
         <span className="font-black">{c.assets_deployed}</span>

--- a/apps/web/src/app/org/[slug]/goods/insight/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/insight/page.tsx
@@ -4,9 +4,11 @@ import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/servic
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsFunderInsight } from '@/lib/services/goods-funder-insight';
 import { getGoodsRelationshipPower, powerBand, type RelationshipPower } from '@/lib/services/goods-relationship-power';
+import { getGoodsRelationshipFunding, type RelationshipFunding } from '@/lib/services/goods-relationship-funding';
 import { TEMP_LABEL, temperatureTone, type FunderInsight, type InsightFlag } from '@/lib/services/goods-funder-insight-shared';
 import { relDays, money, moneyShort } from '@/lib/services/goods-engagement-shared';
 import { GoodsSubNav } from '../_components/goods-sub-nav';
+import { FundingChip } from '../_components/goods-funding-chip';
 
 export const dynamic = 'force-dynamic';
 
@@ -119,7 +121,7 @@ function PowerChip({ power }: { power: RelationshipPower | null }) {
   );
 }
 
-function InsightCard({ i, power }: { i: FunderInsight; power: RelationshipPower | null }) {
+function InsightCard({ i, power, funding }: { i: FunderInsight; power: RelationshipPower | null; funding: RelationshipFunding | null }) {
   return (
     <div className="flex items-stretch gap-0 border-b border-bauhaus-black/10 last:border-b-0">
       <div className={`w-1.5 shrink-0 ${ATTENTION_BAR[i.attention]}`} aria-hidden />
@@ -136,6 +138,7 @@ function InsightCard({ i, power }: { i: FunderInsight; power: RelationshipPower 
               </span>
             ))}
             <PowerChip power={power} />
+            <FundingChip funding={funding} />
           </div>
 
           <div className="mt-1 flex flex-wrap items-center gap-2 text-[13px] font-bold text-bauhaus-black">
@@ -214,9 +217,10 @@ export default async function GoodsInsightPage({
   const profile = shouldUseFastLocalOrg() && isActSlug(slug) ? ACT_FAST_PROFILE : await getOrgProfileBySlug(slug);
   if (!profile) notFound();
 
-  const [{ insights, summary, fetchError }, powerMap] = await Promise.all([
+  const [{ insights, summary, fetchError }, powerMap, fundingMap] = await Promise.all([
     getGoodsFunderInsight(),
     getGoodsRelationshipPower(),
+    getGoodsRelationshipFunding(),
   ]);
   const actNowOnly = filter === 'act-now';
   const shown = actNowOnly ? insights.filter((i) => i.attention === 'act-now') : insights;
@@ -294,7 +298,7 @@ export default async function GoodsInsightPage({
           </div>
         ) : (
           <div className="border-4 border-bauhaus-black bg-white">
-            {shown.map((i) => <InsightCard key={i.id} i={i} power={powerMap.get(i.id) ?? null} />)}
+            {shown.map((i) => <InsightCard key={i.id} i={i} power={powerMap.get(i.id) ?? null} funding={fundingMap.get(i.id) ?? null} />)}
           </div>
         )}
 

--- a/apps/web/src/app/org/[slug]/goods/insight/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/insight/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsFunderInsight } from '@/lib/services/goods-funder-insight';
+import { getGoodsRelationshipPower, powerBand, type RelationshipPower } from '@/lib/services/goods-relationship-power';
 import { TEMP_LABEL, temperatureTone, type FunderInsight, type InsightFlag } from '@/lib/services/goods-funder-insight-shared';
 import { relDays, money, moneyShort } from '@/lib/services/goods-engagement-shared';
 import { GoodsSubNav } from '../_components/goods-sub-nav';
@@ -94,7 +95,31 @@ function FramingBlock({ framing }: { framing: FunderInsight['framing'] }) {
   );
 }
 
-function InsightCard({ i }: { i: FunderInsight }) {
+/**
+ * Cross-system power chip — how embedded this funder is across the 7 power
+ * systems, and whether they sit in the revolving-door set. A high-reach yes
+ * carries weight and opens doors; it is also a public profile worth knowing
+ * before we attach the Goods name. Detail on hover. Renders nothing without signal.
+ */
+function PowerChip({ power }: { power: RelationshipPower | null }) {
+  if (!power || power.systemCount < 1) return null;
+  const band = powerBand(power);
+  const tone =
+    band === 'high' ? 'bg-bauhaus-black text-bauhaus-yellow'
+    : band === 'notable' ? 'bg-bauhaus-blue text-white'
+    : 'bg-bauhaus-canvas text-bauhaus-muted';
+  const rd = power.revolvingDoor ? ` · revolving door (${power.vectors.join(', ')})` : '';
+  return (
+    <span
+      className={`px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest ${tone}`}
+      title={`Cross-system reach: ${power.systems.join(', ') || 'none'}${rd}`}
+    >
+      Power {power.systemCount}/7{power.revolvingDoor ? ' · RD' : ''}
+    </span>
+  );
+}
+
+function InsightCard({ i, power }: { i: FunderInsight; power: RelationshipPower | null }) {
   return (
     <div className="flex items-stretch gap-0 border-b border-bauhaus-black/10 last:border-b-0">
       <div className={`w-1.5 shrink-0 ${ATTENTION_BAR[i.attention]}`} aria-hidden />
@@ -110,6 +135,7 @@ function InsightCard({ i }: { i: FunderInsight }) {
                 {f.label}
               </span>
             ))}
+            <PowerChip power={power} />
           </div>
 
           <div className="mt-1 flex flex-wrap items-center gap-2 text-[13px] font-bold text-bauhaus-black">
@@ -188,7 +214,10 @@ export default async function GoodsInsightPage({
   const profile = shouldUseFastLocalOrg() && isActSlug(slug) ? ACT_FAST_PROFILE : await getOrgProfileBySlug(slug);
   if (!profile) notFound();
 
-  const { insights, summary, fetchError } = await getGoodsFunderInsight();
+  const [{ insights, summary, fetchError }, powerMap] = await Promise.all([
+    getGoodsFunderInsight(),
+    getGoodsRelationshipPower(),
+  ]);
   const actNowOnly = filter === 'act-now';
   const shown = actNowOnly ? insights.filter((i) => i.attention === 'act-now') : insights;
 
@@ -265,7 +294,7 @@ export default async function GoodsInsightPage({
           </div>
         ) : (
           <div className="border-4 border-bauhaus-black bg-white">
-            {shown.map((i) => <InsightCard key={i.id} i={i} />)}
+            {shown.map((i) => <InsightCard key={i.id} i={i} power={powerMap.get(i.id) ?? null} />)}
           </div>
         )}
 

--- a/apps/web/src/app/org/[slug]/goods/intros/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/intros/page.tsx
@@ -3,8 +3,10 @@ import { notFound } from 'next/navigation';
 import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsWarmIntros } from '@/lib/services/goods-warm-intros';
+import { getGoodsRelationshipFunding } from '@/lib/services/goods-relationship-funding';
 import { REL_TYPE_LABEL, type GoodsRelType } from '@/lib/services/goods-engagement-shared';
 import { GoodsSubNav } from '../_components/goods-sub-nav';
+import { FundingChip } from '../_components/goods-funding-chip';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,7 +28,10 @@ export default async function GoodsIntrosPage({ params }: { params: Promise<{ sl
   const profile = shouldUseFastLocalOrg() && isActSlug(slug) ? ACT_FAST_PROFILE : await getOrgProfileBySlug(slug);
   if (!profile) notFound();
 
-  const { targets, summary } = await getGoodsWarmIntros();
+  const [{ targets, summary }, fundingMap] = await Promise.all([
+    getGoodsWarmIntros(),
+    getGoodsRelationshipFunding(),
+  ]);
 
   return (
     <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
@@ -72,6 +77,7 @@ export default async function GoodsIntrosPage({ params }: { params: Promise<{ sl
                     <span className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
                       {REL_TYPE_LABEL[t.relationshipType as GoodsRelType] ?? t.relationshipType}
                     </span>
+                    <FundingChip funding={fundingMap.get(t.relId) ?? null} />
                   </div>
                   {t.hasBridge && (
                     <span className="bg-bauhaus-blue px-2 py-0.5 text-[10px] font-black uppercase tracking-widest text-white">

--- a/apps/web/src/lib/services/goods-communities-hub.ts
+++ b/apps/web/src/lib/services/goods-communities-hub.ts
@@ -12,6 +12,11 @@ export type CommunityHubRow = {
   total_demand: number;
   assets_deployed: number;
   land_council: string | null;
+  // SEIFA disadvantage overlay (v_goods_community_priority)
+  seifa_irsd_decile: number | null;   // 1 = most disadvantaged, 10 = least; null if no SEIFA match
+  disadvantage_score: number | null;  // 0..100, decile 1 -> 100
+  unmet_beds: number;                 // GREATEST(demand_beds - assets_deployed, 0)
+  serve_next_score: number;           // unmet beds amplified up to 2x by disadvantage
   open_signals: number;
   reviewing_signals: number;
   actioned_signals: number;
@@ -28,6 +33,7 @@ export type CommunityHubSummary = {
   with_deployments: number;
   with_open_signals: number;
   with_ghl: number;
+  high_disadvantage: number;  // SEIFA IRSD decile <= 3
   total_beds_demanded: number;
   total_beds_deployed: number;
   total_washers_demanded: number;
@@ -56,10 +62,12 @@ export async function getGoodsCommunitiesHub({
   scope = 'active',
   state,
   search,
+  sort = 'priority',
 }: {
   scope?: 'active' | 'lead' | 'all' | 'with_deployments';
   state?: string;
   search?: string;
+  sort?: 'priority' | 'serve_next';
 } = {}): Promise<CommunitiesHubResult> {
   const db = getServiceSupabase();
 
@@ -90,10 +98,11 @@ export async function getGoodsCommunitiesHub({
 
   const ids = communities.map(c => c.id);
 
-  // Signals and buyers per community — parallel chunked fetches
-  const [signals, buyers] = await Promise.all([
+  // Signals, buyers, and SEIFA/serve-next priority per community — parallel chunked fetches
+  const [signals, buyers, priority] = await Promise.all([
     fetchChunked(db, 'goods_procurement_signals', 'community_id, status, actioned_at', ids),
     fetchChunked(db, 'goods_procurement_entities', 'community_id, ghl_contact_id', ids),
+    fetchChunked(db, 'v_goods_community_priority', 'community_id, seifa_irsd_decile, disadvantage_score, unmet_beds, serve_next_score', ids),
   ]);
 
   const sigByCommunity = new Map<string, { open: number; reviewing: number; actioned: number; total: number; last_action: string | null }>();
@@ -121,9 +130,22 @@ export async function getGoodsCommunitiesHub({
     buyerByCommunity.set(cid, cur);
   }
 
+  const priorityByCommunity = new Map<string, { decile: number | null; disadvantage: number | null; unmet: number; serveNext: number }>();
+  for (const p of priority) {
+    const cid = p.community_id;
+    if (!cid) continue;
+    priorityByCommunity.set(cid, {
+      decile: p.seifa_irsd_decile == null ? null : Number(p.seifa_irsd_decile),
+      disadvantage: p.disadvantage_score == null ? null : Number(p.disadvantage_score),
+      unmet: Number(p.unmet_beds) || 0,
+      serveNext: Number(p.serve_next_score) || 0,
+    });
+  }
+
   const rows: CommunityHubRow[] = communities.map(c => {
     const sig = sigByCommunity.get(c.id) || { open: 0, reviewing: 0, actioned: 0, total: 0, last_action: null };
     const buy = buyerByCommunity.get(c.id) || { mapped: 0, ghl_linked: 0 };
+    const pri = priorityByCommunity.get(c.id) || { decile: null, disadvantage: null, unmet: 0, serveNext: 0 };
     return {
       id: c.id,
       community_name: c.community_name,
@@ -136,6 +158,10 @@ export async function getGoodsCommunitiesHub({
       total_demand: (Number(c.demand_beds) || 0) + (Number(c.demand_washers) || 0),
       assets_deployed: Number(c.assets_deployed) || 0,
       land_council: c.land_council,
+      seifa_irsd_decile: pri.decile,
+      disadvantage_score: pri.disadvantage,
+      unmet_beds: pri.unmet,
+      serve_next_score: pri.serveNext,
       open_signals: sig.open,
       reviewing_signals: sig.reviewing,
       actioned_signals: sig.actioned,
@@ -146,14 +172,23 @@ export async function getGoodsCommunitiesHub({
     };
   });
 
-  // Default sort: priority (lead first) → demand desc → name
-  const priorityRank: Record<string, number> = { lead: 4, active: 3, warm: 2, monitor: 1, background: 0 };
-  rows.sort((a, b) => {
-    const pr = (priorityRank[b.priority] || 0) - (priorityRank[a.priority] || 0);
-    if (pr !== 0) return pr;
-    if (b.total_demand !== a.total_demand) return b.total_demand - a.total_demand;
-    return (a.community_name || '').localeCompare(b.community_name || '');
-  });
+  if (sort === 'serve_next') {
+    // Serve-next: SEIFA-weighted unmet demand desc → demand desc → name
+    rows.sort((a, b) => {
+      if (b.serve_next_score !== a.serve_next_score) return b.serve_next_score - a.serve_next_score;
+      if (b.total_demand !== a.total_demand) return b.total_demand - a.total_demand;
+      return (a.community_name || '').localeCompare(b.community_name || '');
+    });
+  } else {
+    // Default sort: priority (lead first) → demand desc → name
+    const priorityRank: Record<string, number> = { lead: 4, active: 3, warm: 2, monitor: 1, background: 0 };
+    rows.sort((a, b) => {
+      const pr = (priorityRank[b.priority] || 0) - (priorityRank[a.priority] || 0);
+      if (pr !== 0) return pr;
+      if (b.total_demand !== a.total_demand) return b.total_demand - a.total_demand;
+      return (a.community_name || '').localeCompare(b.community_name || '');
+    });
+  }
 
   const summary: CommunityHubSummary = {
     total: rows.length,
@@ -162,6 +197,7 @@ export async function getGoodsCommunitiesHub({
     with_deployments: 0,
     with_open_signals: 0,
     with_ghl: 0,
+    high_disadvantage: 0,
     total_beds_demanded: 0,
     total_beds_deployed: 0,
     total_washers_demanded: 0,
@@ -172,6 +208,7 @@ export async function getGoodsCommunitiesHub({
     if (r.assets_deployed > 0) summary.with_deployments++;
     if (r.open_signals + r.reviewing_signals > 0) summary.with_open_signals++;
     if (r.ghl_linked_buyer_count > 0) summary.with_ghl++;
+    if (r.seifa_irsd_decile != null && r.seifa_irsd_decile <= 3) summary.high_disadvantage++;
     summary.total_beds_demanded += r.demand_beds;
     summary.total_beds_deployed += r.assets_deployed;
     summary.total_washers_demanded += r.demand_washers;

--- a/apps/web/src/lib/services/goods-relationship-funding.ts
+++ b/apps/web/src/lib/services/goods-relationship-funding.ts
@@ -1,0 +1,128 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Goods Command Center — Funder Funding-History overlay.
+ * Reads v_goods_relationship_funding (foundation grantmaking + political giving
+ * = MONEY OUT; justice + procurement received = MONEY IN, joined onto
+ * entity-linked Goods relationships) and returns a map keyed by
+ * goods_relationships.id — what a counterpart actually funds vs what they have
+ * received — so any Goods surface can show it without touching its own loader.
+ * View: supabase/migrations/20260620120200_goods_relationship_funding.sql
+ *
+ * Coverage caveat: only ~⅓ of registry rows are entity-linked with an ABN, and
+ * several top-dollar funders (e.g. Snow, FRRR) are name-only rows. Unmatched
+ * relationships simply carry no funding signal — the chip degrades to nothing.
+ */
+
+export type RelationshipFunding = {
+  relId: string;
+
+  // MONEY OUT — what they give / fund
+  foundationGivingAnnual: number; // 0 if not a registered grantmaker
+  foundationAvgGrant: number;
+  foundationThemes: string[];
+  foundationGeo: string[];
+  politicalTotal: number; // political donations made (donor side)
+  politicalCount: number;
+  politicalLatestFy: string | null;
+  givesTotal: number; // foundation giving + political
+
+  // MONEY IN — what they have received
+  justiceTotal: number;
+  justiceProgramCount: number;
+  justiceLatestFy: string | null;
+  austenderTotal: number;
+  austenderContractCount: number;
+  austenderLatest: string | null;
+  receivesTotal: number; // justice + procurement
+};
+
+type ViewRow = {
+  rel_id: string;
+  foundation_giving_annual: number | string | null;
+  foundation_avg_grant: number | string | null;
+  foundation_themes: string[] | null;
+  foundation_geo: string[] | null;
+  political_total: number | string | null;
+  political_count: number | string | null;
+  political_latest_fy: string | null;
+  justice_total: number | string | null;
+  justice_program_count: number | string | null;
+  justice_latest_fy: string | null;
+  austender_total: number | string | null;
+  austender_contract_count: number | string | null;
+  austender_latest: string | null;
+  gives_total: number | string | null;
+  receives_total: number | string | null;
+};
+
+const num = (v: number | string | null | undefined): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const arr = (v: string[] | null | undefined): string[] =>
+  Array.isArray(v) ? v.filter((s): s is string => Boolean(s)) : [];
+
+/** Returns a map of goods_relationships.id -> funding-history signal. */
+export async function getGoodsRelationshipFunding(): Promise<Map<string, RelationshipFunding>> {
+  const map = new Map<string, RelationshipFunding>();
+  try {
+    const supabase = getServiceSupabase();
+    const { data, error } = await supabase
+      .from('v_goods_relationship_funding')
+      .select('*');
+    if (error) {
+      console.error('[goods-relationship-funding] query failed:', error.message);
+      return map;
+    }
+    for (const r of (data as ViewRow[] | null) ?? []) {
+      map.set(r.rel_id, {
+        relId: r.rel_id,
+        foundationGivingAnnual: num(r.foundation_giving_annual),
+        foundationAvgGrant: num(r.foundation_avg_grant),
+        foundationThemes: arr(r.foundation_themes),
+        foundationGeo: arr(r.foundation_geo),
+        politicalTotal: num(r.political_total),
+        politicalCount: num(r.political_count),
+        politicalLatestFy: r.political_latest_fy,
+        givesTotal: num(r.gives_total),
+        justiceTotal: num(r.justice_total),
+        justiceProgramCount: num(r.justice_program_count),
+        justiceLatestFy: r.justice_latest_fy,
+        austenderTotal: num(r.austender_total),
+        austenderContractCount: num(r.austender_contract_count),
+        austenderLatest: r.austender_latest,
+        receivesTotal: num(r.receives_total),
+      });
+    }
+    return map;
+  } catch (e) {
+    console.error('[goods-relationship-funding] unexpected:', e);
+    return map;
+  }
+}
+
+export type FundingDirection = 'grantmaker' | 'recipient' | 'both' | 'none';
+
+/**
+ * Which way the money flows for this counterpart. A registered grantmaker (or a
+ * pure political giver) is someone we'd *ask*; a recipient is a peer we might
+ * *co-apply* with; both = a funder that also wins contracts/grants itself.
+ */
+export function fundingDirection(f: RelationshipFunding): FundingDirection {
+  const gives = f.givesTotal > 0;
+  const receives = f.receivesTotal > 0;
+  if (gives && receives) return 'both';
+  if (gives) return 'grantmaker';
+  if (receives) return 'recipient';
+  return 'none';
+}
+
+/** Headline for the UI chip — the most decision-relevant figure, foundation-first. */
+export function fundingHeadline(f: RelationshipFunding): { label: string; amount: number } | null {
+  if (f.foundationGivingAnnual > 0) return { label: 'funds', amount: f.foundationGivingAnnual };
+  if (f.givesTotal > 0) return { label: 'gives', amount: f.givesTotal };
+  if (f.receivesTotal > 0) return { label: 'receives', amount: f.receivesTotal };
+  return null;
+}

--- a/apps/web/src/lib/services/goods-relationship-power.ts
+++ b/apps/web/src/lib/services/goods-relationship-power.ts
@@ -1,0 +1,112 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Goods Command Center — Cross-System Power overlay.
+ * Reads v_goods_relationship_power (mv_entity_power_index + mv_revolving_door
+ * joined onto entity-linked Goods relationships) and returns a map keyed by
+ * goods_relationships.id, so any Goods surface can show how cross-system
+ * embedded a counterpart is without touching its own loader.
+ * View: supabase/migrations/20260620120000_goods_relationship_power.sql
+ */
+
+export type RelationshipPower = {
+  relId: string;
+  powerScore: number;
+  systemCount: number;
+  systems: string[];          // human labels of the power systems present
+  totalDollarFlow: number;    // procurement + justice + donations $
+  influenceVectors: number;   // 0 if not in revolving-door set
+  revolvingDoorScore: number;
+  revolvingDoor: boolean;     // in mv_revolving_door (>=2 influence vectors)
+  vectors: string[];          // lobbying / donations / contracts / funding
+};
+
+type ViewRow = {
+  rel_id: string;
+  power_score: number | string | null;
+  system_count: number | string | null;
+  in_procurement: number | null;
+  in_justice_funding: number | null;
+  in_political_donations: number | null;
+  in_charity_registry: number | null;
+  in_foundation: number | null;
+  in_alma_evidence: number | null;
+  in_ato_transparency: number | null;
+  total_dollar_flow: number | string | null;
+  influence_vectors: number | string | null;
+  revolving_door_score: number | string | null;
+  lobbies: boolean | null;
+  donates: boolean | null;
+  contracts: boolean | null;
+  receives_funding: boolean | null;
+};
+
+const num = (v: number | string | null | undefined): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+function systemsOf(r: ViewRow): string[] {
+  const out: string[] = [];
+  if (r.in_procurement) out.push('procurement');
+  if (r.in_justice_funding) out.push('justice funding');
+  if (r.in_political_donations) out.push('donations');
+  if (r.in_charity_registry) out.push('charity');
+  if (r.in_foundation) out.push('foundation');
+  if (r.in_alma_evidence) out.push('evidence');
+  if (r.in_ato_transparency) out.push('ATO');
+  return out;
+}
+
+function vectorsOf(r: ViewRow): string[] {
+  const out: string[] = [];
+  if (r.lobbies) out.push('lobbying');
+  if (r.donates) out.push('donations');
+  if (r.contracts) out.push('contracts');
+  if (r.receives_funding) out.push('funding');
+  return out;
+}
+
+/** Returns a map of goods_relationships.id -> cross-system power signal. */
+export async function getGoodsRelationshipPower(): Promise<Map<string, RelationshipPower>> {
+  const map = new Map<string, RelationshipPower>();
+  try {
+    const supabase = getServiceSupabase();
+    const { data, error } = await supabase
+      .from('v_goods_relationship_power')
+      .select('*');
+    if (error) {
+      console.error('[goods-relationship-power] query failed:', error.message);
+      return map;
+    }
+    for (const r of (data as ViewRow[] | null) ?? []) {
+      const influenceVectors = num(r.influence_vectors);
+      map.set(r.rel_id, {
+        relId: r.rel_id,
+        powerScore: num(r.power_score),
+        systemCount: num(r.system_count),
+        systems: systemsOf(r),
+        totalDollarFlow: num(r.total_dollar_flow),
+        influenceVectors,
+        revolvingDoorScore: num(r.revolving_door_score),
+        revolvingDoor: influenceVectors >= 2,
+        vectors: vectorsOf(r),
+      });
+    }
+    return map;
+  } catch (e) {
+    console.error('[goods-relationship-power] unexpected:', e);
+    return map;
+  }
+}
+
+/**
+ * Compact band for the UI chip. "High" reach = embedded across many systems or
+ * a strong revolving-door footprint; these are the counterparts whose yes (and
+ * whose public profile) carry the most weight.
+ */
+export function powerBand(p: RelationshipPower): 'high' | 'notable' | 'low' {
+  if (p.systemCount >= 4 || p.revolvingDoorScore >= 8) return 'high';
+  if (p.systemCount >= 2 || p.revolvingDoor) return 'notable';
+  return 'low';
+}

--- a/supabase/migrations/20260620120000_goods_relationship_power.sql
+++ b/supabase/migrations/20260620120000_goods_relationship_power.sql
@@ -1,0 +1,58 @@
+-- Goods Command Center — Cross-System Power overlay.
+--
+-- Wires the two cross-system influence MVs (mv_entity_power_index,
+-- mv_revolving_door) into the Goods relationship spine. For every
+-- entity-linked Goods relationship (funder / impact_investor / buyer / ...),
+-- surface how embedded that counterpart is across the 7 power systems
+-- (procurement, justice funding, political donations, charity, foundations,
+-- ALMA evidence, ATO transparency) and whether they sit in the revolving-door
+-- set (>=2 influence vectors: lobbying / donations / contracts / funding).
+--
+-- Why: a funder or buyer who is deeply cross-system embedded is both a more
+-- powerful ally (their yes carries weight, their board opens doors) and a
+-- relationship to handle with more care (donations + lobbying = a public
+-- profile worth knowing before we attach the Goods name). It also flags anchor
+-- buyers (high procurement power) inside the funder cohort.
+--
+-- Both MVs key on gs_entities.id; goods_relationships.entity_id is that same id.
+-- A VIEW (not materialized): request-time, always current, tiny once filtered
+-- to the entity-linked Goods relationships. Read by goods-relationship-power.ts.
+
+CREATE OR REPLACE VIEW v_goods_relationship_power AS
+SELECT
+  gr.id                              AS rel_id,
+  gr.entity_id,
+  gr.display_name,
+  gr.relationship_type,
+  COALESCE(gr.warmth_display, 0)::int AS warmth_display,
+
+  -- cross-system power (mv_entity_power_index)
+  pi.power_score,
+  pi.system_count,
+  pi.in_procurement,
+  pi.in_justice_funding,
+  pi.in_political_donations,
+  pi.in_charity_registry,
+  pi.in_foundation,
+  pi.in_alma_evidence,
+  pi.in_ato_transparency,
+  pi.total_dollar_flow,
+  pi.foundation_giving,
+
+  -- revolving door (mv_revolving_door)
+  rd.influence_vectors,
+  rd.revolving_door_score,
+  rd.lobbies,
+  rd.donates,
+  rd.contracts,
+  rd.receives_funding
+
+FROM goods_relationships gr
+LEFT JOIN mv_entity_power_index pi ON pi.id = gr.entity_id
+LEFT JOIN mv_revolving_door    rd ON rd.id = gr.entity_id
+WHERE gr.entity_id IS NOT NULL
+  -- keep only relationships that actually carry a cross-system signal
+  AND (pi.id IS NOT NULL OR rd.id IS NOT NULL);
+
+COMMENT ON VIEW v_goods_relationship_power IS
+  'Cross-system power overlay on Goods relationships: mv_entity_power_index (power_score, system_count, per-system flags) + mv_revolving_door (influence_vectors, lobbying/donation/contract/funding flags), joined on entity_id. Only rows with a signal. Read by goods-relationship-power.ts.';

--- a/supabase/migrations/20260620120100_goods_community_priority.sql
+++ b/supabase/migrations/20260620120100_goods_community_priority.sql
@@ -1,0 +1,62 @@
+-- Goods Command Center — SEIFA disadvantage overlay + serve-next score.
+--
+-- Overlays ABS SEIFA 2021 IRSD (Index of Relative Socio-economic Disadvantage)
+-- onto goods_communities by postcode, and derives a "serve next" score so the
+-- Communities Hub can rank where to deploy beds next by REAL unmet demand,
+-- amplified by how disadvantaged the place is.
+--
+-- IRSD decile: 1 = most disadvantaged, 10 = least. We join postcode -> decile.
+-- index_type is stored uppercase ('IRSD'); a couple of legacy migrations wrote
+-- lowercase, so we match case-insensitively to stay correct either way.
+--
+-- serve_next_score = unmet bed demand * (1 .. 2x disadvantage multiplier).
+--   - A community with no unmet demand scores ~0 regardless of disadvantage
+--     (you don't "serve next" where there's nothing to serve).
+--   - Most-disadvantaged (decile 1) doubles the weight of its unmet demand.
+--   - No SEIFA match -> multiplier 1.0 (ranks on demand alone, not penalised).
+-- unmet_beds follows the Hub's existing convention (demand_beds vs the
+-- assets_deployed counter), so the score lines up with the Beds (D / Demand)
+-- column already on the page.
+--
+-- A VIEW (not materialized): request-time, always current, small. Exposes
+-- community_id so it slots into the Hub's chunked .in('community_id', ...) fetch.
+-- Read by goods-communities-hub.ts.
+
+CREATE OR REPLACE VIEW v_goods_community_priority AS
+WITH seifa AS (
+  -- one decile per postcode; MIN = the most disadvantaged pocket in that postcode
+  SELECT postcode, MIN(decile_national)::int AS irsd_decile
+  FROM seifa_2021
+  WHERE UPPER(index_type) = 'IRSD'
+    AND decile_national IS NOT NULL
+  GROUP BY postcode
+)
+SELECT
+  gc.id                                                   AS community_id,
+  gc.community_name,
+  gc.state,
+  gc.postcode,
+  s.irsd_decile                                           AS seifa_irsd_decile,
+  (s.irsd_decile IS NOT NULL)                             AS seifa_available,
+
+  -- 0..100 disadvantage: decile 1 -> 100, decile 10 -> 0
+  CASE WHEN s.irsd_decile IS NULL THEN NULL
+       ELSE ROUND((10 - s.irsd_decile) * (100.0 / 9.0))::int
+  END                                                     AS disadvantage_score,
+
+  COALESCE(gc.demand_beds, 0)                             AS demand_beds,
+  COALESCE(gc.assets_deployed, 0)                         AS assets_deployed,
+  GREATEST(COALESCE(gc.demand_beds, 0) - COALESCE(gc.assets_deployed, 0), 0) AS unmet_beds,
+  COALESCE(gc.indigenous_population_pct, 0)               AS indigenous_population_pct,
+
+  -- serve-next: unmet bed demand, amplified up to 2x by disadvantage
+  ROUND(
+    GREATEST(COALESCE(gc.demand_beds, 0) - COALESCE(gc.assets_deployed, 0), 0)
+    * (1 + COALESCE((10 - s.irsd_decile) / 9.0, 0))
+  , 1)                                                    AS serve_next_score
+
+FROM goods_communities gc
+LEFT JOIN seifa s ON s.postcode = gc.postcode;
+
+COMMENT ON VIEW v_goods_community_priority IS
+  'SEIFA 2021 IRSD disadvantage (postcode-joined, decile 1=most disadvantaged) overlaid on goods_communities, with serve_next_score = unmet bed demand amplified up to 2x by disadvantage. Read by goods-communities-hub.ts.';

--- a/supabase/migrations/20260620120200_goods_relationship_funding.sql
+++ b/supabase/migrations/20260620120200_goods_relationship_funding.sql
@@ -1,0 +1,143 @@
+-- Goods Command Center — Funder Funding-History overlay.
+--
+-- For every entity-linked Goods relationship, surface the counterpart's real
+-- funding footprint from data we already hold, in two clearly-separated
+-- directions:
+--
+--   MONEY OUT — what this funder actually funds / gives
+--     • foundations.total_giving_annual   — annual grantmaking (+ avg grant, themes, geo)
+--     • political_donations (donor side)   — political giving (labelled distinctly)
+--
+--   MONEY IN — what this counterpart has received
+--     • justice_funding (recipient)        — government justice money received
+--     • austender_contracts (supplier)     — procurement revenue
+--
+-- Why: the warmth map says who we know; this says what they fund. A funder's
+-- giving scale + themes is the single best read on fit and ask-size; a
+-- counterpart's money-in flags a peer recipient (a partner to co-apply with)
+-- rather than a grantmaker. Turns the "who could match this grant" question
+-- into evidence instead of memory.
+--
+-- Directionality verified over the 88 ABN-linked relationships (2026-06-20):
+--   foundations.gs_entity_id       66/88   (giver — richest signal)
+--   austender_contracts.supplier   27/88   (recipient)
+--   justice_funding.gs_entity_id   11/88   (recipient)
+--   political_donations.donor_abn  10/88   (giver — political)
+--
+-- Join chain: goods_relationships.entity_id = gs_entities.id, then by the uuid
+-- FK where the source carries one (foundations.gs_entity_id,
+-- justice_funding.gs_entity_id) or by ABN (gs_entities.abn = donor_abn /
+-- supplier_abn). Preferring the gs_entity_id FK avoids ABN-format mismatch.
+--
+-- Each source is pre-aggregated to ONE row per entity BEFORE the join, so the
+-- relationship spine never fans out. A VIEW (not materialized): request-time,
+-- always current, tiny once filtered to entity-linked relationships with a
+-- signal. Read by goods-relationship-funding.ts.
+
+CREATE OR REPLACE VIEW v_goods_relationship_funding AS
+WITH ent AS (
+  SELECT
+    gr.id                               AS rel_id,
+    gr.entity_id,
+    gr.display_name,
+    gr.relationship_type,
+    COALESCE(gr.warmth_display, 0)::int AS warmth_display,
+    NULLIF(e.abn, '')                   AS abn
+  FROM goods_relationships gr
+  JOIN gs_entities e ON e.id = gr.entity_id
+  WHERE gr.entity_id IS NOT NULL
+),
+
+-- MONEY OUT — grantmaking. One row per entity: the primary (largest-giving)
+-- foundation record, so a counterpart with multiple foundation rows can't fan out.
+fnd AS (
+  SELECT DISTINCT ON (f.gs_entity_id)
+    f.gs_entity_id        AS entity_id,
+    f.total_giving_annual AS foundation_giving_annual,
+    f.avg_grant_size      AS foundation_avg_grant,
+    f.thematic_focus      AS foundation_themes,
+    f.geographic_focus    AS foundation_geo
+  FROM foundations f
+  WHERE f.gs_entity_id IS NOT NULL
+  ORDER BY f.gs_entity_id, f.total_giving_annual DESC NULLS LAST
+),
+
+-- MONEY OUT — political giving (donor side, by ABN).
+pol AS (
+  SELECT
+    donor_abn           AS abn,
+    SUM(amount)         AS political_total,
+    COUNT(*)            AS political_count,
+    MAX(financial_year) AS political_latest_fy
+  FROM political_donations
+  WHERE donor_abn IS NOT NULL AND donor_abn <> ''
+  GROUP BY donor_abn
+),
+
+-- MONEY IN — justice funding received (recipient; prefer the gs_entity_id FK).
+jf AS (
+  SELECT
+    gs_entity_id                 AS entity_id,
+    SUM(amount_dollars)          AS justice_total,
+    COUNT(DISTINCT program_name) AS justice_program_count,
+    MAX(financial_year)          AS justice_latest_fy
+  FROM justice_funding
+  WHERE gs_entity_id IS NOT NULL
+  GROUP BY gs_entity_id
+),
+
+-- MONEY IN — procurement revenue (supplier side, by ABN).
+aus AS (
+  SELECT
+    supplier_abn        AS abn,
+    SUM(contract_value) AS austender_total,
+    COUNT(*)            AS austender_contract_count,
+    MAX(contract_start) AS austender_latest
+  FROM austender_contracts
+  WHERE supplier_abn IS NOT NULL AND supplier_abn <> ''
+  GROUP BY supplier_abn
+)
+
+SELECT
+  ent.rel_id,
+  ent.entity_id,
+  ent.display_name,
+  ent.relationship_type,
+  ent.warmth_display,
+  ent.abn,
+
+  -- money out (gives)
+  fnd.foundation_giving_annual,
+  fnd.foundation_avg_grant,
+  fnd.foundation_themes,
+  fnd.foundation_geo,
+  pol.political_total,
+  pol.political_count,
+  pol.political_latest_fy,
+
+  -- money in (receives)
+  jf.justice_total,
+  jf.justice_program_count,
+  jf.justice_latest_fy,
+  aus.austender_total,
+  aus.austender_contract_count,
+  aus.austender_latest,
+
+  -- rollups
+  (COALESCE(fnd.foundation_giving_annual, 0) + COALESCE(pol.political_total, 0)) AS gives_total,
+  (COALESCE(jf.justice_total, 0) + COALESCE(aus.austender_total, 0))             AS receives_total
+
+FROM ent
+LEFT JOIN fnd ON fnd.entity_id = ent.entity_id
+LEFT JOIN jf  ON jf.entity_id  = ent.entity_id
+LEFT JOIN pol ON pol.abn       = ent.abn
+LEFT JOIN aus ON aus.abn       = ent.abn
+WHERE
+  -- keep only relationships that actually carry a funding signal
+  fnd.entity_id IS NOT NULL
+  OR jf.entity_id IS NOT NULL
+  OR pol.abn IS NOT NULL
+  OR aus.abn IS NOT NULL;
+
+COMMENT ON VIEW v_goods_relationship_funding IS
+  'Funder funding-history overlay on Goods relationships: MONEY OUT (foundations.total_giving_annual grantmaking + political_donations donor giving) and MONEY IN (justice_funding + austender_contracts received), each pre-aggregated per entity and joined on entity_id/abn. Only rows with a funding signal. Read by goods-relationship-funding.ts.';


### PR DESCRIPTION
## What

Two **deepen-not-widen** overlays over data CivicGraph already holds but wasn't exploiting for Goods on Country. No new data sources; both wire existing MVs/tables into request-time views and surface them on existing Goods Command Center tabs.

### 1. Cross-system power on Goods relationships
- `v_goods_relationship_power` — joins `mv_entity_power_index` + `mv_revolving_door` onto `goods_relationships.entity_id`; only rows that carry a signal.
- `goods-relationship-power.ts` service returns a map keyed by `rel_id`, plus a `powerBand()` helper.
- **Funder Insight** page now shows a compact `Power N/7` chip per funder (`· RD` when they're in the revolving-door set; full system/vector detail on hover). The existing funder-insight service/decoder is untouched — power is merged at the page level, fetched in parallel.

Why: a funder/buyer embedded across many systems is both a more powerful ally (their yes carries weight, their board opens doors) and a public profile worth knowing before attaching the Goods name.

### 2. SEIFA disadvantage on goods_communities
- `v_goods_community_priority` — joins ABS SEIFA 2021 IRSD by postcode (decile 1 = most disadvantaged) and derives `serve_next_score` = unmet bed demand × a 1–2× disadvantage multiplier. No demand → ~0 regardless of how disadvantaged; no SEIFA match → ranks on demand alone (not penalised). `index_type` matched case-insensitively.
- `goods-communities-hub.ts` adds `seifa_irsd_decile` / `disadvantage_score` / `unmet_beds` / `serve_next_score` per row, a `serve_next` sort mode, and a `high_disadvantage` (≤D3) summary count.
- **Communities Hub** page adds a `Disadv./Serve` column, a "Most disadvantaged (≤D3)" summary cell, and a "Serve next (SEIFA × unmet beds)" sort toggle.

Why: lets the Hub answer "where do we serve next" with data — most-disadvantaged remote communities with the largest unmet bed gaps first.

## Verification (applied + live)
Both views are applied to `tednluwflfhxyucgwigh` and verified against live data:
- `v_goods_relationship_power`: **79 rows** (top: Barnardos 6/7 systems, Central Queensland University, The Smith Family, NACCHO…).
- `v_goods_community_priority`: **1,542 communities, 1,508 with SEIFA (98%), 1,125 at ≤D3**. Serve-next ranks Wadeye (918 unmet beds × 2.0 = 1836), Maningrida, Galiwinku… all NT decile-1.
- `cd apps/web && npx tsc --noEmit` — clean.

## Notes
- Migrations are `CREATE OR REPLACE VIEW` (additive, reversible). UI degrades gracefully if a view is absent (chips hide, disadvantage column shows "—").
- Aligns with the paused-widening strategy: connect/deepen existing data, no new ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
