### PR TITLE
feat(skill): /make-the-ask ritual + grounded Balnaves EOI draft

### DIFF
--- a/.claude/skills/make-the-ask/SKILL.md
+++ b/.claude/skills/make-the-ask/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: make-the-ask
+description: Walk one funding Ask through the whole three-pipeline ritual — pull CivicGraph evidence, fetch the funder's real requirements, draft in ACT voice, ground every claim, surface the Ben-only questions, park the artefact in Notion, set the GHL next action. Use on /make-the-ask <funder>, "make the X ask", "draft the EOI for X", or when a desk decision-due row gets a pursue. Never submits anything.
+---
+
+# Make the Ask
+
+One repeatable ritual per Ask. Balnaves 2026-08-05 is the reference run
+(thoughts/shared/drafts/balnaves-eoi-2026-08-05.md). The three-pipeline rule
+holds throughout: **GHL owns the Ask's state, CivicGraph owns the evidence,
+Notion owns the produced artefact.** You produce a grounded draft and a set of
+decisions for Ben. You never submit, send, or push "Submitted".
+
+## The eight steps, in order
+
+### 1. Pull what we already know (CivicGraph)
+- Funder row: `node --env-file=.env scripts/gsql.mjs "SELECT name, total_giving_annual, thematic_focus, geographic_focus, giving_philosophy, application_tips, website FROM foundations WHERE name ILIKE '%<funder>%'"`
+- Match row (fit, stage, next step): join `org_project_foundations` on `foundations`.
+- Org record surface: `/org/act/orgs/<org-slug>` holds relationships, people, money history, GHL door. Loaders in `apps/web/src/lib/services/act-org-record.ts`.
+- Check the desk: is it already a GHL Ask or still a decision-due Signal? Not in GHL = not yet an Ask.
+
+### 2. Fetch the funder's actual requirements (their site, today)
+WebFetch the application/EOI pages. Extract literally: eligibility (DGR class,
+auspice rules), funding range and duration, word limits and fields, submission
+method, review timing, exclusions, special conditions (child safety, First
+Nations leadership/partnership rules). Never draft against remembered or
+DB-cached requirements; the DB row is a lead, the site is the source.
+
+### 3. Frame the ask against the capital plan
+- Grant-side blocks and amounts: `GOODS_CAPITAL_BLOCK_SEED` in `apps/web/src/lib/services/goods-capital-workspace.ts`. Grants route via Butterfly; repayable/equipment route via ACT Pty — never mix them in one ask.
+- The ask amount = the blocks that fit the funder's range, named as blocks.
+- DGR runs ONLY through The Butterfly Movement Ltd (Item 1 DGR + PBI since 2012). Never ACT Pty, never A Kind Tractor. Verify entity facts against `act-global-infrastructure/wiki/decisions/act-core-facts.md`.
+
+### 4. Draft in voice
+- Load `/act-voice` BEFORE writing a word of copy. Institutional-but-warm register for funder docs.
+- Reuse the claims library: `act-global-infrastructure/wiki/narrative/goods/` (and sibling project dirs). Only use claims marked as published/deployed; attribute quotes.
+- Respect standing house rules found there (e.g. claim-unit-economics-must-be-real: never pitch delivered cost without an actual number — promise the measurement instead).
+- Structure: ask table (applicant entity, amount, duration, pillar) → need → what the work is → what this grant funds (blocks) → partnership statement → outcomes/measurement → **Open questions for Ben** → Sources.
+
+### 5. Ground it
+Run `/ground` on the draft. HOLD items get fixed inline (soften, attribute, or
+flag `[UNVERIFIED — BEN TO CONFIRM]`), never invented around. Structural risks
+(revenue-percentage caps, geography mismatches, timing rules) go in Open
+questions even when the copy itself is clean.
+
+### 6. Park the artefact (Notion)
+Duplicate **"Ask template — Goods funding (duplicate me)"**
+(https://app.notion.com/p/3b3ebcf981cf8176b805f86126ab9677, under Goods Sales
+Hub), rename to "Ask — [Funder] — [YYYY-MM]", fill it from the draft including
+the claims-and-grounding table. It extends the standing **Goods Investment Ask
+Template + Workflow** page (https://app.notion.com/p/391ebcf981cf81dfa10eeab7a8ef6950)
+— follow that page's status/stage rules and its discipline: Notion first for
+deadlines/evidence, GHL first for relationship-stage changes, never let either
+become the other. Reference run: "Ask — Balnaves Foundation — 2026-08". The
+repo copy under `thoughts/shared/drafts/` is working scratch; Notion is where
+production lives once the draft survives grounding.
+
+### 7. Set the next action (GHL)
+The Ask's state lives in GHL. If it's already a card: update next action to
+"review + submit EOI" with Ben as owner (Tier 2: one-line confirm first). If
+it's still a Signal: the pursue push (grants triage / funder scan buttons)
+mints the card — that's Ben's click or an explicit instruction, not yours.
+
+### 8. Hand over and stop
+Final message: the ask shape in one table, the ground verdict, the Ben-only
+questions ranked by structural risk. Then stop. Submission (portals, emails)
+is day-shift, human-in-loop, always.
+
+## Boundaries
+- Tier 3 (never without an explicit verb): submitting anything, sending email, moving a GHL stage to Submitted/Won/Lost.
+- Tier 2 (confirm first): GHL field writes, Notion edits outside the template duplication.
+- No fabricated numbers, names, or endorsements — grounding is the gate, not a formality.

--- a/thoughts/shared/drafts/balnaves-eoi-2026-08-05.md
+++ b/thoughts/shared/drafts/balnaves-eoi-2026-08-05.md
@@ -1,0 +1,53 @@
+# Balnaves Foundation EOI — Goods on Country (draft for Ben, 2026-08-05)
+
+**Status: DRAFT. Not submitted. Portal-only submission (they reject emailed EOIs).**
+Submit at balnavesfoundation.com/how-to-apply → General EOIs.
+
+## The shape of the ask
+
+| | |
+|---|---|
+| Applicant | The Butterfly Movement Ltd (Item 1 DGR + PBI since 17 Jan 2012, ABN 22 155 132 684), auspicing Goods on Country |
+| Ask | $175,000–$253,000 per year, multi-year (their preferred range is $150K–$250K/yr; trim the top block to land inside it, see below) |
+| Pillar | Health (their "medicine" pillar), young people, First Nations |
+| What it funds | The three grant-side capital blocks: measured 50-bed production run ($60–80K), operating cover ($110–165K), servicing + site scoping ($5–8K) |
+
+Their rules, verified from the site 2026-08-05: DGR Item 1 + TCC or approved auspice, projects not recurrent admin, review within four weeks, trustees quarterly, 3–6 months EOI-to-trustees, unlikely to progress if the project starts inside 3 months. First Nations projects must be First Nations-led or in genuine partnership.
+
+## Draft EOI copy (portal fields will dictate final shape)
+
+### Project title
+Goods on Country: beds as health infrastructure in remote Northern Territory communities.
+
+### The need
+One in three children in remote communities has scabies at any given time. Scabies leads to rheumatic heart disease. 59 per cent of remote homes have no washing machine, and many have no beds. "Hardly anyone around the community has beds. When family comes to visit, people sleep on the floor," Ivy from Palm Island says. Sick kids miss school, and kids outside school drift toward the justice system. The line from a bedroom floor to a courtroom is short and you can draw it with your finger.
+
+### What Goods on Country does
+Goods on Country manufactures robust beds and gets them into remote community homes, working through the organisations communities already trust: health services, women's councils, community stores. [UNVERIFIED — BEN TO CONFIRM COUNT: "24 assets already deployed" appears only in the Maningrida narrative field (goods_communities.proof_line); the structured deployment table (goods_deployment_batches) is empty. Confirm the real number and place before this goes in.] The work is run as an enterprise with a charitable spine: The Butterfly Movement Ltd (DGR Item 1, PBI, registered since 2012) holds the charitable and philanthropic side, and communities are customers and partners, never recipients of charity.
+
+### What this grant funds (per year)
+1. **A measured 50-bed production run** ($60–80K): a timed, fully costed run that proves delivered cost and throughput, so every later dollar buys a known quantity.
+2. **Operating cover** ($110–165K): full-cost operations while bed volume and earned revenue build. This is the honest ask most funders never see: the project cost of running the thing, named as such.
+3. **Servicing and site scoping** ($5–8K): keeping existing deployments working and scoping the first on-Country manufacturing site.
+
+### First Nations partnership
+[BEN TO CONFIRM BEFORE SUBMISSION — this must be true and current.] Delivery runs with First Nations community-controlled organisations in each place. Butterfly's board is being handed to Indigenous leadership (stewardship handover June 2026). Name the live partners here: Anyinginyi (Tennant Creek), Julalikari, and the channel organisations in conversation (Tangentyere, Waltja, RASAC, Tjuwanpa). Only name orgs whose permission we have.
+
+### Outcomes and measurement
+Beds in homes (counted per community, deployment-batch records), delivered cost per bed published from actual runs, school attendance and skin-health referral partnerships with local health services where communities want them measured. We publish actual delivered cost, even when it is bad.
+
+## Open questions before this goes anywhere
+
+1. **The 15 per cent rule.** Their grant cannot exceed 15 per cent of the applicant's total annual revenue. The applicant is Butterfly. A $200K grant implies Butterfly revenue near $1.3M, which is almost certainly not true. The EOI allows an explanation for exceeding it, but this needs a deliberate answer, possibly a smaller year-one ask. **This is the biggest structural risk in the whole application.**
+2. **First Nations partnership statement.** Which named orgs, with whose sign-off?
+3. **Commencement date.** Must be 3+ months out; pick a quarter that fits their trustee cycle.
+4. **Unit economics.** House rule (claim-unit-economics-must-be-real): do not pitch delivered cost without an actual number from the last 50 beds. The measured-run block IS the answer to that rule; the EOI deliberately promises the number rather than claiming it.
+5. **Geography.** Their stated focus is NSW/VIC/QLD/WA; the NT is not on the list. The $5M-annual figure and First Nations emphasis are from their own site; NT eligibility needs a direct check (phone 02 9188 4281) before the EOI burns the one shot.
+
+## Sources
+- Eligibility/process: balnavesfoundation.com/how-to-apply/general-eois/ (fetched 2026-08-05)
+- Fit assessment: org_project_foundations row (fit 90, VERIFIED 2026-08-04)
+- Capital blocks: apps/web/src/lib/services/goods-capital-workspace.ts (GOODS funder search brief)
+- Health claims: wiki/narrative/goods/claim-bed-to-courtroom.md (published in The Cure Already Exists essay + oped)
+- Maningrida 24 assets: goods_communities.proof_line
+- Butterfly facts: act-core-facts.md (ABR verified 2026-06-02)


### PR DESCRIPTION
The repeatable Ask process as a skill (.claude/skills/make-the-ask) plus the grounded Balnaves EOI reference draft. Notion template + Balnaves instance created under Goods Sales Hub.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)