### PR TITLE
feat(act): One Desk spans projects — pipeline commitments join the pool, project chips are real filters

### DIFF
--- a/apps/web/src/app/org/[slug]/desk/page.tsx
+++ b/apps/web/src/app/org/[slug]/desk/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata() {
 }
 
 const KIND_STYLE: Record<DeskRecord['kind'], string> = {
-  funder: 'bg-purple-700', grant: 'bg-bauhaus-blue', buyer: 'bg-emerald-700', money: 'bg-bauhaus-red',
+  funder: 'bg-purple-700', grant: 'bg-bauhaus-blue', buyer: 'bg-emerald-700', money: 'bg-bauhaus-red', commitment: 'bg-amber-600',
 };
 
 const HORIZON_LABEL: Record<DeskHorizon, string> = {
@@ -39,14 +39,16 @@ export default async function OneDeskPage({ params, searchParams }: {
   const { slug } = await params;
   if (!isActSlug(slug)) notFound();
   const sp = await searchParams;
-  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer', 'money'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
+  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer', 'money', 'commitment'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
+  const project = typeof sp.project === 'string' ? sp.project : null;
 
   const all = await getOneDeskPool(slug);
-  const pool = kind ? all.filter((r) => r.kind === kind) : all;
+  const projects = [...new Set(all.map((r) => r.project))].sort();
+  const pool = all.filter((r) => (!kind || r.kind === kind) && (!project || r.project === project));
   const selected = (typeof sp.rec === 'string' ? pool.find((r) => r.id === sp.rec) : null) ?? pool[0] ?? null;
   const base = `/org/${slug}/desk`;
   const qs = (extra: Record<string, string>) => {
-    const p = new URLSearchParams({ ...(kind ? { kind } : {}), ...extra });
+    const p = new URLSearchParams({ ...(kind ? { kind } : {}), ...(project ? { project } : {}), ...extra });
     const s = p.toString();
     return s ? `${base}?${s}` : base;
   };
@@ -69,11 +71,20 @@ export default async function OneDeskPage({ params, searchParams }: {
             <h1 className="mt-1 text-3xl font-black uppercase tracking-widest">One Desk</h1>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="border-2 border-bauhaus-black bg-bauhaus-yellow px-2 py-1 text-[10px] font-black uppercase tracking-widest">Project: Goods</span>
-            {([null, 'money', 'funder', 'grant', 'buyer'] as const).map((k) => (
+            {projects.map((p) => (
+              <Link
+                key={p}
+                href={project === p ? (kind ? `${base}?kind=${kind}` : base) : qs({ project: p })}
+                className={`border-2 border-bauhaus-black px-2 py-1 text-[10px] font-black uppercase tracking-widest ${project === p ? 'bg-bauhaus-yellow' : 'bg-white hover:bg-bauhaus-canvas'}`}
+              >
+                {p}{project === p ? ' ✕' : ''}
+              </Link>
+            ))}
+            <span className="mx-1 text-bauhaus-muted">·</span>
+            {([null, 'money', 'commitment', 'funder', 'grant', 'buyer'] as const).map((k) => (
               <Link
                 key={k ?? 'all'}
-                href={k ? `${base}?kind=${k}` : base}
+                href={k ? (project ? `${base}?kind=${k}&project=${encodeURIComponent(project)}` : `${base}?kind=${k}`) : (project ? `${base}?project=${encodeURIComponent(project)}` : base)}
                 className={`border-2 border-bauhaus-black px-2 py-1 text-[10px] font-black uppercase tracking-widest ${kind === k ? 'bg-bauhaus-black text-white' : 'bg-white hover:bg-bauhaus-canvas'}`}
               >
                 {k ?? 'everything'}

--- a/apps/web/src/lib/services/act-one-desk.ts
+++ b/apps/web/src/lib/services/act-one-desk.ts
@@ -4,17 +4,28 @@
 // filters, never places.
 import { getGoodsFunderScan } from '@/lib/services/goods-funder-scan';
 import { getActRelationshipLedger } from '@/lib/services/act-relationship-ledger';
+import { getOrgPipelineData } from '@/lib/services/org-pipeline-service';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsGrantsTriage } from '@/lib/services/goods-grants-triage';
 import { getGoodsBuyerPipeline } from '@/lib/services/goods-buyer-pipeline';
 import { ghlContactUrl } from '@/lib/ghl-links';
 
-export type DeskRecordKind = 'funder' | 'grant' | 'buyer' | 'money';
+export type DeskRecordKind = 'funder' | 'grant' | 'buyer' | 'money' | 'commitment';
+
+const PROJECT_LABELS: Record<string, string> = {
+  'ACT-GD': 'Goods', 'ACT-EL': 'Empathy Ledger', 'ACT-JH': 'JusticeHub',
+  'ACT-HV': 'Harvest', 'ACT-PI': 'Palm Island', 'ACT-MY': 'ACT',
+};
+
+export function deskProjectLabel(code: string | null): string {
+  if (!code) return 'ACT';
+  return PROJECT_LABELS[code] ?? code.replace(/^ACT-/, '');
+}
 
 export type DeskRecord = {
   id: string;
   kind: DeskRecordKind;
-  project: 'Goods';
+  project: string;
   name: string;
   /** Warmth / stage / status chip text. */
   signal: string;
@@ -52,13 +63,30 @@ function urgency(r: DeskRecord): number {
 
 export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {
   const profile = await getOrgProfileBySlug(slug).catch(() => null);
-  const [scan, triage, buyers, ledger] = await Promise.all([
+  const [scan, triage, buyers, ledger, pipeline] = await Promise.all([
     getGoodsFunderScan().catch(() => null),
     getGoodsGrantsTriage({ scope: 'closing' }).catch(() => null),
     getGoodsBuyerPipeline().catch(() => null),
     profile ? getActRelationshipLedger(slug, profile.id).catch(() => null) : null,
+    getOrgPipelineData(slug).catch(() => null),
   ]);
   const pool: DeskRecord[] = [];
+  // Committed work: human-decided pipeline cards in live stages, any project.
+  for (const card of pipeline?.cards ?? []) {
+    if (card.is_historical) continue;
+    if (!['watching', 'pursuing', 'submitted'].includes(card.decision)) continue;
+    pool.push({
+      id: `c-${card.opportunity_id}`, kind: 'commitment',
+      project: deskProjectLabel(card.project_code),
+      name: card.opportunity_name,
+      signal: card.decision,
+      next: card.decision === 'submitted' ? 'Set owner + next action for the follow-through' : 'Plan the next concrete move',
+      dueDays: days(card.deadline), score: card.fit_score ?? 0,
+      amount: card.max_grant_amount ? `$${Math.round(card.max_grant_amount / 1000)}K` : null,
+      ghlUrl: null,
+      workHref: `/org/${slug}?view=pipeline&commitment=${encodeURIComponent(card.opportunity_id)}#pipeline`,
+    });
+  }
   // Money owed: outstanding invoices become chase records — the old Today
   // queue's "collect" items, so nothing lives only on that screen.
   for (const item of ledger?.items ?? []) {


### PR DESCRIPTION
- human-decided pipeline cards (watching/pursuing/submitted, non-historical)
  become 'commitment' records with deadlines, across every project code
- project chips derive from the pool (Goods, Empathy Ledger, JusticeHub, ...)
  and filter it; kind gains 'commitment'
- the old Today queue now has no record type exclusive to it

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
