### PR TITLE
feat(org-record): the Org record surface — /org/act/orgs/[org]

### DIFF
--- a/apps/web/src/app/org/[slug]/orgs/[org]/page.tsx
+++ b/apps/web/src/app/org/[slug]/orgs/[org]/page.tsx
@@ -1,0 +1,265 @@
+// The Org record — everything ACT knows about one Org on one screen.
+// Quiet Ledger skin. Composes the loaders behind the old Listen view; the desk
+// links here, GHL stays the system of record (every GHL fact shows its age).
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import {
+  getActOrgRecord,
+  ASK_STAGE_LABEL, ASK_STAGE_ORDER, DOMAIN_REL_LABEL,
+  type ActDomainRelType, type ActOrgRecord,
+} from '@/lib/services/act-org-record';
+import type { ActRelationshipTimelineEvent } from '@/lib/services/act-relationship-ledger';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string; org: string }> }) {
+  const { org } = await params;
+  return { title: `${org.replace(/-/g, ' ')} — Org record — CivicGraph` };
+}
+
+const money = (n: number) => new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: 0 }).format(n);
+
+const REL_CHIP: Record<ActDomainRelType, string> = {
+  funds: 'bg-ql-kind-funder', buys: 'bg-ql-kind-buyer', distributes: 'bg-ql-moss',
+  auspices: 'bg-ql-accent', collaborates: 'bg-ql-kind-commitment', opens: 'bg-ql-kind-grant',
+};
+
+function ago(iso: string | null): string {
+  if (!iso) return 'never';
+  const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days < 60) return `${days}d ago`;
+  if (days < 730) return `${Math.round(days / 30)}mo ago`;
+  return `${Math.round(days / 365)}y ago`;
+}
+
+/** Freshness badge for GHL-derived facts: stale when the sync is > 24h old. */
+function Freshness({ at }: { at: string | null }) {
+  if (!at) {
+    return <span className="rounded-full border border-ql-border px-2 py-0.5 font-ql-mono text-[9px] uppercase tracking-[0.08em] text-ql-muted">sync age unknown</span>;
+  }
+  const hours = Math.floor((Date.now() - new Date(at).getTime()) / 3_600_000);
+  const stale = hours > 24;
+  return (
+    <span className={`rounded-full border px-2 py-0.5 font-ql-mono text-[9px] uppercase tracking-[0.08em] ${stale ? 'border-ql-alert text-ql-alert' : 'border-ql-moss text-ql-moss'}`}>
+      {stale ? `stale · synced ${hours > 48 ? `${Math.floor(hours / 24)}d` : `${hours}h`} ago` : `synced ${hours <= 1 ? 'this hour' : `${hours}h ago`}`}
+    </span>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h2 className="font-ql-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-ql-accent">{children}</h2>;
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return <section className="rounded-lg border border-ql-border bg-ql-surface p-5">{children}</section>;
+}
+
+function TimelineRow({ event }: { event: ActRelationshipTimelineEvent }) {
+  return (
+    <li className="border-t border-ql-border/60 py-2.5 first:border-t-0">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="font-ql-mono text-[9px] uppercase tracking-[0.08em] text-ql-muted">{event.kind}</span>
+        <span className="text-sm font-semibold">{event.title}</span>
+        {event.amount != null && <span className="font-ql-mono text-[11px] font-semibold">{money(event.amount)}</span>}
+        <span className="ml-auto font-ql-mono text-[10px] text-ql-muted">{event.happenedAt ? event.happenedAt.slice(0, 10) : '—'}</span>
+      </div>
+      <p className="mt-0.5 text-[13px] leading-5 text-ql-text2">{event.summary}</p>
+    </li>
+  );
+}
+
+function Asks({ record }: { record: ActOrgRecord }) {
+  if (record.asks.length === 0) {
+    return <p className="mt-2 text-sm text-ql-text2">No Asks yet. Deciding to chase money here mints one in GHL.</p>;
+  }
+  return (
+    <div className="mt-2 space-y-2">
+      {ASK_STAGE_ORDER.filter((stage) => record.asks.some((ask) => ask.stage === stage)).map((stage) => (
+        <div key={stage}>
+          <div className="font-ql-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-ql-text2">{ASK_STAGE_LABEL[stage]}</div>
+          {record.asks.filter((ask) => ask.stage === stage).map((ask) => (
+            <div key={ask.id} className="mt-1 rounded-md border border-ql-border bg-ql-surface2 px-3 py-2">
+              <div className="flex flex-wrap items-baseline gap-2 text-sm">
+                <span className="font-semibold">{ask.purpose ?? ask.relType.replace(/_/g, ' ')}</span>
+                {ask.amountAud != null && <span className="font-ql-mono text-[11px] font-semibold">{money(ask.amountAud)}</span>}
+                <span className="ml-auto font-ql-mono text-[10px] text-ql-muted">warmth {ask.warmth}</span>
+              </div>
+              {ask.nextAction && (
+                <p className="mt-1 text-[13px] text-ql-text2">
+                  Next: {ask.nextAction}
+                  {ask.nextActionDue ? <span className="font-ql-mono text-[10px]"> · due {ask.nextActionDue.slice(0, 10)}</span> : null}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default async function ActOrgRecordPage({ params }: { params: Promise<{ slug: string; org: string }> }) {
+  const { slug, org } = await params;
+  if (!isActSlug(slug)) notFound();
+  const profile = await getOrgProfileBySlug(slug).catch(() => null);
+  if (!profile) notFound();
+  const record = await getActOrgRecord(slug, profile.id, org);
+  if (!record) notFound();
+
+  const item = record.ledgerItem;
+  const followUps = [
+    ...(item?.followUp && item.followUp.status === 'planned' ? [{ id: item.followUp.id, text: `${item.followUp.action} — ${item.followUp.owner}, due ${item.followUp.dueAt}` }] : []),
+    ...(item?.obligations ?? []).map((obligation) => ({
+      id: obligation.id,
+      text: `${obligation.kind === 'return' ? 'Return owed' : 'Promise'}: ${obligation.action} (${obligation.owner}${obligation.dueAt ? `, due ${obligation.dueAt}` : ''})`,
+    })),
+  ];
+
+  return (
+    <main className="min-h-screen bg-ql-surface2 p-6 text-ql-ink" data-testid="act-org-record">
+      <div className="mx-auto max-w-[1760px]">
+        <div className="font-ql-mono text-[10px] uppercase tracking-[0.14em] text-ql-text2">
+          <Link href={`/org/${slug}/orgs`} className="hover:text-ql-ink">Orgs</Link> / Org record
+        </div>
+        <div className="mt-1 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="font-ql-display text-4xl font-semibold">{record.name}</h1>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              {record.relationships.length === 0 && <span className="text-sm text-ql-text2">No relationship on record yet.</span>}
+              {record.relationships.map((rel) => (
+                <span key={rel.type} title={rel.basis} className={`rounded px-2 py-0.5 font-ql-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-ql-inverse ${REL_CHIP[rel.type]}`}>
+                  {DOMAIN_REL_LABEL[rel.type]}{rel.warmth != null ? ` · ${rel.warmth}` : ''}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {record.ghl?.url ? (
+              <>
+                <Freshness at={record.ghl.lastSyncedAt} />
+                <a href={record.ghl.url} target="_blank" rel="noopener noreferrer" className="rounded-md border border-ql-border bg-ql-surface px-4 py-2 text-xs font-semibold text-ql-accent hover:bg-ql-surface2">
+                  Open in GHL ↗
+                </a>
+              </>
+            ) : (
+              <span className="rounded-full border border-ql-border px-2 py-0.5 font-ql-mono text-[9px] uppercase tracking-[0.08em] text-ql-muted">not in GHL — not yet an Ask</span>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]">
+          <div className="space-y-4">
+            <Card>
+              <SectionTitle>Asks · the five stages</SectionTitle>
+              <Asks record={record} />
+            </Card>
+
+            <Card>
+              <SectionTitle>Next moves & follow-ups</SectionTitle>
+              {item?.nextMove && <p className="mt-2 rounded-md bg-ql-warm px-3 py-2 text-sm font-medium leading-6">{item.nextMove}</p>}
+              {record.brief?.actions.length ? (
+                <ul className="mt-2 space-y-1.5">
+                  {record.brief.actions.map((action) => (
+                    <li key={action.id} className="text-[13px] leading-5">
+                      <span className="font-ql-mono text-[9px] uppercase tracking-[0.08em] text-ql-muted">{action.kind}</span>{' '}
+                      <span className="font-semibold">{action.title}</span>
+                      <span className="text-ql-text2"> — {action.detail}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {followUps.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {followUps.map((followUp) => <li key={followUp.id} className="text-[13px] text-ql-text2">• {followUp.text}</li>)}
+                </ul>
+              )}
+              {!item?.nextMove && !record.brief?.actions.length && followUps.length === 0 && (
+                <p className="mt-2 text-sm text-ql-text2">No next move recorded.</p>
+              )}
+            </Card>
+
+            <Card>
+              <SectionTitle>Money · Xero</SectionTitle>
+              {item ? (
+                <>
+                  <div className="mt-2 grid grid-cols-3 gap-3">
+                    {[
+                      { label: 'Invoiced', value: item.invoicedTotal, tone: 'text-ql-ink' },
+                      { label: 'Paid', value: item.receivedTotal, tone: 'text-ql-moss' },
+                      { label: 'Outstanding', value: item.outstandingTotal, tone: item.outstandingTotal > 0 ? 'text-ql-alert' : 'text-ql-muted' },
+                    ].map((stat) => (
+                      <div key={stat.label} className="rounded-md border border-ql-border bg-ql-surface2 px-3 py-2">
+                        <div className="font-ql-mono text-[9px] uppercase tracking-[0.1em] text-ql-muted">{stat.label}</div>
+                        <div className={`font-ql-mono text-lg font-semibold ${stat.tone}`}>{money(stat.value)}</div>
+                      </div>
+                    ))}
+                  </div>
+                  {item.oldestOverdueDays > 0 && <p className="mt-2 text-[13px] font-medium text-ql-alert">Oldest invoice {item.oldestOverdueDays} days overdue.</p>}
+                  <ul className="mt-3">
+                    {item.invoices.slice(0, 8).map((invoice) => (
+                      <li key={invoice.id} className="flex flex-wrap items-baseline gap-2 border-t border-ql-border/60 py-1.5 text-[13px] first:border-t-0">
+                        <span className="font-ql-mono">{invoice.number ?? 'Invoice'}</span>
+                        <span className="text-ql-text2">{invoice.date?.slice(0, 10) ?? '—'}</span>
+                        <span className="font-ql-mono text-[9px] uppercase tracking-[0.08em] text-ql-muted">{invoice.status}</span>
+                        <span className="ml-auto font-ql-mono font-semibold">{money(invoice.total)}</span>
+                        {invoice.due > 0 && <span className="font-ql-mono text-[11px] text-ql-alert">{money(invoice.due)} due</span>}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : (
+                <p className="mt-2 text-sm text-ql-text2">No invoice history linked to this Org yet.</p>
+              )}
+            </Card>
+          </div>
+
+          <div className="space-y-4">
+            <Card>
+              <SectionTitle>People</SectionTitle>
+              {item?.people.length ? (
+                <ul className="mt-2 space-y-1.5">
+                  {item.people.slice(0, 10).map((person) => (
+                    <li key={person.id} className="flex flex-wrap items-baseline gap-2 text-[13px]">
+                      <span className="font-semibold">{person.name}</span>
+                      {person.role && <span className="text-ql-text2">{person.role}</span>}
+                      {person.email && <span className="font-ql-mono text-[11px] text-ql-text2">{person.email}</span>}
+                      <span className="ml-auto flex items-center gap-1.5 font-ql-mono text-[10px] text-ql-muted">
+                        {person.lastContactAt ? ago(person.lastContactAt) : 'no contact recorded'}
+                        {person.source === 'ghl' && <Freshness at={record.ghl?.lastSyncedAt ?? null} />}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-ql-text2">No named people yet — find the person who can explain this relationship.</p>
+              )}
+            </Card>
+
+            <Card>
+              <SectionTitle>Conversations & history</SectionTitle>
+              {record.timeline.length ? (
+                <ul className="mt-1 max-h-[52vh] overflow-y-auto">
+                  {record.timeline.slice(0, 30).map((event) => <TimelineRow key={event.id} event={event} />)}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-ql-text2">No conversations or exchanges recorded yet.</p>
+              )}
+            </Card>
+
+            {item?.evidenceGaps.length ? (
+              <Card>
+                <SectionTitle>Evidence gaps</SectionTitle>
+                <ul className="mt-2 space-y-1">
+                  {item.evidenceGaps.map((gap) => <li key={gap} className="text-[13px] text-ql-text2">• {gap}</li>)}
+                </ul>
+              </Card>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/services/act-org-record.ts
+++ b/apps/web/src/lib/services/act-org-record.ts
@@ -1,0 +1,309 @@
+// The Org record: everything ACT knows about one Org on one screen.
+// Composes the loaders that already fed the Listen view (relationship ledger,
+// funder intelligence, relationship brief) plus the goods_relationships
+// registry — no new queries against raw tables beyond a GHL freshness lookup.
+// Domain language per CONTEXT.md: an Org holds typed Relationships; its Asks
+// move through the five stages.
+import { cache } from 'react';
+import { getServiceSupabase } from '@/lib/supabase';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import {
+  getActRelationshipLedger,
+  normaliseRelationshipIdentity,
+  relationshipNamesMatch,
+  buildActRelationshipTimeline,
+  type ActRelationshipLedger,
+  type ActRelationshipLedgerItem,
+  type ActRelationshipTimelineEvent,
+} from '@/lib/services/act-relationship-ledger';
+import { getActFunderIntelligence, type ActFunderDossier } from '@/lib/services/act-funder-intelligence';
+import { buildActRelationshipBrief, type ActRelationshipBrief } from '@/lib/services/act-relationship-brief';
+import { getGoodsRelationshipsSafe } from '@/lib/services/goods-engagement';
+import type { GoodsRelationship, GoodsRelType, GoodsStage } from '@/lib/services/goods-engagement-shared';
+import { ghlContactUrl } from '@/lib/ghl-links';
+
+/** The six relationship types an Org can hold with ACT (CONTEXT.md). */
+export type ActDomainRelType = 'funds' | 'buys' | 'distributes' | 'auspices' | 'collaborates' | 'opens';
+
+export const DOMAIN_REL_LABEL: Record<ActDomainRelType, string> = {
+  funds: 'Funds', buys: 'Buys', distributes: 'Distributes',
+  auspices: 'Auspices', collaborates: 'Collaborates', opens: 'Opens',
+};
+
+/** The five Ask stages (CONTEXT.md), plus Dormant as the parked state. */
+export type ActAskStage = 'open_door' | 'in_conversation' | 'asked' | 'won' | 'lost' | 'dormant';
+
+export const ASK_STAGE_LABEL: Record<ActAskStage, string> = {
+  open_door: 'Open door', in_conversation: 'In conversation', asked: 'Asked',
+  won: 'Won', lost: 'Lost', dormant: 'Dormant',
+};
+
+export const ASK_STAGE_ORDER: ActAskStage[] = ['open_door', 'in_conversation', 'asked', 'won', 'lost', 'dormant'];
+
+/** Every GoodsRelType maps onto exactly one domain relationship type. */
+const GOODS_TYPE_TO_DOMAIN: Record<GoodsRelType, ActDomainRelType> = {
+  funder: 'funds', impact_investor: 'funds', repayable_finance: 'funds',
+  buyer: 'buys', production_partner: 'collaborates',
+  supporter: 'opens', advocate: 'opens',
+};
+
+/** Every legacy GoodsStage maps onto exactly one of the five stages. */
+const GOODS_STAGE_TO_ASK: Record<GoodsStage, ActAskStage> = {
+  identified: 'open_door', researching: 'open_door',
+  contacted: 'in_conversation', in_conversation: 'in_conversation',
+  proposal: 'asked', committed: 'won', repeat: 'won',
+  declined: 'lost', dormant: 'dormant',
+};
+
+/** Butterfly is ACT's DGR route — the one auspices relationship (act-core-facts). */
+const AUSPICE_ORGS = ['butterfly movement'];
+
+export interface ActOrgRelationship {
+  type: ActDomainRelType;
+  /** Human evidence for why the Org holds this relationship. */
+  basis: string;
+  warmth: number | null;
+  source: 'goods_registry' | 'ledger' | 'derived';
+}
+
+export interface ActOrgAsk {
+  id: string;
+  stage: ActAskStage;
+  purpose: string | null;
+  amountAud: number | null;
+  nextAction: string | null;
+  nextActionDue: string | null;
+  warmth: number;
+  ghlContactId: string | null;
+  ghlOpportunityId: string | null;
+  relType: GoodsRelType;
+}
+
+export interface ActOrgGhlDoor {
+  contactId: string;
+  url: string | null;
+  contactName: string | null;
+  lastSyncedAt: string | null;
+}
+
+export interface ActOrgRecord {
+  slug: string;
+  name: string;
+  relationships: ActOrgRelationship[];
+  asks: ActOrgAsk[];
+  ledgerItem: ActRelationshipLedgerItem | null;
+  brief: ActRelationshipBrief | null;
+  dossier: ActFunderDossier | null;
+  timeline: ActRelationshipTimelineEvent[];
+  ghl: ActOrgGhlDoor | null;
+  generatedAt: string;
+}
+
+/** URL slug for an Org: its normalised identity, hyphenated. */
+export function actOrgSlug(name: string): string {
+  return normaliseRelationshipIdentity(name).replace(/ /g, '-');
+}
+
+export function actOrgHref(slug: string, orgName: string): string {
+  return `/org/${slug}/orgs/${actOrgSlug(orgName)}`;
+}
+
+function slugToIdentity(orgParam: string): string {
+  return normaliseRelationshipIdentity(orgParam.replace(/-/g, ' '));
+}
+
+function titleCase(identity: string): string {
+  return identity.split(' ').map((t) => (t.length > 3 ? t[0].toUpperCase() + t.slice(1) : t.toUpperCase())).join(' ');
+}
+
+interface GhlSyncRow extends Record<string, unknown> {
+  id: string;
+  full_name: string | null;
+  company_name: string | null;
+  last_synced_at: string | null;
+  ghl_updated_at: string | null;
+  updated_at: string | null;
+}
+
+function relationshipsFor(orgName: string, goodsRows: GoodsRelationship[], ledgerItem: ActRelationshipLedgerItem | null): ActOrgRelationship[] {
+  const rels: ActOrgRelationship[] = [];
+  const add = (rel: ActOrgRelationship) => {
+    if (!rels.some((existing) => existing.type === rel.type)) rels.push(rel);
+  };
+  for (const row of goodsRows) {
+    add({
+      type: GOODS_TYPE_TO_DOMAIN[row.relationship_type],
+      basis: `${row.relationship_type.replace(/_/g, ' ')} in the Goods registry`,
+      warmth: row.warmth_display,
+      source: 'goods_registry',
+    });
+  }
+  const identity = normaliseRelationshipIdentity(orgName);
+  if (AUSPICE_ORGS.some((token) => identity.includes(token))) {
+    add({ type: 'auspices', basis: 'DGR route for philanthropic money (Item 1 DGR + PBI)', warmth: null, source: 'derived' });
+  }
+  if (ledgerItem && rels.length === 0 && (ledgerItem.receivedTotal > 0 || ledgerItem.outstandingTotal > 0)) {
+    add({ type: 'buys', basis: 'has paid ACT invoices (Xero)', warmth: null, source: 'ledger' });
+  }
+  return rels;
+}
+
+export const getActOrgRecord = cache(async function getActOrgRecord(
+  slug: string,
+  orgProfileId: string,
+  orgParam: string,
+): Promise<ActOrgRecord | null> {
+  if (!isActSlug(slug)) return null;
+  const identity = slugToIdentity(orgParam);
+  if (!identity) return null;
+
+  const [ledger, goods, intelligence] = await Promise.all([
+    getActRelationshipLedger(slug, orgProfileId).catch(() => null as ActRelationshipLedger | null),
+    getGoodsRelationshipsSafe().catch(() => ({ rows: [] as GoodsRelationship[], fetchError: 'unavailable' })),
+    getActFunderIntelligence(orgProfileId).catch(() => null),
+  ]);
+
+  const ledgerItem = ledger?.items.find((item) => item.key === identity)
+    ?? ledger?.items.find((item) => relationshipNamesMatch(item.organisation, identity))
+    ?? null;
+  const goodsRows = goods.rows.filter((row) => normaliseRelationshipIdentity(row.display_name) === identity
+    || relationshipNamesMatch(row.display_name, identity));
+  const dossier = intelligence?.dossiers.find((candidate) => normaliseRelationshipIdentity(candidate.name) === identity
+    || relationshipNamesMatch(candidate.name, identity)) ?? null;
+
+  const name = ledgerItem?.organisation ?? goodsRows[0]?.display_name ?? dossier?.name ?? null;
+  if (!name && goodsRows.length === 0 && !ledgerItem && !dossier) {
+    // Unknown Org: render honestly rather than 404 so links from stale data
+    // still open a page that says what is missing.
+    return {
+      slug, name: titleCase(identity), relationships: [], asks: [],
+      ledgerItem: null, brief: null, dossier: null, timeline: [], ghl: null,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+  const displayName = name ?? titleCase(identity);
+
+  const brief = dossier ? buildActRelationshipBrief(dossier, ledger) : null;
+
+  const asks: ActOrgAsk[] = goodsRows.map((row) => ({
+    id: row.id,
+    stage: GOODS_STAGE_TO_ASK[row.stage] ?? 'open_door',
+    purpose: row.ask_purpose,
+    amountAud: row.ask_amount_aud,
+    nextAction: row.next_action,
+    nextActionDue: row.next_action_due,
+    warmth: row.warmth_display,
+    ghlContactId: row.ghl_contact_id,
+    ghlOpportunityId: row.ghl_opportunity_id,
+    relType: row.relationship_type,
+  })).sort((left, right) => ASK_STAGE_ORDER.indexOf(left.stage) - ASK_STAGE_ORDER.indexOf(right.stage));
+
+  // GHL door + freshness: the Ask lives in GHL, so every GHL-derived fact on
+  // this screen carries its sync age (CONTEXT.md data-trust rules).
+  let ghl: ActOrgGhlDoor | null = null;
+  const knownContactId = goodsRows.find((row) => row.ghl_contact_id)?.ghl_contact_id ?? null;
+  try {
+    const db = getServiceSupabase();
+    const { data } = await db
+      .from('ghl_contacts')
+      .select('id, full_name, company_name, last_synced_at, ghl_updated_at, updated_at')
+      .or(knownContactId ? `id.eq.${knownContactId}` : `company_name.ilike.%${identity.split(' ')[0]}%`)
+      .range(0, 49);
+    const rows = ((data ?? []) as GhlSyncRow[]).filter((row) => (knownContactId && row.id === knownContactId)
+      || relationshipNamesMatch(row.company_name, displayName));
+    const best = rows[0] ?? null;
+    if (best) {
+      ghl = {
+        contactId: best.id,
+        url: ghlContactUrl(best.id),
+        contactName: best.full_name,
+        lastSyncedAt: best.last_synced_at ?? best.ghl_updated_at ?? best.updated_at ?? null,
+      };
+    }
+  } catch {
+    ghl = null;
+  }
+  if (!ghl && knownContactId) {
+    ghl = { contactId: knownContactId, url: ghlContactUrl(knownContactId), contactName: null, lastSyncedAt: null };
+  }
+
+  return {
+    slug,
+    name: displayName,
+    relationships: relationshipsFor(displayName, goodsRows, ledgerItem),
+    asks,
+    ledgerItem,
+    brief,
+    dossier,
+    timeline: ledgerItem ? buildActRelationshipTimeline(ledgerItem) : [],
+    ghl,
+    generatedAt: new Date().toISOString(),
+  };
+});
+
+export interface ActOrgListRow {
+  slug: string;
+  name: string;
+  relationships: ActDomainRelType[];
+  warmth: number | null;
+  stage: ActAskStage | null;
+  nextAction: string | null;
+  outstandingTotal: number;
+  receivedTotal: number;
+  lastContactAt: string | null;
+  hasGhl: boolean;
+}
+
+/** One searchable list of every Org ACT holds a relationship with. */
+export async function getActOrgList(slug: string, orgProfileId: string): Promise<ActOrgListRow[]> {
+  if (!isActSlug(slug)) return [];
+  const [ledger, goods] = await Promise.all([
+    getActRelationshipLedger(slug, orgProfileId).catch(() => null as ActRelationshipLedger | null),
+    getGoodsRelationshipsSafe().catch(() => ({ rows: [] as GoodsRelationship[], fetchError: 'unavailable' })),
+  ]);
+  const rows = new Map<string, ActOrgListRow>();
+  for (const item of ledger?.items ?? []) {
+    rows.set(item.key, {
+      slug: actOrgSlug(item.organisation),
+      name: item.organisation,
+      relationships: relationshipsFor(item.organisation, [], item).map((rel) => rel.type),
+      warmth: null,
+      stage: null,
+      nextAction: item.followUp?.status === 'planned' ? item.followUp.action : item.nextMove,
+      outstandingTotal: item.outstandingTotal,
+      receivedTotal: item.receivedTotal,
+      lastContactAt: item.lastContactAt,
+      hasGhl: item.people.some((person) => person.source === 'ghl'),
+    });
+  }
+  for (const row of goods.rows) {
+    const key = normaliseRelationshipIdentity(row.display_name);
+    if (!key) continue;
+    const existing = rows.get(key);
+    const domainType = GOODS_TYPE_TO_DOMAIN[row.relationship_type];
+    if (existing) {
+      if (!existing.relationships.includes(domainType)) existing.relationships.push(domainType);
+      existing.warmth = Math.max(existing.warmth ?? 0, row.warmth_display);
+      existing.stage = existing.stage ?? GOODS_STAGE_TO_ASK[row.stage] ?? null;
+      existing.nextAction = existing.nextAction ?? row.next_action;
+      existing.hasGhl = existing.hasGhl || Boolean(row.ghl_contact_id);
+    } else {
+      rows.set(key, {
+        slug: actOrgSlug(row.display_name),
+        name: row.display_name,
+        relationships: [domainType],
+        warmth: row.warmth_display,
+        stage: GOODS_STAGE_TO_ASK[row.stage] ?? null,
+        nextAction: row.next_action,
+        outstandingTotal: 0,
+        receivedTotal: row.total_received_aud,
+        lastContactAt: row.last_touch_at,
+        hasGhl: Boolean(row.ghl_contact_id),
+      });
+    }
+  }
+  return [...rows.values()].sort((left, right) => Number(right.outstandingTotal > 0) - Number(left.outstandingTotal > 0)
+    || (right.warmth ?? -1) - (left.warmth ?? -1)
+    || right.receivedTotal - left.receivedTotal
+    || left.name.localeCompare(right.name));
+}

--- a/apps/web/tests/e2e/act-field-desk.spec.ts
+++ b/apps/web/tests/e2e/act-field-desk.spec.ts
@@ -344,6 +344,19 @@ test.describe('ACT Field Desk pilot workflow', () => {
     await expect(page.locator('nav[aria-label="ACT project fields"]')).toHaveCount(1);
   });
 
+  test('opens an Org record with relationships, asks, money and history sections', async ({ page }) => {
+    await page.goto('/org/act/orgs/snow-foundation');
+
+    const record = page.getByTestId('act-org-record');
+    await expect(record).toBeVisible();
+    await expect(record.getByRole('heading', { level: 1 })).toContainText(/snow/i);
+    await expect(record.getByRole('heading', { name: /Asks · the five stages/i })).toBeVisible();
+    await expect(record.getByRole('heading', { name: /Money · Xero/i })).toBeVisible();
+    await expect(record.getByRole('heading', { name: /Conversations & history/i })).toBeVisible();
+    // The workspace shell stays around the record.
+    await expect(page.getByTestId('act-desk-sidebar')).toBeVisible();
+  });
+
   test('surfaces ACT history and known people for an Atlas funder', async ({ page }) => {
     await page.goto('/org/act/explore?q=Snow%20Foundation');
 


### PR DESCRIPTION
Builds the Org record in Quiet Ledger per CONTEXT.md and the ledger's build block: typed Relationships (six domain types), Asks in the five stages, next moves + follow-ups, People, money history, conversations, GHL deep link, and last-synced freshness badges on GHL-derived facts.

Reuses the Listen view's loaders (act-relationship-ledger / funder intelligence / relationship brief). Adds an E2E smoke for the new route.

Gates: tsc clean · vitest 550 passed · Playwright 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)