### PR TITLE
feat(act): Done → next on One Desk — marks persist through the daily-actions store

### DIFF
--- a/apps/web/src/app/org/[slug]/desk/desk-mark-buttons.tsx
+++ b/apps/web/src/app/org/[slug]/desk/desk-mark-buttons.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+// Done → next: persists through the same daily-actions store as the Today
+// queue, then refreshes — the queue advances and the next record is selected.
+export function DeskMarkButtons({ orgProfileId, actionId, title, detail }: {
+  orgProfileId: string;
+  actionId: string;
+  title: string;
+  detail: string;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function mark(status: 'done' | 'waiting' | 'tomorrow') {
+    setBusy(status);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/${orgProfileId}/daily-actions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action_id: actionId, title, detail, status }),
+      });
+      if (!res.ok) throw new Error(((await res.json()) as { error?: string }).error || 'failed');
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const btn = 'border-2 border-bauhaus-black px-3 py-1.5 text-xs font-black uppercase tracking-widest disabled:opacity-50';
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button type="button" onClick={() => mark('done')} disabled={busy !== null} className={`${btn} bg-bauhaus-black text-white hover:bg-bauhaus-red`}>
+        {busy === 'done' ? '…' : 'Done → next'}
+      </button>
+      <button type="button" onClick={() => mark('waiting')} disabled={busy !== null} className={`${btn} bg-white hover:bg-bauhaus-canvas`}>
+        {busy === 'waiting' ? '…' : 'Waiting'}
+      </button>
+      <button type="button" onClick={() => mark('tomorrow')} disabled={busy !== null} className={`${btn} bg-white hover:bg-bauhaus-canvas`}>
+        {busy === 'tomorrow' ? '…' : 'Tomorrow'}
+      </button>
+      {error && <span className="text-[10px] text-bauhaus-red">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/src/app/org/[slug]/desk/page.tsx
+++ b/apps/web/src/app/org/[slug]/desk/page.tsx
@@ -5,7 +5,8 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { isActSlug } from '@/lib/services/fast-local-org';
-import { getOneDeskPool, deskHorizon, type DeskRecord, type DeskHorizon } from '@/lib/services/act-one-desk';
+import { getOneDesk, deskHorizon, type DeskRecord, type DeskHorizon } from '@/lib/services/act-one-desk';
+import { DeskMarkButtons } from './desk-mark-buttons';
 
 export const dynamic = 'force-dynamic';
 
@@ -42,7 +43,7 @@ export default async function OneDeskPage({ params, searchParams }: {
   const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer', 'money', 'commitment'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
   const project = typeof sp.project === 'string' ? sp.project : null;
 
-  const all = await getOneDeskPool(slug);
+  const { active: all, handled, orgProfileId } = await getOneDesk(slug);
   const projects = [...new Set(all.map((r) => r.project))].sort();
   const pool = all.filter((r) => (!kind || r.kind === kind) && (!project || r.project === project));
   const selected = (typeof sp.rec === 'string' ? pool.find((r) => r.id === sp.rec) : null) ?? pool[0] ?? null;
@@ -67,7 +68,9 @@ export default async function OneDeskPage({ params, searchParams }: {
       <div className="mx-auto max-w-[1760px]">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <div className="font-mono text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">One pool · deadline first · {all.length} records</div>
+            <div className="font-mono text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+              One pool · deadline first · {all.length} records{handled.length > 0 ? ` · ${handled.length} handled today` : ''}
+            </div>
             <h1 className="mt-1 text-3xl font-black uppercase tracking-widest">One Desk</h1>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -143,6 +146,11 @@ export default async function OneDeskPage({ params, searchParams }: {
                   <div className="text-[9px] font-black uppercase tracking-widest text-bauhaus-red">Next move</div>
                   <p className="mt-1 font-bold">{selected.next}</p>
                 </div>
+                {orgProfileId ? (
+                  <div className="mt-4">
+                    <DeskMarkButtons orgProfileId={orgProfileId} actionId={selected.id} title={selected.name} detail={selected.next} />
+                  </div>
+                ) : null}
                 <div className="mt-4 flex flex-wrap gap-2">
                   {selected.ghlUrl && (
                     <a href={selected.ghlUrl} target="_blank" rel="noopener noreferrer" className="border-2 border-bauhaus-black bg-bauhaus-yellow px-3 py-1.5 text-xs font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-white">

--- a/apps/web/src/lib/services/act-one-desk.ts
+++ b/apps/web/src/lib/services/act-one-desk.ts
@@ -5,6 +5,7 @@
 import { getGoodsFunderScan } from '@/lib/services/goods-funder-scan';
 import { getActRelationshipLedger } from '@/lib/services/act-relationship-ledger';
 import { getOrgPipelineData } from '@/lib/services/org-pipeline-service';
+import { getOrgDailyActionStates, type ActDailyActionStatus } from '@/lib/services/act-daily-actions';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsGrantsTriage } from '@/lib/services/goods-grants-triage';
 import { getGoodsBuyerPipeline } from '@/lib/services/goods-buyer-pipeline';
@@ -59,6 +60,30 @@ function days(iso: string | null): number | null {
 function urgency(r: DeskRecord): number {
   if (r.dueDays != null) return r.dueDays < 0 ? -1000 + r.dueDays : r.dueDays;
   return 500 - r.score;
+}
+
+export type OneDeskPool = {
+  /** Ranked records still needing a move today. */
+  active: DeskRecord[];
+  /** Records marked done/waiting/tomorrow today (same store as the Today queue). */
+  handled: Array<{ record: DeskRecord; status: ActDailyActionStatus }>;
+  orgProfileId: string | null;
+};
+
+export async function getOneDesk(slug: string): Promise<OneDeskPool> {
+  const pool = await getOneDeskPool(slug);
+  const profile = await getOrgProfileBySlug(slug).catch(() => null);
+  const states: Record<string, ActDailyActionStatus> = profile
+    ? await getOrgDailyActionStates(profile.id).catch(() => ({}))
+    : {};
+  const active: DeskRecord[] = [];
+  const handled: OneDeskPool['handled'] = [];
+  for (const r of pool) {
+    const status = states[r.id];
+    if (status) handled.push({ record: r, status });
+    else active.push(r);
+  }
+  return { active, handled, orgProfileId: profile?.id ?? null };
 }
 
 export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {


### PR DESCRIPTION
Done/Waiting/Tomorrow on the selected record writes the same
opportunity_context_events rows as the Today queue, the pool refreshes, and the
next record is selected. Handled-today count in the header.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
