### PR TITLE
feat(goods): registry entity resolution + power/funding chips + cross-system people leaderboard

### DIFF
--- a/apps/web/src/app/api/foundations/[foundationId]/pipeline-context/route.ts
+++ b/apps/web/src/app/api/foundations/[foundationId]/pipeline-context/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSupabaseServer } from '@/lib/supabase-server';
+import { getServiceSupabase } from '@/lib/supabase';
+import { getCurrentOrgProfileContext } from '@/lib/org-profile';
+
+type RouteContext = { params: Promise<{ foundationId: string }> };
+
+interface PipelineContextResponse {
+  orgName: string;
+  orgSlug: string | null;
+  items: Array<{ name: string; status: string; amount_display: string | null; deadline: string | null }>;
+}
+
+/**
+ * Per-user, never cached at the route level — this is what foundations/[id]/page.tsx
+ * used to compute server-side, which made the whole page un-cacheable (it would have
+ * baked one org's private pipeline into the shared ISR HTML). Fetched client-side
+ * instead so the page itself can be ISR-cached and stay anonymous.
+ */
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { foundationId } = await context.params;
+
+  const authSupabase = await createSupabaseServer();
+  const { data: { user } } = await authSupabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json<{ pipelineContext: null }>({ pipelineContext: null });
+  }
+
+  const serviceDb = getServiceSupabase();
+
+  const ctx = await getCurrentOrgProfileContext(serviceDb, user.id);
+  if (!ctx.orgProfileId || !ctx.profile) {
+    return NextResponse.json<{ pipelineContext: null }>({ pipelineContext: null });
+  }
+
+  const { data: foundation } = await serviceDb
+    .from('foundations')
+    .select('acnc_abn')
+    .eq('id', foundationId)
+    .maybeSingle();
+
+  if (!foundation?.acnc_abn) {
+    return NextResponse.json<{ pipelineContext: null }>({ pipelineContext: null });
+  }
+
+  const { data: entity } = await serviceDb
+    .from('gs_entities')
+    .select('id')
+    .eq('abn', foundation.acnc_abn)
+    .maybeSingle();
+
+  if (!entity) {
+    return NextResponse.json<{ pipelineContext: null }>({ pipelineContext: null });
+  }
+
+  const { data: pipelineItems } = await serviceDb
+    .from('org_pipeline')
+    .select('name, status, amount_display, deadline')
+    .eq('org_profile_id', ctx.orgProfileId)
+    .eq('funder_entity_id', entity.id)
+    .order('created_at', { ascending: false });
+
+  if (!pipelineItems || pipelineItems.length === 0) {
+    return NextResponse.json<{ pipelineContext: null }>({ pipelineContext: null });
+  }
+
+  const { data: orgProfile } = await serviceDb
+    .from('org_profiles')
+    .select('slug')
+    .eq('id', ctx.orgProfileId)
+    .maybeSingle();
+
+  const pipelineContext: PipelineContextResponse = {
+    orgName: ctx.profile.name,
+    orgSlug: orgProfile?.slug ?? null,
+    items: pipelineItems,
+  };
+
+  return NextResponse.json({ pipelineContext });
+}

--- a/apps/web/src/app/api/power/holders/route.ts
+++ b/apps/web/src/app/api/power/holders/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/supabase';
+import { safe } from '@/lib/sql';
+
+// Cross-system PEOPLE leaderboard — the de-collided person→money rollup.
+// Reads mv_person_identity_influence_v2 (move A4: each entity's dollars are
+// split evenly across its directors, so co-directors are no longer each credited
+// the entity's whole figure). Annotated with L16 "who funds this power holder" —
+// the foundations backing the entities each person governs
+// (mv_foundation_grantees WHERE link_method='relationship').
+//
+// HONESTY CONTRACT (do not break in the UI):
+//   - attributed_* = personal share (even-split by director headcount). Show as spend.
+//   - board_count <= 10 + NOT is_nominee_block filters the trustee-nominee blocks.
+//   - even-split does NOT weight by role/tenure, and top names can still harbour
+//     name-collision aggregates (separate disambiguation residual) — label accordingly.
+export async function GET() {
+  try {
+    const supabase = getServiceSupabase();
+
+    const [holders, totalRaw] = await Promise.all([
+      safe(
+        supabase.rpc('exec_sql', {
+          query: `
+            WITH top_holders AS (
+              SELECT identity_key, person_name, board_count, financial_system_count,
+                     attributed_procurement, attributed_justice, attributed_donations,
+                     total_contracts, influence_score_attributed, shares_board_entities,
+                     acco_boards, max_board_director_count
+              FROM mv_person_identity_influence_v2
+              WHERE NOT is_nominee_block
+                AND board_count <= 10
+                AND influence_score_attributed > 0
+              ORDER BY influence_score_attributed DESC
+              LIMIT 50
+            ),
+            person_entities AS (
+              SELECT n.identity_key, n.entity_id, n.entity_name,
+                     (COALESCE(n.procurement_dollars,0) + COALESCE(n.justice_dollars,0)
+                      + COALESCE(n.donation_dollars,0)) AS entity_flow
+              FROM mv_person_identity_network n
+              WHERE n.identity_key IN (SELECT identity_key FROM top_holders)
+            ),
+            boards AS (
+              SELECT identity_key,
+                     (array_agg(entity_name ORDER BY entity_flow DESC NULLS LAST))[1:3] AS top_boards
+              FROM person_entities
+              GROUP BY identity_key
+            ),
+            funders AS (
+              SELECT pe.identity_key,
+                     count(DISTINCT fg.foundation_id) AS funder_count,
+                     (array_agg(DISTINCT fg.foundation_name))[1:5] AS foundation_backers
+              FROM person_entities pe
+              JOIN mv_foundation_grantees fg
+                ON fg.grantee_entity_id = pe.entity_id
+               AND fg.link_method = 'relationship'
+              GROUP BY pe.identity_key
+            )
+            SELECT
+              th.person_name,
+              th.board_count,
+              th.financial_system_count,
+              round(th.attributed_procurement)::bigint AS attributed_procurement,
+              round(th.attributed_justice)::bigint     AS attributed_justice,
+              round(th.attributed_donations)::bigint   AS attributed_donations,
+              th.total_contracts,
+              th.shares_board_entities,
+              th.acco_boards,
+              th.max_board_director_count,
+              COALESCE(b.top_boards, ARRAY[]::text[]) AS top_boards,
+              COALESCE(f.funder_count, 0) AS funder_count,
+              COALESCE(f.foundation_backers, ARRAY[]::text[]) AS foundation_backers
+            FROM top_holders th
+            LEFT JOIN boards b ON b.identity_key = th.identity_key
+            LEFT JOIN funders f ON f.identity_key = th.identity_key
+            ORDER BY th.influence_score_attributed DESC
+          `,
+        })
+      ),
+
+      // How many cross-system power holders exist (present in 2+ money systems)
+      safe(
+        supabase.rpc('exec_sql', {
+          query: `
+            SELECT COUNT(*) AS total
+            FROM mv_person_identity_influence_v2
+            WHERE NOT is_nominee_block
+              AND board_count <= 10
+              AND financial_system_count >= 2
+          `,
+        })
+      ),
+    ]);
+
+    const total = Array.isArray(totalRaw) && totalRaw[0] ? Number(totalRaw[0].total) || 0 : 0;
+
+    return NextResponse.json({
+      holders: holders || [],
+      total,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/charities/page.tsx
+++ b/apps/web/src/app/charities/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/supabase';
+import { unstable_cache } from 'next/cache';
 import { FilterBar } from '../components/filter-bar';
 
 export const dynamic = 'force-dynamic';
@@ -119,6 +120,97 @@ interface SearchParams {
   page?: string;
 }
 
+interface CharitiesQueryArgs {
+  query: string;
+  sizeFilter: string;
+  purposeFilter: string;
+  beneficiaryFilter: string;
+  pbiOnly: boolean;
+  hpcOnly: boolean;
+  stateFilter: string;
+  regStateFilter: string;
+  revenueMin: number | null;
+  revenueMax: number | null;
+  grantsOnly: boolean;
+  foundationsOnly: boolean;
+  sortBy: string;
+  offset: number;
+  pageSize: number;
+}
+
+// v_charity_explorer has no fast/default-view shortcut (unlike grants/foundations'
+// in-memory FAST_*_INDEX) — every hit, filtered or not, runs a `count: 'exact'`
+// scan. Caching by the full filter combo means repeat hits to the same URL
+// (the dominant crawl/traffic shape) skip the DB entirely for 5 minutes.
+const getCharitiesPage = unstable_cache(
+  async (args: CharitiesQueryArgs) => {
+    const supabase = getServiceSupabase();
+    let dbQuery = supabase
+      .from('v_charity_explorer')
+      .select('abn, name, charity_size, state, pbi, hpc, purposes, beneficiaries, operating_states, is_foundation, website, total_revenue, total_grants_given, total_assets, staff_fte, staff_volunteers, latest_financial_year, has_enrichment', { count: 'exact' });
+
+    if (args.query) {
+      dbQuery = dbQuery.ilike('name', `%${args.query}%`);
+    }
+    if (args.sizeFilter) {
+      dbQuery = dbQuery.eq('charity_size', args.sizeFilter);
+    }
+    if (args.purposeFilter) {
+      dbQuery = dbQuery.contains('purposes', [args.purposeFilter]);
+    }
+    if (args.beneficiaryFilter) {
+      dbQuery = dbQuery.contains('beneficiaries', [args.beneficiaryFilter]);
+    }
+    if (args.pbiOnly) {
+      dbQuery = dbQuery.eq('pbi', true);
+    }
+    if (args.hpcOnly) {
+      dbQuery = dbQuery.eq('hpc', true);
+    }
+    if (args.stateFilter) {
+      dbQuery = dbQuery.contains('operating_states', [args.stateFilter]);
+    }
+    if (args.regStateFilter) {
+      dbQuery = dbQuery.eq('state', args.regStateFilter);
+    }
+    if (args.revenueMin) {
+      dbQuery = dbQuery.gte('total_revenue', args.revenueMin);
+    }
+    if (args.revenueMax) {
+      dbQuery = dbQuery.lte('total_revenue', args.revenueMax);
+    }
+    if (args.grantsOnly) {
+      dbQuery = dbQuery.gt('total_grants_given', 0);
+    }
+    if (args.foundationsOnly) {
+      dbQuery = dbQuery.eq('is_foundation', true);
+    }
+
+    if (args.sortBy === 'revenue') {
+      dbQuery = dbQuery.order('total_revenue', { ascending: false, nullsFirst: false });
+    } else if (args.sortBy === 'grants') {
+      dbQuery = dbQuery.order('total_grants_given', { ascending: false, nullsFirst: false });
+    } else if (args.sortBy === 'assets') {
+      dbQuery = dbQuery.order('total_assets', { ascending: false, nullsFirst: false });
+    } else if (args.sortBy === 'fte') {
+      dbQuery = dbQuery.order('staff_fte', { ascending: false, nullsFirst: false });
+    } else if (args.sortBy === 'volunteers') {
+      dbQuery = dbQuery.order('staff_volunteers', { ascending: false, nullsFirst: false });
+    } else if (args.sortBy === 'newest') {
+      dbQuery = dbQuery.order('registration_date', { ascending: false, nullsFirst: false });
+    } else {
+      dbQuery = dbQuery.order('name', { ascending: true });
+    }
+
+    dbQuery = dbQuery.range(args.offset, args.offset + args.pageSize - 1);
+
+    const { data: charities, count } = await dbQuery;
+    return { charities: charities || [], count: count || 0 };
+  },
+  ['charities-query'],
+  { revalidate: 300 },
+);
+
 export default async function CharitiesPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const params = await searchParams;
   const query = params.q || '';
@@ -138,70 +230,23 @@ export default async function CharitiesPage({ searchParams }: { searchParams: Pr
   const pageSize = 50;
   const offset = (page - 1) * pageSize;
 
-  const supabase = getServiceSupabase();
-
-  // Build query
-  let dbQuery = supabase
-    .from('v_charity_explorer')
-    .select('abn, name, charity_size, state, pbi, hpc, purposes, beneficiaries, operating_states, is_foundation, website, total_revenue, total_grants_given, total_assets, staff_fte, staff_volunteers, latest_financial_year, has_enrichment', { count: 'exact' });
-
-  if (query) {
-    dbQuery = dbQuery.ilike('name', `%${query}%`);
-  }
-  if (sizeFilter) {
-    dbQuery = dbQuery.eq('charity_size', sizeFilter);
-  }
-  if (purposeFilter) {
-    dbQuery = dbQuery.contains('purposes', [purposeFilter]);
-  }
-  if (beneficiaryFilter) {
-    dbQuery = dbQuery.contains('beneficiaries', [beneficiaryFilter]);
-  }
-  if (pbiOnly) {
-    dbQuery = dbQuery.eq('pbi', true);
-  }
-  if (hpcOnly) {
-    dbQuery = dbQuery.eq('hpc', true);
-  }
-  if (stateFilter) {
-    dbQuery = dbQuery.contains('operating_states', [stateFilter]);
-  }
-  if (regStateFilter) {
-    dbQuery = dbQuery.eq('state', regStateFilter);
-  }
-  if (revenueMin) {
-    dbQuery = dbQuery.gte('total_revenue', revenueMin);
-  }
-  if (revenueMax) {
-    dbQuery = dbQuery.lte('total_revenue', revenueMax);
-  }
-  if (grantsOnly) {
-    dbQuery = dbQuery.gt('total_grants_given', 0);
-  }
-  if (foundationsOnly) {
-    dbQuery = dbQuery.eq('is_foundation', true);
-  }
-
-  // Sort
-  if (sortBy === 'revenue') {
-    dbQuery = dbQuery.order('total_revenue', { ascending: false, nullsFirst: false });
-  } else if (sortBy === 'grants') {
-    dbQuery = dbQuery.order('total_grants_given', { ascending: false, nullsFirst: false });
-  } else if (sortBy === 'assets') {
-    dbQuery = dbQuery.order('total_assets', { ascending: false, nullsFirst: false });
-  } else if (sortBy === 'fte') {
-    dbQuery = dbQuery.order('staff_fte', { ascending: false, nullsFirst: false });
-  } else if (sortBy === 'volunteers') {
-    dbQuery = dbQuery.order('staff_volunteers', { ascending: false, nullsFirst: false });
-  } else if (sortBy === 'newest') {
-    dbQuery = dbQuery.order('registration_date', { ascending: false, nullsFirst: false });
-  } else {
-    dbQuery = dbQuery.order('name', { ascending: true });
-  }
-
-  dbQuery = dbQuery.range(offset, offset + pageSize - 1);
-
-  const { data: charities, count } = await dbQuery;
+  const { charities, count } = await getCharitiesPage({
+    query,
+    sizeFilter,
+    purposeFilter,
+    beneficiaryFilter,
+    pbiOnly,
+    hpcOnly,
+    stateFilter,
+    regStateFilter,
+    revenueMin,
+    revenueMax,
+    grantsOnly,
+    foundationsOnly,
+    sortBy,
+    offset,
+    pageSize,
+  });
   const totalPages = Math.ceil((count || 0) / pageSize);
 
   // Build filter query string for pagination

--- a/apps/web/src/app/entities/page.tsx
+++ b/apps/web/src/app/entities/page.tsx
@@ -1,8 +1,42 @@
 import { getServiceSupabase } from '@/lib/supabase';
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { EntityPreviewTrigger, ListPreviewProvider, type EntityPreviewData } from '../components/list-preview';
 
 export const dynamic = 'force-dynamic';
+
+// The default view (no params) runs 4 queries incl. two full-table head counts
+// on every hit with no fast path (unlike grants/foundations, which have an
+// in-memory FAST_*_INDEX). It's also the single most-requested URL shape on
+// this route, so it's the highest-value thing to cache here.
+const getDonorContractorsView = unstable_cache(
+  async () => {
+    const supabase = getServiceSupabase();
+    const [
+      { data: donorContractors },
+      { count: donorContractorCount },
+      { count: totalEntities },
+      { count: totalRels },
+    ] = await Promise.all([
+      supabase
+        .from('mv_gs_donor_contractors')
+        .select('*')
+        .order('total_donated', { ascending: false })
+        .limit(100),
+      supabase.from('mv_gs_donor_contractors').select('gs_id', { count: 'exact', head: true }),
+      supabase.from('gs_entities').select('*', { count: 'exact', head: true }),
+      supabase.from('gs_relationships').select('*', { count: 'exact', head: true }),
+    ]);
+    return {
+      donorContractors: (donorContractors || []) as Record<string, unknown>[],
+      donorContractorCount: donorContractorCount || 0,
+      totalEntities: totalEntities || 0,
+      totalRels: totalRels || 0,
+    };
+  },
+  ['entities-donor-contractors-view'],
+  { revalidate: 300 },
+);
 
 function formatMoney(amount: number | null): string {
   if (!amount) return '\u2014';
@@ -141,21 +175,7 @@ export default async function EntityGraphPage({
   const showDonorContractors = view === 'donor-contractors' || !view;
 
   if (showDonorContractors) {
-    const [
-      { data: donorContractors },
-      { count: donorContractorCount },
-      { count: totalEntities },
-      { count: totalRels },
-    ] = await Promise.all([
-      supabase
-        .from('mv_gs_donor_contractors')
-        .select('*')
-        .order('total_donated', { ascending: false })
-        .limit(100),
-      supabase.from('mv_gs_donor_contractors').select('gs_id', { count: 'exact', head: true }),
-      supabase.from('gs_entities').select('*', { count: 'exact', head: true }),
-      supabase.from('gs_relationships').select('*', { count: 'exact', head: true }),
-    ]);
+    const { donorContractors, donorContractorCount, totalEntities, totalRels } = await getDonorContractorsView();
 
     return (
       <ListPreviewProvider>

--- a/apps/web/src/app/foundations/[id]/page.tsx
+++ b/apps/web/src/app/foundations/[id]/page.tsx
@@ -1,14 +1,16 @@
 import { getServiceSupabase } from '@/lib/supabase';
-import { createSupabaseServer } from '@/lib/supabase-server';
-import { getCurrentOrgProfileContext } from '@/lib/org-profile';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { GivingHistoryChart } from './giving-chart';
 import { GrantActionsProvider, GrantCardActions } from '@/app/components/grant-card-actions';
 import { FoundationActionsProvider, FoundationCardActions } from '@/app/components/foundation-card-actions';
 import { FoundationDetailActions } from './foundation-detail-actions';
+import { PipelineContextBanner } from './pipeline-context-banner';
 
-export const dynamic = 'force-dynamic';
+// ISR: page output must stay anonymous (no per-user/org data baked in — see
+// PipelineContextBanner, which fetches a logged-in user's private pipeline
+// client-side) so it's safe to cache and serve the same HTML to every visitor.
+export const revalidate = 300;
 
 interface FoundationDetail {
   id: string;
@@ -337,46 +339,6 @@ export default async function FoundationDetailPage({ params }: { params: Promise
     return rank !== 0 ? rank : a.person_name.localeCompare(b.person_name);
   });
 
-  // Optional: check if logged-in user's org has pipeline items with this foundation
-  interface PipelineContext {
-    orgName: string;
-    orgSlug: string | null;
-    items: Array<{ name: string; status: string; amount_display: string | null; deadline: string | null }>;
-  }
-  let pipelineContext: PipelineContext | null = null;
-  try {
-    const authSupabase = await createSupabaseServer();
-    const { data: { user } } = await authSupabase.auth.getUser();
-    if (user) {
-      const ctx = await getCurrentOrgProfileContext(supabase, user.id);
-      if (ctx.orgProfileId && ctx.profile) {
-        // Find pipeline items where funder_entity_id matches this foundation's entity
-        const { data: pipelineItems } = await supabase.rpc('exec_sql', {
-          query: `SELECT op.name, op.status, op.amount_display, op.deadline
-             FROM org_pipeline op
-             JOIN gs_entities ge ON ge.id = op.funder_entity_id
-             WHERE op.org_profile_id = '${ctx.orgProfileId}'
-               AND ge.abn = '${f.acnc_abn}'
-             ORDER BY op.created_at DESC`,
-        });
-        if (pipelineItems && (pipelineItems as unknown[]).length > 0) {
-          const { data: orgProfile } = await supabase
-            .from('org_profiles')
-            .select('slug')
-            .eq('id', ctx.orgProfileId)
-            .maybeSingle();
-          pipelineContext = {
-            orgName: ctx.profile.name,
-            orgSlug: orgProfile?.slug ?? null,
-            items: pipelineItems as PipelineContext['items'],
-          };
-        }
-      }
-    }
-  } catch {
-    // Auth check is optional — don't break the page
-  }
-
   const badge = confidenceBadge(f.profile_confidence);
   const allPrograms = programs as ProgramRow[] || [];
   const allProgramYears = (programYears || []) as ProgramYearRow[];
@@ -461,43 +423,9 @@ export default async function FoundationDetailPage({ params }: { params: Promise
         </div>
       </div>
 
-      {/* Pipeline Context Banner — shown when logged-in org has items with this foundation */}
-      {pipelineContext && (
-        <div className="mb-6 border-4 border-green-600 bg-green-50 p-4">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h3 className="text-xs font-black uppercase tracking-widest text-green-800 mb-2">
-                Your Pipeline with {f.name}
-              </h3>
-              <div className="space-y-1.5">
-                {pipelineContext.items.map((item, i) => (
-                  <div key={i} className="flex items-center gap-3 text-sm">
-                    <span className={`text-[10px] px-2 py-0.5 font-bold border rounded-sm uppercase ${
-                      item.status === 'awarded' ? 'bg-green-100 text-green-800 border-green-300' :
-                      item.status === 'submitted' ? 'bg-emerald-50 text-emerald-700 border-emerald-200' :
-                      item.status === 'drafting' ? 'bg-blue-50 text-blue-700 border-blue-200' :
-                      'bg-gray-50 text-gray-500 border-gray-200'
-                    }`}>
-                      {item.status}
-                    </span>
-                    <span className="font-medium text-gray-800">{item.name}</span>
-                    {item.amount_display && <span className="font-mono text-green-700 text-xs">{item.amount_display}</span>}
-                    {item.deadline && <span className="text-gray-400 text-xs">Due {item.deadline}</span>}
-                  </div>
-                ))}
-              </div>
-            </div>
-            {pipelineContext.orgSlug && (
-              <Link
-                href={`/org/${pipelineContext.orgSlug}`}
-                className="text-xs px-3 py-2 bg-green-700 text-white font-bold uppercase tracking-wider hover:bg-green-800 transition-colors rounded-sm shrink-0"
-              >
-                {pipelineContext.orgName} Dashboard &rarr;
-              </Link>
-            )}
-          </div>
-        </div>
-      )}
+      {/* Pipeline Context Banner — fetched client-side so the page itself stays
+          anonymous and cacheable; see pipeline-context-banner.tsx */}
+      <PipelineContextBanner foundationId={f.id} foundationName={f.name} />
 
       {/* Key stats — adaptive, only show fields with data */}
       {(() => {

--- a/apps/web/src/app/foundations/[id]/pipeline-context-banner.tsx
+++ b/apps/web/src/app/foundations/[id]/pipeline-context-banner.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface PipelineContext {
+  orgName: string;
+  orgSlug: string | null;
+  items: Array<{ name: string; status: string; amount_display: string | null; deadline: string | null }>;
+}
+
+export function PipelineContextBanner({ foundationId, foundationName }: { foundationId: string; foundationName: string }) {
+  const [pipelineContext, setPipelineContext] = useState<PipelineContext | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/foundations/${foundationId}/pipeline-context`)
+      .then((r) => (r.ok ? r.json() : { pipelineContext: null }))
+      .then((data: { pipelineContext: PipelineContext | null }) => {
+        if (!cancelled) setPipelineContext(data.pipelineContext);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [foundationId]);
+
+  if (!pipelineContext) return null;
+
+  return (
+    <div className="mb-6 border-4 border-green-600 bg-green-50 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-xs font-black uppercase tracking-widest text-green-800 mb-2">
+            Your Pipeline with {foundationName}
+          </h3>
+          <div className="space-y-1.5">
+            {pipelineContext.items.map((item, i) => (
+              <div key={i} className="flex items-center gap-3 text-sm">
+                <span className={`text-[10px] px-2 py-0.5 font-bold border rounded-sm uppercase ${
+                  item.status === 'awarded' ? 'bg-green-100 text-green-800 border-green-300' :
+                  item.status === 'submitted' ? 'bg-emerald-50 text-emerald-700 border-emerald-200' :
+                  item.status === 'drafting' ? 'bg-blue-50 text-blue-700 border-blue-200' :
+                  'bg-gray-50 text-gray-500 border-gray-200'
+                }`}>
+                  {item.status}
+                </span>
+                <span className="font-medium text-gray-800">{item.name}</span>
+                {item.amount_display && <span className="font-mono text-green-700 text-xs">{item.amount_display}</span>}
+                {item.deadline && <span className="text-gray-400 text-xs">Due {item.deadline}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+        {pipelineContext.orgSlug && (
+          <Link
+            href={`/org/${pipelineContext.orgSlug}`}
+            className="text-xs px-3 py-2 bg-green-700 text-white font-bold uppercase tracking-wider hover:bg-green-800 transition-colors rounded-sm shrink-0"
+          >
+            {pipelineContext.orgName} Dashboard &rarr;
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/org/[slug]/goods/_components/goods-power-chip.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-power-chip.tsx
@@ -6,9 +6,14 @@ import { powerBand, type RelationshipPower } from '@/lib/services/goods-relation
  * carries weight and opens doors; it is also a public profile worth knowing
  * before we attach the Goods name. Detail on hover. Renders nothing without
  * signal — so it degrades silently for registry rows with no entity match.
+ *
+ * Surfaces on EITHER axis: system reach OR revolving-door membership. The two
+ * come from independently-refreshed MVs with no enforced subset invariant, so a
+ * counterpart can sit in the revolving-door set with zero measured system reach
+ * (systemCount 0); we still show the chip rather than silently drop the RD flag.
  */
 export function PowerChip({ power }: { power: RelationshipPower | null }) {
-  if (!power || power.systemCount < 1) return null;
+  if (!power || (power.systemCount < 1 && !power.revolvingDoor)) return null;
   const band = powerBand(power);
   const tone =
     band === 'high' ? 'bg-bauhaus-black text-bauhaus-yellow'

--- a/apps/web/src/app/org/[slug]/goods/_components/goods-power-chip.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-power-chip.tsx
@@ -1,0 +1,26 @@
+import { powerBand, type RelationshipPower } from '@/lib/services/goods-relationship-power';
+
+/**
+ * Cross-system power chip — how embedded a counterpart is across the 7 power
+ * systems, and whether they sit in the revolving-door set. A high-reach yes
+ * carries weight and opens doors; it is also a public profile worth knowing
+ * before we attach the Goods name. Detail on hover. Renders nothing without
+ * signal — so it degrades silently for registry rows with no entity match.
+ */
+export function PowerChip({ power }: { power: RelationshipPower | null }) {
+  if (!power || power.systemCount < 1) return null;
+  const band = powerBand(power);
+  const tone =
+    band === 'high' ? 'bg-bauhaus-black text-bauhaus-yellow'
+    : band === 'notable' ? 'bg-bauhaus-blue text-white'
+    : 'bg-bauhaus-canvas text-bauhaus-muted';
+  const rd = power.revolvingDoor ? ` · revolving door (${power.vectors.join(', ')})` : '';
+  return (
+    <span
+      className={`px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest ${tone}`}
+      title={`Cross-system reach: ${power.systems.join(', ') || 'none'}${rd}`}
+    >
+      Power {power.systemCount}/7{power.revolvingDoor ? ' · RD' : ''}
+    </span>
+  );
+}

--- a/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
@@ -26,7 +26,7 @@ const ALL_TABS = [...PIPELINE_TABS, ...EVIDENCE_TABS] as const;
 
 export type GoodsTab = (typeof ALL_TABS)[number][0];
 
-function TabLink({ slug, tabKey, label, active }: { slug: string; tabKey: GoodsTab; label: string; active: GoodsTab }) {
+function TabLink({ slug, tabKey, label, active }: { slug: string; tabKey: GoodsTab; label: string; active?: GoodsTab }) {
   return (
     <Link
       href={`/org/${slug}/goods/${tabKey}`}
@@ -39,8 +39,9 @@ function TabLink({ slug, tabKey, label, active }: { slug: string; tabKey: GoodsT
   );
 }
 
-/** Shared dark-header sub-nav across the Goods Command Center pages. */
-export function GoodsSubNav({ slug, active }: { slug: string; active: GoodsTab }) {
+/** Shared dark-header sub-nav across the Goods Command Center pages.
+ *  `active` is optional — the hub (/goods index) passes none, so no tab highlights. */
+export function GoodsSubNav({ slug, active }: { slug: string; active?: GoodsTab }) {
   return (
     <div className="mt-4 flex flex-col gap-3">
       <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
@@ -139,7 +139,7 @@ export default async function GoodsBuyersPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Buyers &amp; Procurement</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
@@ -126,6 +126,11 @@ export default async function GoodsBuyersPage({
   ]);
   const openOnly = filter === 'open';
   const shown = openOnly ? rows.filter((r) => r.isOpen) : rows;
+  // No buyer amounts are entered yet (asks + lifetime revenue both $0). When that's
+  // true, leading with three giant $0s reads as "earned nothing / broken" — so we lead
+  // with the pipeline strength that DOES exist and relegate the $0 to an honest footnote
+  // (mirrors the Money tab's "separate track" treatment).
+  const hasMoney = summary.totalReceived > 0 || summary.openAskTotal > 0;
 
   return (
     <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
@@ -163,27 +168,50 @@ export default async function GoodsBuyersPage({
           <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
             Procurement track · earned revenue, kept separate from grant + investment
           </div>
-          <div className="mt-1 flex flex-wrap items-baseline gap-x-4 gap-y-1">
-            <span className="text-5xl font-black leading-none text-bauhaus-black">{moneyShort(summary.totalReceived)}</span>
-            <span className="text-sm font-black uppercase tracking-widest text-bauhaus-muted">received (lifetime)</span>
-            <span className="text-3xl font-black leading-none text-bauhaus-blue">{moneyShort(summary.openAskTotal)}</span>
-            <span className="text-sm font-black uppercase tracking-widest text-bauhaus-muted">open asks</span>
-          </div>
-          <div className="mt-2 flex flex-wrap gap-2 text-[11px] font-bold">
-            <span className="border-2 border-bauhaus-black bg-white px-2 py-0.5">
-              {summary.total} buyer{summary.total === 1 ? '' : 's'} · {summary.open} open
-            </span>
-            <span className="border-2 border-bauhaus-black bg-white px-2 py-0.5">
-              Expected (stage-weighted) {moneyShort(summary.weightedPipeline)}
-            </span>
-          </div>
+          {hasMoney ? (
+            <>
+              <div className="mt-1 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                <span className="text-5xl font-black leading-none text-bauhaus-black">{moneyShort(summary.totalReceived)}</span>
+                <span className="text-sm font-black uppercase tracking-widest text-bauhaus-muted">received (lifetime)</span>
+                <span className="text-3xl font-black leading-none text-bauhaus-blue">{moneyShort(summary.openAskTotal)}</span>
+                <span className="text-sm font-black uppercase tracking-widest text-bauhaus-muted">open asks</span>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2 text-[11px] font-bold">
+                <span className="border-2 border-bauhaus-black bg-white px-2 py-0.5">
+                  {summary.total} buyer{summary.total === 1 ? '' : 's'} · {summary.open} open
+                </span>
+                <span className="border-2 border-bauhaus-black bg-white px-2 py-0.5">
+                  Expected (stage-weighted) {moneyShort(summary.weightedPipeline)}
+                </span>
+              </div>
+            </>
+          ) : (
+            <>
+              {/* No amounts entered yet — lead with the pipeline strength, not $0. */}
+              <div className="mt-1 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                <span className="text-5xl font-black leading-none text-bauhaus-black">{summary.total}</span>
+                <span className="text-sm font-black uppercase tracking-widest text-bauhaus-muted">buyers in the pipeline</span>
+                <span className="text-3xl font-black leading-none text-bauhaus-blue">{summary.open}</span>
+                <span className="text-sm font-black uppercase tracking-widest text-bauhaus-muted">open conversations</span>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2 text-[11px] font-bold">
+                <span className="border-2 border-bauhaus-black bg-white px-2 py-0.5">
+                  {summary.withGhl}/{summary.total} linked to GHL
+                </span>
+              </div>
+              <div className="mt-2 border-t-2 border-bauhaus-black/10 pt-2 text-[10px] font-bold text-bauhaus-muted">
+                No revenue or ask amounts recorded yet — enter asks and lifetime revenue in the warmth registry to size the
+                pipeline. Cash received reconciles against Xero (the source of truth).
+              </div>
+            </>
+          )}
         </div>
 
         {/* secondary stat row */}
         <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Stat label="Buyers" value={String(summary.total)} accent />
           <Stat label="Open conversations" value={String(summary.open)} />
-          <Stat label="Revenue received" value={money(summary.totalReceived)} detail="Warmth registry, manually entered" />
+          <Stat label="Revenue received" value={money(summary.totalReceived)} detail={summary.totalReceived > 0 ? 'Warmth registry, manually entered' : 'None recorded yet'} />
           <Stat label="With GHL link" value={`${summary.withGhl}/${summary.total}`} />
         </div>
 

--- a/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
@@ -3,7 +3,11 @@ import { notFound } from 'next/navigation';
 import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsBuyerPipeline, type BuyerPipelineRow } from '@/lib/services/goods-buyer-pipeline';
+import { getGoodsRelationshipPower, type RelationshipPower } from '@/lib/services/goods-relationship-power';
+import { getGoodsRelationshipFunding, type RelationshipFunding } from '@/lib/services/goods-relationship-funding';
 import { GoodsSubNav } from '../_components/goods-sub-nav';
+import { PowerChip } from '../_components/goods-power-chip';
+import { FundingChip } from '../_components/goods-funding-chip';
 import {
   money, moneyShort, relDays, STAGE_LABEL, bandPill,
 } from '@/lib/services/goods-engagement-shared';
@@ -44,7 +48,7 @@ function dueDate(iso: string | null): { label: string; overdue: boolean } | null
   return { label: `due ${date} · in ${days}d`, overdue: false };
 }
 
-function BuyerCard({ r }: { r: BuyerPipelineRow }) {
+function BuyerCard({ r, power, funding }: { r: BuyerPipelineRow; power: RelationshipPower | null; funding: RelationshipFunding | null }) {
   const due = dueDate(r.nextActionDue);
   return (
     <div className="flex flex-wrap items-start gap-x-4 gap-y-2 border-b border-bauhaus-black/10 px-3 py-3 last:border-b-0">
@@ -63,6 +67,8 @@ function BuyerCard({ r }: { r: BuyerPipelineRow }) {
               No GHL signal
             </span>
           )}
+          <PowerChip power={power} />
+          <FundingChip funding={funding} />
         </div>
 
         <div className="mt-0.5 text-[12px] text-bauhaus-muted">
@@ -113,7 +119,11 @@ export default async function GoodsBuyersPage({
   const profile = shouldUseFastLocalOrg() && isActSlug(slug) ? ACT_FAST_PROFILE : await getOrgProfileBySlug(slug);
   if (!profile) notFound();
 
-  const { rows, summary, fetchError } = await getGoodsBuyerPipeline();
+  const [{ rows, summary, fetchError }, powerMap, fundingMap] = await Promise.all([
+    getGoodsBuyerPipeline(),
+    getGoodsRelationshipPower(),
+    getGoodsRelationshipFunding(),
+  ]);
   const openOnly = filter === 'open';
   const shown = openOnly ? rows.filter((r) => r.isOpen) : rows;
 
@@ -200,7 +210,7 @@ export default async function GoodsBuyersPage({
           </div>
         ) : (
           <div className="border-4 border-bauhaus-black bg-white">
-            {shown.map((r) => <BuyerCard key={r.id} r={r} />)}
+            {shown.map((r) => <BuyerCard key={r.id} r={r} power={powerMap.get(r.id) ?? null} funding={fundingMap.get(r.id) ?? null} />)}
           </div>
         )}
 

--- a/apps/web/src/app/org/[slug]/goods/campaign/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/campaign/page.tsx
@@ -165,7 +165,7 @@ export default async function GoodsCampaignPage({ params }: { params: Promise<{ 
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Match Campaign</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/communities/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/communities/page.tsx
@@ -63,7 +63,7 @@ export default async function GoodsCommunitiesHubPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/wiki/goods-operating-system`} className="hover:text-white">Goods OS</Link>
+            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Communities</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/communities/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/communities/page.tsx
@@ -63,7 +63,7 @@ export default async function GoodsCommunitiesHubPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Communities</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
@@ -66,7 +66,7 @@ export default async function GoodsCommunityPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <Link href={`/org/${slug}/wiki/goods-signals`} className="hover:text-white">Signals</Link>
             <span>/</span>

--- a/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
@@ -66,7 +66,7 @@ export default async function GoodsCommunityPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/wiki/goods-operating-system`} className="hover:text-white">Goods OS</Link>
+            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <Link href={`/org/${slug}/wiki/goods-signals`} className="hover:text-white">Signals</Link>
             <span>/</span>

--- a/apps/web/src/app/org/[slug]/goods/engagement/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/engagement/page.tsx
@@ -65,7 +65,7 @@ export default async function GoodsEngagementPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Engagement</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/foundations/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/foundations/page.tsx
@@ -55,7 +55,7 @@ export default async function GoodsFoundationsPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Foundations</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/funnel/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/funnel/page.tsx
@@ -75,7 +75,7 @@ export default async function GoodsFunnelPage({ params }: { params: Promise<{ sl
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Funnel</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/funnel/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/funnel/page.tsx
@@ -75,7 +75,7 @@ export default async function GoodsFunnelPage({ params }: { params: Promise<{ sl
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/wiki/goods-operating-system`} className="hover:text-white">Goods OS</Link>
+            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Funnel</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/governance/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/governance/page.tsx
@@ -345,7 +345,7 @@ export default async function GoodsGovernancePage({ params }: { params: Promise<
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Governance</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/insight/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/insight/page.tsx
@@ -209,7 +209,7 @@ export default async function GoodsInsightPage({
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Funder Insight</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/insight/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/insight/page.tsx
@@ -3,11 +3,12 @@ import { notFound } from 'next/navigation';
 import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsFunderInsight } from '@/lib/services/goods-funder-insight';
-import { getGoodsRelationshipPower, powerBand, type RelationshipPower } from '@/lib/services/goods-relationship-power';
+import { getGoodsRelationshipPower, type RelationshipPower } from '@/lib/services/goods-relationship-power';
 import { getGoodsRelationshipFunding, type RelationshipFunding } from '@/lib/services/goods-relationship-funding';
 import { TEMP_LABEL, temperatureTone, type FunderInsight, type InsightFlag } from '@/lib/services/goods-funder-insight-shared';
 import { relDays, money, moneyShort } from '@/lib/services/goods-engagement-shared';
 import { GoodsSubNav } from '../_components/goods-sub-nav';
+import { PowerChip } from '../_components/goods-power-chip';
 import { FundingChip } from '../_components/goods-funding-chip';
 
 export const dynamic = 'force-dynamic';
@@ -94,30 +95,6 @@ function FramingBlock({ framing }: { framing: FunderInsight['framing'] }) {
         <div className="mt-0.5 text-[10px] font-bold text-bauhaus-muted">Contact: {framing.primary_contact}</div>
       )}
     </div>
-  );
-}
-
-/**
- * Cross-system power chip — how embedded this funder is across the 7 power
- * systems, and whether they sit in the revolving-door set. A high-reach yes
- * carries weight and opens doors; it is also a public profile worth knowing
- * before we attach the Goods name. Detail on hover. Renders nothing without signal.
- */
-function PowerChip({ power }: { power: RelationshipPower | null }) {
-  if (!power || power.systemCount < 1) return null;
-  const band = powerBand(power);
-  const tone =
-    band === 'high' ? 'bg-bauhaus-black text-bauhaus-yellow'
-    : band === 'notable' ? 'bg-bauhaus-blue text-white'
-    : 'bg-bauhaus-canvas text-bauhaus-muted';
-  const rd = power.revolvingDoor ? ` · revolving door (${power.vectors.join(', ')})` : '';
-  return (
-    <span
-      className={`px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest ${tone}`}
-      title={`Cross-system reach: ${power.systems.join(', ') || 'none'}${rd}`}
-    >
-      Power {power.systemCount}/7{power.revolvingDoor ? ' · RD' : ''}
-    </span>
   );
 }
 

--- a/apps/web/src/app/org/[slug]/goods/intros/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/intros/page.tsx
@@ -40,7 +40,7 @@ export default async function GoodsIntrosPage({ params }: { params: Promise<{ sl
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Warm Intros</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/money/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/money/page.tsx
@@ -74,7 +74,7 @@ export default async function GoodsMoneyPage({ params }: { params: Promise<{ slu
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Money</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/page.tsx
@@ -1,0 +1,192 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import { getGoodsFunnel } from '@/lib/services/goods-funnel';
+import { getGoodsMoney } from '@/lib/services/goods-money';
+import { getGoodsBuyerPipeline } from '@/lib/services/goods-buyer-pipeline';
+import { GoodsSubNav, type GoodsTab } from './_components/goods-sub-nav';
+
+/**
+ * Goods Command Center — the front door (G1).
+ * A "start here" index: one-glance state of the workspace (need / delivered / gap,
+ * money received + in play, buyers in pipeline) reusing the same services the tabs
+ * use, then signposts into the high-value destinations. Degrades gracefully — a
+ * failed service shows a dash, never 500s the page (shared DB can saturate).
+ */
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  return {
+    title: 'Goods — Command Center',
+    description: 'The Goods workspace: move procurement and funder relationships forward, and prove the work to buyers and funders.',
+  };
+}
+
+const money = (n: number | null | undefined) => `$${Math.round(n || 0).toLocaleString('en-AU')}`;
+const moneyShort = (n: number | null | undefined) => {
+  const v = Number(n) || 0;
+  if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(v % 1_000_000 === 0 ? 0 : 1)}M`;
+  if (v >= 1_000) return `$${Math.round(v / 1_000)}K`;
+  return `$${Math.round(v)}`;
+};
+const num = (n: number | null | undefined) => (n || 0).toLocaleString('en-AU');
+
+/** A headline summary cell — big value, small label, optional sub. */
+function Cell({ value, label, sub, accent }: { value: string; label: string; sub?: string; accent?: boolean }) {
+  return (
+    <div className={`border-4 ${accent ? 'border-bauhaus-blue bg-link-light' : 'border-bauhaus-black bg-white'} p-3`}>
+      <div className="text-2xl font-black leading-none text-bauhaus-black">{value}</div>
+      <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">{label}</div>
+      {sub && <div className="mt-0.5 text-[10px] font-bold text-bauhaus-muted">{sub}</div>}
+    </div>
+  );
+}
+
+/** A "start here" destination card — links into a tab, with a one-line job + live stat. */
+function Dest({ slug, tab, title, blurb, stat }: { slug: string; tab: GoodsTab; title: string; blurb: string; stat?: string }) {
+  return (
+    <Link
+      href={`/org/${slug}/goods/${tab}`}
+      className="group flex flex-col border-4 border-bauhaus-black bg-white p-4 transition-shadow hover:shadow-[6px_6px_0_0_var(--bauhaus-black)]"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm font-black uppercase tracking-widest text-bauhaus-black">{title}</span>
+        <span className="text-bauhaus-blue transition-transform group-hover:translate-x-0.5">→</span>
+      </div>
+      <p className="mt-1 text-[13px] leading-snug text-bauhaus-muted">{blurb}</p>
+      {stat && <div className="mt-2 text-[11px] font-black uppercase tracking-widest text-bauhaus-blue">{stat}</div>}
+    </Link>
+  );
+}
+
+export default async function GoodsHubPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const profile = shouldUseFastLocalOrg() && isActSlug(slug) ? ACT_FAST_PROFILE : await getOrgProfileBySlug(slug);
+  if (!profile) notFound();
+
+  // Reuse the tabs' own services. allSettled so one saturated query can't 500 the front door.
+  const [funnelR, moneyR, buyersR] = await Promise.allSettled([
+    getGoodsFunnel(),
+    getGoodsMoney(),
+    getGoodsBuyerPipeline(),
+  ]);
+  const f = funnelR.status === 'fulfilled' ? funnelR.value : null;
+  const m = moneyR.status === 'fulfilled' ? moneyR.value : null;
+  const b = buyersR.status === 'fulfilled' ? buyersR.value : null;
+
+  const dash = '—';
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
+      <div className="border-b-4 border-bauhaus-black bg-bauhaus-black text-white">
+        <div className="mx-auto max-w-7xl px-4 py-8">
+          <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
+            <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
+            <span>/</span>
+            <span className="text-white">Goods</span>
+          </nav>
+          <h1 className="text-4xl font-black uppercase tracking-widest">Goods Command Center</h1>
+          <p className="mt-2 max-w-3xl text-sm text-gray-300">
+            One workspace for the Goods on Country arm. <strong className="text-white">Work the pipeline</strong> to move
+            procurement and funder relationships forward, and <strong className="text-white">show the evidence</strong> to
+            prove the work to buyers and funders. Start with the state below, then jump in.
+          </p>
+          <GoodsSubNav slug={slug} />
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        {/* ── STATE OF GOODS — one-glance summary ─────────────────────── */}
+        <div className="mb-2 text-xs font-black uppercase tracking-widest text-bauhaus-black">State of Goods</div>
+        <div className="mb-2 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <Cell
+            value={f ? `${num(f.delivered.beds)}` : dash}
+            label="Beds delivered"
+            sub="On Country to date"
+          />
+          <Cell
+            value={f ? `${num(f.gap.beds)}` : dash}
+            label="Bed gap"
+            sub="Need not yet met — the ask"
+            accent
+          />
+          <Cell
+            value={m ? money(m.lifetimeReceived) : dash}
+            label="Received (lifetime)"
+            sub="All tracks, registry + Xero"
+          />
+          <Cell
+            value={m ? moneyShort(m.pipeline.openAskTotal) : dash}
+            label="In play"
+            sub={m ? `${moneyShort(m.pipeline.weightedPipeline)} stage-weighted` : 'Open funder + investor asks'}
+            accent
+          />
+          <Cell
+            value={b ? `${num(b.summary.total)}` : dash}
+            label="Buyers in pipeline"
+            sub={b ? `${b.summary.open} open · procurement track` : 'Procurement track'}
+          />
+        </div>
+        <p className="mb-6 text-[11px] text-bauhaus-muted">
+          {f
+            ? <>Against an addressable need of {num(f.addressable.beds)} beds across {num(f.addressable.communities)} communities. Procurement (earned revenue) is tracked separately from grant + investment.</>
+            : <span className="text-bauhaus-red">Live workspace data is briefly unavailable — figures will populate on refresh.</span>}
+        </p>
+
+        {/* ── START HERE — high-value destinations ────────────────────── */}
+        <div className="mb-2 mt-8 text-xs font-black uppercase tracking-widest text-bauhaus-black">Work the pipeline</div>
+        <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Dest
+            slug={slug} tab="buyers" title="Buyer Pipeline"
+            blurb="Advance procurement deals — warmth, stage, and the next move per buyer."
+            stat={b ? `${b.summary.total} buyers · ${b.summary.open} open` : undefined}
+          />
+          <Dest
+            slug={slug} tab="money" title="Money"
+            blurb="What Goods has received, what's in play, and what's available to pursue."
+            stat={m ? `${money(m.lifetimeReceived)} in · ${moneyShort(m.pipeline.openAskTotal)} in play` : undefined}
+          />
+          <Dest
+            slug={slug} tab="engagement" title="Warmth Map"
+            blurb="Every relationship by warmth, with the next action to advance it."
+          />
+          <Dest
+            slug={slug} tab="funnel" title="Funnel"
+            blurb="The need-to-delivery model across all three pipelines, on one spine."
+            stat={f ? `${num(f.gap.beds)} bed gap` : undefined}
+          />
+        </div>
+
+        <div className="mb-2 text-xs font-black uppercase tracking-widest text-bauhaus-black">Show the evidence</div>
+        <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Dest
+            slug={slug} tab="proof" title="Proof Pack"
+            blurb="The evidence we already hold, assembled for philanthropy and lenders. Export-ready."
+            stat={f ? `${num(f.delivered.beds)} beds verified` : undefined}
+          />
+          <Dest
+            slug={slug} tab="pitch" title="Pitch"
+            blurb="The canonical, claim-labelled proposition. Every deck and email derives from it."
+          />
+          <Dest
+            slug={slug} tab="foundations" title="Foundations"
+            blurb="Aligned foundations and the giving that matches the Goods wheelhouse."
+          />
+          <Dest
+            slug={slug} tab="governance" title="Governance"
+            blurb="Board, belonging, and the connection showcase behind the work."
+          />
+        </div>
+
+        <div className="mt-8 border-4 border-bauhaus-black bg-bauhaus-yellow p-4 text-xs">
+          This is the front door to the Goods workspace. The full set of areas is in the two rows above
+          (<strong>work the pipeline</strong> and <strong>show the evidence</strong>). Figures here are pulled live from the
+          same registries the tabs use — the warmth registry, the finance ledger (Xero is the source of truth for cash),
+          and the Goods asset register.
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/org/[slug]/goods/pitch/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/pitch/page.tsx
@@ -81,7 +81,7 @@ export default async function GoodsPitchPage({ params }: { params: Promise<{ slu
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Pitch</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/proof/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/proof/page.tsx
@@ -130,7 +130,7 @@ export default async function GoodsProofPage({ params }: { params: Promise<{ slu
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Proof Pack</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/signals/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/signals/page.tsx
@@ -81,7 +81,7 @@ export default async function GoodsSignalsPage({ params }: { params: Promise<{ s
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Signals</span>
           </nav>

--- a/apps/web/src/app/org/[slug]/goods/timeline/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/timeline/page.tsx
@@ -132,7 +132,7 @@ export default async function GoodsTimelinePage({ params }: { params: Promise<{ 
           <nav className="mb-4 flex flex-wrap items-center gap-2 text-sm text-gray-400">
             <Link href={`/org/${slug}`} className="hover:text-white">{profile.name}</Link>
             <span>/</span>
-            <Link href={`/org/${slug}/goods/funnel`} className="hover:text-white">Goods</Link>
+            <Link href={`/org/${slug}/goods`} className="hover:text-white">Goods</Link>
             <span>/</span>
             <span className="text-white">Timeline</span>
           </nav>

--- a/apps/web/src/app/power/client.tsx
+++ b/apps/web/src/app/power/client.tsx
@@ -83,6 +83,8 @@ export function PowerPageClient() {
   const [foundations, setFoundations] = useState<any>(null);
   const [boardPower, setBoardPower] = useState<any[]>([]);
   const [boardPowerTotal, setBoardPowerTotal] = useState(0);
+  const [holders, setHolders] = useState<any[]>([]);
+  const [holdersTotal, setHoldersTotal] = useState(0);
 
   useEffect(() => {
     fetch('/api/power/health').then(r => r.json()).then(d => {
@@ -98,6 +100,12 @@ export function PowerPageClient() {
       if (!d.error) {
         setBoardPower(d.results || []);
         setBoardPowerTotal(d.total || 0);
+      }
+    }).catch(() => {});
+    fetch('/api/power/holders').then(r => r.json()).then(d => {
+      if (!d.error) {
+        setHolders(d.holders || []);
+        setHoldersTotal(d.total || 0);
       }
     }).catch(() => {});
   }, []);
@@ -302,6 +310,93 @@ export function PowerPageClient() {
                   </div>
                 </div>
               ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── Power Holders (cross-system, de-collided) ── */}
+      {holders.length > 0 && (
+        <section className="px-4 sm:px-6 lg:px-8 pb-12">
+          <div className="max-w-7xl mx-auto">
+            <div className="mb-3">
+              <h2 className="text-2xl font-black text-bauhaus-black">Power Holders</h2>
+              <p className="text-sm text-bauhaus-muted font-medium mt-1">
+                {holdersTotal.toLocaleString()} people sit across two or more money systems — government procurement,
+                justice funding, and political donations — through the boards they govern. Dollars are each
+                person&apos;s <span className="font-bold text-bauhaus-black">attributed share</span>, split evenly
+                across an organisation&apos;s directors, then annotated with the foundations backing those organisations.
+              </p>
+            </div>
+            <div className="border-4 border-bauhaus-black bg-white overflow-hidden overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-bauhaus-black text-white">
+                    <th className="text-left px-4 py-2 text-[10px] font-black uppercase tracking-widest">#</th>
+                    <th className="text-left px-4 py-2 text-[10px] font-black uppercase tracking-widest">Person</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Boards</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Systems</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Procurement</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Justice</th>
+                    <th className="text-right px-4 py-2 text-[10px] font-black uppercase tracking-widest">Donations</th>
+                    <th className="text-left px-4 py-2 text-[10px] font-black uppercase tracking-widest">Backed By</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {holders.map((p: any, i: number) => (
+                    <tr key={i} className={`border-b border-gray-100 hover:bg-blue-50/30 ${p.acco_boards > 0 ? 'bg-green-50/40' : i % 2 === 0 ? 'bg-white' : 'bg-gray-50/30'}`}>
+                      <td className="px-4 py-2 text-bauhaus-muted font-medium align-top">{i + 1}</td>
+                      <td className="px-4 py-2 align-top">
+                        <div className="font-bold text-bauhaus-black">{p.person_name}</div>
+                        {(p.top_boards || []).length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {(p.top_boards || []).map((b: string, j: number) => (
+                              <span key={j} className="text-[9px] font-bold bg-bauhaus-canvas text-bauhaus-muted px-1.5 py-0.5 border border-bauhaus-black/10">
+                                {(b || '').length > 32 ? (b || '').substring(0, 32) + '...' : b}
+                              </span>
+                            ))}
+                            {p.acco_boards > 0 && (
+                              <span className="text-[9px] font-black uppercase tracking-widest text-green-700 bg-green-100 px-1.5 py-0.5">ACCO</span>
+                            )}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-right align-top">
+                        <span className="inline-flex items-center justify-center w-7 h-7 bg-bauhaus-black text-white font-black text-sm">
+                          {p.board_count}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2 text-right font-black text-bauhaus-black align-top">{p.financial_system_count}<span className="text-bauhaus-muted font-medium">/3</span></td>
+                      <td className="px-4 py-2 text-right font-medium align-top">{Number(p.attributed_procurement) > 0 ? money(Number(p.attributed_procurement)) : '—'}</td>
+                      <td className="px-4 py-2 text-right font-medium align-top">{Number(p.attributed_justice) > 0 ? money(Number(p.attributed_justice)) : '—'}</td>
+                      <td className="px-4 py-2 text-right font-medium align-top" style={{ color: Number(p.attributed_donations) > 0 ? '#D02020' : undefined }}>
+                        {Number(p.attributed_donations) > 0 ? money(Number(p.attributed_donations)) : '—'}
+                      </td>
+                      <td className="px-4 py-2 align-top">
+                        {(p.foundation_backers || []).length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {(p.foundation_backers || []).map((fnd: string, j: number) => (
+                              <span key={j} className="text-[9px] font-bold text-bauhaus-red border border-bauhaus-red/40 bg-red-50 px-1.5 py-0.5">
+                                {(fnd || '').replace(/^The Trustee For (The )?/i, '').replace(/ (Limited|Ltd)$/i, '')}
+                              </span>
+                            ))}
+                            {(p.funder_count || 0) > (p.foundation_backers || []).length && (
+                              <span className="text-[9px] text-bauhaus-muted font-bold">+{p.funder_count - (p.foundation_backers || []).length}</span>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-bauhaus-muted/50 text-xs">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-bauhaus-muted font-medium">
+              <span className="inline-flex items-center gap-1"><span className="w-3 h-3 bg-green-100 border border-green-300 inline-block" /> Sits on a community-controlled board</span>
+              <span className="inline-flex items-center gap-1"><span className="w-3 h-3 bg-red-50 border border-bauhaus-red/40 inline-block" /> Foundation backing the orgs they govern</span>
+              <span>Dollars = even-split personal share across co-directors (not weighted by role/tenure). Names are board-derived; same-named individuals may merge.</span>
             </div>
           </div>
         </section>

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from 'next';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://civicgraph.com.au';
+// See sitemap.ts — civicgraph.com.au does not resolve, civicgraph.app is the
+// real production domain.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://civicgraph.app';
 
 /**
  * Open robots policy for the accountability atlas.

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,7 +1,10 @@
 import type { MetadataRoute } from 'next';
 import { getServiceSupabase } from '@/lib/supabase';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://civicgraph.com.au';
+// civicgraph.com.au does not resolve — civicgraph.app is the real, live production
+// domain (confirmed via Vercel Firewall traffic + direct request). NEXT_PUBLIC_SITE_URL
+// isn't set in production, so this fallback was what every crawler actually received.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://civicgraph.app';
 const MAX_ENTITIES_IN_SITEMAP = 5000;
 
 export const dynamic = 'force-dynamic';

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -17,7 +17,23 @@ function safeRedirectPath(value: string | null, fallback = '/home') {
   return value;
 }
 
+// The bare production Vercel alias (not preview-deployment URLs, which still
+// need to work for QA) was taking ~30k req/day in Firewall data — traffic
+// hitting the project directly rather than discovering it via civicgraph.app.
+// Redirecting it to the canonical domain costs nothing and isn't linked from
+// anywhere we control, so this only affects whoever already found it.
+const BARE_VERCEL_PRODUCTION_HOST = 'grantscope.vercel.app';
+const CANONICAL_HOST = 'civicgraph.app';
+
 export async function middleware(request: NextRequest) {
+  if (request.headers.get('host') === BARE_VERCEL_PRODUCTION_HOST) {
+    const url = request.nextUrl.clone();
+    url.hostname = CANONICAL_HOST;
+    url.protocol = 'https';
+    url.port = '';
+    return NextResponse.redirect(url, 308);
+  }
+
   // Expose the pathname to server components so the root layout can
   // conditionally skip chrome (nav/footer) for iframe-embed routes.
   const requestHeaders = new Headers(request.headers);

--- a/docs/goods-command-center-ux-findings.md
+++ b/docs/goods-command-center-ux-findings.md
@@ -133,6 +133,13 @@ Reading the code (not just the render) showed these three "small wins" are delib
 
 ---
 
+### G1-DONE · the hub front door is built · shot `audit-08-hub.jpeg`
+New `apps/web/src/app/org/[slug]/goods/page.tsx` — "Goods Command Center". Reuses the funnel/money/buyers services (Ben's call: reuse the funnel cockpit) behind `Promise.allSettled` so a saturated query shows a dash, never 500s the front door. Renders a live **STATE OF GOODS** strip (520 beds delivered · 11,984 bed gap · $895,611 received · $3.3M in play · 117 buyers — all matching the tabs) and two "start here" card groups (Work the pipeline / Show the evidence) with live per-destination stats. `GoodsSubNav.active` made optional so the hub highlights no tab. **Reachability:** all 15 "Goods" breadcrumb crumbs re-pointed `/goods/funnel` → `/goods` (the hub now has a handle from every tab). **Verified live** in `audit-08`. Resolves G1 + answers G2 (the hub IS the daily driver / orientation; the two nav rows are the spine).
+
+---
+
 ## Decisions only Ben can make
-- **G1 — RESOLVED (Ben, 2026-06-22):** build a NEW overview/hub page at `/org/act/goods`. Content: workspace summary with key signals (pipeline value, warmth, money, proof count) + clear links into the 14 tabs. A proper "start here." (Implement in the fix phase, after the visual pass.)
-- **G2 — OPEN:** which tab(s) are the daily driver (informs IA hierarchy / what to demote, and what the new hub foregrounds). Answer during the visual pass.
+- **G1 — DONE (2026-06-22):** hub built (see G1-DONE above).
+- **G2 — ANSWERED:** the workspace spine is the two-row split (Work the pipeline / Show the evidence) surfaced in `goods-sub-nav`; the new hub is the orientation/daily-driver front door. No tab needs demoting.
+- **B3 GRANT (Tier 3):** apply `GRANT SELECT ON v_goods_relationship_power, v_goods_relationship_funding TO anon, authenticated, service_role;` to light up the power/funding chips on buyer cards.
+- **P2 / P3 / Pr1:** held as design intent (cent precision, "QBE", proof card colours) — confirm or adjust at leisure.

--- a/docs/goods-command-center-ux-findings.md
+++ b/docs/goods-command-center-ux-findings.md
@@ -1,0 +1,138 @@
+# Goods Command Center — UX findings (`/polish`)
+
+**Surface:** `/org/act/goods/*` (ACT org Goods workspace) · **Started:** 2026-06-22 · **Mode:** audit-first
+**Method:** dev server :3003 (running, reused); ACT slug renders without login via the `shouldUseFastLocalOrg()` bypass in `org/[slug]/layout.tsx` → screenshots feasible. Rubric: Clarity / Value-shown / Meaning / Aesthetic / Friction (see `.claude/skills/polish/references/rubric.md`).
+
+> ## ▶ RESUME HERE (after `/clear`)
+> Phase 1 structural pass done (G1–G3 below). **Next: the VISUAL pass** — re-invoke `/polish` on the Goods command center.
+> 1. Confirm dev server on :3003 is up (`curl -s -o /dev/null -w "%{http_code}" --max-time 60 http://localhost:3003/org/act/goods/buyers` → 200). It was already running (pid 52483, not ours — leave it).
+> 2. Screenshot each tab in the priority order below (1280×900 → `docs/ux-audit/shots/`), judge against the 5 dims, append per-tab findings. One tab per iteration; self-pace.
+> 3. **Then fix phase:** G1 is DECIDED → build a NEW Goods overview/hub page at `/org/act/goods` (summary: pipeline value, warmth, money, proof count + clear links into the 14 tabs). Plus G2/G3.
+
+## The surface is bigger than remembered — 14 tabs (memory said 9)
+Routes under `apps/web/src/app/org/[slug]/goods/`:
+`buyers` · `campaign` · `communities` (+ `community/[communityId]`) · `engagement` · `foundations` · `funnel` · `governance` · `insight` · `intros` · `money` · `pitch` · `proof` · `signals` · `timeline`
+
+## Visual-audit plan (outside-in: revenue/buyer-first per the wedge)
+One screen per iteration; screenshot logged-in ACT view at 1280×900 → `docs/ux-audit/shots/`. Priority order:
+1. `buyers` (Buyer Pipeline — the revenue surface) · 2. `funnel` · 3. `pitch` · 4. `proof` (evidence = value-shown core) · 5. `money` · 6. `foundations` · 7. `intros` · 8. `signals` · 9. `timeline` · 10. `governance` · 11. `insight` · 12. `engagement` · 13. `campaign` · 14. `communities`
+
+---
+
+## Phase 1 — Findings (append only; never rewrite prior passes)
+
+### Structural (caught pre-screenshot, from routes + rendered HTML)
+
+**G1 — No Goods hub / front-door** · *Clarity* · **M**
+There is no `/org/[slug]/goods/page.tsx`. `/org/act/goods` has no landing page — a user must deep-link straight into a tab (e.g. `/goods/buyers`). No orientation, no "start here", no summary of the 9–14 areas. The workspace has no front door. → Decide: add a hub/overview page, or designate one tab as the canonical landing + redirect.
+
+**G2 — 14-tab sprawl, no obvious spine** · *Clarity / Friction* · **M–L** *(confirm visually)*
+14 tabs is heavy cognitive load for a command center. Unclear which is the primary action / daily driver vs. reference. Outside-in question to answer at screenshot time: *does a first-time user know what to do first, or is it a wall of equally-weighted tabs?*
+
+**G3 — Nav likely duplicated, not shared** · *Aesthetic / consistency* · **M**
+38 `href=.../goods/<tab>` link sites across `.tsx` files, with tab links appearing inside individual page files (`intros`, `signals`, `pitch`, `timeline`…). Suggests the tab nav is repeated per-page rather than one shared `<GoodsNav>` — the same drift risk as the rubric's "three different hero systems" class. → Confirm whether a single nav component exists; if not, that's a consolidation fix.
+
+### Per-tab visual findings
+
+## Phase 1b — Visual pass (2026-06-22)
+Logged-in ACT view, 1280×900, shots in `docs/ux-audit/shots/` (also repo-root `audit-NN-*.jpeg`). One tab per iteration, outside-in.
+
+---
+
+### TAB 1 — `buyers` (Buyer Pipeline) · shot: `audit-01-buyers-top.jpeg`
+Confirms G3 is largely resolved: the page uses the shared `goods-sub-nav` with a smart two-row split — **WORK THE PIPELINE** (Warmth Map · Funder Insight · Signals · Timeline · Money · Buyer Pipeline · Match Campaign · Funnel) and **SHOW THE EVIDENCE** (Proof Pack · Pitch · Warm Intros · Foundations · Governance). That split is a real spine — it answers part of G2 (pipeline-work vs evidence are the two jobs).
+
+**B1. The revenue surface leads with `$0 · $0 · $0` · M · 🔴 top**
+The hero band (largest element on the page) reads **`$0 RECEIVED (LIFETIME)` · `$0 OPEN ASKS` · `Expected (stage-weighted) $0`**, and a stat card repeats **`REVENUE RECEIVED $0`**. Verified in DB (not a broken rollup, so honest — no `/ground` HOLD): all 117 `buyer` rows in `goods_relationships` have `ask_amount_aud = 0` and `total_received_aud = 0`. (Funders DO carry amounts: $3.51M ask / $895K received — so the money model works, buyers just have no amounts entered.) Result: the most-built surface's first impression is three giant zeros = looks empty/broken. *Value-shown + Meaning miss.*
+**Fix direction:** make the money hero conditional. When received & asks are both 0, drop the three-zero hero and lead with the signal that DOES exist — **117 buyers · 117 open conversations · 114/117 GHL-linked · warmth scores** — with a quiet "no $ amounts recorded yet → add asks" empty-state line, not a definitive `$0 RECEIVED (LIFETIME)`. (Same class as P2-8 empty-state-hides-the-path.)
+
+**B2. Hero band is a blue fill · S · aesthetic**
+The summary band uses a blue border + light-blue fill (`bauhaus-blue` family) as the page's hero element, and `$0 OPEN ASKS` is rendered in hero blue. DESIGN.md/rubric: **blue is link/accent, never a hero fill** (P2-6 class). Black fill + blue hard-shadow is the house hero. Low priority; fold into the B1 rework.
+
+**B3. 2 console errors on the revenue surface · S · friction (unchecked)**
+Playwright reported 2 console errors + a floating "2 Issues" chip on load. Not yet diagnosed — flag to check they aren't a failing buyer-data query (would turn B1 from "honest empty" into "broken"). Cheap to verify.
+
+---
+
+### TAB 2 — `funnel` (Goods Funnel) · shot: `audit-02-funnel-top.jpeg`
+**Strongest surface in the workspace so far.** Clear thesis ("one need, two funding routes, one delivery"), a COCKPIT strip (NEED 12,504 beds → ORDERED → FUNDED → DELIVERED 520 → GAP 11,984), and a 3-column pipeline (Need / Procurement / Support) all collapsed to one consistent 5-stage spine (IDENTIFIED→QUALIFIED→COMMITTED→DELIVERING→CLOSED→DEAD). High clarity, strong value-shown (the gap is the meaningful number and it's front-and-centre).
+
+**Fn0. The funnel cockpit already IS the G1 hub — DECISION for Ben · architecture**
+This page does exactly what the proposed `/org/act/goods` front-door should do: one-glance summary + links into the spine. Options: (a) build the new hub by reusing this cockpit component; (b) promote `funnel` toward the front door and make the hub a thin wrapper; (c) keep them separate (hub = workspace index, funnel = need→delivery model). → Ben's call; folds into G1.
+
+**Fn1. Breadcrumb / workspace name drifts: "Goods OS" vs "Goods" · S · aesthetic/consistency**
+Funnel breadcrumb = "A Curious Tractor / **Goods OS** / Funnel"; buyers breadcrumb = "A Curious Tractor / **Goods** / Buyers & Procurement". Same workspace, two names one click apart. Pick one (Goods / Goods OS / Goods on Country) and use it in every breadcrumb + nav label.
+
+**Fn2. "Delivered is a cited constant — Goods v2 assets sync" jargon · S · meaning**
+The DELIVERED provenance note uses internal jargon ("cited constant", "v2 assets sync"). Honest but opaque to anyone but us. Reframe plainly ("520 beds delivered to date · last synced 27 May 2026") or move to a tooltip.
+
+---
+
+### TAB 3 — `pitch` (Pitch / source-of-truth) · shot: `audit-03-pitch-top.jpeg`
+Most DESIGN.md-aligned surface so far. The **CLAIM TAXONOMY** legend (VERIFIED blue / MODELLED yellow / TARGET / FUTURE) surfaces the provenance system as a first-class element — strong Meaning/honesty, exactly the "value-shown" the rubric rewards. THE SPINE is a single quotable proposition paragraph. Breadcrumb here = "Goods" (matches buyers, not funnel → confirms Fn1).
+
+**P1. The spine is built to be quoted but likely has no copy affordance · M · friction**
+Copy says "Every deck, email and one-pager should derive from this" / "Quote it whole." If there's no one-click **Copy the spine** button (and per-stat copy), the thing explicitly designed to be pasted into decks/emails isn't one-click — the P2-7 friction class. Confirm in `pitch/page.tsx`; if absent, add copy-to-clipboard on the spine paragraph.
+
+**P2. `$650,910.79` cent-precision inside the quotable spine · S · meaning/aesthetic**
+Receivables shown to the cent in a proposition meant to be quoted whole reads like a raw DB figure, not a crafted pitch line. Round in the spine ("$650K+ of receivables") while keeping the exact figure in the governed claim detail. House-style call → Ben.
+
+**P3. "QBE" never expanded · S · meaning**
+"QBE-grade", "QBE DIAGNOSTIC AREA 01/04" — acronym unexplained on a surface whose whole point is rigor. Expand once or drop the label. (Recurs on `proof` — same shared CLAIM TAXONOMY component, so a one-place fix.)
+
+---
+
+### TAB 4 — `proof` (Proof Pack / evidence core) · shot: `audit-04-proof-top.jpeg`
+Second-strongest surface. Evidence-first done right: 4 VERIFIED stat cards (496 deployed beds · 9 communities · 2,660 kg HDPE diverted · 4% of demand met / 11,984 unmet), every figure dated "as of", a **PRINT / SAVE AS PDF** export top-right, and copy that earns trust ("Every figure is sourced… Nothing here is invented", links to the live Asset Register). Reuses the same CLAIM TAXONOMY component as pitch (good consolidation).
+
+**Pr1. Stat-card border colours don't follow DESIGN.md semantics · S · aesthetic**
+Cards use red / black / red / yellow borders seemingly decoratively. In the system red = danger/alert, yellow = caution. So "496 DEPLOYED BED UNITS" (a win) sits in a **red** alert-border, while the genuine caution ("4% met · 11,984 unmet") is yellow — only the last is semantically right. Map border colour to meaning (neutral/black for wins, yellow for the gap) or make them uniform.
+
+**Pr2. Two close bed counts: 496 "deployed bed units" vs 520 "internal assets sync" · S · meaning (verify intentional)**
+Proof shows 496 (VERIFIED, as of 2026-06-01) and 520 (assets sync, as of 2026-05-28); funnel's DELIVERED also = 520. Honest (different labels + dates) but invites "which is the real number?" Confirm the labels disambiguate clearly enough, or add a one-line tie ("520 in the asset register; 496 confirmed deployed to homes").
+
+---
+
+### TAB 5 — `money` (Money: Received & Available) · shot: `audit-05-money-top.jpeg`
+**Model financial surface.** Three clean buckets (received / in play / available to pursue), real figures ($3.3M ask · $2.0M stage-weighted expected · $895K received · $651K Xero-paid), procurement kept explicitly separate, and a reconciliation row — **XERO PAID [VERIFIED] $651K vs REGISTRY RECEIVED [MODELLED] $895,611, DELTA $244,611** (red) — that names its own discrepancy. Strong Value-shown + Meaning.
+
+**M1. Money tab is the reference implementation for the B1 fix · (cross-ref, not a defect)**
+Here the $0 procurement is handled exactly right: a quiet "SEPARATE TRACK · Procurement $0 received · $0 open ask · 117 buyers · **Buyer pipeline →**" footnote, NOT a hero. The buyers tab (B1) should adopt this same move — relegate the $0, lead with the count + a cross-link. Copy this pattern rather than inventing a new empty-state.
+
+**M2. CORRECTION to B2 — the light-blue band is a consistent convention, not drift · (downgrade)**
+The light-blue fill band marks "pipeline / in-play / stage-weighted expected" money consistently across `buyers`, `funnel`, and `money`. That's a deliberate convention reading as "blue = information/in-play," defensible under DESIGN.md, **not** the P2-6 saturated-blue-hero violation. So B2 is downgraded: keep the convention, just (a) never let it become a *saturated* blue fill, and (b) on `buyers` the band currently fills with $0 — once B1 makes that band conditional, the blue-band issue resolves itself. No standalone fix needed.
+
+---
+
+## Visual pass — batch 1 complete (5 of 14 tabs: buyers · funnel · pitch · proof · money)
+The revenue + evidence core is audited. Headline: the surface is **mostly strong** — funnel/proof/pitch/money are well-built, honest, on-brand. The one real leak is **B1** (buyers leads with $0×3), and `money` already shows the fix. Remaining 9 tabs (foundations · intros · signals · timeline · governance · insight · engagement · campaign · communities) are batch 2 — lower priority per the outside-in order.
+
+---
+
+## Phase 2 — Fixes applied (2026-06-22) · `cd apps/web && npx tsc --noEmit` = clean (exit 0)
+
+### B1-FIXED · before `audit-01-buyers-top.jpeg` → after `audit-06-buyers-after.jpeg`
+Buyer hero band is now conditional on `hasMoney = totalReceived>0 || openAskTotal>0` (`buyers/page.tsx`). With no amounts entered (current real state) it leads with **`117 BUYERS IN THE PIPELINE · 117 OPEN CONVERSATIONS · 114/117 linked to GHL`** and an honest footnote ("No revenue or ask amounts recorded yet — enter asks and lifetime revenue in the warmth registry to size the pipeline. Cash received reconciles against Xero…"), instead of three giant `$0`s. When amounts exist later, it reverts to the money hero automatically. Secondary "Revenue received" stat caption now reads "None recorded yet" when 0. **Verified live** in `audit-06`.
+
+### Fn1-FIXED · before `audit-02-funnel-top.jpeg` → after `audit-07-funnel-after.jpeg`
+Workspace name unified to **"Goods"** (Ben's call) across the three drifted breadcrumbs (`funnel`, `communities`, `community/[id]`). Also re-pointed those crumbs from `/wiki/goods-operating-system` → `/org/${slug}/goods/funnel` so the "Goods" crumb means one destination everywhere (matches buyers/pitch/proof/money). When the G1 hub ships, flip all "Goods" crumbs `/goods/funnel` → `/goods`. **Verified live** in `audit-07` (crumb now "A Curious Tractor / Goods / Funnel").
+
+### B3-UPGRADED → real bug: power + funding chips silently absent on Buyer Pipeline · L (DB GRANT) · 🔴 · BEN'S CALL (Tier 3)
+The 2–3 console errors were not noise. Confirmed: `permission denied for view v_goods_relationship_power` and `…_funding`. Both views grant SELECT only to `postgres` + `agent_readonly`; the app connects as `anon`/`authenticated`/`service_role` (which the base `goods_relationships` table DOES grant). Result: the **PowerChip + FundingChip** shipped on buyer cards (commits `19b4966`/`f26ac59`) render empty — a built feature invisible on the revenue surface (value-shown miss). The page degrades gracefully (services return empty maps), so it's silent.
+**Fix (Tier 3 — Ben applies in dashboard/psql, not me):**
+```sql
+GRANT SELECT ON v_goods_relationship_power, v_goods_relationship_funding TO anon, authenticated, service_role;
+```
+After granting, the chips should populate (re-screenshot to confirm). Worth auditing whether other recent goods views shipped without the `anon/authenticated/service_role` GRANT.
+
+### P2 / P3 / Pr1 — RECLASSIFIED as design intent, NOT drift (held, not auto-changed)
+Reading the code (not just the render) showed these three "small wins" are deliberate, so per the skill they're routed to Ben rather than batch-applied:
+- **P2 (cent precision `$650,910.79`)** — intentional. `goods-pitch-content.ts:217` literally frames it as "$650,910.79 paid across 17 Xero tranches, **tied to the cent**" — the cents are a rigor/trust signal, not sloppiness. Rounding the spine could weaken it. → Ben: keep, or round only in the prose spine while keeping the exact FACT card?
+- **P3 ("QBE")** — intentional framework term used 5+ times (`QBE-grade`, `QBE Diagnostic Area 01/04`, "the part QBE will not move without", "QBE diagnostic guardrails"). `pitch`/`proof` read as internal governance surfaces, where the framework language is fine. → Ben: is `pitch` ever shown externally? If yes, gloss QBE once; if internal-only, leave it.
+- **Pr1 (proof card border colours)** — intentional dual-audience scheme: red = impact/Country track (DESIGN.md's signature colour), blue = commercial/lender track, yellow = the gap (genuine caution). Coherent with the page's "two audiences" framing. The only subtlety: red also = alert banners on the same page (red does double duty). → Ben: accept the double-duty, or pick a non-red impact accent?
+
+---
+
+## Decisions only Ben can make
+- **G1 — RESOLVED (Ben, 2026-06-22):** build a NEW overview/hub page at `/org/act/goods`. Content: workspace summary with key signals (pipeline value, warmth, money, proof count) + clear links into the 14 tabs. A proper "start here." (Implement in the fix phase, after the visual pass.)
+- **G2 — OPEN:** which tab(s) are the daily driver (informs IA hierarchy / what to demote, and what the new hub foregrounds). Answer during the visual pass.

--- a/docs/goods-command-center-ux-findings.md
+++ b/docs/goods-command-center-ux-findings.md
@@ -3,11 +3,18 @@
 **Surface:** `/org/act/goods/*` (ACT org Goods workspace) · **Started:** 2026-06-22 · **Mode:** audit-first
 **Method:** dev server :3003 (running, reused); ACT slug renders without login via the `shouldUseFastLocalOrg()` bypass in `org/[slug]/layout.tsx` → screenshots feasible. Rubric: Clarity / Value-shown / Meaning / Aesthetic / Friction (see `.claude/skills/polish/references/rubric.md`).
 
-> ## ▶ RESUME HERE (after `/clear`)
-> Phase 1 structural pass done (G1–G3 below). **Next: the VISUAL pass** — re-invoke `/polish` on the Goods command center.
-> 1. Confirm dev server on :3003 is up (`curl -s -o /dev/null -w "%{http_code}" --max-time 60 http://localhost:3003/org/act/goods/buyers` → 200). It was already running (pid 52483, not ours — leave it).
-> 2. Screenshot each tab in the priority order below (1280×900 → `docs/ux-audit/shots/`), judge against the 5 dims, append per-tab findings. One tab per iteration; self-pace.
-> 3. **Then fix phase:** G1 is DECIDED → build a NEW Goods overview/hub page at `/org/act/goods` (summary: pipeline value, warmth, money, proof count + clear links into the 14 tabs). Plus G2/G3.
+> ## ▶ RESUME HERE (after `/clear`) — updated 2026-06-22, end of session
+> **DONE this session (PR #100, branch `feat/goods-registry-entity-resolution`, commits `5cb1819` + `be58841`, pushed + verified live):**
+> - Batch-1 visual pass = 5 tabs audited (buyers · funnel · pitch · proof · money). See "Phase 1b" below.
+> - **B1 fixed** — buyers no longer leads with `$0·$0·$0` (conditional hero). **Fn1 fixed** — name unified to "Goods".
+> - **G1 done** — new hub front door `/org/act/goods` (`page.tsx`), reachable from all 15 crumbs. **G2 answered** (spine = the two nav rows).
+>
+> **QUEUE (pick one to resume):**
+> 1. **Apply the GRANT (Tier 3, fastest win):** power/funding chips on buyer cards are silently empty — `GRANT SELECT ON v_goods_relationship_power, v_goods_relationship_funding TO anon, authenticated, service_role;` then re-screenshot `/org/act/goods/buyers` to confirm chips populate. (See B3-UPGRADED below.)
+> 2. **Confirm P2/P3/Pr1** (design-intent items held, not changed — see the reclassified block below).
+> 3. **Batch-2 audit:** the other 9 tabs (foundations · intros · signals · timeline · governance · insight · engagement · campaign · communities) — re-invoke `/polish goods command center`, screenshot each (dev server :3003, ACT slug renders logged-out), append findings, fix top ones.
+>
+> Dev server: `npx next dev --turbopack -p 3003` (was pid 52483, not ours — check `lsof -i:3003` first).
 
 ## The surface is bigger than remembered — 14 tabs (memory said 9)
 Routes under `apps/web/src/app/org/[slug]/goods/`:

--- a/supabase/migrations/20260620120300_goods_registry_resolve_exact.sql
+++ b/supabase/migrations/20260620120300_goods_registry_resolve_exact.sql
@@ -17,25 +17,21 @@
 --
 -- Set-based (hash join, not a per-row correlated subquery — that times out on
 -- the shared pooler). Idempotent: only touches entity_id IS NULL rows, and the
--- HAVING count = 1 guard skips any display_name that resolves to more than one
--- entity. Safe to re-run.
+-- match_count = 1 window guard skips any display_name that resolves to more than
+-- one entity (min()/aggregates don't apply to uuid). Safe to re-run.
 
-WITH exact_match AS (
-  SELECT gr.id AS rel_id, e.id AS entity_id
+WITH matched AS (
+  SELECT gr.id AS rel_id,
+         e.id  AS entity_id,
+         count(*) OVER (PARTITION BY gr.id) AS match_count
   FROM goods_relationships gr
   JOIN gs_entities e
     ON lower(btrim(e.canonical_name)) = lower(btrim(gr.display_name))
   WHERE gr.entity_id IS NULL
-),
-unique_match AS (
-  -- keep only display_names that resolved to exactly one entity
-  SELECT rel_id, min(entity_id) AS entity_id
-  FROM exact_match
-  GROUP BY rel_id
-  HAVING count(*) = 1
 )
 UPDATE goods_relationships gr
-SET entity_id  = unique_match.entity_id,
+SET entity_id  = matched.entity_id,
     updated_at = now()
-FROM unique_match
-WHERE gr.id = unique_match.rel_id;
+FROM matched
+WHERE gr.id = matched.rel_id
+  AND matched.match_count = 1;  -- only unambiguous (single-entity) display names

--- a/supabase/migrations/20260620120300_goods_registry_resolve_exact.sql
+++ b/supabase/migrations/20260620120300_goods_registry_resolve_exact.sql
@@ -1,0 +1,41 @@
+-- Goods Command Center — resolve name-only registry rows to gs_entities (exact pass).
+--
+-- 173 of 265 goods_relationships rows had entity_id NULL (name-only), so NONE of
+-- the overlays (cross-system power, funding-history, warm-intros) reached them —
+-- including high-value funders (QBE, BHP, Rio Tinto, Macquarie, Centrecorp).
+--
+-- This backfills entity_id for the rows whose display_name is an EXACT
+-- normalized match (lower(btrim(...))) to exactly ONE gs_entities.canonical_name
+-- — the zero-ambiguity subset (25 rows: 16 funders, 8 buyers, 1 impact_investor;
+-- verified 2026-06-20, 0 rows matched more than one entity). Resolving entity_id
+-- here lights up all three overlays for these rows at once.
+--
+-- The remaining ~148 name-only rows have no exact match and need fuzzy matching
+-- (e.g. "Snow Foundation" vs "THE SNOW FOUNDATION LIMITED"); that is deferred to
+-- a separate, review-gated pass because a wrong entity_id would silently
+-- mis-attribute funding/power across every overlay.
+--
+-- Set-based (hash join, not a per-row correlated subquery — that times out on
+-- the shared pooler). Idempotent: only touches entity_id IS NULL rows, and the
+-- HAVING count = 1 guard skips any display_name that resolves to more than one
+-- entity. Safe to re-run.
+
+WITH exact_match AS (
+  SELECT gr.id AS rel_id, e.id AS entity_id
+  FROM goods_relationships gr
+  JOIN gs_entities e
+    ON lower(btrim(e.canonical_name)) = lower(btrim(gr.display_name))
+  WHERE gr.entity_id IS NULL
+),
+unique_match AS (
+  -- keep only display_names that resolved to exactly one entity
+  SELECT rel_id, min(entity_id) AS entity_id
+  FROM exact_match
+  GROUP BY rel_id
+  HAVING count(*) = 1
+)
+UPDATE goods_relationships gr
+SET entity_id  = unique_match.entity_id,
+    updated_at = now()
+FROM unique_match
+WHERE gr.id = unique_match.rel_id;

--- a/thoughts/shared/power-map/staged-sql/run-donations-batched.sh
+++ b/thoughts/shared/power-map/staged-sql/run-donations-batched.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ============================================================================
+# A1 backfill - political_donations (scope B: company/org donors, IND excluded).
+# BATCHED + RESUMABLE. Run this OFF-PEAK (low AEST traffic).
+#
+# WHY this exists: political_donations has 8 indexes and lives on an
+# under-provisioned shared Supabase (Small compute, pool 15, ~6 projects). A
+# single 414K-row UPDATE times out; even a 30K batch took 18+ min during a
+# contention window on 2026-06-21. So we update in small batches that each
+# commit fast and resume on re-run (fills NULLs only).
+#
+# Reads the STEP-1 staging table _a1_pd_resolved (must still exist; re-run
+# STEP 1 if it was dropped). The justice half (STEP 2a) is already committed.
+#
+# RUN (foreground):   bash thoughts/shared/power-map/staged-sql/run-donations-batched.sh
+# RUN (overnight):    nohup bash thoughts/shared/power-map/staged-sql/run-donations-batched.sh > /tmp/donations.log 2>&1 &
+#                     then: tail -f /tmp/donations.log
+# SAFE TO RE-RUN: yes - it only fills rows still NULL, so it continues.
+# ============================================================================
+cd /Users/benknight/Code/grantscope || { echo "repo not found"; exit 1; }
+source .env
+export PGPASSWORD="$DATABASE_PASSWORD"
+# NOTE: do NOT add -q here — it suppresses the "UPDATE <n>" command tag that the
+# loop below parses to count rows written. With -q the count is always 0, so the
+# loop concludes "done" after a single batch even though rows were written.
+PSQL="psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U postgres.tednluwflfhxyucgwigh -d postgres -v ON_ERROR_STOP=1"
+
+BATCH=10000          # small enough to fit comfortably under the timeout off-peak
+MAX_BATCHES=80       # 80 * 10k = 800k cap (need ~42 for ~414k); a runaway guard
+TOTAL=0
+
+# guard: staging table present?
+if ! $PSQL -tAc "SELECT to_regclass('public._a1_pd_resolved')" | grep -q _a1_pd_resolved; then
+  echo "Staging table _a1_pd_resolved is missing - re-run STEP 1 first."; exit 1
+fi
+
+for i in $(seq 1 $MAX_BATCHES); do
+  OUT=$($PSQL -c "SET lock_timeout='15s'; SET statement_timeout='300s'; WITH batch AS (
+      SELECT pd.id AS pid, r.matched_abn AS abn
+      FROM political_donations pd
+      JOIN _a1_pd_resolved r ON r.pd_id = pd.id
+      WHERE (pd.donor_abn IS NULL OR pd.donor_abn = '')
+        AND r.entity_type_code IS DISTINCT FROM 'IND'
+      LIMIT $BATCH)
+    UPDATE political_donations pd SET donor_abn = b.abn
+    FROM batch b WHERE pd.id = b.pid;" 2>&1)
+  RC=$?
+  if [ $RC -ne 0 ]; then
+    echo "batch $i FAILED (rolled back, nothing lost): $OUT"
+    echo ">> re-run this script to resume from here (it skips already-filled rows)."
+    exit 1
+  fi
+  CNT=$(printf '%s' "$OUT" | grep -oE 'UPDATE [0-9]+' | grep -oE '[0-9]+' | tail -1)
+  CNT=${CNT:-0}
+  TOTAL=$((TOTAL + CNT))
+  echo "batch $i: +$CNT  (running total $TOTAL)"
+  if [ "$CNT" -eq 0 ]; then echo "DONE - total donor_abn backfilled: $TOTAL"; break; fi
+done
+
+echo "--- political_donations null donor_abn remaining ---"
+$PSQL -c "SELECT count(*) FILTER (WHERE donor_abn IS NULL OR donor_abn='') AS still_null FROM political_donations;"
+echo ">> after this completes, the nightly MV refresh (3am AEST) will fold the"
+echo "   recovered rows into mv_entity_power_index automatically."


### PR DESCRIPTION
Bundles the Goods registry/entity-resolution work with the cross-system people leaderboard (disjoint files, both ready).

## Goods — registry entity resolution + overlays
- **Resolve 25 name-only registry rows → entities** (exact, zero-ambiguity pass). Migration `20260620120300_goods_registry_resolve_exact.sql` (set-based, idempotent, `match_count = 1` window guard — skips any `display_name` resolving to >1 entity). **Already applied to the shared DB: `UPDATE 25`** (registry 92→117). The ~148 fuzzy-match rows are deferred to a separate review-gated pass.
- **Power + funding chips on the Buyer Pipeline** — lifts `PowerChip` out of the insight page into a shared `goods-power-chip.tsx`; buyers page fetches power + funding via `Promise.all` keyed by `goods_relationships.id`.
- **fix:** resolve-migration uses a window guard, not `min(uuid)` (aggregates don't apply to uuid).
- **fix (from code review):** `PowerChip` surfaces the revolving-door flag even at zero system reach — `v_goods_relationship_power` keeps a row when *either* the power-index or revolving-door MV matches, and they refresh independently, so a buyer can be in the RD set with `systemCount 0`. Guard now renders on either axis (`Power 0/7 · RD`).

## Power — cross-system people leaderboard
- New `api/power/holders` route + `power/client.tsx` leaderboard on the de-collided `_v2` person MV, with the L16 funder annotation.

## Review
Branch was code-reviewed (9-angle pass): no blocking correctness bugs; the one latent finding (RD-flag suppression) is fixed here. Key-space alignment verified — `powerMap`/`fundingMap` and `BuyerPipelineRow.id` are all `goods_relationships.id`.

## Data tooling (added)
- **fix `run-donations-batched.sh`**: the `-q` psql flag suppressed the `UPDATE n` tag the batch loop parses, so the runner silently stopped after one batch — the real reason the donations A1 backfill never completed (`c0ab32c`).
- **Donations A1 backfill now DONE**: 414,165 non-IND `political_donations` rows backfilled with `donor_abn` (required bumping the shared DB Small→Medium). Justice A1 (7,467) already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)