### PR TITLE
docs(ask): grounded auDA Community Grant draft

### DIFF
--- a/thoughts/shared/drafts/auda-community-grant-2026-08-05.md
+++ b/thoughts/shared/drafts/auda-community-grant-2026-08-05.md
@@ -1,0 +1,51 @@
+# auDA 2026 Community Grant — Goods draft (for Ben, 2026-08-05)
+
+**Status: DRAFT. Not submitted. Deadline 5pm AEST 31 August 2026.**
+Apply via the portal link inside their Guidelines PDF (auda.org.au → Community Grant Program).
+
+## The shape of the ask
+
+| | |
+|---|---|
+| Applicant | The Butterfly Movement Ltd (ACNC-registered since 3 Dec 2012) — auDA requires ACNC registration, not DGR |
+| Ask | $50,000 (their grant size; total project budget must exceed $50K, so the 10% co-contribution does part of that work) |
+| Activity period | 1 Jan – 31 Dec 2027, deliverable in 12 months |
+| Co-contribution | At least 10% of the grant, in-kind or financial |
+| Priority groups matched | Rural/remote Australians, Aboriginal and Torres Strait Islander peoples, young Australians 12–24 |
+
+Their rules, verified from the site 2026-08-05: ACNC-registered NFP with a current Charity Register entry and a weblink to the most recent Annual Report; excludes device purchases and basic digital skills training; websites/apps only if they deliver high-impact functionality with accessibility features or serve under-served languages; community-led with partner letters; outputs broadly accessible online; AI-assisted applications must be disclosed.
+
+## The framing decision (Ben's call before anything else)
+
+Goods is physical health hardware. auDA funds digital inclusion. The honest bridge is the digital layer Goods already runs:
+
+**Recommended: the Goods Asset Register as community-facing digital infrastructure.** The asset-tracking system exists today (goods-asset-tracker repo, 404 asset lifecycle records, production at goodsoncountry.com). The project: open it to the communities themselves — each community sees, reports on, and requests service for its own assets (beds, washers), in language, built for low-bandwidth remote use, with outputs published openly. That is digital inclusion for remote First Nations communities on top of infrastructure that already works, community-led by design, and sustainable because the Goods enterprise carries it after the grant year. It also directly answers their "optimisation of community assets" sector priority.
+
+Alternatives if the register angle doesn't sit right: an Empathy Ledger-based community storytelling deployment (digital platform, under-served languages), or sit this round out — a forced digital framing of a beds enterprise would read as exactly that.
+
+## Draft copy skeleton (portal fields will dictate final shape)
+
+**Need:** remote NT communities hold community assets (beds, washing machines, whitegoods) with no digital way to see, manage, or request service for them; connectivity is thin, English is often a second or third language, and the digital tools that exist were not built for these places. [Evidence rows to be added — attendance/connectivity data per the assessment criteria's "well-evidenced need".]
+
+**Solution:** extend the working Goods Asset Register into a community-facing platform: per-community asset views, service requests, plain-language and first-language interfaces, offline-tolerant design, open publication of asset and service data.
+
+**Community-led:** partner letters from the communities and organisations who would run their own registers. [BEN TO CONFIRM which orgs — same permission rule as Balnaves: only name orgs whose sign-off we have.]
+
+**Sustainability:** the register is operating infrastructure for the Goods enterprise; it does not die when the grant ends because the enterprise needs it to trade.
+
+**AI disclosure:** state plainly that drafting was AI-assisted and human-reviewed (their rule; it does not affect assessment).
+
+## Open questions before this goes anywhere
+
+1. **The framing decision itself.** Register-as-inclusion, Empathy Ledger, or pass. If the digital story feels forced, passing is a legitimate answer; fifteen $50K grants nationally will be competitive.
+2. **Butterfly's ACNC hygiene.** Their eligibility requires current Charity Register details (contacts, responsible persons, financial reporting) and a public Annual Report weblink. Butterfly is mid-handover; is its register entry current, and does an Annual Report link exist? [UNVERIFIED — check acnc.gov.au before drafting further.]
+3. **The 10% co-contribution** — cash or in-kind, and whose budget line.
+4. **Partner letters** — which communities/orgs, with sign-off, in time for 31 August.
+5. **Grant size and count**: "fifteen $50,000 grants" comes from our DB row; today's site fetch confirmed neither the $50K figure nor the count (it only says total project budget must exceed $50K). Check the Guidelines PDF before fixing the ask amount.
+6. **Asset Register live status**: "infrastructure that already works" is inferred from the repo, the 404 DB records, and the production URL; confirm the tracker's actual operational state before it anchors the pitch.
+
+## Sources
+- Round facts: auda.org.au community-grant-program page (fetched 2026-08-05)
+- Grant row: grant_opportunities (deadline 2026-08-31, $50K, not yet in GHL)
+- Asset register exists: project-codes.json ACT-GD github_repo, goods_asset_lifecycle (404 rows), goodsoncountry.com
+- Butterfly ACNC facts: act-core-facts.md (ACNC-registered 3 Dec 2012)


### PR DESCRIPTION
Second run of /make-the-ask. Draft + claims table; blocked on Ben's framing decision (Asset Register vs Empathy Ledger vs pass). Notion instance created under Goods Sales Hub.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)