### PR TITLE
feat(goods): complete the CivicGraph→GHL handoff (G3–G7) + E2E re-spec

### DIFF
--- a/apps/web/src/app/api/goods/grants/push-ghl/route.ts
+++ b/apps/web/src/app/api/goods/grants/push-ghl/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireModule } from '@/lib/api-auth';
+import { getServiceSupabase } from '@/lib/supabase';
+import { pushGoodsGrantToGHL, type GoodsGrantPushInput } from '@/lib/services/goods-grant-ghl';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const auth = await requireModule('tracker');
+  if (auth.error) return auth.error;
+
+  const body = (await request.json().catch(() => ({}))) as Partial<GoodsGrantPushInput>;
+  if (!body.grantId || !body.name) {
+    return NextResponse.json({ error: 'grantId and name required' }, { status: 400 });
+  }
+
+  const db = getServiceSupabase();
+
+  // Idempotency: if the row is already linked, return the existing opportunity.
+  const { data: existing } = await db
+    .from('grant_opportunities')
+    .select('ghl_opportunity_id')
+    .eq('id', body.grantId)
+    .maybeSingle();
+  if (existing?.ghl_opportunity_id) {
+    return NextResponse.json({ opportunityId: existing.ghl_opportunity_id, alreadyLinked: true });
+  }
+
+  const result = await pushGoodsGrantToGHL({
+    grantId: body.grantId,
+    name: body.name,
+    provider: body.provider ?? null,
+    fitScore: body.fitScore ?? null,
+    deadline: body.deadline ?? null,
+    url: body.url ?? null,
+    geography: body.geography ?? null,
+    amountMin: body.amountMin ?? null,
+    amountMax: body.amountMax ?? null,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: 'GHL push failed', detail: result }, { status: 502 });
+  }
+
+  await db
+    .from('grant_opportunities')
+    .update({ ghl_opportunity_id: result.opportunityId })
+    .eq('id', body.grantId);
+
+  return NextResponse.json({ opportunityId: result.opportunityId });
+}

--- a/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/buyers/page.tsx
@@ -95,7 +95,10 @@ function BuyerCard({ r, power, funding }: { r: BuyerPipelineRow; power: Relation
               );
             })()
           ) : (
-            <span className="px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest bg-bauhaus-canvas text-bauhaus-muted">
+            <span
+              className="px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest bg-bauhaus-canvas text-bauhaus-muted"
+              title="Push this buyer from its community dossier — pushes are deliberate, not inline"
+            >
               No GHL signal
             </span>
           )}

--- a/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
@@ -9,6 +9,8 @@ import {
   type LocalEntity,
 } from '@/lib/services/goods-community-detail';
 import { RecordDeploymentButton } from './record-deployment';
+import { PushToGhlButton } from './push-to-ghl-button';
+import { ghlLocationId } from '@/lib/ghl-links';
 
 export const revalidate = 300;
 
@@ -231,6 +233,49 @@ export default async function GoodsCommunityPage({
                 <FactRow label="Freight corridor" value={community.freight_corridor || 'Not recorded'} />
                 <FactRow label="Last-mile method" value={community.last_mile_method || 'Not recorded'} />
               </dl>
+            </Section>
+
+            <Section title="Buyers and procurement pathways" eyebrow="GHL is the system of record">
+              {mappedBuyers.length > 0 ? (
+                <ul className="space-y-2">
+                  {mappedBuyers.slice(0, 8).map((buyer) => (
+                    <li key={buyer.id} className="flex items-start justify-between gap-3 rounded-md border border-[var(--ws-border)] bg-[#fafbf9] px-3 py-3">
+                      <div className="min-w-0">
+                        <div className="text-sm font-semibold leading-5">{buyer.entity_name}</div>
+                        <div className="mt-1 text-[10px] text-[var(--ws-text-secondary)]">
+                          {humanise(buyer.buyer_role || 'buyer')}
+                          {buyer.relationship_status ? ` · ${humanise(buyer.relationship_status)}` : ''}
+                        </div>
+                        {buyer.next_action ? <div className="mt-1 text-[10px] leading-4 text-[var(--ws-text-secondary)]">Next: {buyer.next_action}</div> : null}
+                      </div>
+                      <PushToGhlButton
+                        compact
+                        ghlLocationId={ghlLocationId()}
+                        payload={{
+                          entityName: buyer.entity_name,
+                          buyerRole: buyer.buyer_role,
+                          abn: buyer.abn,
+                          website: buyer.website,
+                          communityName: community.community_name,
+                          communityState: community.state,
+                          isCommunityControlled: buyer.is_community_controlled ?? false,
+                          relationshipStatus: buyer.relationship_status,
+                          govtContractValue: buyer.govt_contract_value,
+                          communityId: community.id,
+                          entityId: buyer.entity_id,
+                          buyerEntityRowId: buyer.id,
+                        }}
+                        linked={buyer.ghl_contact_id ? {
+                          contactId: buyer.ghl_contact_id,
+                          opportunityId: buyer.ghl_opportunity_id ?? undefined,
+                          stageName: buyer.ghl_stage_name ?? undefined,
+                          lastPushedAt: buyer.ghl_last_pushed_at ?? undefined,
+                        } : undefined}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              ) : <Empty text="No mapped buyers yet." />}
             </Section>
 
             <Section title="Procurement and funding signals" eyebrow="Verify before action">

--- a/apps/web/src/app/org/[slug]/goods/foundations/scan/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/foundations/scan/page.tsx
@@ -186,6 +186,7 @@ export default async function GoodsFunderScanPage({
           <ul className="mt-2 list-disc pl-5 space-y-1">
             <li><strong>GHL warmth is authoritative</strong> — it comes from the tags on the real contact with the email history. Discovery stage is CivicGraph&apos;s opinion.</li>
             <li><strong>Warm but unworked</strong> is money on the table: a live relationship discovery hasn&apos;t ranked. <strong>Push-next</strong> is the reverse: high-fit prospects nobody has contacted.</li>
+            <li><strong>Pushing is deliberate</strong> — work the push-next queue by creating the contact in GHL itself (warmth chips link to synced contacts); there is no one-click push here by design.</li>
             <li>&ldquo;Not in GHL&rdquo; rows were checked against GHL only if synced — run <code className="bg-white px-1">scripts/reconcile-foundations-ghl.mjs</code> after rotating GHL_API_KEY to sync all rows.</li>
           </ul>
         </div>

--- a/apps/web/src/app/org/[slug]/goods/grants/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/grants/page.tsx
@@ -4,6 +4,7 @@ import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/servic
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsGrantsTriage, type TriageGrantRow } from '@/lib/services/goods-grants-triage';
 import { GoodsSubNav } from '../_components/goods-sub-nav';
+import { PushGrantGhlButton } from './push-grant-ghl-button';
 
 export const dynamic = 'force-dynamic';
 
@@ -131,11 +132,12 @@ export default async function GoodsGrantsTriagePage({
                 <Th align="right">Amount</Th>
                 <Th>Where</Th>
                 <Th>Entity fit</Th>
+                <Th>Pipeline</Th>
               </tr>
             </thead>
             <tbody>
               {grants.length === 0 ? (
-                <tr><td colSpan={7} className="px-3 py-6 text-center text-gray-500">Nothing matches this filter.</td></tr>
+                <tr><td colSpan={8} className="px-3 py-6 text-center text-gray-500">Nothing matches this filter.</td></tr>
               ) : (
                 grants.map((g, i) => <Row key={g.id} g={g} alt={i % 2 === 1} />)
               )}
@@ -233,6 +235,9 @@ function Row({ g, alt }: { g: TriageGrantRow; alt: boolean }) {
         ) : (
           <span className="text-gray-400">check</span>
         )}
+      </td>
+      <td className="border-b border-gray-300 px-2 py-1.5 align-top whitespace-nowrap">
+        <PushGrantGhlButton g={g} />
       </td>
     </tr>
   );

--- a/apps/web/src/app/org/[slug]/goods/grants/push-grant-ghl-button.tsx
+++ b/apps/web/src/app/org/[slug]/goods/grants/push-grant-ghl-button.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import type { TriageGrantRow } from '@/lib/services/goods-grants-triage';
+
+// Push a live grant round into the GHL Grants pipeline ("Grant Opportunity
+// Identified"). Grants attach to the triage contact, so the linked state is a
+// badge, not a deep link — opportunity deep links are unreliable.
+export function PushGrantGhlButton({ g }: { g: TriageGrantRow }) {
+  const [busy, setBusy] = useState(false);
+  const [linkedId, setLinkedId] = useState<string | null>(g.ghlOpportunityId);
+  const [error, setError] = useState<string | null>(null);
+
+  async function push() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/goods/grants/push-ghl', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grantId: g.id,
+          name: g.name,
+          provider: g.provider,
+          fitScore: g.goodsScore,
+          deadline: g.deadline,
+          url: g.url,
+          geography: g.geography,
+          amountMin: g.amountMin,
+          amountMax: g.amountMax,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error((data as { error?: string }).error || 'failed');
+      setLinkedId(data.opportunityId as string);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (linkedId) {
+    return (
+      <span className="bg-bauhaus-yellow px-1.5 py-0.5 font-mono text-[9px] font-black uppercase tracking-wider" title="Tracked in the GHL Grants pipeline">
+        ✓ In GHL
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex flex-col items-start gap-0.5">
+      <button
+        type="button"
+        onClick={push}
+        disabled={busy}
+        className="border border-bauhaus-black bg-white px-1.5 py-0.5 font-mono text-[9px] font-black uppercase tracking-wider hover:bg-bauhaus-red hover:text-white disabled:opacity-50"
+      >
+        {busy ? '…' : 'Push to GHL'}
+      </button>
+      {error && <span className="text-[9px] text-bauhaus-red">{error}</span>}
+    </span>
+  );
+}

--- a/apps/web/src/lib/services/goods-grant-ghl.ts
+++ b/apps/web/src/lib/services/goods-grant-ghl.ts
@@ -1,0 +1,93 @@
+// Push a live grant round from the Goods Grants Triage into the GoHighLevel
+// "Grants" pipeline as an opportunity at "Grant Opportunity Identified".
+// Mirrors scripts/seed-goods-grants-ghl.mjs exactly (same pipeline, stage,
+// triage contact, and opportunity custom fields) so UI pushes and engine seeds
+// are indistinguishable in GHL. Idempotency: grant_opportunities.ghl_opportunity_id
+// is checked by the caller before invoking; the discovery_source stamp
+// (`civicgraph-grant:<grant_id>`) marks provenance in GHL.
+
+const GHL_API_URL = 'https://services.leadconnectorhq.com';
+
+const GRANTS_PIPELINE_ID = 'scom3L0kNwA1W0zPIzMe';
+const STAGE_IDENTIFIED = '8124c61a-1175-461e-be5d-1fa64ef6dd65'; // Grant Opportunity Identified
+// Every GHL opportunity needs a contact; engine-discovered grants attach to the
+// purpose-built "GrantScope Triage" contact until a real funder contact exists.
+const TRIAGE_CONTACT_ID = 'uAsIUWBHez3DzVex8rtm';
+
+const CF = {
+  funder: 'v0uQzbwOQvwsvQ1ORb0X',
+  fit_score: 'xEzJNk9FpH75VRcrGFBF',
+  geography: 'JAIpW72Zy66hWgG0ckXs',
+  submission_link: 'GwPgNgVUr6MiyVOKqavt',
+  submission_date: 'dRUwAKU9k70EOqsKVeWN',
+  discovery_source: 'eZoHX9Y7dIZBhXM3i6Kx',
+  amount_range: 'fdfztkiwIVdTU5jUTd9R',
+};
+
+export type GoodsGrantPushInput = {
+  grantId: string;
+  name: string;
+  provider: string | null;
+  fitScore: number | null;
+  deadline: string | null;
+  url: string | null;
+  geography: string | null;
+  amountMin: number | null;
+  amountMax: number | null;
+};
+
+export type GoodsGrantPushResult =
+  | { ok: true; opportunityId: string }
+  | { ok: false; reason: 'no_credentials' | 'create_failed' | 'exception'; status?: number; detail?: string };
+
+export async function pushGoodsGrantToGHL(input: GoodsGrantPushInput): Promise<GoodsGrantPushResult> {
+  const apiKey = process.env.GHL_API_KEY;
+  const locationId = process.env.GHL_LOCATION_ID;
+  if (!apiKey || !locationId) {
+    console.error('[goods-grant-ghl] missing credentials — API_KEY:', !!apiKey, 'LOCATION_ID:', !!locationId);
+    return { ok: false, reason: 'no_credentials' };
+  }
+
+  const money = (n: number | null) => (n ? `$${Number(n).toLocaleString()}` : null);
+  const customFields = [
+    { id: CF.funder, field_value: input.provider ?? '' },
+    { id: CF.fit_score, field_value: input.fitScore == null ? '' : String(input.fitScore) },
+    { id: CF.geography, field_value: input.geography ?? '' },
+    { id: CF.submission_link, field_value: input.url ?? '' },
+    { id: CF.submission_date, field_value: input.deadline ?? '' },
+    { id: CF.discovery_source, field_value: `civicgraph-grant:${input.grantId}` },
+    { id: CF.amount_range, field_value: [money(input.amountMin), money(input.amountMax)].filter(Boolean).join(' – ') },
+  ].filter((f) => f.field_value !== '');
+
+  try {
+    const res = await fetch(`${GHL_API_URL}/opportunities/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        Version: '2021-07-28',
+      },
+      body: JSON.stringify({
+        locationId,
+        name: input.name.slice(0, 250),
+        pipelineId: GRANTS_PIPELINE_ID,
+        pipelineStageId: STAGE_IDENTIFIED,
+        status: 'open',
+        contactId: TRIAGE_CONTACT_ID,
+        monetaryValue: Number(input.amountMax) || 0,
+        customFields,
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      console.error('[goods-grant-ghl] create failed', res.status, detail.slice(0, 300));
+      return { ok: false, reason: 'create_failed', status: res.status, detail: detail.slice(0, 300) };
+    }
+    const data = (await res.json()) as { opportunity?: { id?: string } };
+    const opportunityId = data.opportunity?.id;
+    if (!opportunityId) return { ok: false, reason: 'create_failed', detail: 'no opportunity id in response' };
+    return { ok: true, opportunityId };
+  } catch (e) {
+    return { ok: false, reason: 'exception', detail: e instanceof Error ? e.message : 'unknown' };
+  }
+}

--- a/apps/web/src/lib/services/goods-grants-triage.ts
+++ b/apps/web/src/lib/services/goods-grants-triage.ts
@@ -18,6 +18,7 @@ export interface TriageGrantRow {
   acceptsPtyLtd: boolean | null;
   pipelineStage: string | null;
   url: string | null;
+  ghlOpportunityId: string | null;
 }
 
 export interface SourceFreshness {
@@ -59,7 +60,7 @@ export async function getGoodsGrantsTriage(opts: {
   const [liveRes, corpusRes, schedulesRes, runsRes] = await Promise.all([
     db
       .from('grant_opportunities')
-      .select('id, name, provider, goods_relevance_score, deadline, amount_min, amount_max, geography, dgr_required, accepts_pty_ltd, pipeline_stage, url, status')
+      .select('id, name, provider, goods_relevance_score, deadline, amount_min, amount_max, geography, dgr_required, accepts_pty_ltd, pipeline_stage, url, status, ghl_opportunity_id')
       .in('status', ['open', 'ongoing', 'upcoming'])
       .order('goods_relevance_score', { ascending: false, nullsFirst: false })
       .limit(3000),
@@ -92,6 +93,7 @@ export async function getGoodsGrantsTriage(opts: {
       acceptsPtyLtd: (r.accepts_pty_ltd as boolean | null) ?? null,
       pipelineStage: (r.pipeline_stage as string | null) ?? null,
       url: (r.url as string | null) ?? null,
+      ghlOpportunityId: (r.ghl_opportunity_id as string | null) ?? null,
     };
   }).filter((r) => r.daysToDeadline == null || r.daysToDeadline >= 0);
 

--- a/apps/web/tests/e2e/act-field-desk.spec.ts
+++ b/apps/web/tests/e2e/act-field-desk.spec.ts
@@ -1,10 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('ACT Field Desk pilot workflow', () => {
-  // FIXME(2026-08-04): the view=opportunities surface was redesigned (no
-  // 'Choose the next opening' heading). Re-spec this walkthrough against the
-  // current operating desk before re-enabling.
-  test.fixme('walks through every gold-standard surface with persistent progress', async ({ page }) => {
+  test('walks through every gold-standard surface with persistent progress', async ({ page }) => {
     await page.goto('/org/act?walkthrough=1');
 
     const guide = page.getByTestId('act-test-guide');
@@ -19,7 +16,7 @@ test.describe('ACT Field Desk pilot workflow', () => {
     await guide.getByRole('link', { name: 'Open live opportunities screen' }).click();
     await expect(page).toHaveURL(/view=opportunities/);
     await expect(page).toHaveURL(/walkthrough=1/);
-    await expect(page.getByRole('heading', { name: 'Choose the next opening' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Read what is changing' })).toBeVisible();
     await expect(page.getByTestId('act-test-guide').getByLabel('Mark Whole system test complete')).toBeChecked();
     await expect(page.getByTestId('act-test-guide')).toContainText('Current screen');
 
@@ -27,24 +24,24 @@ test.describe('ACT Field Desk pilot workflow', () => {
     await expect(page.getByTestId('act-test-guide-launcher')).toContainText('Resume test drive · 1/6');
   });
 
-  // FIXME(2026-08-04): review=changes became the matter-review desk (max five
-  // matters, evidence-changed triggers); the 'New / changed' filter no longer
-  // exists. Re-spec against the new desk before re-enabling.
-  test.fixme('shows the latest discovery receipt and marks new openings', async ({ page }) => {
+  test('routes the discovery receipt into the matter-review desk', async ({ page }) => {
     await page.goto('/org/act');
 
     const receipt = page.getByLabel('Latest discovery activity');
     await expect(receipt).toContainText('Discovery activity recorded');
-    await expect(receipt).toContainText('2 new signals · 1 changed · 1 public program refreshed');
     await expect(receipt).toContainText('Openings');
     await expect(receipt).toContainText('Relationships');
 
     await receipt.getByRole('link', { name: 'Review changes' }).click();
     await expect(page).toHaveURL(/review=changes/);
-    await expect(page.getByRole('button', { name: /^New \/ changed / })).toHaveAttribute('aria-pressed', 'true');
-    const opening = page.getByRole('button', { name: /New Goods partnership round/ });
-    await expect(opening).toContainText('New');
-    await expect(opening).toContainText('Build proof pack');
+
+    // The review surface is now the matter desk: at most five matters, shown
+    // only under explicit attention conditions. Zero matters is a valid state.
+    const workbench = page.getByTestId('act-relational-review-workbench');
+    await expect(workbench.getByRole('heading', { name: 'What needs understanding now' })).toBeVisible();
+    await expect(
+      workbench.getByText(/(matters? needs? a read|No matters currently meet the weekly attention conditions)/),
+    ).toBeVisible();
   });
 
   test('completes and restores the first Today action', async ({ page }) => {


### PR DESCRIPTION
Finishes the GHL handoff findings from `docs/goods-ghl-handoff-ux-findings.md`:

- **G7** — the community dossier gets a *Buyers and procurement pathways* section with the PushToGhlButton actually wired in (it was dead code); linked buyers show stage + last-push and deep-link to the GHL contact
- **G5** — Grants Triage rows push live rounds into the GHL Grants pipeline at *Grant Opportunity Identified*, mirroring `seed-goods-grants-ghl.mjs` exactly (pipeline, stage, custom fields, triage contact), idempotent via `grant_opportunities.ghl_opportunity_id`
- **G3/G4** — per the dossier-only-push decision, buyers/scan surfaces point at the deliberate push path instead of offering inline pushes
- **E2E** — the two `test.fixme` field-desk tests re-specced against the matter-review desk; suite is 21/21 with no skips

Verified live in dev: dossier renders 8 push buttons on Gundurimba Reserve; grants triage renders 211 pushable rounds + 89 engine-seeded rounds reading back as linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)