### PR TITLE
feat(engine): foundation-match agent — philanthropy find-loop per ACT project

### DIFF
--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -441,6 +441,21 @@ export const AGENTS = {
     timeoutMs: 3_600_000,
     dependencies: [],
   },
+  // Philanthropy "find" agent — the foundation analogue of the grant pipeline.
+  // Scores every foundation against each active ACT project and lands top fits
+  // into org_project_foundations as candidates (stage=saved / researching),
+  // awaiting human review. FINDS only — never approaches or sends.
+  // Registered as dry-run (Tier 1, no writes). Once a human has approved the
+  // first `--apply` run and eyeballed the results in the /org pipeline UI,
+  // flip command to add '--apply' to make the nightly population autonomous.
+  'match-foundations-for-projects': {
+    command: ['node', '--env-file=.env', 'scripts/match-foundations-for-projects.mjs'],
+    displayName: 'Match foundations to ACT projects (philanthropy find agent · dry-run)',
+    category: 'discovery',
+    defaultPriority: 3,
+    timeoutMs: 300_000,
+    dependencies: [],
+  },
   'auto-classify-llm': {
     command: ['node', '--env-file=.env', 'scripts/auto-classify-llm.mjs', '--limit=300'],
     displayName: 'Auto-classify unverified alma rows (LLM)',

--- a/scripts/match-foundations-for-projects.mjs
+++ b/scripts/match-foundations-for-projects.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * match-foundations-for-projects — the "find" agent for the philanthropy half
+ * of the ACT Opportunity Engine.
+ *
+ * The grant side already self-populates: `act_grant_recommendations` (MV) is
+ * refreshed nightly and renders in the /org pipeline kanban. The foundation
+ * side had a matching pipeline table (`org_project_foundations`) + full CRUD
+ * UI, but nothing FED it — every foundation match was added by hand. This
+ * closes that asymmetry: it scores every foundation against each active ACT
+ * project and lands the top fits into the existing pipeline as candidates
+ * (`stage='saved'`, `engagement_status='researching'`) — awaiting human review.
+ *
+ * BOUNDARY (non-negotiable, per workflow.md): this agent FINDS and DRAFTS only.
+ * It never approaches, emails, or sends. New rows land as "saved / researching"
+ * so a human decides whether to approach. Night-shift, Tier 1-2.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/match-foundations-for-projects.mjs            # dry-run (default, Tier 1, no writes)
+ *   node --env-file=.env scripts/match-foundations-for-projects.mjs --apply    # insert candidates (Tier 2/3 — explicit authorization)
+ *   node --env-file=.env scripts/match-foundations-for-projects.mjs --limit=10 --min-score=65
+ *
+ * Scorer (0..100): theme overlap (55) + target-recipient overlap (15)
+ *                + geography (20) + giving-scale signal (10). Must share >=1
+ *                theme; faith-purpose funders excluded as noise.
+ */
+import { writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { createClient } from '@supabase/supabase-js';
+import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+
+const AGENT_ID = 'match-foundations-for-projects';
+const ACT_ORG_PROFILE_ID = '8b6160a1-7eea-4bd2-8404-71c196381de0';
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const APPLY = argv.includes('--apply');
+const PER_PROJECT_LIMIT = Number((argv.find(a => a.startsWith('--limit=')) || '').split('=')[1]) || 8;
+const MIN_SCORE = Number((argv.find(a => a.startsWith('--min-score=')) || '').split('=')[1]) || 60;
+
+/**
+ * Per-project match config. `themes` are the coarse `foundations.thematic_focus`
+ * vocab (community/indigenous/youth/environment/arts/legal/social-enterprise/…)
+ * that each project's fine-grained `theme_keywords` map to — the crosswalk that
+ * bridges the two vocabularies. States are mapped to the `AU-<STATE>` tokens the
+ * foundations table uses. Curated here for transparency; a later hardening pass
+ * can move this into an `act_grant_recommendation_projects.foundation_themes`
+ * column so it is DB-editable alongside `theme_keywords`.
+ */
+const CROSSWALK = [
+  { code: 'ACT-JH', themes: ['youth', 'community', 'legal', 'human_rights', 'education'],   home: ['AU-QLD', 'AU-NT'], sec: ['AU-NSW', 'AU-VIC', 'AU-WA', 'AU-National'] },
+  { code: 'ACT-PI', themes: ['indigenous', 'community', 'youth', 'arts'],                    home: ['AU-QLD'],          sec: ['AU-NT', 'AU-National'] },
+  { code: 'ACT-GD', themes: ['indigenous', 'community', 'social-enterprise', 'employment'], home: ['AU-QLD', 'AU-NT'], sec: ['AU-NSW', 'AU-WA', 'AU-SA', 'AU-VIC'] },
+  { code: 'ACT-HV', themes: ['environment', 'rural_remote', 'community', 'employment'],      home: ['AU-QLD'],          sec: ['AU-NSW', 'AU-National'] },
+  { code: 'ACT-FM', themes: ['environment', 'rural_remote'],                                 home: ['AU-QLD'],          sec: ['AU-NSW'] },
+  { code: 'ACT-EL', themes: ['indigenous', 'arts', 'community', 'human_rights'],             home: ['AU-QLD', 'AU-NSW'], sec: ['AU-VIC', 'AU-National', 'AU-NT'] },
+];
+
+const sqlArr = (a) => `ARRAY[${a.map(s => `'${s.replace(/'/g, "''")}'`).join(',')}]`;
+
+/**
+ * The scorer, as a single reusable CTE chain. Both the dry-run SELECT and the
+ * --apply INSERT read from the final `ranked` CTE, so the ranking logic has one
+ * home. Ends after the `ranked` CTE (no trailing SELECT) so callers append theirs.
+ */
+function scorerCTE() {
+  const rows = CROSSWALK.map(p =>
+    `('${p.code}', ${sqlArr(p.themes)}, ${sqlArr(p.home)}, ${sqlArr(p.sec)})`
+  ).join(',\n    ');
+  return `
+WITH proj AS (
+  SELECT * FROM (VALUES
+    ${rows}
+  ) AS v(code, themes, home_geo, sec_geo)
+),
+scored AS (
+  SELECT
+    p.code, op.id AS org_project_id, f.id AS foundation_id, f.name AS foundation,
+    ARRAY(SELECT unnest(f.thematic_focus) INTERSECT SELECT unnest(p.themes))      AS matched_themes,
+    cardinality(ARRAY(SELECT unnest(f.thematic_focus) INTERSECT SELECT unnest(p.themes)))    AS theme_overlap,
+    cardinality(ARRAY(SELECT unnest(f.target_recipients) INTERSECT SELECT unnest(p.themes))) AS target_overlap,
+    (f.geographic_focus && p.home_geo)        AS home_match,
+    ('AU-National' = ANY(f.geographic_focus)) AS national,
+    (f.geographic_focus && p.sec_geo)         AS sec_match,
+    f.total_giving_annual
+  FROM proj p
+  JOIN org_projects op ON op.code = p.code
+  JOIN foundations f
+    ON f.thematic_focus IS NOT NULL
+   AND f.thematic_focus && p.themes
+   AND NOT ('religion' = ANY(f.thematic_focus))   -- faith-purpose funders are noise for these projects
+),
+fit AS (
+  SELECT s.*,
+    ROUND(
+      LEAST(theme_overlap,3)/3.0 * 55
+      + LEAST(target_overlap,2)/2.0 * 15
+      + CASE WHEN home_match THEN 20 WHEN national THEN 15 WHEN sec_match THEN 10 ELSE 0 END
+      + CASE WHEN total_giving_annual >= 50000 THEN 10 WHEN total_giving_annual > 0 THEN 5 ELSE 0 END
+    )::int AS fit_score
+  FROM scored s
+),
+ranked AS (
+  SELECT fit.*,
+    ROW_NUMBER() OVER (PARTITION BY fit.code ORDER BY fit.fit_score DESC, fit.total_giving_annual DESC NULLS LAST) AS rn
+  FROM fit
+  LEFT JOIN org_project_foundations existing
+    ON existing.org_project_id = fit.org_project_id AND existing.foundation_id = fit.foundation_id
+  WHERE existing.id IS NULL            -- never touch a foundation already in the pipeline (human-curated)
+    AND fit.fit_score >= ${MIN_SCORE}
+)`;
+}
+
+/** Human-readable "why" that doubles as agent provenance in fit_summary. */
+const FIT_SUMMARY_SQL = `
+  '[auto-matched] themes: ' || array_to_string(matched_themes, ', ')
+  || CASE WHEN home_match THEN ' · home-state funder'
+          WHEN national THEN ' · national funder'
+          WHEN sec_match THEN ' · secondary-state funder' ELSE '' END
+  || CASE WHEN total_giving_annual >= 50000
+          THEN ' · gives ~$' || to_char(total_giving_annual, 'FM999,999,999') || '/yr' ELSE '' END`;
+
+function runSelect(supabase, sql) {
+  return supabase.rpc('exec_sql', { query: sql });
+}
+
+async function dryRun(supabase) {
+  const sql = `${scorerCTE()}
+SELECT code, rn, fit_score, LEFT(foundation, 48) AS foundation,
+       array_to_string(matched_themes, ',') AS themes,
+       COALESCE(total_giving_annual,0)::bigint AS giving
+FROM ranked WHERE rn <= ${PER_PROJECT_LIMIT}
+ORDER BY code, rn`;                       // no trailing ';' — exec_sql wraps the query and rejects one
+  const { data, error } = await runSelect(supabase, sql);
+  if (error) throw new Error(`scorer failed: ${error.message}`);
+  const rows = data || [];
+  let lastCode = null;
+  for (const r of rows) {
+    if (r.code !== lastCode) { console.log(`\n${r.code}`); lastCode = r.code; }
+    console.log(`  ${String(r.fit_score).padStart(3)}  ${String(r.foundation).padEnd(50)} [${r.themes}] $${Number(r.giving).toLocaleString()}`);
+  }
+  console.log(`\n${rows.length} candidate matches across ${new Set(rows.map(r => r.code)).size} projects (min-score ${MIN_SCORE}, top ${PER_PROJECT_LIMIT}/project).`);
+  console.log('Dry-run only — no rows written. Re-run with --apply to land these as "saved / researching" in the pipeline.');
+  return { candidates: rows.length };
+}
+
+async function apply(supabase) {
+  const dbPassword = process.env.DATABASE_PASSWORD;
+  if (!dbPassword) throw new Error('DATABASE_PASSWORD not set — required for --apply (INSERT via psql).');
+  const insertSql = `${scorerCTE()}
+INSERT INTO org_project_foundations
+  (org_profile_id, org_project_id, foundation_id, stage, engagement_status, fit_score, fit_summary)
+SELECT '${ACT_ORG_PROFILE_ID}'::uuid, org_project_id, foundation_id,
+       'saved', 'researching', fit_score, ${FIT_SUMMARY_SQL}
+FROM ranked WHERE rn <= ${PER_PROJECT_LIMIT}
+ON CONFLICT (org_project_id, foundation_id) DO NOTHING;`;
+  const tmp = `/tmp/match-foundations-${AGENT_ID}.sql`;
+  writeFileSync(tmp, insertSql);
+  const out = execSync(
+    `psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -v ON_ERROR_STOP=1 -f ${tmp}`,
+    { env: { ...process.env, PGPASSWORD: dbPassword }, encoding: 'utf8', timeout: 120000 }
+  );
+  const m = out.match(/INSERT 0 (\d+)/);
+  const inserted = m ? Number(m[1]) : 0;
+  console.log(`Inserted ${inserted} new foundation candidates (stage=saved, status=researching) into org_project_foundations.`);
+  console.log('These are now visible in the /org pipeline UI, awaiting human review. Nothing was sent.');
+  return { inserted };
+}
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+  const runRow = await logStart(supabase, AGENT_ID, 'Match foundations to ACT projects (philanthropy find agent)');
+  console.log(`=== match-foundations-for-projects · ${new Date().toISOString()} · mode=${APPLY ? 'APPLY' : 'dry-run'} ===`);
+  try {
+    const stats = APPLY ? await apply(supabase) : await dryRun(supabase);
+    if (runRow?.id) await logComplete(supabase, runRow.id, {
+      items_found: stats.candidates ?? stats.inserted ?? 0,
+      items_new: stats.inserted ?? 0,
+    });
+  } catch (err) {
+    console.error('FAILED:', err.message);
+    if (runRow?.id) await logFailed(supabase, runRow.id, err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/thoughts/shared/plans/act-opportunity-engine-phase7.md
+++ b/thoughts/shared/plans/act-opportunity-engine-phase7.md
@@ -1,0 +1,94 @@
+# Phase 7 — The ACT Opportunity Engine
+
+**Proposed 2026-07-06. Status: IN BUILD — reality-corrected 2026-07-06.**
+
+---
+
+## ⚠️ REALITY CORRECTION (2026-07-06) — the plan below was written against a greenfield that does not exist
+
+A pre-build DB + code audit found **Bricks 1–3 already exist and are wired to live UI** (built by a prior session / the seed scripts). Do NOT rebuild them:
+
+| Plan brick | Actual state |
+|---|---|
+| **1. Project profiles** | ✅ `org_projects` (11 ACT projects, `code` = ACT-GD/JH/HV/FM/PI/EL…) + `act_grant_recommendation_projects` (12 in-scope, `theme_keywords`, `home_states`, `entity_preference`, `dgr_required`, `qbe_ready`). Richer than proposed. |
+| **2. Unified feed** | ✅ Grants: `act_grant_recommendations` **MV** (grant→project fit, nightly-refreshed by agent `nightly-grant-pipeline`), rendered in `/org/[slug]/pipeline` kanban + `/ops/grant-recommendations`. Foundations: `org_project_foundations` (per-project fit) rendered on `/org/[slug]` + per-project page, full CRUD API. |
+| **3. Engagement pipeline** | ✅ `org_project_foundations` engagement cols (stage/engagement_status/next_touch, 16 live rows) + `act_grant_recommendation_decisions` (90 grant decisions). |
+| **4. Daily agent loop** | ◐ EXISTS for grants (nightly MV refresh). **MISSING for foundations.** |
+| **5. Outcome feedback** | ✗ decisions logged, not fed back to scorer/funders.json. |
+
+**Orphaned (decide keep/drop later):** `opportunities_unified` (17.8K rows, retired platform-wide concept, no app code writes it), `funding_relationship_engagements` (0 consumers).
+
+### The real gap → what's being built
+The sharp asymmetry: **grants self-populate per project; foundations were hand-fed.** Ben's decision (2026-07-06): build the **foundation matching agent** first — the philanthropy analogue of the nightly grant pipeline.
+
+**SHIPPED this session:**
+- `scripts/match-foundations-for-projects.mjs` — scores every foundation against each active ACT project (theme-overlap 55 + target-recipient 15 + geography 20 + giving-scale 10; faith-purpose funders excluded; must share ≥1 theme), lands top fits into `org_project_foundations` as `stage='saved', engagement_status='researching'` (candidates awaiting human review). **Dry-run verified: 35 matches across 6 projects, quality good** (ACT-PI→Port Curtis Coral Coast Aboriginal/WCCT trusts; ACT-FM/HV→Burnett Mary NRM/QLD Farmers' Fed/NQ Dry Tropics). Default `--dry-run` (Tier 1); `--apply` inserts via psql (Tier 2/3, explicit go).
+- Registered in `scripts/lib/agent-registry.mjs` as `match-foundations-for-projects` (dry-run command; flip to `--apply` for nightly once first apply is human-approved).
+- Crosswalk (project coarse-themes) lives in-script (`CROSSWALK` const) — transparent; hardening follow-up = move to an `act_grant_recommendation_projects.foundation_themes` column.
+
+**NEXT (not yet done):**
+- Ben authorizes first `--apply` run (Tier 3 — write to shared prod), then eyeball in `/org` pipeline UI.
+- Extractive-industry funders (BHP/Rio Tinto Foundations rank high mechanically) = **values decision** for Ben — kept as candidates, not auto-filtered.
+- Then: Brick 5 (won/lost → scorer + funders.json), coherence cleanup (orphaned tables), and the "connect brain to engine" rewire (`/find-grants` reads `act_grant_recommendations`, not raw `grant_opportunities`).
+
+---
+
+## Original proposal (superseded above — kept for context)
+
+**Proposed 2026-07-06. Status: PROPOSAL (awaiting Ben's scope decision).**
+
+> One pipeline, three sources, per-project: `find → engage → learn`. Make A Curious Tractor the live pilot account for an agentic system that finds AND engages philanthropy, grants, and procurement support across all ACT projects.
+
+## The gap (why this phase)
+
+The **FIND** half is largely built and live:
+- Grant finder overhauled (trust layer, CLASSIE tags, award-history join, vector org→grant matching, scorer with proven-track-record boost). Shipped in PR #101.
+- Substrate exists for the other two sources: `foundations` (10.8K, thematic_focus/geographic_focus/total_giving_annual), `grant_opportunities` (18K), `austender_contracts` (770K) + state tenders scrapable (VIC/SA), `funders.json` ledger (ACT's actual funder relationships), `act-money-brain` skills (`find-grants`, `brief-funder`, `draft-funder`, `decision`).
+
+Three things are missing to reach the vision:
+1. **Per-project grain.** Matching is org-level. ACT is 72 project codes / multiple entities (Harvest, Farm, Goods, etc.), each with distinct thematic fit, stage, and $ need. A grant/funder should route to the *right project*.
+2. **Engagement pipeline.** The skills draft one-offs. Nothing persists state, tracks status, schedules follow-up, or learns from outcomes. "Find" never becomes "engage."
+3. **Unified three-source feed.** Grants are a first-class flow; philanthropy (foundations) and procurement (tenders ACT could bid on, esp. Goods on Country contracting) are not yet.
+
+## The build (connect/deepen, not widen — respects the data-widening pause)
+
+Every brick reuses existing substrate.
+
+### Brick 1 — Project profiles (the unlock for "across all projects")
+Seed ~5–8 active ACT projects as matchable profiles at project grain, reusing the org-profile/vector infra.
+- Source of truth: `act-global-infrastructure/config/project-codes.json` (72 codes) — pick the ~5–8 actively fundraising ones.
+- Each profile: thematic tags (CLASSIE-compatible), stage, $ need band, geography, entity (which ACT vehicle receives — Butterfly for DGR, ACT Pty for contracting, etc. per act-core-facts).
+- Table: `act_project_profiles` (or extend `org_profiles` with a project_code dimension).
+
+### Brick 2 — Unified opportunity feed (per project)
+Extend the finder to emit **grants + foundations (philanthropy)** as one ranked feed per project profile.
+- Grants: reuse the live vector path.
+- Philanthropy: foundation→project fit on thematic_focus ∩ project tags + geographic_focus + giving-history signal. New matcher, same shape as grant matcher.
+- Procurement/tenders: **Phase 7b** (austender/state tenders as bid opportunities for Goods on Country). Deferred from the pilot slice — needs the UNSPSC→theme crosswalk that's already on the deferred list.
+
+### Brick 3 — Engagement pipeline (the state an agent works down)
+Table `opportunity_engagements`: `project_code, opportunity_ref, source (grant|foundation|tender), status (new→matched→drafted→sent→followup→won|lost|ghosted), next_action_at, draft_text, notes, updated_at`.
+This is the CRM spine. Nothing here sends — it holds drafts awaiting human approval.
+
+### Brick 4 — Daily agent loop
+Scheduled agent (night shift, Tier 1–2 only): scan new opportunities across sources → match per project → draft outreach in ACT voice (reuse `draft-funder` + writing-voice.md) for top matches → land in pipeline as **"drafted, awaiting approval."**
+**Human does SEND/ENGAGE** (Tier 3, day shift, explicit verb). This respects the AFK boundary in workflow.md exactly — never queue an external send into an AFK backlog.
+
+### Brick 5 — Outcome feedback loop
+won/lost/ghosted updates:
+- the scorer's proven-track-record signal (already has the hook), and
+- the `funders.json` ledger (ACT's real relationship state).
+
+## Wedge alignment
+This is on-wedge: it dogfoods the paid product direction ("paid evidence + tender tools for buyers") using ACT as the test account. Building ACT's engagement loop = building the engagement tools the paid product will sell. Check `docs/strategy/buyer-wedge.md` before hardening any of it into a public feature.
+
+## Boundary guardrails (non-negotiable)
+- Agent FINDS + DRAFTS (night shift, Tier 1–2). Human SENDS (day shift, Tier 3, explicit verb). No autonomous outreach, ever.
+- No new data widening — connect/deepen the estate we have.
+- Money/entity routing must respect act-core-facts (DGR only through Butterfly; contracting through ACT Pty t/a Goods on Country).
+
+## Open decision for Ben (scopes the pilot slice)
+1. **Lead source:** grants-only (fastest, extends what's live) · grants+philanthropy (foundations — the real unlock) · all three incl. procurement (biggest, needs the UNSPSC crosswalk first).
+2. **First brick:** project profiles (Brick 1) vs the pipeline table + daily loop (Bricks 3–4). Recommend Brick 1 first — nothing routes per-project without it.
+
+**Recommendation:** pilot slice = Bricks 1 → 2 (grants+philanthropy) → 3, with ACT's ~5 active fundraising projects. Prove `find→draft→track` end-to-end for ACT, then add procurement (7b) and the daily agent loop (Brick 4) once the manual loop is trusted.


### PR DESCRIPTION
## What

Adds the missing **philanthropy half** of the ACT Opportunity Engine. Grants already self-populate per project (`act_grant_recommendations` MV, refreshed nightly by `nightly-grant-pipeline`) and render in the `/org` pipeline. Foundations had the same pipeline table + CRUD UI but **nothing fed it** — every match was added by hand. This closes that asymmetry.

## The build

`scripts/match-foundations-for-projects.mjs` — scores every foundation against each active ACT project and lands the top fits into the existing `org_project_foundations` pipeline as candidates (`stage=saved`, `engagement_status=researching`), awaiting human review.

- **Scorer (0–100):** theme-overlap (55) + target-recipient overlap (15) + geography (20) + giving-scale (10). Requires ≥1 shared theme; excludes faith-purpose funders as noise.
- **Crosswalk:** project fine-grained `theme_keywords` → coarse `foundations.thematic_focus` vocab, in-script (`CROSSWALK` const) for transparency. Hardening follow-up: move to an `act_grant_recommendation_projects.foundation_themes` column.
- **Modes:** default `--dry-run` (Tier 1, no writes); `--apply` inserts via psql with `ON CONFLICT (org_project_id, foundation_id) DO NOTHING` (never touches human-curated rows).
- Registered in `agent-registry.mjs` as `match-foundations-for-projects` (dry-run command; flip to `--apply` for nightly once trusted).

## Boundary

**FINDS only, never sends.** Candidates land as `saved`/`researching` for a human to approve. Respects the AFK/day-shift boundary — no autonomous outreach.

## Verification

- Dry-run: 35 matches across 6 projects; quality confirmed (ACT-PI → Port Curtis Coral Coast Aboriginal + WCCT trusts; ACT-FM/HV → Burnett Mary NRM, QLD Farmers' Fed, NQ Dry Tropics).
- First `--apply` (min-score 70): **30 candidates across 5 projects; 16 pre-existing human rows untouched** (46 total).

## Notes / follow-ups

- Plan doc reality-corrected: Phase 7 Bricks 1–3 already existed and were UI-wired; the real gap was this find-loop.
- **ACT-FM** scores under 70 (2-theme overlap only) — needs a lower threshold or different sourcing angle.
- **Extractive-industry funders** (BHP/Rio Tinto Foundations) rank high mechanically — left as candidates, not auto-filtered (values decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)