### PR TITLE
feat(engine): Brick 5 won/lost feedback + /find-grants rewire

### DIFF
--- a/scripts/draft-funders-json-from-wins.mjs
+++ b/scripts/draft-funders-json-from-wins.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * draft-funders-json-from-wins — Phase 7 · Brick 5, the funders.json half.
+ *
+ * The scorer half of Brick 5 lives in the DB: `won` decisions in
+ * `act_grant_recommendation_decisions` feed the `track_record_score` in the
+ * `act_grant_recommendations` engine. This is the OTHER half — reflecting those
+ * wins into ACT's real funder-relationship ledger,
+ * `act-global-infrastructure/wiki/narrative/funders.json`.
+ *
+ * BOUNDARY (Ben's call, 2026-07-06): this NEVER writes to funders.json. That file
+ * is a human-curated relationship system-of-record in a separate repo. This script
+ * READS the wins + the current ledger and emits a reviewable PROPOSAL (printed +
+ * a markdown file with paste-ready JSON patches). Ben applies + commits by hand.
+ *
+ * For each funder ACT has a `won` decision with, it proposes one of:
+ *   - UPDATE an existing ledger entry: add the project_code to projects_funded,
+ *     advance a pre-funded stage → 'active-partner', bump last_communicated_at.
+ *   - ADD a new entry — but only for names that look like actual funders. Wins
+ *     from commercial customers (Goods/Harvest sales) and community/partner orgs
+ *     are surfaced as "review — probably not a philanthropic funder", not drafted
+ *     as funder entries, so the ledger stays clean.
+ *
+ * Usage (read-only, always):
+ *   node --env-file=.env scripts/draft-funders-json-from-wins.mjs
+ *   node --env-file=.env scripts/draft-funders-json-from-wins.mjs --funders=/path/to/funders.json --out=/path/to/proposal.md
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+
+const argv = process.argv.slice(2);
+const argVal = (name, dflt) => {
+  const hit = argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=').slice(1).join('=') : dflt;
+};
+const FUNDERS_PATH = argVal(
+  'funders',
+  '/Users/benknight/Code/act-global-infrastructure/wiki/narrative/funders.json',
+);
+const OUT_PATH = argVal(
+  'out',
+  'thoughts/shared/plans/funders-json-from-wins.proposal.md',
+);
+
+// ── name normalization + classification ──────────────────────────────────────
+const norm = (s) =>
+  (s || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[’'`]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/\b(pty|proprietary|ltd|limited|inc|incorporated|the)\b/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+/** A funder we should draft an entry for, vs a customer/partner we should only flag. */
+function classify(name) {
+  const n = (name || '').toLowerCase();
+  if (/\b(foundation|trust|fund\b|philanthrop|grants?)\b/.test(n)) return 'funder';
+  if (/\b(government|department|dept|agency|council(?! aboriginal)|authority|commission)\b/.test(n))
+    return 'government';
+  if (/\b(aboriginal corporation|community company|community shed|health service|services aboriginal)\b/.test(n))
+    return 'partner-or-community-org';
+  if (/\b(pty|proprietary|ltd|limited|station|properties|holdings|studio|meats|obsession)\b/.test(n))
+    return 'likely-customer';
+  return 'unclear';
+}
+
+function bestMatch(wonName, ledger) {
+  const target = norm(wonName);
+  if (!target) return null;
+  let best = null;
+  for (const [slug, entry] of Object.entries(ledger.funders)) {
+    for (const cand of [entry.name, slug.replace(/-/g, ' ')]) {
+      const c = norm(cand);
+      if (!c) continue;
+      let score = 0;
+      if (c === target) score = 100;
+      else if (c.includes(target) || target.includes(c)) {
+        // contains match — require the shorter to be a real word run, not 1-2 chars
+        const shorter = c.length < target.length ? c : target;
+        if (shorter.length >= 6) score = 80;
+      }
+      if (score > (best?.score ?? 0)) best = { slug, entry, score };
+    }
+  }
+  return best && best.score >= 80 ? best : null;
+}
+
+const PRE_FUNDED_STAGES = new Set([
+  'cold',
+  'warm-cold',
+  'warm',
+  'ask-pending',
+  'term-sheet-pending',
+  'procurement-prospect',
+  'lapsed',
+]);
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  // Wins, with the funder name from the alma opportunity + latest decision date.
+  const { data: decisions, error } = await supabase
+    .from('act_grant_recommendation_decisions')
+    .select('project_code, opportunity_id, decided_at, alma_funding_opportunities!inner(funder_name, max_grant_amount)')
+    .eq('decision', 'won');
+  if (error) {
+    console.error('query failed:', error.message);
+    process.exit(1);
+  }
+
+  // Collapse to one row per funder_name with the set of projects + newest date.
+  const byFunder = new Map();
+  for (const d of decisions) {
+    const fname = d.alma_funding_opportunities?.funder_name;
+    if (!fname) continue;
+    const key = norm(fname);
+    if (!byFunder.has(key)) byFunder.set(key, { name: fname, projects: new Set(), lastAt: null, amount: 0 });
+    const rec = byFunder.get(key);
+    rec.projects.add(d.project_code);
+    if (!rec.lastAt || (d.decided_at && d.decided_at > rec.lastAt)) rec.lastAt = d.decided_at;
+    const amt = Number(d.alma_funding_opportunities?.max_grant_amount) || 0;
+    if (amt > rec.amount) rec.amount = amt;
+  }
+
+  const ledger = JSON.parse(readFileSync(FUNDERS_PATH, 'utf8'));
+
+  const updates = []; // matched existing entries needing a change
+  const additions = []; // unmatched, look like real funders → propose new entry
+  const flagged = []; // unmatched customers/partners → surface, don't draft
+
+  for (const rec of byFunder.values()) {
+    const projects = [...rec.projects].sort();
+    const lastAt = rec.lastAt ? rec.lastAt.slice(0, 10) : null;
+    const m = bestMatch(rec.name, ledger);
+    if (m) {
+      const e = m.entry;
+      const changes = [];
+      const missingProjects = projects.filter((p) => !(e.projects_funded || []).includes(p));
+      if (missingProjects.length) changes.push({ field: 'projects_funded', add: missingProjects });
+      if (PRE_FUNDED_STAGES.has(e.stage)) changes.push({ field: 'stage', from: e.stage, to: 'active-partner' });
+      if (lastAt && (!e.last_communicated_at || lastAt > e.last_communicated_at))
+        changes.push({ field: 'last_communicated_at', from: e.last_communicated_at || null, to: lastAt });
+      if (changes.length) updates.push({ slug: m.slug, name: e.name, wonAs: rec.name, changes });
+    } else {
+      const cls = classify(rec.name);
+      if (cls === 'funder' || cls === 'government') {
+        additions.push({ name: rec.name, projects, lastAt, amount: rec.amount, cls });
+      } else {
+        flagged.push({ name: rec.name, projects, cls });
+      }
+    }
+  }
+
+  // ── console summary ─────────────────────────────────────────────────────────
+  console.log(`=== draft-funders-json-from-wins · ${new Date().toISOString()} ===`);
+  console.log(`Wins cover ${byFunder.size} distinct funders. Ledger has ${Object.keys(ledger.funders).length} entries.`);
+  console.log(`Proposed: ${updates.length} updates · ${additions.length} new funder entries · ${flagged.length} flagged (not drafted).`);
+  console.log(`READ-ONLY. Nothing written to funders.json. Proposal → ${OUT_PATH}\n`);
+  for (const u of updates)
+    console.log(`  UPDATE ${u.slug}: ${u.changes.map((c) => c.field + (c.add ? ` +${c.add.join(',')}` : ` → ${c.to}`)).join(' · ')}`);
+  for (const a of additions) console.log(`  ADD    ${a.name} (${a.cls}) — projects ${a.projects.join(',')}`);
+  for (const f of flagged) console.log(`  FLAG   ${f.name} (${f.cls}) — won for ${f.projects.join(',')}, review before adding`);
+
+  // ── proposal file (paste-ready) ─────────────────────────────────────────────
+  const slugify = (s) => norm(s).replace(/\s+/g, '-');
+  const lines = [];
+  lines.push('# funders.json — proposed updates from `won` grant decisions');
+  lines.push('');
+  lines.push(`_Generated ${new Date().toISOString()} by \`scripts/draft-funders-json-from-wins.mjs\`. Read-only draft — apply by hand in \`act-global-infrastructure\`._`);
+  lines.push('');
+  lines.push('## 1. Update existing ledger entries');
+  if (!updates.length) lines.push('_None — all matched funders already reflect their wins._');
+  for (const u of updates) {
+    lines.push(`\n### \`${u.slug}\` — ${u.name}  _(won as "${u.wonAs}")_`);
+    for (const c of u.changes) {
+      if (c.field === 'projects_funded') lines.push(`- \`projects_funded\`: add ${c.add.map((x) => `\`${x}\``).join(', ')}`);
+      else lines.push(`- \`${c.field}\`: \`${c.from ?? 'null'}\` → \`${c.to}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## 2. New funder entries to consider (looked like real funders)');
+  if (!additions.length) lines.push('_None._');
+  for (const a of additions) {
+    const entry = {
+      name: a.name,
+      stage: 'active-partner',
+      themes: [],
+      projects_funded: a.projects,
+      last_communicated_at: a.lastAt || undefined,
+      source_note: `Added from won grant decision (${a.cls}). Fill themes/contact before relying on it.`,
+    };
+    lines.push(`\n### \`${slugify(a.name)}\``);
+    lines.push('```json');
+    lines.push(`"${slugify(a.name)}": ${JSON.stringify(entry, null, 2)}`);
+    lines.push('```');
+  }
+  lines.push('');
+  lines.push('## 3. Flagged — a win, but probably NOT a philanthropic funder (do not add without review)');
+  if (!flagged.length) lines.push('_None._');
+  for (const f of flagged) lines.push(`- **${f.name}** _(${f.cls})_ — won for ${f.projects.join(', ')}. Likely a customer/partner, not a grantmaker.`);
+  lines.push('');
+
+  writeFileSync(OUT_PATH, lines.join('\n'));
+  console.log(`\nWrote proposal: ${OUT_PATH}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -449,8 +449,8 @@ export const AGENTS = {
   // first `--apply` run and eyeballed the results in the /org pipeline UI,
   // flip command to add '--apply' to make the nightly population autonomous.
   'match-foundations-for-projects': {
-    command: ['node', '--env-file=.env', 'scripts/match-foundations-for-projects.mjs'],
-    displayName: 'Match foundations to ACT projects (philanthropy find agent · dry-run)',
+    command: ['node', '--env-file=.env', 'scripts/match-foundations-for-projects.mjs', '--apply'],
+    displayName: 'Match foundations to ACT projects (philanthropy find agent · apply)',
     category: 'discovery',
     defaultPriority: 3,
     timeoutMs: 300_000,

--- a/scripts/match-foundations-for-projects.mjs
+++ b/scripts/match-foundations-for-projects.mjs
@@ -60,17 +60,32 @@ const sqlArr = (a) => `ARRAY[${a.map(s => `'${s.replace(/'/g, "''")}'`).join(','
 const ilikeArr = (a) => `ARRAY[${a.map(s => `'%${s.replace(/'/g, "''")}%'`).join(',')}]`;
 
 /**
- * Values-based exclusion (Ben's call, encoded so no future run re-litigates it):
- * extractive-industry corporate foundations are filtered out even when they score
- * high mechanically. Name-pattern match (case-insensitive substring) because these
- * are specific funders, not a `thematic_focus` tag. Kept tight and named — add a
- * peer here rather than rejecting the same funder in the UI every nightly run.
- * NOTE: Minderoo (Forrest/Fortescue-derived) is deliberately NOT here — it's a
- * borderline call left to human review in the /org pipeline, not auto-filtered.
+ * Values / off-mission exclusion (Ben's call, encoded so no future run re-litigates
+ * it): funders filtered out even when they score high mechanically. Name-pattern
+ * match (case-insensitive substring) because these are specific funders, not a
+ * `thematic_focus` tag. Kept tight and named — add a peer here rather than rejecting
+ * the same funder in the UI every nightly run.
+ *
+ * Two groups:
+ *  - EXTRACTIVE: mining / fossil-fuel corporate foundations.
+ *  - FAITH: faith-mission orgs that dodge the `religion` theme filter (they're tagged
+ *    community/youth, not religion) but are off-mission noise for these projects.
+ *    Specific observed names only — a broad faith-term regex would false-positive on
+ *    legit secular community funders (e.g. some Uniting/Catholic community trusts).
+ *
+ * NOTE 1: Minderoo (Forrest/Fortescue-derived) is deliberately NOT here — borderline,
+ *   left to human review in the /org pipeline, not auto-filtered.
+ * NOTE 2: Aboriginal community benefit-trusts funded by mining royalties (WCCT,
+ *   Groote Eylandt Aboriginal Trust, McArthur River Mine Community Benefits Trust)
+ *   are NOT here — excluding indigenous community money is a distinct values call;
+ *   they're also wrong-geography, so per-project parking handles them.
  */
 const EXCLUDE_FUNDERS = [
+  // extractive
   'BHP', 'Rio Tinto', 'Glencore', 'Adani', 'Woodside', 'Santos',
   'Fortescue', 'Whitehaven', 'Peabody', 'Yancoal',
+  // faith-mission
+  'WIZO', 'Human Appeal', 'Tzedek', 'Bodhicitta', 'Salvation Army', 'Art Of Living',
 ];
 
 /**

--- a/scripts/match-foundations-for-projects.mjs
+++ b/scripts/match-foundations-for-projects.mjs
@@ -52,11 +52,26 @@ const CROSSWALK = [
   { code: 'ACT-PI', themes: ['indigenous', 'community', 'youth', 'arts'],                    home: ['AU-QLD'],          sec: ['AU-NT', 'AU-National'] },
   { code: 'ACT-GD', themes: ['indigenous', 'community', 'social-enterprise', 'employment'], home: ['AU-QLD', 'AU-NT'], sec: ['AU-NSW', 'AU-WA', 'AU-SA', 'AU-VIC'] },
   { code: 'ACT-HV', themes: ['environment', 'rural_remote', 'community', 'employment'],      home: ['AU-QLD'],          sec: ['AU-NSW', 'AU-National'] },
-  { code: 'ACT-FM', themes: ['environment', 'rural_remote'],                                 home: ['AU-QLD'],          sec: ['AU-NSW'] },
+  { code: 'ACT-FM', themes: ['environment', 'rural_remote', 'community', 'employment', 'indigenous'], home: ['AU-QLD'], sec: ['AU-NSW', 'AU-National'] },
   { code: 'ACT-EL', themes: ['indigenous', 'arts', 'community', 'human_rights'],             home: ['AU-QLD', 'AU-NSW'], sec: ['AU-VIC', 'AU-National', 'AU-NT'] },
 ];
 
 const sqlArr = (a) => `ARRAY[${a.map(s => `'${s.replace(/'/g, "''")}'`).join(',')}]`;
+const ilikeArr = (a) => `ARRAY[${a.map(s => `'%${s.replace(/'/g, "''")}%'`).join(',')}]`;
+
+/**
+ * Values-based exclusion (Ben's call, encoded so no future run re-litigates it):
+ * extractive-industry corporate foundations are filtered out even when they score
+ * high mechanically. Name-pattern match (case-insensitive substring) because these
+ * are specific funders, not a `thematic_focus` tag. Kept tight and named — add a
+ * peer here rather than rejecting the same funder in the UI every nightly run.
+ * NOTE: Minderoo (Forrest/Fortescue-derived) is deliberately NOT here — it's a
+ * borderline call left to human review in the /org pipeline, not auto-filtered.
+ */
+const EXCLUDE_FUNDERS = [
+  'BHP', 'Rio Tinto', 'Glencore', 'Adani', 'Woodside', 'Santos',
+  'Fortescue', 'Whitehaven', 'Peabody', 'Yancoal',
+];
 
 /**
  * The scorer, as a single reusable CTE chain. Both the dry-run SELECT and the
@@ -89,6 +104,7 @@ scored AS (
     ON f.thematic_focus IS NOT NULL
    AND f.thematic_focus && p.themes
    AND NOT ('religion' = ANY(f.thematic_focus))   -- faith-purpose funders are noise for these projects
+   AND NOT (f.name ILIKE ANY (${ilikeArr(EXCLUDE_FUNDERS)}))   -- extractive-industry funders (values exclusion)
 ),
 fit AS (
   SELECT s.*,

--- a/supabase/migrations/20260706120000_act_grant_recommendations_track_record.sql
+++ b/supabase/migrations/20260706120000_act_grant_recommendations_track_record.sql
@@ -1,0 +1,260 @@
+-- Phase 7 · Brick 5 — outcome feedback into the per-project grant engine.
+--
+-- Feeds ACT's actual grant decisions (act_grant_recommendation_decisions) back
+-- into the act_grant_recommendations scorer, so the engine that /find-grants now
+-- reads learns from won/lost:
+--
+--   * won_funder_boost (+15): ACT has WON money from this funder before (any
+--     project). Funder relationships are org-level, so a win anywhere is a strong
+--     "this funder actually funds us" signal for every project's feed.
+--   * passed_penalty (-10): ACT has PASSED on this funder >=2 times FOR THIS
+--     PROJECT — a repeated project-level misfit, so it's project-scoped.
+--   * exclude terminally-decided opps (won / passed / pursuing) for a project so
+--     the feed stays fresh; 'watching' rows are kept (still live candidates).
+--
+-- track_record_score = won_funder_boost + passed_penalty is added into fit_score
+-- (it can lift a proven funder over the is_strong_fit >=55 bar, but theme_score>0
+-- is still required so a proven funder with no thematic overlap never surfaces).
+--
+-- The MV is a full rebuild (materialized views can't be REPLACEd). The dependent
+-- view v_act_pipeline_unified is dropped and recreated verbatim; indexes + grants
+-- are restored. All new columns are additive (track_record_score, won_funder),
+-- so existing readers (v_act_pipeline_unified, app SELECTs) are unaffected.
+
+BEGIN;
+
+DROP VIEW IF EXISTS v_act_pipeline_unified;
+DROP MATERIALIZED VIEW IF EXISTS act_grant_recommendations;
+
+CREATE MATERIALIZED VIEW act_grant_recommendations AS
+ WITH project_themes AS (
+         SELECT arp.project_code,
+            p.name AS project_name,
+            arp.theme_keywords,
+            arp.home_states,
+            arp.secondary_states
+           FROM act_grant_recommendation_projects arp
+             JOIN projects p ON p.code = arp.project_code
+          WHERE arp.in_scope = true
+        ), opps AS (
+         SELECT a.id,
+            a.name,
+            a.funder_name,
+            a.min_grant_amount,
+            a.max_grant_amount,
+            a.opens_at,
+            a.deadline,
+            a.jurisdictions,
+            a.is_national,
+            a.eligible_org_types,
+            a.requires_deductible_gift_recipient,
+            a.focus_areas,
+            a.keywords,
+            a.source_url,
+            a.application_url,
+            a.opportunity_type,
+            a.verification_status,
+            a.verified_at
+           FROM alma_funding_opportunities a
+          WHERE (COALESCE(a.status, 'open'::text) <> ALL (ARRAY['archived'::text, 'closed'::text, 'cancelled'::text, 'rejected'::text])) AND (a.deadline IS NULL OR a.deadline >= now()) AND a.opportunity_type = 'open_grant'::text AND a.verification_status = 'verified'::text AND NOT (EXISTS ( SELECT 1
+                   FROM funder_blocklist b
+                  WHERE b.active = true AND lower(b.funder_name) = lower(a.funder_name)))
+        ),
+        -- ── Brick 5: outcome-feedback CTEs, derived from ACT's real decisions ──
+        tr_decisions AS (
+         SELECT d.project_code,
+            d.opportunity_id,
+            d.decision,
+            lower(a.funder_name) AS funder_lc
+           FROM act_grant_recommendation_decisions d
+             JOIN alma_funding_opportunities a ON a.id = d.opportunity_id
+        ), tr_won_funders AS (
+         SELECT DISTINCT funder_lc
+           FROM tr_decisions
+          WHERE decision = 'won' AND funder_lc IS NOT NULL
+        ), tr_passed AS (
+         SELECT project_code, funder_lc
+           FROM tr_decisions
+          WHERE decision = 'passed' AND funder_lc IS NOT NULL
+          GROUP BY project_code, funder_lc
+         HAVING count(*) >= 2
+        ), tr_decided_opps AS (
+         SELECT DISTINCT project_code, opportunity_id
+           FROM act_grant_recommendation_decisions
+          WHERE decision = ANY (ARRAY['won'::text, 'passed'::text, 'pursuing'::text])
+        ), scored AS (
+         SELECT pt.project_code,
+            pt.project_name,
+            o.id AS opportunity_id,
+            o.name AS opportunity_name,
+            o.funder_name,
+            o.deadline,
+            o.opens_at,
+            o.min_grant_amount,
+            o.max_grant_amount,
+            o.is_national,
+            o.jurisdictions,
+            o.eligible_org_types,
+            o.focus_areas,
+            o.keywords,
+            o.source_url,
+            o.application_url,
+            o.opportunity_type,
+            o.verification_status,
+            o.verified_at,
+            LEAST(50::bigint, ( SELECT count(DISTINCT pk.pk) * 10
+                   FROM unnest(pt.theme_keywords) pk(pk)
+                  WHERE length(pk.pk) >= 4 AND (EXISTS ( SELECT 1
+                           FROM unnest(COALESCE(o.focus_areas, '{}'::text[]) || COALESCE(o.keywords, '{}'::text[])) okw(okw)
+                          WHERE length(okw.okw) >= 4 AND (lower(okw.okw) ~~ (('%'::text || lower(pk.pk)) || '%'::text) OR lower(pk.pk) ~~ (('%'::text || lower(okw.okw)) || '%'::text))))))::numeric AS theme_score_raw,
+            COALESCE(tdp.theme_multiplier, 1.0) AS theme_multiplier,
+            COALESCE(tdp.avg_tag_count, 0::numeric) AS funder_avg_tags,
+                CASE
+                    WHEN o.is_national THEN 15
+                    WHEN o.jurisdictions && pt.home_states THEN 15
+                    WHEN o.jurisdictions && pt.secondary_states THEN 9
+                    ELSE 0
+                END AS geography_score,
+                CASE
+                    WHEN o.eligible_org_types && ARRAY['charity'::text, 'company'::text, 'community_organisation'::text, 'social_enterprise'::text, 'arts_organisation'::text, 'collective'::text] THEN 20
+                    WHEN o.eligible_org_types && ARRAY['aboriginal_corporation'::text, 'indigenous_charity'::text, 'indigenous_org'::text, 'community_org'::text] THEN 10
+                    ELSE 5
+                END AS eligibility_score,
+                CASE
+                    WHEN o.deadline IS NULL THEN 8
+                    WHEN o.deadline >= (now() + '30 days'::interval) THEN 15
+                    WHEN o.deadline >= (now() + '7 days'::interval) THEN 8
+                    WHEN o.deadline >= now() THEN 4
+                    ELSE 0
+                END AS timing_score,
+                -- Brick 5 track-record components
+                CASE WHEN wf.funder_lc IS NOT NULL THEN 15 ELSE 0 END AS won_funder_boost,
+                CASE WHEN pp.funder_lc IS NOT NULL THEN -10 ELSE 0 END AS passed_penalty,
+                (wf.funder_lc IS NOT NULL) AS won_funder,
+            array_remove(ARRAY[
+                CASE
+                    WHEN o.requires_deductible_gift_recipient THEN 'requires_dgr'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN o.eligible_org_types && ARRAY['aboriginal_corporation'::text, 'indigenous_charity'::text, 'indigenous_org'::text] AND NOT o.eligible_org_types && ARRAY['charity'::text, 'company'::text, 'community_organisation'::text] THEN 'partner_required'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN o.deadline IS NOT NULL AND o.deadline < (now() + '14 days'::interval) THEN 'tight_deadline'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN o.is_national THEN 'national'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN o.max_grant_amount IS NOT NULL AND o.max_grant_amount >= 500000::numeric THEN 'large_grant'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN o.max_grant_amount IS NOT NULL AND o.max_grant_amount < 50000::numeric THEN 'small_grant'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN COALESCE(tdp.theme_multiplier, 1.0) < 1.0 THEN 'tag_stuffed'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN wf.funder_lc IS NOT NULL THEN 'won_funder'::text
+                    ELSE NULL::text
+                END,
+                CASE
+                    WHEN pp.funder_lc IS NOT NULL THEN 'repeatedly_passed'::text
+                    ELSE NULL::text
+                END], NULL::text) AS flags
+           FROM project_themes pt
+             CROSS JOIN opps o
+             LEFT JOIN v_funder_tag_density tdp ON tdp.funder_name = o.funder_name
+             LEFT JOIN tr_won_funders wf ON wf.funder_lc = lower(o.funder_name)
+             LEFT JOIN tr_passed pp ON pp.funder_lc = lower(o.funder_name) AND pp.project_code = pt.project_code
+          -- keep the feed fresh: drop opps ACT has already terminally decided on
+          WHERE NOT (EXISTS ( SELECT 1
+                   FROM tr_decided_opps td
+                  WHERE td.project_code = pt.project_code AND td.opportunity_id = o.id))
+        )
+ SELECT project_code,
+    project_name,
+    opportunity_id,
+    opportunity_name,
+    funder_name,
+    deadline,
+    opens_at,
+    min_grant_amount,
+    max_grant_amount,
+    is_national,
+    jurisdictions,
+    eligible_org_types,
+    focus_areas,
+    keywords,
+    source_url,
+    application_url,
+    opportunity_type,
+    verification_status,
+    verified_at,
+    round(theme_score_raw * theme_multiplier)::integer AS theme_score,
+    geography_score,
+    eligibility_score,
+    timing_score,
+    won_funder_boost + passed_penalty AS track_record_score,
+    won_funder,
+    round(theme_score_raw * theme_multiplier)::integer + geography_score + eligibility_score + timing_score + won_funder_boost + passed_penalty AS fit_score,
+    round(theme_score_raw * theme_multiplier)::integer > 0 AND (round(theme_score_raw * theme_multiplier)::integer + geography_score + eligibility_score + timing_score + won_funder_boost + passed_penalty) >= 55 AS is_strong_fit,
+    theme_multiplier < 1.0 AS tag_density_penalised,
+    funder_avg_tags,
+    flags,
+    now() AS computed_at
+   FROM scored;
+
+-- Restore indexes (unique pk index is required for REFRESH ... CONCURRENTLY)
+CREATE UNIQUE INDEX act_grant_recommendations_pk_idx ON public.act_grant_recommendations USING btree (project_code, opportunity_id);
+CREATE INDEX act_grant_recommendations_strong_idx ON public.act_grant_recommendations USING btree (is_strong_fit) WHERE is_strong_fit;
+
+-- Restore the dependent unified-pipeline view verbatim
+CREATE VIEW v_act_pipeline_unified AS
+ SELECT op.id AS pipeline_id,
+    op.project_code,
+    op.name AS opportunity_name,
+    op.funder,
+    op.amount_display,
+    op.amount_numeric,
+    op.deadline,
+    op.status AS pipeline_status,
+    op.opportunity_type,
+    op.qbe_stage,
+    op.qbe_outcome,
+    op.qbe_bid_amount,
+    op.pathway,
+    op.recommended_role,
+    agr.fit_score,
+    agr.is_strong_fit,
+    agr.flags AS recommendation_flags,
+    agrd.decision AS last_decision,
+    agrd.decided_at,
+    agrd.notes AS decision_notes,
+    arp.project_label,
+    arp.layer AS project_layer,
+    arp.readiness AS project_readiness,
+    arp.dgr_required AS project_dgr_required,
+    arp.entity_preference AS project_entity_preference,
+    op.created_at,
+    op.updated_at
+   FROM org_pipeline op
+     LEFT JOIN act_grant_recommendation_projects arp ON arp.project_code = op.project_code
+     LEFT JOIN act_grant_recommendations agr ON agr.project_code = op.project_code AND agr.opportunity_id = op.grant_opportunity_id
+     LEFT JOIN LATERAL ( SELECT act_grant_recommendation_decisions.decision,
+            act_grant_recommendation_decisions.decided_at,
+            act_grant_recommendation_decisions.notes
+           FROM act_grant_recommendation_decisions
+          WHERE act_grant_recommendation_decisions.project_code = op.project_code AND act_grant_recommendation_decisions.opportunity_id = op.grant_opportunity_id
+          ORDER BY act_grant_recommendation_decisions.decided_at DESC
+         LIMIT 1) agrd ON true;
+
+GRANT ALL ON v_act_pipeline_unified TO anon, authenticated, service_role;
+
+COMMIT;

--- a/thoughts/shared/plans/act-opportunity-engine-phase7.md
+++ b/thoughts/shared/plans/act-opportunity-engine-phase7.md
@@ -26,10 +26,21 @@ The sharp asymmetry: **grants self-populate per project; foundations were hand-f
 - Registered in `scripts/lib/agent-registry.mjs` as `match-foundations-for-projects` (dry-run command; flip to `--apply` for nightly once first apply is human-approved).
 - Crosswalk (project coarse-themes) lives in-script (`CROSSWALK` const) — transparent; hardening follow-up = move to an `act_grant_recommendation_projects.foundation_themes` column.
 
-**NEXT (not yet done):**
+**NEXT (foundation-match agent):**
 - Ben authorizes first `--apply` run (Tier 3 — write to shared prod), then eyeball in `/org` pipeline UI.
 - Extractive-industry funders (BHP/Rio Tinto Foundations rank high mechanically) = **values decision** for Ben — kept as candidates, not auto-filtered.
-- Then: Brick 5 (won/lost → scorer + funders.json), coherence cleanup (orphaned tables), and the "connect brain to engine" rewire (`/find-grants` reads `act_grant_recommendations`, not raw `grant_opportunities`).
+
+### Item 4 — Brick 5 (won/lost feedback) + /find-grants→engine rewire — BUILT 2026-07-06 (awaiting Ben's Tier 3 apply)
+Ben's scope decisions: scorer sink = **the per-project engine MV** (not the web-app org scorer); funders.json = **draft-a-diff, Ben applies** (no cross-repo write).
+
+1. **Scorer (Brick 5) — `supabase/migrations/20260706120000_act_grant_recommendations_track_record.sql`.** Rebuilds the `act_grant_recommendations` MV with a decisions-derived `track_record_score` (−10…+15) folded into `fit_score`:
+   - +15 `won_funder_boost` if ACT has a `won` decision with this funder (org-level, any project) → `won_funder=true`, `won_funder` flag.
+   - −10 `passed_penalty` if ACT `passed` on this funder ≥2× for THIS project → `repeatedly_passed` flag.
+   - Excludes terminally-decided opps (won/passed/pursuing) so the feed stays fresh; `watching` kept.
+   - New additive cols: `track_record_score`, `won_funder`. Dependent view `v_act_pipeline_unified` dropped/recreated verbatim; indexes + grants restored.
+   - **Validated in a rolled-back prod txn:** DDL runs clean, 0 decided opps leak, 12 boosts / 25 penalties, `theme_score>0` gate still governs `is_strong_fit`, dependent view resolves. **NOT YET APPLIED — Ben runs psql (Tier 3), then nightly-grant-pipeline's `REFRESH … CONCURRENTLY` keeps it live.**
+2. **Rewire — `act-grant-triage.md`** (skill behind `/find-grants`, canonical in `~/Code/act-claude-plugins`, synced to active plugin dir). Now reads the `act_grant_recommendations` engine MV per project (was raw `grant_opportunities` JOIN `foundations`) — inherits verification gating, blocklist, the decision loop, and per-project `fit_score`/`is_strong_fit`. Plugins repo has one uncommitted file for Ben to commit.
+3. **funders.json half — `scripts/draft-funders-json-from-wins.mjs`** (read-only, never writes the cross-repo ledger). Emits `thoughts/shared/plans/funders-json-from-wins.proposal.md`: 22 proposed updates (add project_code to `projects_funded`, advance genuine funders' pre-funded stage → `active-partner`, bump `last_communicated_at`). Commercial customers already in the ledger at `stage=needs-writeup` are correctly left un-advanced. **Ben reviews + applies by hand.** Note surfaced: the ledger was previously bulk-seeded with commercial customers (Berry Obsession, Bigmeats, etc.) — a hygiene call for Ben, out of scope here.
 
 ---
 

--- a/thoughts/shared/plans/funders-json-from-wins.proposal.md
+++ b/thoughts/shared/plans/funders-json-from-wins.proposal.md
@@ -1,0 +1,103 @@
+# funders.json — proposed updates from `won` grant decisions
+
+_Generated 2026-07-06T09:21:52.373Z by `scripts/draft-funders-json-from-wins.mjs`. Read-only draft — apply by hand in `act-global-infrastructure`._
+
+## 1. Update existing ledger entries
+
+### `homeland-school-company` — Homeland School Company  _(won as "Homeland School Company")_
+- `projects_funded`: add `ACT-JH`
+- `last_communicated_at`: `null` → `2026-05-18`
+
+### `sonas-properties-pty-ltd` — Sonas Properties Pty Ltd  _(won as "Sonas Properties Pty Ltd")_
+- `projects_funded`: add `ACT-HV`
+- `last_communicated_at`: `null` → `2026-03-20`
+
+### `blue-gum-station` — Blue Gum Station  _(won as "Blue Gum Station")_
+- `projects_funded`: add `ACT-HV`
+- `last_communicated_at`: `null` → `2026-03-14`
+
+### `just-reinvest` — Just Reinvest  _(won as "Just Reinvest")_
+- `projects_funded`: add `ACT-JH`
+- `last_communicated_at`: `null` → `2026-03-01`
+
+### `berry-obsession-pty-ltd` — Berry Obsession PTY LTD  _(won as "Berry Obsession PTY LTD")_
+- `projects_funded`: add `ACT-HV`
+- `last_communicated_at`: `null` → `2026-02-10`
+
+### `smart-recovery-australia` — SMART Recovery Australia  _(won as "SMART Recovery Australia")_
+- `projects_funded`: add `ACT-SM`
+- `last_communicated_at`: `null` → `2026-02-09`
+
+### `our-community-shed-incorporated` — Our Community Shed Incorporated  _(won as "Our Community Shed Incorporated")_
+- `projects_funded`: add `ACT-GD`
+- `last_communicated_at`: `null` → `2026-01-20`
+
+### `regional-arts-australia` — Regional Arts Australia  _(won as "Regional Arts Australia")_
+- `projects_funded`: add `ACT-HV`
+- `last_communicated_at`: `null` → `2025-12-11`
+
+### `social-impact-hub` — Social Impact Hub Foundation  _(won as "Social Impact Hub Foundation")_
+- `projects_funded`: add `ACT-CP`
+- `stage`: `lapsed` → `active-partner`
+- `last_communicated_at`: `null` → `2025-11-18`
+
+### `palm-island-community-company-limited-picc` — Palm Island Community Company Limited (PICC)  _(won as "Palm Island Community Company Limited (PICC)")_
+- `projects_funded`: add `ACT-PI`
+- `last_communicated_at`: `null` → `2025-11-03`
+
+### `malala-health-service-aboriginal-corporation` — Mala’la Health Service Aboriginal Corporation  _(won as "Mala’la Health Service Aboriginal Corporation")_
+- `projects_funded`: add `ACT-GD`
+- `last_communicated_at`: `null` → `2025-10-21`
+
+### `julalikari-council-aboriginal-corporation` — Julalikari Council Aboriginal Corporation  _(won as "Julalikari Council Aboriginal Corporation")_
+- `projects_funded`: add `ACT-GD`
+- `last_communicated_at`: `null` → `2025-10-21`
+
+### `ingkerreke-services-aboriginal-corporation` — Ingkerreke Services Aboriginal Corporation  _(won as "Ingkerreke Services Aboriginal Corporation")_
+- `projects_funded`: add `ACT-OO`
+- `last_communicated_at`: `null` → `2025-09-27`
+
+### `brisbane-powerhouse-foundation` — Brisbane Powerhouse Foundation  _(won as "Brisbane Powerhouse Foundation")_
+- `projects_funded`: add `ACT-CF`
+- `stage`: `lapsed` → `active-partner`
+- `last_communicated_at`: `null` → `2025-09-25`
+
+### `red-dust-role-models-limited` — Red Dust Role Models Limited  _(won as "Red Dust Role Models Limited")_
+- `projects_funded`: add `ACT-GD`
+- `last_communicated_at`: `null` → `2025-07-30`
+
+### `vincent-fairfax` — Vincent Fairfax Family Foundation  _(won as "Vincent Fairfax Family Foundation")_
+- `projects_funded`: add `ACT-GD`
+- `stage`: `lapsed` → `active-partner`
+- `last_communicated_at`: `null` → `2025-07-24`
+
+### `green-fox-training-studio-limited` — GREEN FOX TRAINING STUDIO LIMITED  _(won as "GREEN FOX TRAINING STUDIO LIMITED")_
+- `projects_funded`: add `ACT-JH`
+- `last_communicated_at`: `null` → `2025-07-17`
+
+### `jenn-brazier` — Jenn Brazier  _(won as "Jenn Brazier")_
+- `projects_funded`: add `ACT-GP`
+- `last_communicated_at`: `null` → `2025-07-17`
+
+### `paul-ramsay-foundation` — Paul Ramsay Foundation  _(won as "Paul Ramsay Foundation")_
+- `projects_funded`: add `ACT-EL`
+- `stage`: `warm` → `active-partner`
+- `last_communicated_at`: `null` → `2025-07-05`
+
+### `qic-limited` — QIC LIMITED  _(won as "QIC LIMITED")_
+- `projects_funded`: add `ACT-GD`
+- `last_communicated_at`: `null` → `2025-06-30`
+
+### `state-of-queensland-acting-through-the-department-of-familie` — State of Queensland (acting through the Department of Families, Seniors, Disability Services and Child Safety)  _(won as "State of Queensland (acting through the Department of Families, Seniors, Disability Services and Child Safety)")_
+- `projects_funded`: add `ACT-EL`
+- `last_communicated_at`: `null` → `2025-05-15`
+
+### `bigmeats-qld-pty-ltd` — Bigmeats Qld Pty Ltd  _(won as "Bigmeats Qld Pty Ltd")_
+- `projects_funded`: add `ACT-FM`
+- `last_communicated_at`: `null` → `2025-02-09`
+
+## 2. New funder entries to consider (looked like real funders)
+_None._
+
+## 3. Flagged — a win, but probably NOT a philanthropic funder (do not add without review)
+_None._


### PR DESCRIPTION
## Phase 7 · Item 4 — close the find→engage→**learn** loop

ACT's grant decisions now feed the per-project recommendation engine, and `/find-grants` reads that engine instead of a raw table.

### 1. Brick 5 scorer — `act_grant_recommendations` MV learns from decisions
Rebuilds the MV with a decisions-derived `track_record_score` (−10…+15) folded into `fit_score`:
- **+15** if ACT has a `won` decision with the funder (org-level, any project) → `won_funder=true`, `won_funder` flag
- **−10** if ACT `passed` on the funder ≥2× for that project → `repeatedly_passed` flag
- **Excludes** terminally-decided opps (won/passed/pursuing); keeps `watching`

New additive columns `track_record_score` / `won_funder`. Dependent view `v_act_pipeline_unified` + indexes + grants restored (MVs can't be `REPLACE`d → full DROP+CREATE). Validated in a rolled-back prod txn, **already applied to prod** (`SELECT 6640`; 12 boosts / 25 penalties / 370 strong). The nightly `REFRESH … CONCURRENTLY` in `nightly-grant-pipeline.mjs` keeps it live.

### 2. `/find-grants` → engine rewire
`act-grant-triage.md` (skill behind `/find-grants`, in the `act-claude-plugins` repo — committed there separately) now reads the `act_grant_recommendations` engine MV per project instead of raw `grant_opportunities` JOIN `foundations`, inheriting verification gating, the funder blocklist, per-project `fit_score`, and the decision loop.

### 3. funders.json half — draft, not write
`scripts/draft-funders-json-from-wins.mjs` (read-only) emits `thoughts/shared/plans/funders-json-from-wins.proposal.md` — 22 proposed ledger updates from `won` decisions. Never writes the cross-repo `funders.json`; Ben applies by hand.

## Test / verification
- Migration validated in a rolled-back prod transaction (0 decided-opps leak, `theme_score>0` still gates `is_strong_fit`, dependent view resolves), then applied live — persisted numbers match exactly.
- No TypeScript touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)