### PR TITLE
Fix the agents failing 100% of runs: psql PATH and a second unique index

### DIFF
--- a/scripts/build-se-search-index.mjs
+++ b/scripts/build-se-search-index.mjs
@@ -17,9 +17,16 @@ import { execSync } from 'node:child_process';
 import { writeFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { createClient } from '@supabase/supabase-js';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import { resolveBin } from './lib/agent-resilience.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const CONN = `postgresql://postgres.tednluwflfhxyucgwigh:${process.env.DATABASE_PASSWORD}@aws-0-ap-southeast-2.pooler.supabase.com:5432/postgres`;
+
+// Resolve psql by full path. The agent runner starts from a non-interactive
+// shell whose PATH does not include the Postgres bin directory, so a bare
+// `psql` fails with "command not found" in under a second. Every run of this
+// agent failed that way; the scripts that call resolveBin have been fine.
+const PSQL_BIN = resolveBin('psql');
 const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
 if (!process.env.DATABASE_PASSWORD) {
@@ -74,7 +81,7 @@ function runPsql(sql, { label = 'se-search-index' } = {}) {
   const outFile = `/tmp/${label}-${stamp}.out`;
   writeFileSync(sqlFile, `\\t on\n\\a\n\\o ${outFile}\n${sql}\n\\o\n`);
   try {
-    execSync(`psql "${CONN}" -v ON_ERROR_STOP=1 -f ${sqlFile}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+    execSync(`"${PSQL_BIN}" "${CONN}" -v ON_ERROR_STOP=1 -f ${sqlFile}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
     return readFileSync(outFile, 'utf-8').trim();
   } catch (err) {
     throw new Error(`psql failed: ${err.stderr || err.message}`);

--- a/scripts/compute-se-verification-tiers.mjs
+++ b/scripts/compute-se-verification-tiers.mjs
@@ -21,9 +21,16 @@ import { execSync } from 'node:child_process';
 import { writeFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { createClient } from '@supabase/supabase-js';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import { resolveBin } from './lib/agent-resilience.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const CONN = `postgresql://postgres.tednluwflfhxyucgwigh:${process.env.DATABASE_PASSWORD}@aws-0-ap-southeast-2.pooler.supabase.com:5432/postgres`;
+
+// Resolve psql by full path. The agent runner starts from a non-interactive
+// shell whose PATH does not include the Postgres bin directory, so a bare
+// `psql` fails with "command not found" in under a second. Every run of this
+// agent failed that way; the scripts that call resolveBin have been fine.
+const PSQL_BIN = resolveBin('psql');
 const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
 if (!process.env.DATABASE_PASSWORD) {
@@ -90,7 +97,7 @@ function runPsql(sql, { label = 'se-tiers' } = {}) {
   const outFile = `/tmp/${label}-${stamp}.out`;
   writeFileSync(sqlFile, `SET statement_timeout = '120s';\n\\t on\n\\a\n\\o ${outFile}\n${sql}\n\\o\n`);
   try {
-    const stdout = execSync(`psql "${CONN}" -v ON_ERROR_STOP=1 -f ${sqlFile}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdout = execSync(`"${PSQL_BIN}" "${CONN}" -v ON_ERROR_STOP=1 -f ${sqlFile}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
     return { out: readFileSync(outFile, 'utf-8').trim(), stdout };
   } catch (err) {
     throw new Error(`psql failed: ${err.stderr || err.message}`);

--- a/scripts/ingest-grantconnect-go.mjs
+++ b/scripts/ingest-grantconnect-go.mjs
@@ -154,10 +154,32 @@ async function main() {
     return;
   }
 
-  // url has a non-partial UNIQUE index — safe PostgREST onConflict target
+  // grant_opportunities carries FOUR unique indexes: url, (source, name),
+  // (name, source_id) and the primary key. PostgREST ON CONFLICT can only name one,
+  // so an upsert on `url` still trips the others.
+  //
+  // That is what has been failing every run:
+  //   duplicate key value violates "grant_opportunities_source_name_full_uniq"
+  //
+  // The stored rows are clean, so the collision is INSIDE the batch: GrantConnect
+  // lists the same grant name twice under different GoUuids, which produces two
+  // distinct urls and one (source, name). Deduplicate before writing, keeping the
+  // last occurrence, and count what was dropped rather than discarding it silently.
+  const bySourceName = new Map();
+  let collapsed = 0;
+  for (const row of rows) {
+    const key = `${row.source}::${row.name}`;
+    if (bySourceName.has(key)) collapsed += 1;
+    bySourceName.set(key, row);
+  }
+  const deduped = [...bySourceName.values()];
+  if (collapsed > 0) {
+    console.log(`  ${collapsed} duplicate (source, name) rows collapsed before upsert`);
+  }
+
   let upserted = 0;
-  for (let i = 0; i < rows.length; i += 100) {
-    const batch = rows.slice(i, i + 100);
+  for (let i = 0; i < deduped.length; i += 100) {
+    const batch = deduped.slice(i, i + 100);
     const { error } = await supabase.from('grant_opportunities').upsert(batch, { onConflict: 'url', ignoreDuplicates: false });
     if (error) throw new Error(`upsert failed: ${error.message}`);
     upserted += batch.length;

--- a/scripts/lib/psql.mjs
+++ b/scripts/lib/psql.mjs
@@ -18,8 +18,15 @@
 
 import { execSync } from 'child_process';
 import { writeFileSync, unlinkSync } from 'fs';
+import { resolveBin } from './agent-resilience.mjs';
 
 const CONN_STR = `postgresql://postgres.tednluwflfhxyucgwigh:${process.env.DATABASE_PASSWORD}@aws-0-ap-southeast-2.pooler.supabase.com:5432/postgres`;
+
+// Resolve psql by full path. The agent runner starts from a non-interactive shell
+// whose PATH does not include the Postgres bin directory, so a bare `psql` fails
+// with "command not found" in under a second. 18 scripts import this helper, so
+// resolving it here fixes all of them rather than one at a time.
+const PSQL_BIN = resolveBin('psql');
 
 /**
  * Execute a SQL query via psql and return parsed rows.
@@ -37,7 +44,7 @@ export function psql(sql, { timeout = 120000, parse = true, maxBuffer = 50 * 102
   writeFileSync(tmpFile, sql);
   try {
     const result = execSync(
-      `psql "${CONN_STR}" --csv -f ${tmpFile} 2>/dev/null`,
+      `"${PSQL_BIN}" "${CONN_STR}" --csv -f ${tmpFile} 2>/dev/null`,
       { encoding: 'utf-8', maxBuffer, timeout }
     );
     unlinkSync(tmpFile);


### PR DESCRIPTION
Four agents have failed every run for weeks. Both causes are one-line fixes, and neither needed credentials to diagnose — `agent_runs.errors` had the answer.

## `psql: command not found` — SE Search Index Builder, SE Verification Tiers

Not a missing install. The agent runner starts from a non-interactive shell whose PATH excludes the Postgres bin directory, so bare `psql` isn't found and both agents fail in under a second. An interactive terminal finds it fine, which is why it reads as an environment problem.

The repo already had the answer: `resolveBin()` in `scripts/lib/agent-resilience.mjs` checks a `*_BIN` override, then `which`, then known install paths. Every script using it has been fine.

Verified: `resolveBin('psql')` returns `/opt/homebrew/opt/postgresql@16/bin/psql`, and `env -i PATH=/usr/bin:/bin command -v psql` finds nothing — the runner's situation.

Fixed in three places, and the third is the one that matters:
- `scripts/build-se-search-index.mjs`
- `scripts/compute-se-verification-tiers.mjs`
- **`scripts/lib/psql.mjs`** — imported by 18 scripts

Patching the shared helper covers every script using it rather than the two failing today.

## Duplicate key — GrantConnect Open Opportunities

`grant_opportunities` carries four unique indexes (`url`, `(source, name)`, `(name, source_id)`, pkey). PostgREST `ON CONFLICT` can only name one, so upserting on `url` still trips the others.

The stored data is clean — all 232 grantconnect rows agree on both keys — so the collision is inside the batch: GrantConnect lists the same grant name under different GoUuids, giving two urls and one `(source, name)`. Now deduplicated before writing, with the collapsed count logged rather than dropped silently.

## Not fixed

- **Refresh Youth Justice Source Chain** exits status 1 after ~19 minutes. Real failure inside a long pipeline; `docs/health-backlog.md` already tracks it at 7% success.
- **Discover Foundation Programs** times out with `duration_ms: 0` — never starts, which points at the orchestrator rather than the script.

Neither fix is verified against a live run; the psql one can't be until those agents next fire.