### PR TITLE
feat(goods): rail owns navigation — Goods section tree in the ACT rail, header pills removed on desktop

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -156,13 +156,17 @@ export function ActWorkspaceShell({
             <div className="mt-5 px-2 font-mono text-[9px] font-semibold uppercase tracking-widest text-[#8fa196] [@media(max-height:680px)]:mt-3">Project fields</div>
             <nav className="mt-1" aria-label="ACT project fields">
               {fieldProjects.map((project, index) => (
-                <WorkspaceProjectLink
-                  key={project.id}
-                  project={project}
-                  slug={slug}
-                  index={index}
-                  active={pathname.startsWith(`/org/${slug}/${project.slug}`)}
-                />
+                <div key={project.id}>
+                  <WorkspaceProjectLink
+                    project={project}
+                    slug={slug}
+                    index={index}
+                    active={pathname.startsWith(`/org/${slug}/${project.slug}`)}
+                  />
+                  {project.slug === 'goods' && pathname.startsWith(`/org/${slug}/goods`) ? (
+                    <GoodsRailTree slug={slug} pathname={pathname} />
+                  ) : null}
+                </div>
               ))}
               {fieldProjects.length === 0 ? <div className="px-2 py-3 text-xs text-[#aebcb2]">No project fields loaded.</div> : null}
             </nav>
@@ -310,6 +314,46 @@ function WorkspaceModeLink({ href, label, active, index }: WorkspaceLink & { ind
       </span>
       <span className="truncate text-sm font-semibold">{label}</span>
     </Link>
+  );
+}
+
+// Rail-owned Goods navigation (Ben's call, 2026-08-05): the rail is the ONE
+// nav. These groups replace the pill rows that lived in the green page header.
+const GOODS_RAIL_SECTIONS: ReadonlyArray<{ label: string; items: ReadonlyArray<readonly [string, string]> }> = [
+  { label: 'Work', items: [['today', 'Today'], ['capital', 'Capital'], ['matters', 'Matters'], ['network', 'Network'], ['applications', 'Applications'], ['learning', 'Learning']] },
+  { label: 'Money in', items: [['foundations', 'Foundations'], ['foundations/scan', 'Funder Scan'], ['grants', 'Grants'], ['money', 'Money']] },
+  { label: 'Delivery', items: [['funnel', 'Delivery map'], ['communities', 'Communities'], ['channels', 'Channels'], ['buyers', 'Buyers']] },
+  { label: 'Trust', items: [['model', 'Story & model'], ['proof', 'Evidence'], ['governance', 'Governance']] },
+];
+
+function GoodsRailTree({ slug, pathname }: { slug: string; pathname: string }) {
+  const base = `/org/${slug}/goods`;
+  // Highlight only the deepest matching entry so foundations/scan doesn't also
+  // light up foundations.
+  const allPaths = GOODS_RAIL_SECTIONS.flatMap((s) => s.items.map(([p]) => p));
+  const best = allPaths
+    .filter((p) => pathname === `${base}/${p}` || pathname.startsWith(`${base}/${p}/`))
+    .sort((a, b) => b.length - a.length)[0];
+  return (
+    <div className="ml-3 border-l border-white/15 pb-1 pl-2">
+      {GOODS_RAIL_SECTIONS.map((section) => (
+        <div key={section.label}>
+          <div className="mt-1.5 px-1 font-mono text-[8px] font-semibold uppercase tracking-widest text-[#8fa196]">{section.label}</div>
+          {section.items.map(([path, label]) => (
+            <Link
+              key={path}
+              href={`${base}/${path}`}
+              aria-current={best === path ? 'page' : undefined}
+              className={`block rounded px-1.5 py-1 text-[11px] leading-4 hover:bg-white/5 hover:text-white ${
+                best === path ? 'bg-white/10 font-semibold text-white' : 'text-[#c7d1ca]'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
@@ -72,41 +72,25 @@ function TabLink({ slug, tabKey, label, active }: { slug: string; tabKey: GoodsT
   );
 }
 
-/** Shared dark-header sub-nav across the Goods Command Center pages.
- *  `active` is optional — the hub (/goods index) passes none, so no tab highlights. */
+/** The rail owns Goods navigation now (GoodsRailTree in act-workspace-shell —
+ *  Ben's one-system call, 2026-08-05). This renders a compact nav only below
+ *  lg, where the rail is hidden; on desktop it renders nothing. */
 export function GoodsSubNav({ slug, active }: { slug: string; active?: GoodsTab }) {
   return (
-    <div className="mt-6 flex flex-col gap-3 rounded-2xl border border-white/10 bg-black/10 p-3 backdrop-blur-sm">
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="mr-1 text-[10px] font-semibold text-white/45">Capital & relationships</span>
-        {OPERATING_TABS.map(([key, label]) => (
-          <TabLink key={key} slug={slug} tabKey={key} label={label} active={active} />
-        ))}
-      </div>
-      <div className="flex flex-wrap items-center gap-2 border-t border-white/10 pt-3">
-        <span className="mr-1 text-[10px] font-semibold text-white/45">Money in</span>
-        {FUNDING_TABS.map(([path, label]) => (
-          <Link
-            key={path}
-            href={`/org/${slug}/goods/${path}`}
-            className={`inline-flex min-h-9 items-center rounded-full border px-3 py-1.5 text-[11px] font-semibold transition-all ${
-              active === path || (path === 'foundations' && active === 'foundations')
-                ? 'border-white bg-white text-[#17352b] shadow-sm'
-                : 'border-white/15 bg-white/5 text-white/75 hover:border-white/35 hover:bg-white/10 hover:text-white'
-            }`}
-          >
-            {label}
-          </Link>
-        ))}
-        <span className="ml-2 mr-1 text-[10px] font-semibold text-white/45">Delivery</span>
-        {DELIVERY_TABS.map(([key, label]) => (
-          <TabLink key={key} slug={slug} tabKey={key} label={label} active={active} />
-        ))}
-        <span className="ml-2 mr-1 text-[10px] font-semibold text-white/45">Trust & structure</span>
-        {EVIDENCE_TABS.map(([key, label]) => (
-          <TabLink key={key} slug={slug} tabKey={key} label={label} active={active} />
-        ))}
-      </div>
+    <div className="mt-4 flex flex-wrap items-center gap-2 lg:hidden">
+      {[...OPERATING_TABS, ...FUNDING_TABS, ...DELIVERY_TABS, ...EVIDENCE_TABS].map(([key, label]) => (
+        <Link
+          key={key}
+          href={`/org/${slug}/goods/${key}`}
+          className={`inline-flex min-h-8 items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold ${
+            active === key
+              ? 'border-white bg-white text-[#17352b]'
+              : 'border-white/15 bg-white/5 text-white/75'
+          }`}
+        >
+          {label}
+        </Link>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
One nav system (Ben's call): the rail's Goods entry expands into Work / Money in /
Delivery / Trust groups with deepest-match highlighting; the green header keeps
breadcrumb + title + stats only. The pill nav survives solely below lg where the
rail is hidden.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
