### PR TITLE
feat(act): One Desk — split-desk queue over every workable record, in the shell

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -92,6 +92,12 @@ export function ActWorkspaceShell({
   ];
   const utilityLinks = [
     {
+      label: 'One Desk',
+      detail: 'Everything, ranked',
+      href: `/org/${slug}/desk`,
+      active: pathname.startsWith(`/org/${slug}/desk`),
+    },
+    {
       label: 'Atlas',
       detail: 'Search the whole field',
       href: `/org/${slug}/explore`,

--- a/apps/web/src/app/org/[slug]/desk/page.tsx
+++ b/apps/web/src/app/org/[slug]/desk/page.tsx
@@ -1,0 +1,156 @@
+// The One Desk — promoted from /prototype-one (Ben picked variant B, 2026-08-05,
+// with A's "do this now" hero and C's urgency grouping folded in). One ranked
+// pool over every workable record; project and type are filters, never places.
+// Renders inside the ACT shell, so the rail is the only other chrome.
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import { getOneDeskPool, deskHorizon, type DeskRecord, type DeskHorizon } from '@/lib/services/act-one-desk';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  return { title: 'One Desk — everything ranked — CivicGraph' };
+}
+
+const KIND_STYLE: Record<DeskRecord['kind'], string> = {
+  funder: 'bg-purple-700', grant: 'bg-bauhaus-blue', buyer: 'bg-emerald-700',
+};
+
+const HORIZON_LABEL: Record<DeskHorizon, string> = {
+  overdue: 'Overdue', fortnight: 'This fortnight', quarter: 'This quarter', undated: 'No date · ranked by fit',
+};
+
+function Due({ d }: { d: number | null }) {
+  if (d == null) return <span className="text-[11px] text-gray-400">—</span>;
+  if (d < 0) return <span className="text-[11px] font-black text-bauhaus-red">{-d}d overdue</span>;
+  if (d <= 14) return <span className="text-[11px] font-black text-bauhaus-red">{d}d</span>;
+  return <span className="text-[11px] font-bold">{d}d</span>;
+}
+
+function KindChip({ k }: { k: DeskRecord['kind'] }) {
+  return <span className={`px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest text-white ${KIND_STYLE[k]}`}>{k}</span>;
+}
+
+export default async function OneDeskPage({ params, searchParams }: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { slug } = await params;
+  if (!isActSlug(slug)) notFound();
+  const sp = await searchParams;
+  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
+
+  const all = await getOneDeskPool(slug);
+  const pool = kind ? all.filter((r) => r.kind === kind) : all;
+  const selected = (typeof sp.rec === 'string' ? pool.find((r) => r.id === sp.rec) : null) ?? pool[0] ?? null;
+  const base = `/org/${slug}/desk`;
+  const qs = (extra: Record<string, string>) => {
+    const p = new URLSearchParams({ ...(kind ? { kind } : {}), ...extra });
+    const s = p.toString();
+    return s ? `${base}?${s}` : base;
+  };
+
+  // Group the ranked list by horizon (C's contribution) while keeping order.
+  const groups: Array<{ horizon: DeskHorizon; items: DeskRecord[] }> = [];
+  for (const r of pool.slice(0, 80)) {
+    const h = deskHorizon(r);
+    const last = groups[groups.length - 1];
+    if (last && last.horizon === h) last.items.push(r);
+    else groups.push({ horizon: h, items: [r] });
+  }
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas p-5 text-bauhaus-black">
+      <div className="mx-auto max-w-[1760px]">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <div className="font-mono text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">One pool · deadline first · {all.length} records</div>
+            <h1 className="mt-1 text-3xl font-black uppercase tracking-widest">One Desk</h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="border-2 border-bauhaus-black bg-bauhaus-yellow px-2 py-1 text-[10px] font-black uppercase tracking-widest">Project: Goods</span>
+            {([null, 'funder', 'grant', 'buyer'] as const).map((k) => (
+              <Link
+                key={k ?? 'all'}
+                href={k ? `${base}?kind=${k}` : base}
+                className={`border-2 border-bauhaus-black px-2 py-1 text-[10px] font-black uppercase tracking-widest ${kind === k ? 'bg-bauhaus-black text-white' : 'bg-white hover:bg-bauhaus-canvas'}`}
+              >
+                {k ?? 'everything'}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* A's contribution: the single directed move, always on top. */}
+        {selected && selected.id === pool[0]?.id ? (
+          <div className="mt-4 border-4 border-bauhaus-black bg-bauhaus-black px-5 py-3 text-white">
+            <span className="text-[10px] font-black uppercase tracking-widest text-bauhaus-yellow">Do this now</span>
+            <span className="ml-3 font-bold">{pool[0].name}</span>
+            <span className="ml-3 text-sm text-white/70">{pool[0].next}</span>
+          </div>
+        ) : null}
+
+        {/* B: the split desk. */}
+        <div className="mt-4 grid gap-0 border-4 border-bauhaus-black bg-white lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
+          <div className="max-h-[74vh] overflow-y-auto lg:border-r-4 lg:border-bauhaus-black">
+            {groups.map((group) => (
+              <div key={group.horizon}>
+                <div className={`sticky top-0 z-10 px-3 py-1.5 text-[9px] font-black uppercase tracking-widest text-white ${group.horizon === 'overdue' ? 'bg-bauhaus-red' : 'bg-bauhaus-black'}`}>
+                  {HORIZON_LABEL[group.horizon]} · {group.items.length}
+                </div>
+                {group.items.map((r) => (
+                  <Link
+                    key={r.id}
+                    href={qs({ rec: r.id })}
+                    className={`flex items-center gap-2 border-t border-gray-200 px-3 py-2 text-sm first:border-t-0 ${selected?.id === r.id ? 'bg-bauhaus-yellow' : 'hover:bg-bauhaus-canvas'}`}
+                  >
+                    <KindChip k={r.kind} />
+                    <span className="min-w-0 flex-1 truncate font-bold">{r.name}</span>
+                    {r.amount && <span className="font-mono text-[11px] font-black">{r.amount}</span>}
+                    <Due d={r.dueDays} />
+                  </Link>
+                ))}
+              </div>
+            ))}
+            {pool.length === 0 ? <div className="px-4 py-8 text-center text-sm text-bauhaus-muted">Nothing matches this filter.</div> : null}
+          </div>
+
+          <div className="p-6">
+            {selected ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <KindChip k={selected.kind} />
+                  <span className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">{selected.signal}</span>
+                </div>
+                <h2 className="mt-2 text-2xl font-black">{selected.name}</h2>
+                <div className="mt-1 flex items-center gap-3 font-mono text-sm">
+                  {selected.amount && <span className="font-black">{selected.amount}</span>}
+                  <Due d={selected.dueDays} />
+                </div>
+                <div className="mt-4 border-l-4 border-bauhaus-red bg-red-50 px-3 py-2">
+                  <div className="text-[9px] font-black uppercase tracking-widest text-bauhaus-red">Next move</div>
+                  <p className="mt-1 font-bold">{selected.next}</p>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {selected.ghlUrl && (
+                    <a href={selected.ghlUrl} target="_blank" rel="noopener noreferrer" className="border-2 border-bauhaus-black bg-bauhaus-yellow px-3 py-1.5 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white">
+                      Open in GHL ↗
+                    </a>
+                  )}
+                  {selected.workHref && (
+                    <Link href={selected.workHref} className="border-2 border-bauhaus-black bg-white px-3 py-1.5 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-canvas">
+                      Open full workspace →
+                    </Link>
+                  )}
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-bauhaus-muted">Nothing selected.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/services/act-one-desk.ts
+++ b/apps/web/src/lib/services/act-one-desk.ts
@@ -1,0 +1,89 @@
+// The one-system desk pool: every workable record — funders, grants, buyers —
+// merged into a single deadline-first ranked queue. Born from the /prototype-one
+// session (2026-08-05): Ben picked the split-desk shape with project and type as
+// filters, never places.
+import { getGoodsFunderScan } from '@/lib/services/goods-funder-scan';
+import { getGoodsGrantsTriage } from '@/lib/services/goods-grants-triage';
+import { getGoodsBuyerPipeline } from '@/lib/services/goods-buyer-pipeline';
+import { ghlContactUrl } from '@/lib/ghl-links';
+
+export type DeskRecordKind = 'funder' | 'grant' | 'buyer';
+
+export type DeskRecord = {
+  id: string;
+  kind: DeskRecordKind;
+  project: 'Goods';
+  name: string;
+  /** Warmth / stage / status chip text. */
+  signal: string;
+  /** The one next move. */
+  next: string;
+  /** Days until deadline or next action; negative = overdue; null = undated. */
+  dueDays: number | null;
+  /** Fit or warmth, used to rank undated records. */
+  score: number;
+  amount: string | null;
+  ghlUrl: string | null;
+  /** Deep link to the record's full workspace surface. */
+  workHref: string | null;
+};
+
+export type DeskHorizon = 'overdue' | 'fortnight' | 'quarter' | 'undated';
+
+export function deskHorizon(r: DeskRecord): DeskHorizon {
+  if (r.dueDays == null || r.dueDays > 90) return 'undated';
+  if (r.dueDays < 0) return 'overdue';
+  if (r.dueDays <= 14) return 'fortnight';
+  return 'quarter';
+}
+
+function days(iso: string | null): number | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? null : Math.ceil((t - Date.now()) / 86_400_000);
+}
+
+function urgency(r: DeskRecord): number {
+  if (r.dueDays != null) return r.dueDays < 0 ? -1000 + r.dueDays : r.dueDays;
+  return 500 - r.score;
+}
+
+export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {
+  const [scan, triage, buyers] = await Promise.all([
+    getGoodsFunderScan().catch(() => null),
+    getGoodsGrantsTriage({ scope: 'closing' }).catch(() => null),
+    getGoodsBuyerPipeline().catch(() => null),
+  ]);
+  const pool: DeskRecord[] = [];
+  for (const r of scan?.rows ?? []) {
+    if (!r.stage || ['parked', 'declined'].includes(r.stage)) continue;
+    pool.push({
+      id: `f-${r.id}`, kind: 'funder', project: 'Goods', name: r.name,
+      signal: r.ghlWarmth === 'not_in_ghl' ? 'not in GHL' : r.ghlWarmth,
+      next: r.nextStep || 'Set a next step', dueDays: null,
+      score: r.fitScore ?? 0, amount: null, ghlUrl: ghlContactUrl(r.ghlContactId),
+      workHref: `/org/${slug}/goods/foundations/scan`,
+    });
+  }
+  for (const g of (triage?.grants ?? []).slice(0, 40)) {
+    pool.push({
+      id: `g-${g.id}`, kind: 'grant', project: 'Goods', name: g.name,
+      signal: g.ghlOpportunityId ? 'in GHL' : 'live round',
+      next: g.ghlOpportunityId ? 'Work the application' : 'Decide: pursue or pass',
+      dueDays: g.daysToDeadline, score: g.goodsScore ?? 0,
+      amount: g.amountMax ? `$${Math.round(g.amountMax / 1000)}K` : null,
+      ghlUrl: null, workHref: `/org/${slug}/goods/grants`,
+    });
+  }
+  for (const b of buyers?.rows ?? []) {
+    if (!b.isOpen) continue;
+    pool.push({
+      id: `b-${b.id}`, kind: 'buyer', project: 'Goods', name: b.name,
+      signal: `${b.band} ${b.warmth}`, next: b.nextMove,
+      dueDays: days(b.nextActionDue), score: b.warmth,
+      amount: b.askAmount ? `$${Math.round(b.askAmount / 1000)}K` : null,
+      ghlUrl: ghlContactUrl(b.ghlContactId), workHref: `/org/${slug}/goods/buyers`,
+    });
+  }
+  return pool.sort((a, b) => urgency(a) - urgency(b));
+}


### PR DESCRIPTION
Prototype verdict (/prototype-one, 2026-08-05): variant B (split desk) won, with
A's 'do this now' hero and C's urgency grouping folded in. One ranked pool
(funders + grants + buyers, deadline-first then fit); project and type are
filter chips, never places. Lives at /org/act/desk inside the ACT rail, with a
rail entry. Prototype route deleted.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
