### PR TITLE
feat(act): One Desk IS today — bare /org/act lands on the desk, Today leaves the rail

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -81,8 +81,8 @@ export function ActWorkspaceShell({
   const artProject = projectRows.find((project) => /harvest|witta|art/.test(`${project.slug} ${project.name}`.toLowerCase()));
   const workModes: WorkspaceLink[] = [
     // The one-system front door: every workable record, one ranked queue.
-    { label: 'One Desk', href: `/org/${slug}/desk`, active: pathname.startsWith(`/org/${slug}/desk`) },
-    { label: 'Today', href: rootHref(slug), active: onOrgRoot && view === 'today' },
+    // "Today" retired 2026-08-05 — One Desk IS today (CONTEXT.md).
+    { label: 'One Desk', href: `/org/${slug}/desk`, active: pathname.startsWith(`/org/${slug}/desk`) || (onOrgRoot && view === 'today') },
     { label: 'Listen', href: rootHref(slug, 'relationships', 'relationships'), active: onOrgRoot && view === 'relationships' },
     { label: 'Curiosity', href: rootHref(slug, 'opportunities', 'opportunities'), active: onOrgRoot && (view === 'opportunities' || view === 'triage') },
     { label: 'Action', href: rootHref(slug, 'pipeline', 'pipeline'), active: onOrgRoot && view === 'pipeline' },

--- a/apps/web/src/app/org/[slug]/page.tsx
+++ b/apps/web/src/app/org/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getWikiSupportIndex, type WikiSupportIndex } from '@/lib/services/wiki-support-index';
 import { getWikiSupportFrontierQueue, type WikiSupportFrontierQueue } from '@/lib/services/wiki-support-frontier';
 import { workshopWikiHref } from '@/lib/services/act-workshop-wiki';
@@ -705,8 +705,12 @@ export default async function OrgDashboard({ params, searchParams }: { params: P
   const { slug } = await params;
   const sp = await searchParams;
   const fundingYearFilter = typeof sp.fy === 'string' ? sp.fy : undefined;
-  // ACT always opens in the Field Desk. The old full dashboard made production
-  // and `?full=1` behave differently from the daily workspace tested in CI.
+  // One Desk IS today (CONTEXT.md screen ownership): the bare org root goes to
+  // the desk. The legacy field-desk views stay reachable only when a view,
+  // walkthrough, or deep-link param is explicitly present, until they retire.
+  if (isActSlug(slug) && !sp.view && !sp.walkthrough && !sp.review && !sp.relationship && !sp.commitment && !sp.ledger && !sp.full) {
+    redirect(`/org/${slug}/desk`);
+  }
   if (isActSlug(slug)) {
     return (
       <FastOrgDashboard

--- a/apps/web/tests/e2e/act-field-desk.spec.ts
+++ b/apps/web/tests/e2e/act-field-desk.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('ACT Field Desk pilot workflow', () => {
+  test('bare org root lands on One Desk', async ({ page }) => {
+    await page.goto('/org/act');
+    await expect(page).toHaveURL(/\/org\/act\/desk/);
+    await expect(page.getByRole('heading', { name: 'One Desk' })).toBeVisible();
+  });
+
   test('walks through every gold-standard surface with persistent progress', async ({ page }) => {
     await page.goto('/org/act?walkthrough=1');
 
@@ -25,7 +31,7 @@ test.describe('ACT Field Desk pilot workflow', () => {
   });
 
   test('routes the discovery receipt into the matter-review desk', async ({ page }) => {
-    await page.goto('/org/act');
+    await page.goto('/org/act?view=today');
 
     const receipt = page.getByLabel('Latest discovery activity');
     await expect(receipt).toContainText('Discovery activity recorded');
@@ -49,7 +55,7 @@ test.describe('ACT Field Desk pilot workflow', () => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
     });
 
-    await page.goto('/org/act');
+    await page.goto('/org/act?view=today');
 
     const today = page.getByTestId('act-today-focus');
     await expect(today.getByTestId('today-primary')).toContainText('Return: share the delivery evidence');
@@ -265,7 +271,7 @@ test.describe('ACT Field Desk pilot workflow', () => {
 
   test('keeps the daily desk usable on a phone-sized viewport', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('/org/act');
+    await page.goto('/org/act?view=today');
 
     await expect(page.getByRole('heading', { name: 'What needs moving today' })).toBeVisible();
     await expect(page.getByTestId('today-primary')).toBeVisible();
@@ -319,7 +325,7 @@ test.describe('ACT Field Desk pilot workflow', () => {
 
   test('keeps one ACT shell across the desk, Atlas, and project records', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
-    await page.goto('/org/act');
+    await page.goto('/org/act?view=today');
 
     const sidebar = page.getByTestId('act-desk-sidebar');
     await expect(sidebar).toBeVisible();


### PR DESCRIPTION
Legacy field-desk views stay reachable behind explicit params (?view=today,
?full=1, walkthrough/deep-links) until they retire. New E2E pins the redirect;
suite is 22/22.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
