### PR TITLE
feat(theme): Curiosity + legacy ACT surfaces join Quiet Ledger

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -118,20 +118,23 @@ h1, h2, h3, h4 {
   -webkit-font-smoothing: antialiased;
 }
 
+/* ACT workspace speaks Quiet Ledger (2026-08-05): the soft-green family is
+   retired; these vars mirror the ql-* tokens so every legacy ACT surface
+   (Curiosity, ?view= lenses, shell) joins the one visual family. */
 .ws.act-desk,
 .ws.act-workspace {
-  --ws-surface-0: #F4F5F1;
-  --ws-surface-1: #FFFFFF;
-  --ws-surface-2: #F8F9F5;
-  --ws-border: #DCE1DC;
-  --ws-border-strong: #183426;
-  --ws-text: #17231B;
-  --ws-text-secondary: #687169;
-  --ws-text-tertiary: #9AA39C;
-  --ws-accent: #2F6B4A;
-  --ws-red: #A44235;
-  --ws-amber: #AD691C;
-  --ws-green: #2F6B4A;
+  --ws-surface-0: #F6F1E8;
+  --ws-surface-1: #FFFCF7;
+  --ws-surface-2: #F2E5D6;
+  --ws-border: #DDD4C7;
+  --ws-border-strong: #211F1C;
+  --ws-text: #27221D;
+  --ws-text-secondary: #70685F;
+  --ws-text-tertiary: #AAA49B;
+  --ws-accent: #9A673B;
+  --ws-red: #A44A3B;
+  --ws-amber: #9A673B;
+  --ws-green: #5F725C;
 }
 
 .act-workspace {

--- a/apps/web/src/app/org/[slug]/_components/act-operating-desk.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-operating-desk.tsx
@@ -218,32 +218,32 @@ function routeTypeToLane(type: WikiSupportRouteType | 'unknown'): WorkLane {
 }
 
 function laneClass(lane: WorkLane): string {
-  if (lane === 'grant') return 'border-blue-200 bg-blue-50 text-blue-700';
-  if (lane === 'foundation' || lane === 'capital') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
-  if (lane === 'procurement') return 'border-amber-200 bg-amber-50 text-amber-800';
-  if (lane === 'relationship') return 'border-purple-200 bg-purple-50 text-purple-700';
-  return 'border-stone-200 bg-stone-50 text-stone-700';
+  if (lane === 'grant') return 'border-ql-kind-grant/40 bg-ql-kind-grant/10 text-ql-kind-grant';
+  if (lane === 'foundation' || lane === 'capital') return 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss';
+  if (lane === 'procurement') return 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent';
+  if (lane === 'relationship') return 'border-ql-kind-funder/40 bg-ql-kind-funder/10 text-ql-kind-funder';
+  return 'border-ql-border bg-ql-surface2 text-ql-ink';
 }
 
 function sourceClass(source: SourceKind): string {
-  if (source === 'grant' || source === 'supabase') return 'border-blue-200 bg-blue-50 text-blue-700';
-  if (source === 'foundation') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+  if (source === 'grant' || source === 'supabase') return 'border-ql-kind-grant/40 bg-ql-kind-grant/10 text-ql-kind-grant';
+  if (source === 'foundation') return 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss';
   if (source === 'highlevel') return 'border-indigo-200 bg-indigo-50 text-indigo-700';
-  if (source === 'gmail') return 'border-purple-200 bg-purple-50 text-purple-700';
+  if (source === 'gmail') return 'border-ql-kind-funder/40 bg-ql-kind-funder/10 text-ql-kind-funder';
   if (source === 'xero') return 'border-teal-200 bg-teal-50 text-teal-700';
-  if (source === 'notion') return 'border-stone-300 bg-white text-stone-700';
+  if (source === 'notion') return 'border-ql-border bg-ql-surface text-ql-ink';
   if (source === 'goods') return 'border-cyan-200 bg-cyan-50 text-cyan-700';
-  return 'border-stone-200 bg-stone-50 text-stone-700';
+  return 'border-ql-border bg-ql-surface2 text-ql-ink';
 }
 
 function healthClass(status: HealthStatus): string {
-  if (status === 'ok' || status === 'verified') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+  if (status === 'ok' || status === 'verified') return 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss';
   if (status === 'configured' || status === 'mirror-only' || status === 'partial') {
-    return 'border-amber-200 bg-amber-50 text-amber-800';
+    return 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent';
   }
   if (status === 'stale') return 'border-orange-200 bg-orange-50 text-orange-800';
-  if (status === 'empty') return 'border-stone-200 bg-stone-50 text-stone-700';
-  return 'border-red-200 bg-red-50 text-red-700';
+  if (status === 'empty') return 'border-ql-border bg-ql-surface2 text-ql-ink';
+  return 'border-ql-alert/40 bg-ql-alert/10 text-ql-alert';
 }
 
 function relationshipStageLabel(row: OrgProjectFoundationPortfolioRow): string {
@@ -1531,7 +1531,7 @@ export function ActOperatingDesk({
                 <div className="min-w-0 overflow-hidden rounded-md border border-[var(--ws-border)] bg-[var(--ws-surface-1)]">
                   <div className="border-b border-[var(--ws-border)] px-5 py-5">
                     <div className="font-mono text-[10px] font-semibold uppercase tracking-widest text-[var(--ws-text-secondary)]">Today</div>
-                    <h2 className="mt-2 text-xl font-semibold tracking-normal">Do these in order</h2>
+                    <h2 className="mt-2 font-ql-display text-xl font-semibold tracking-normal">Do these in order</h2>
                     <p className="mt-1 text-sm text-[var(--ws-text-secondary)]">Finish the first move before opening another queue.</p>
                   </div>
                   {opportunityContext ? (
@@ -1590,7 +1590,7 @@ export function ActOperatingDesk({
                       </span>
                     </div>
                     {row.grant_finder_href ? (
-                      <Link href={row.grant_finder_href} className="mt-2 inline-flex text-xs font-semibold text-blue-700 hover:underline">
+                      <Link href={row.grant_finder_href} className="mt-2 inline-flex text-xs font-semibold text-ql-kind-grant hover:underline">
                         Open search
                       </Link>
                     ) : null}
@@ -1744,12 +1744,12 @@ function RelationshipStudioContactRow({
   selected: boolean;
   slug: string;
 }) {
-  const colours = ['#c99a2e', '#6b78b8', '#4f8b63', '#a06b8b', '#44899b', '#65766b'];
+  const colours = ['#9A673B', '#3F6577', '#5F725C', '#6B5B8A', '#3F6577', '#70685F'];
   return (
     <Link
       href={deskRelationshipHref(slug, contact.id)}
       className={`flex min-h-[82px] items-center gap-3 border-l-4 px-4 py-3 transition-colors ${
-        selected ? 'border-l-[#2f6b4a] bg-white' : 'border-l-transparent hover:bg-white'
+        selected ? 'border-l-[#5F725C] bg-ql-surface' : 'border-l-transparent hover:bg-ql-surface'
       }`}
     >
       <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full font-mono text-[10px] font-semibold text-white" style={{ backgroundColor: colours[index % colours.length] }}>
@@ -1759,7 +1759,7 @@ function RelationshipStudioContactRow({
         <span className="block truncate text-xs font-semibold">{contact.name}</span>
         <span className="mt-1 block truncate text-[10px] text-[var(--ws-text-secondary)]">{contact.organisation || contact.lane}</span>
       </span>
-      <span className="shrink-0 font-mono text-[8px] font-semibold uppercase text-[#2f6b4a]">{contact.warmth}</span>
+      <span className="shrink-0 font-mono text-[8px] font-semibold uppercase text-[#5F725C]">{contact.warmth}</span>
     </Link>
   );
 }
@@ -1776,7 +1776,7 @@ function RelationshipFact({ label, value, last = false }: { label: string; value
 function RelationshipEventRow({ event }: { event: ActOpportunityContextEvent }) {
   return (
     <div className="grid grid-cols-[34px_minmax(0,1fr)] gap-3 py-5">
-      <span className="grid h-8 w-8 place-items-center rounded-full bg-[#e7f1ea] font-mono text-[9px] font-semibold uppercase text-[#2f6b4a]">
+      <span className="grid h-8 w-8 place-items-center rounded-full bg-[#F2E5D6] font-mono text-[9px] font-semibold uppercase text-[#5F725C]">
         {event.sourceSystem.slice(0, 1)}
       </span>
       <div className="min-w-0">
@@ -1792,7 +1792,7 @@ function RelationshipEventRow({ event }: { event: ActOpportunityContextEvent }) 
 
 function EvidenceSource({ label, status }: { label: string; status: HealthStatus }) {
   return (
-    <div className="border border-[var(--ws-border)] bg-white px-3 py-2.5">
+    <div className="border border-[var(--ws-border)] bg-ql-surface px-3 py-2.5">
       <div className="text-[11px] font-semibold">{label}</div>
       <div className="mt-1 font-mono text-[8px] uppercase text-[var(--ws-text-secondary)]">{status}</div>
     </div>
@@ -1813,15 +1813,15 @@ function ActionTile({
   tone: 'red' | 'green' | 'blue' | 'purple' | 'amber';
 }) {
   const tones = {
-    red: 'border-red-200 bg-red-50 text-red-700',
-    green: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-    blue: 'border-blue-200 bg-blue-50 text-blue-700',
-    purple: 'border-purple-200 bg-purple-50 text-purple-700',
-    amber: 'border-amber-200 bg-amber-50 text-amber-800',
+    red: 'border-ql-alert/40 bg-ql-alert/10 text-ql-alert',
+    green: 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss',
+    blue: 'border-ql-kind-grant/40 bg-ql-kind-grant/10 text-ql-kind-grant',
+    purple: 'border-ql-kind-funder/40 bg-ql-kind-funder/10 text-ql-kind-funder',
+    amber: 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent',
   };
 
   return (
-    <Link href={href} className={`block rounded-md border p-3 transition hover:bg-white ${tones[tone]}`}>
+    <Link href={href} className={`block rounded-md border p-3 transition hover:bg-ql-surface ${tones[tone]}`}>
       <div className="text-xs font-semibold uppercase tracking-wide opacity-80">{label}</div>
       <div className="mt-1 font-mono text-2xl font-semibold tabular-nums">{value}</div>
       <div className="mt-1 line-clamp-2 text-xs leading-snug opacity-90">{detail}</div>
@@ -1850,26 +1850,26 @@ function DiscoveryReceipt({
 }) {
   const hasActivity = receipt.newSignals + receipt.changedSignals + receipt.refreshedPrograms > 0;
   return (
-    <div className="border-b border-[var(--ws-border)] bg-[#f1f8f5] px-5 py-4" aria-label="Latest discovery activity">
+    <div className="border-b border-[var(--ws-border)] bg-[#F6F1E8] px-5 py-4" aria-label="Latest discovery activity">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="grid h-7 w-7 place-items-center rounded-full bg-[#2f8f64] text-xs font-semibold text-white" aria-hidden="true">✓</span>
-            <span className="text-sm font-semibold text-[#183426]">
+            <span className="grid h-7 w-7 place-items-center rounded-full bg-[#5F725C] text-xs font-semibold text-white" aria-hidden="true">✓</span>
+            <span className="text-sm font-semibold text-[#211F1C]">
               {hasActivity ? 'Discovery activity recorded' : 'Discovery sources checked'}
             </span>
-            <span className="font-mono text-[9px] uppercase tracking-wide text-[#56715f]">
+            <span className="font-mono text-[9px] uppercase tracking-wide text-[#70685F]">
               latest stored batch · {fmtDateTime(receipt.latestAt)}
             </span>
           </div>
-          <p className="mt-2 text-xs leading-relaxed text-[#4f6657]">
+          <p className="mt-2 text-xs leading-relaxed text-[#70685F]">
             {receipt.newSignals} new signal{receipt.newSignals === 1 ? '' : 's'} · {receipt.changedSignals} changed · {receipt.refreshedPrograms} public program{receipt.refreshedPrograms === 1 ? '' : 's'} refreshed. Ignored mail stays out of the app.
           </p>
         </div>
         <div className="flex shrink-0 gap-2">
           <ReceiptMetric label="Openings" value={receipt.opportunitySignals} />
           <ReceiptMetric label="Relationships" value={receipt.relationshipSignals} />
-          <Link href={opportunitiesHref} className="inline-flex min-h-11 items-center rounded-md bg-[#183426] px-3 text-xs font-semibold text-white hover:bg-[#24523b] focus:outline-none focus:ring-2 focus:ring-[#2f8f64] focus:ring-offset-2">
+          <Link href={opportunitiesHref} className="inline-flex min-h-11 items-center rounded-md bg-[#211F1C] px-3 text-xs font-semibold text-white hover:bg-[#27221D] focus:outline-none focus:ring-2 focus:ring-[#5F725C] focus:ring-offset-2">
             Review changes
           </Link>
         </div>
@@ -1880,9 +1880,9 @@ function DiscoveryReceipt({
 
 function ReceiptMetric({ label, value }: { label: string; value: number }) {
   return (
-    <div className="min-w-[76px] rounded-md border border-[#cfe0d4] bg-white px-3 py-2 text-center">
-      <div className="font-mono text-base font-semibold tabular-nums text-[#183426]">{value}</div>
-      <div className="mt-0.5 text-[9px] font-semibold uppercase tracking-wide text-[#56715f]">{label}</div>
+    <div className="min-w-[76px] rounded-md border border-[#DDD4C7] bg-ql-surface px-3 py-2 text-center">
+      <div className="font-mono text-base font-semibold tabular-nums text-[#211F1C]">{value}</div>
+      <div className="mt-0.5 text-[9px] font-semibold uppercase tracking-wide text-[#70685F]">{label}</div>
     </div>
   );
 }
@@ -1958,9 +1958,9 @@ function ContextSourceRow({ source }: { source: ActOpportunityContextSource }) {
 }
 
 function priorityClass(priority: ActOpportunityContextStep['priority']): string {
-  if (priority === 'high') return 'border-red-200 bg-red-50 text-red-700';
-  if (priority === 'medium') return 'border-amber-200 bg-amber-50 text-amber-800';
-  return 'border-stone-200 bg-stone-50 text-stone-700';
+  if (priority === 'high') return 'border-ql-alert/40 bg-ql-alert/10 text-ql-alert';
+  if (priority === 'medium') return 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent';
+  return 'border-ql-border bg-ql-surface2 text-ql-ink';
 }
 
 function ContextStepRow({ step }: { step: ActOpportunityContextStep }) {
@@ -2016,19 +2016,19 @@ function actionStateLabel(state: RelationshipActionState): string {
 }
 
 function actionStateClass(state: RelationshipActionState): string {
-  if (state === 'ready_to_reply' || state === 'proposal_path') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
-  if (state === 'meeting_needed') return 'border-blue-200 bg-blue-50 text-blue-700';
-  if (state === 'waiting') return 'border-amber-200 bg-amber-50 text-amber-800';
-  if (state === 'parked') return 'border-stone-300 bg-stone-100 text-stone-600';
-  return 'border-purple-200 bg-purple-50 text-purple-700';
+  if (state === 'ready_to_reply' || state === 'proposal_path') return 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss';
+  if (state === 'meeting_needed') return 'border-ql-kind-grant/40 bg-ql-kind-grant/10 text-ql-kind-grant';
+  if (state === 'waiting') return 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent';
+  if (state === 'parked') return 'border-ql-border bg-ql-warm text-ql-text2';
+  return 'border-ql-kind-funder/40 bg-ql-kind-funder/10 text-ql-kind-funder';
 }
 
 function ContactRow({ contact, orgProfileId }: { contact: ContactContextRow; orgProfileId: string }) {
   const warmth = contact.warmth === 'hot'
-    ? 'border-red-200 bg-red-50 text-red-700'
+    ? 'border-ql-alert/40 bg-ql-alert/10 text-ql-alert'
     : contact.warmth === 'warm'
-      ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-      : 'border-stone-200 bg-stone-50 text-stone-700';
+      ? 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss'
+      : 'border-ql-border bg-ql-surface2 text-ql-ink';
 
   return (
     <div className="px-3 py-3 text-sm">

--- a/apps/web/src/app/org/[slug]/_components/act-record-review.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-record-review.tsx
@@ -111,10 +111,10 @@ function triggerLabel(trigger: QueueTrigger): string {
 }
 
 function triggerClass(trigger: QueueTrigger): string {
-  if (trigger === 'official_evidence_changed') return 'border-blue-200 bg-blue-50 text-blue-800';
-  if (trigger === 'deadline_due') return 'border-amber-200 bg-amber-50 text-amber-900';
-  if (trigger === 'evidence_gap') return 'border-stone-300 bg-stone-50 text-stone-700';
-  return 'border-violet-200 bg-violet-50 text-violet-800';
+  if (trigger === 'official_evidence_changed') return 'border-ql-kind-grant/40 bg-ql-kind-grant/10 text-ql-kind-grant';
+  if (trigger === 'deadline_due') return 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent';
+  if (trigger === 'evidence_gap') return 'border-ql-border bg-ql-surface2 text-ql-ink';
+  return 'border-ql-kind-funder/40 bg-ql-kind-funder/10 text-ql-kind-funder';
 }
 
 function whyNow(item: WeeklyReviewItem): string {
@@ -145,11 +145,11 @@ function suggestedQuestion(item: WeeklyReviewItem): string {
 }
 
 function verificationClass(state: OpportunityVerification['state']): string {
-  if (state === 'verified') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
-  if (state === 'forecast') return 'border-blue-200 bg-blue-50 text-blue-800';
-  if (state === 'relationship') return 'border-violet-200 bg-violet-50 text-violet-800';
-  if (state === 'internal') return 'border-stone-200 bg-stone-50 text-stone-700';
-  return 'border-amber-200 bg-amber-50 text-amber-900';
+  if (state === 'verified') return 'border-ql-moss/40 bg-ql-moss/10 text-ql-moss';
+  if (state === 'forecast') return 'border-ql-kind-grant/40 bg-ql-kind-grant/10 text-ql-kind-grant';
+  if (state === 'relationship') return 'border-ql-kind-funder/40 bg-ql-kind-funder/10 text-ql-kind-funder';
+  if (state === 'internal') return 'border-ql-border bg-ql-surface2 text-ql-ink';
+  return 'border-ql-accent/40 bg-ql-accent/10 text-ql-accent';
 }
 
 function VerificationBadge({ verification }: { verification: OpportunityVerification }) {
@@ -298,24 +298,24 @@ export function ActRecordReview({
   return (
     <div className="grid min-w-0 gap-0 xl:grid-cols-[minmax(0,1fr)_420px]" data-testid="act-relational-review-workbench">
       <div className="min-w-0 xl:border-r xl:border-[var(--ws-border)]">
-        <section className="border-b border-[var(--ws-border)] bg-[#f1f8f5] px-4 py-5">
-          <div className="font-mono text-[10px] font-semibold uppercase tracking-widest text-[#1f734f]">Goods relational review</div>
-          <h3 className="mt-2 text-xl font-semibold tracking-normal text-[var(--ws-text)]">What needs understanding now</h3>
+        <section className="border-b border-[var(--ws-border)] bg-[#F6F1E8] px-4 py-5">
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-widest text-[#5F725C]">Goods relational review</div>
+          <h3 className="mt-2 font-ql-display text-xl font-semibold tracking-normal text-[var(--ws-text)]">What needs understanding now</h3>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--ws-text-secondary)]">
             GrantScope shows at most five matters, and only when official evidence changed, a decision is due within 30 days, a named unknown blocks the work, or a human revisit date has arrived.
           </p>
         </section>
 
         {lastReceipt ? (
-          <div className="border-b border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900" role="status">
+          <div className="border-b border-ql-moss/40 bg-ql-moss/10 px-4 py-3 text-sm text-ql-moss" role="status">
             <div className="font-semibold">Review captured as learning.</div>
-            <div className="mt-1 text-xs leading-5 text-emerald-800">
+            <div className="mt-1 text-xs leading-5 text-ql-moss">
               {lastReceipt.nextStep ?? 'The note was appended without moving a relationship stage or creating a CRM opportunity.'}
             </div>
           </div>
         ) : null}
 
-        <div className="border-b border-[var(--ws-border)] bg-white px-4 py-3 text-xs text-[var(--ws-text-secondary)]">
+        <div className="border-b border-[var(--ws-border)] bg-ql-surface px-4 py-3 text-xs text-[var(--ws-text-secondary)]">
           {queue.length === 0
             ? 'No matters currently meet the weekly attention conditions.'
             : `${queue.length} ${queue.length === 1 ? 'matter needs' : 'matters need'} a read · ${reviewedIds.length} captured in this session`}
@@ -334,10 +334,10 @@ export function ActRecordReview({
                   setSelectedId(record.id);
                   setLastReceipt(null);
                 }}
-                className={`min-h-28 w-full border-l-4 px-4 py-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#2f8f64] ${
+                className={`min-h-28 w-full border-l-4 px-4 py-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#5F725C] ${
                   isSelected
-                    ? 'border-l-[#2f8f64] bg-[#f1f8f5]'
-                    : 'border-l-transparent bg-white hover:bg-[var(--ws-surface-2)]'
+                    ? 'border-l-[#5F725C] bg-[#F6F1E8]'
+                    : 'border-l-transparent bg-ql-surface hover:bg-[var(--ws-surface-2)]'
                 }`}
                 aria-current={isSelected ? 'true' : undefined}
               >
@@ -408,7 +408,7 @@ function RelationalMatterNarrative({
   return (
     <div className="divide-y divide-[var(--ws-border)]">
       <section className="px-4 py-4">
-        <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[#1f734f]">Read before deciding</div>
+        <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[#5F725C]">Read before deciding</div>
         <h3 className="mt-2 text-lg font-semibold leading-snug tracking-normal text-[var(--ws-text)]">{record.title}</h3>
         <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-[var(--ws-text-secondary)]">
           <span>{project?.name ?? record.project}</span>
@@ -444,7 +444,7 @@ function RelationalMatterNarrative({
           <ul className="mt-3 space-y-1.5">
             {record.evidenceGaps.map((gap) => (
               <li key={gap} className="flex gap-2">
-                <span className="text-amber-700" aria-hidden="true">?</span>
+                <span className="text-ql-accent" aria-hidden="true">?</span>
                 <span>{gap}</span>
               </li>
             ))}
@@ -453,7 +453,7 @@ function RelationalMatterNarrative({
           <p className="mt-2 text-[var(--ws-text-secondary)]">No named evidence gap is attached.</p>
         )}
         {record.priorCases && record.priorCases.length > 0 ? (
-          <div className="mt-3 rounded border border-[var(--ws-border)] bg-white px-3 py-2">
+          <div className="mt-3 rounded border border-[var(--ws-border)] bg-ql-surface px-3 py-2">
             <div className="font-mono text-[9px] font-semibold uppercase tracking-wide text-[var(--ws-text-secondary)]">What earlier cases remember</div>
             <ul className="mt-2 space-y-2">
               {record.priorCases.slice(0, 3).map((priorCase) => (
@@ -467,7 +467,7 @@ function RelationalMatterNarrative({
             </ul>
           </div>
         ) : record.decisionMemory ? (
-          <div className="mt-3 rounded border border-[var(--ws-border)] bg-white px-3 py-2">
+          <div className="mt-3 rounded border border-[var(--ws-border)] bg-ql-surface px-3 py-2">
             <div className="font-mono text-[9px] font-semibold uppercase tracking-wide text-[var(--ws-text-secondary)]">Prior human read</div>
             <p className="mt-1">{record.decisionMemory.label} · {formatDate(record.decisionMemory.createdAt)}</p>
             {record.decisionMemory.reason ? <p className="mt-1 text-[var(--ws-text-secondary)]">{record.decisionMemory.reason}</p> : null}
@@ -477,21 +477,21 @@ function RelationalMatterNarrative({
           {record.sourceUrl ? (
             <Link
               href={record.sourceUrl}
-              className="inline-flex min-h-11 items-center rounded border border-[var(--ws-border)] bg-white px-3 font-semibold text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f8f64]"
+              className="inline-flex min-h-11 items-center rounded border border-[var(--ws-border)] bg-ql-surface px-3 font-semibold text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5F725C]"
             >
               Open source
             </Link>
           ) : null}
           <Link
             href="/opportunities/ecosystem"
-            className="inline-flex min-h-11 items-center rounded border border-[var(--ws-border)] bg-white px-3 font-semibold text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f8f64]"
+            className="inline-flex min-h-11 items-center rounded border border-[var(--ws-border)] bg-ql-surface px-3 font-semibold text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5F725C]"
           >
             See connected evidence
           </Link>
           {record.relationshipId ? (
             <Link
               href={`/org/${orgSlug}?view=relationships&relationship=${encodeURIComponent(record.relationshipId)}#relationships`}
-              className="inline-flex min-h-11 items-center rounded border border-[var(--ws-border)] bg-white px-3 font-semibold text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f8f64]"
+              className="inline-flex min-h-11 items-center rounded border border-[var(--ws-border)] bg-ql-surface px-3 font-semibold text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5F725C]"
             >
               See relationship
             </Link>
@@ -618,8 +618,8 @@ function RelationalReviewForm({
   }
 
   return (
-    <form onSubmit={submitReview} className="border-t-4 border-[#183426] bg-white px-4 py-5">
-      <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[#1f734f]">Human reflection</div>
+    <form onSubmit={submitReview} className="border-t-4 border-[#211F1C] bg-ql-surface px-4 py-5">
+      <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[#5F725C]">Human reflection</div>
       <h4 className="mt-2 text-base font-semibold text-[var(--ws-text)]">Record only the material change</h4>
       <p className="mt-1 text-xs leading-5 text-[var(--ws-text-secondary)]">
         The system keeps the evidence. You add the meaning, any real obligation, and what happens next.
@@ -634,7 +634,7 @@ function RelationalReviewForm({
           rows={3}
           maxLength={600}
           required
-          className="mt-2 w-full rounded-md border border-[var(--ws-border)] bg-white px-3 py-2 text-sm leading-6 outline-none focus:border-[#2f8f64] focus:ring-2 focus:ring-[#dce9df]"
+          className="mt-2 w-full rounded-md border border-[var(--ws-border)] bg-ql-surface px-3 py-2 text-sm leading-6 outline-none focus:border-[#5F725C] focus:ring-2 focus:ring-[#DDD4C7]"
         />
       </label>
 
@@ -652,10 +652,10 @@ function RelationalReviewForm({
                   if (move.value !== 'revisit') setRevisitAt('');
                 }}
                 aria-pressed={selected}
-                className={`min-h-14 rounded-md border px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f8f64] ${
+                className={`min-h-14 rounded-md border px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5F725C] ${
                   selected
-                    ? 'border-[#2f8f64] bg-[#f1f8f5] text-[#183426]'
-                    : 'border-[var(--ws-border)] bg-white text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)]'
+                    ? 'border-[#5F725C] bg-[#F6F1E8] text-[#211F1C]'
+                    : 'border-[var(--ws-border)] bg-ql-surface text-[var(--ws-text)] hover:bg-[var(--ws-surface-2)]'
                 }`}
               >
                 <span className="block text-sm font-semibold">{move.label}</span>
@@ -674,7 +674,7 @@ function RelationalReviewForm({
             value={revisitAt}
             onChange={(event) => setRevisitAt(event.target.value)}
             required
-            className="mt-2 min-h-11 w-full rounded-md border border-[var(--ws-border)] bg-white px-3 text-sm outline-none focus:border-[#2f8f64] focus:ring-2 focus:ring-[#dce9df]"
+            className="mt-2 min-h-11 w-full rounded-md border border-[var(--ws-border)] bg-ql-surface px-3 text-sm outline-none focus:border-[#5F725C] focus:ring-2 focus:ring-[#DDD4C7]"
           />
         </label>
       ) : null}
@@ -687,7 +687,7 @@ function RelationalReviewForm({
           value={nextLearningQuestion}
           onChange={(event) => setNextLearningQuestion(event.target.value)}
           maxLength={300}
-          className="mt-2 min-h-11 w-full rounded-md border border-[var(--ws-border)] bg-white px-3 text-sm outline-none focus:border-[#2f8f64] focus:ring-2 focus:ring-[#dce9df]"
+          className="mt-2 min-h-11 w-full rounded-md border border-[var(--ws-border)] bg-ql-surface px-3 text-sm outline-none focus:border-[#5F725C] focus:ring-2 focus:ring-[#DDD4C7]"
         />
       </label>
 
@@ -695,7 +695,7 @@ function RelationalReviewForm({
         <summary className="flex min-h-11 cursor-pointer items-center px-3 text-sm font-semibold text-[var(--ws-text)]">
           Add a promise or return <span className="ml-2 text-xs font-normal text-[var(--ws-text-secondary)]">(optional)</span>
         </summary>
-        <div className="space-y-3 border-t border-[var(--ws-border)] bg-white p-3">
+        <div className="space-y-3 border-t border-[var(--ws-border)] bg-ql-surface p-3">
           <fieldset>
             <legend className="text-xs font-semibold text-[var(--ws-text)]">What kind of obligation is this?</legend>
             <div className="mt-2 grid grid-cols-2 gap-2">
@@ -710,8 +710,8 @@ function RelationalReviewForm({
                   aria-pressed={commitmentKind === value}
                   className={`min-h-11 rounded border px-3 text-sm font-semibold ${
                     commitmentKind === value
-                      ? 'border-[#2f8f64] bg-[#f1f8f5] text-[#183426]'
-                      : 'border-[var(--ws-border)] bg-white text-[var(--ws-text)]'
+                      ? 'border-[#5F725C] bg-[#F6F1E8] text-[#211F1C]'
+                      : 'border-[var(--ws-border)] bg-ql-surface text-[var(--ws-text)]'
                   }`}
                 >
                   {label}
@@ -726,7 +726,7 @@ function RelationalReviewForm({
               value={commitmentOwner}
               onChange={(event) => setCommitmentOwner(event.target.value)}
               maxLength={160}
-              className="mt-1 min-h-11 w-full rounded border border-[var(--ws-border)] px-3 text-sm outline-none focus:border-[#2f8f64] focus:ring-2 focus:ring-[#dce9df]"
+              className="mt-1 min-h-11 w-full rounded border border-[var(--ws-border)] px-3 text-sm outline-none focus:border-[#5F725C] focus:ring-2 focus:ring-[#DDD4C7]"
             />
           </label>
           <label className="block">
@@ -736,7 +736,7 @@ function RelationalReviewForm({
               value={commitmentAction}
               onChange={(event) => setCommitmentAction(event.target.value)}
               maxLength={300}
-              className="mt-1 min-h-11 w-full rounded border border-[var(--ws-border)] px-3 text-sm outline-none focus:border-[#2f8f64] focus:ring-2 focus:ring-[#dce9df]"
+              className="mt-1 min-h-11 w-full rounded border border-[var(--ws-border)] px-3 text-sm outline-none focus:border-[#5F725C] focus:ring-2 focus:ring-[#DDD4C7]"
             />
           </label>
           <label className="block">
@@ -745,14 +745,14 @@ function RelationalReviewForm({
               type="date"
               value={commitmentDueAt}
               onChange={(event) => setCommitmentDueAt(event.target.value)}
-              className="mt-1 min-h-11 w-full rounded border border-[var(--ws-border)] px-3 text-sm outline-none focus:border-[#2f8f64] focus:ring-2 focus:ring-[#dce9df]"
+              className="mt-1 min-h-11 w-full rounded border border-[var(--ws-border)] px-3 text-sm outline-none focus:border-[#5F725C] focus:ring-2 focus:ring-[#DDD4C7]"
             />
           </label>
         </div>
       </details>
 
       {error ? (
-        <p className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-xs leading-5 text-red-800" role="alert">
+        <p className="mt-4 rounded-md border border-ql-alert/40 bg-ql-alert/10 p-3 text-xs leading-5 text-ql-alert" role="alert">
           {error}
         </p>
       ) : null}
@@ -760,7 +760,7 @@ function RelationalReviewForm({
       <button
         type="submit"
         disabled={pending}
-        className="mt-5 flex min-h-12 w-full items-center justify-between rounded-md bg-[#183426] px-4 text-sm font-semibold text-white hover:bg-[#24523b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f8f64] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
+        className="mt-5 flex min-h-12 w-full items-center justify-between rounded-md bg-[#211F1C] px-4 text-sm font-semibold text-white hover:bg-[#27221D] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5F725C] focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
       >
         <span>{pending ? 'Recording reflection…' : 'Record reflection and continue'}</span>
         <span aria-hidden="true">→</span>

--- a/apps/web/src/app/org/[slug]/_components/act-workspace-page-header.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-page-header.tsx
@@ -27,7 +27,7 @@ export function ActWorkspacePageHeader({
       <div className={hasControls ? 'grid min-w-0 gap-3 lg:grid-cols-[minmax(200px,300px)_minmax(300px,1fr)_auto] lg:items-center' : 'flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4'}>
         <div className="min-w-0">
           <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[var(--ws-text-secondary)] sm:text-[10px]">{eyebrow}</div>
-          <h1 className="mt-1 break-words text-xl font-semibold tracking-normal text-[var(--ws-text)] sm:truncate sm:text-2xl">{title}</h1>
+          <h1 className="mt-1 break-words font-ql-display text-2xl font-semibold tracking-normal text-[var(--ws-text)] sm:truncate sm:text-2xl">{title}</h1>
           {description ? <p className="mt-0.5 truncate text-xs text-[var(--ws-text-secondary)]">{description}</p> : null}
         </div>
         {controls ? <div className="min-w-0">{controls}</div> : null}


### PR DESCRIPTION
Retires the soft-green family: .ws.act-desk vars re-pointed at ql tokens, Curiosity components' hardcoded hexes and palette classes mapped to Quiet Ledger (moss/accent/kind colours), display serif on headers. Gates: tsc clean, vitest passed, Playwright 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)