### PR TITLE
feat(act): One Desk is the front door — first work mode in the rail, absorbs invoice chases

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -80,6 +80,8 @@ export function ActWorkspaceShell({
   const fieldProjects = projectRows.slice(0, 7);
   const artProject = projectRows.find((project) => /harvest|witta|art/.test(`${project.slug} ${project.name}`.toLowerCase()));
   const workModes: WorkspaceLink[] = [
+    // The one-system front door: every workable record, one ranked queue.
+    { label: 'One Desk', href: `/org/${slug}/desk`, active: pathname.startsWith(`/org/${slug}/desk`) },
     { label: 'Today', href: rootHref(slug), active: onOrgRoot && view === 'today' },
     { label: 'Listen', href: rootHref(slug, 'relationships', 'relationships'), active: onOrgRoot && view === 'relationships' },
     { label: 'Curiosity', href: rootHref(slug, 'opportunities', 'opportunities'), active: onOrgRoot && (view === 'opportunities' || view === 'triage') },
@@ -91,12 +93,6 @@ export function ActWorkspaceShell({
     },
   ];
   const utilityLinks = [
-    {
-      label: 'One Desk',
-      detail: 'Everything, ranked',
-      href: `/org/${slug}/desk`,
-      active: pathname.startsWith(`/org/${slug}/desk`),
-    },
     {
       label: 'Atlas',
       detail: 'Search the whole field',

--- a/apps/web/src/app/org/[slug]/desk/page.tsx
+++ b/apps/web/src/app/org/[slug]/desk/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata() {
 }
 
 const KIND_STYLE: Record<DeskRecord['kind'], string> = {
-  funder: 'bg-purple-700', grant: 'bg-bauhaus-blue', buyer: 'bg-emerald-700',
+  funder: 'bg-purple-700', grant: 'bg-bauhaus-blue', buyer: 'bg-emerald-700', money: 'bg-bauhaus-red',
 };
 
 const HORIZON_LABEL: Record<DeskHorizon, string> = {
@@ -39,7 +39,7 @@ export default async function OneDeskPage({ params, searchParams }: {
   const { slug } = await params;
   if (!isActSlug(slug)) notFound();
   const sp = await searchParams;
-  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
+  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer', 'money'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
 
   const all = await getOneDeskPool(slug);
   const pool = kind ? all.filter((r) => r.kind === kind) : all;
@@ -70,7 +70,7 @@ export default async function OneDeskPage({ params, searchParams }: {
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <span className="border-2 border-bauhaus-black bg-bauhaus-yellow px-2 py-1 text-[10px] font-black uppercase tracking-widest">Project: Goods</span>
-            {([null, 'funder', 'grant', 'buyer'] as const).map((k) => (
+            {([null, 'money', 'funder', 'grant', 'buyer'] as const).map((k) => (
               <Link
                 key={k ?? 'all'}
                 href={k ? `${base}?kind=${k}` : base}

--- a/apps/web/src/lib/services/act-one-desk.ts
+++ b/apps/web/src/lib/services/act-one-desk.ts
@@ -3,11 +3,13 @@
 // session (2026-08-05): Ben picked the split-desk shape with project and type as
 // filters, never places.
 import { getGoodsFunderScan } from '@/lib/services/goods-funder-scan';
+import { getActRelationshipLedger } from '@/lib/services/act-relationship-ledger';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsGrantsTriage } from '@/lib/services/goods-grants-triage';
 import { getGoodsBuyerPipeline } from '@/lib/services/goods-buyer-pipeline';
 import { ghlContactUrl } from '@/lib/ghl-links';
 
-export type DeskRecordKind = 'funder' | 'grant' | 'buyer';
+export type DeskRecordKind = 'funder' | 'grant' | 'buyer' | 'money';
 
 export type DeskRecord = {
   id: string;
@@ -49,12 +51,28 @@ function urgency(r: DeskRecord): number {
 }
 
 export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {
-  const [scan, triage, buyers] = await Promise.all([
+  const profile = await getOrgProfileBySlug(slug).catch(() => null);
+  const [scan, triage, buyers, ledger] = await Promise.all([
     getGoodsFunderScan().catch(() => null),
     getGoodsGrantsTriage({ scope: 'closing' }).catch(() => null),
     getGoodsBuyerPipeline().catch(() => null),
+    profile ? getActRelationshipLedger(slug, profile.id).catch(() => null) : null,
   ]);
   const pool: DeskRecord[] = [];
+  // Money owed: outstanding invoices become chase records — the old Today
+  // queue's "collect" items, so nothing lives only on that screen.
+  for (const item of ledger?.items ?? []) {
+    if (!item.outstandingTotal || item.outstandingInvoiceCount === 0) continue;
+    pool.push({
+      id: `m-${item.key}`, kind: 'money', project: 'Goods', name: item.organisation,
+      signal: `${item.outstandingInvoiceCount} invoice${item.outstandingInvoiceCount === 1 ? '' : 's'} outstanding`,
+      next: item.nextMove || 'Chase payment',
+      dueDays: item.oldestOverdueDays > 0 ? -item.oldestOverdueDays : null,
+      score: Math.min(99, Math.round(item.outstandingTotal / 1000)),
+      amount: `$${Math.round(item.outstandingTotal / 1000)}K`,
+      ghlUrl: null, workHref: `/org/${slug}?view=relationships#relationships`,
+    });
+  }
   for (const r of scan?.rows ?? []) {
     if (!r.stage || ['parked', 'declined'].includes(r.stage)) continue;
     pool.push({


### PR DESCRIPTION
- rail: One Desk moves from the buried utility list to work-mode position 1
- pool: outstanding invoices from the relationship ledger become 'money' chase
  records (deadline = days overdue), so the old Today queue's collect items no
  longer live only there

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
