### PR TITLE
feat(rail): retire Funding from the rail

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -120,12 +120,8 @@ export function ActWorkspaceShell({
       href: `/org/${slug}/research`,
       active: pathname.startsWith(`/org/${slug}/research`),
     },
-    {
-      label: 'Funding',
-      detail: 'Five weekly decisions',
-      href: `/org/${slug}/funding`,
-      active: pathname.startsWith(`/org/${slug}/funding`) || pathname.endsWith('/funding'),
-    },
+    // 'Funding — five weekly decisions' retired from the rail 2026-08-05:
+    // Curiosity + One Desk absorbed the ritual. /funding stays reachable as legacy.
   ];
 
   return (

--- a/apps/web/tests/e2e/act-field-desk.spec.ts
+++ b/apps/web/tests/e2e/act-field-desk.spec.ts
@@ -352,6 +352,8 @@ test.describe('ACT Field Desk pilot workflow', () => {
     await expect(sidebar.getByRole('link', { name: 'Listen' })).toHaveCount(0);
     // Action retired from the rail — One Desk owns committed work (kind=commitment).
     await expect(sidebar.getByRole('link', { name: 'Action', exact: true })).toHaveCount(0);
+    // Funding retired 2026-08-05 — Curiosity + the desk absorbed the ritual.
+    await expect(sidebar.getByRole('link', { name: /^Funding/ })).toHaveCount(0);
     await expect(sidebar.getByRole('link', { name: 'Curiosity' })).toBeVisible();
     await sidebar.getByRole('link', { name: 'Orgs' }).click();
     await expect(page).toHaveURL(/\/org\/act\/orgs/);


### PR DESCRIPTION
Gates: tsc, vitest, Playwright 24/24.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)