### PR TITLE
feat(desk): widen One Desk to five row kinds — obligation + person rows (#153)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -19,7 +19,8 @@
   --color-ql-kind-funder: #6B5B8A;
   --color-ql-kind-grant: #3F6577;
   --color-ql-kind-buyer: #5F725C;
-  --color-ql-kind-commitment: #9A673B;
+  --color-ql-kind-obligation: #9A673B;
+  --color-ql-kind-person: #4A5D8A;
   --font-ql-display: var(--font-newsreader, Georgia), Georgia, serif;
   --font-ql-mono: var(--font-plex-mono, ui-monospace), ui-monospace, monospace;
 

--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -313,11 +313,12 @@ const GOODS_RAIL_SECTIONS: ReadonlyArray<{ label: string; items: ReadonlyArray<r
  * "Open full workspace" remains the full-screen jump. */
 const DESK_LENSES: ReadonlyArray<readonly [string | null, string]> = [
   [null, 'Everything'],
-  ['money', 'Money owed to us'],
-  ['commitment', 'Committed work'],
   ['funder', 'Funders'],
   ['grant', 'Grant rounds'],
   ['buyer', 'Buyers'],
+  ['money', 'Money owed to us'],
+  ['obligation', 'We owe'],
+  ['person', 'People'],
 ];
 
 function DeskRailTree({ slug, activeKind, project }: { slug: string; activeKind: string | null; project: string | null }) {

--- a/apps/web/src/app/org/[slug]/desk/desk-obligation-buttons.tsx
+++ b/apps/web/src/app/org/[slug]/desk/desk-obligation-buttons.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+// Obligation rows get the two terminal states (#147) instead of the generic
+// handled buttons: Done and Dropped. Dropped asks a one-line confirm —
+// community-owed drops carry a relationship cost and the API requires a reason.
+export function DeskObligationButtons({ orgProfileId, obligationId, owedTo }: {
+  orgProfileId: string;
+  obligationId: string;
+  owedTo: 'funder' | 'community';
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function mark(state: 'done' | 'dropped') {
+    let dropReason: string | null = null;
+    if (state === 'dropped') {
+      dropReason = window.prompt(
+        owedTo === 'community'
+          ? 'Dropping community-owed work needs a reason (recorded, never silent):'
+          : 'Drop this obligation? One line on why (optional):',
+      );
+      if (dropReason === null) return; // cancelled
+      if (owedTo === 'community' && !dropReason.trim()) {
+        setError('A reason is required to drop community-owed work.');
+        return;
+      }
+    }
+    setBusy(state);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/${orgProfileId}/obligations`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: obligationId, state, ...(dropReason?.trim() ? { drop_reason: dropReason.trim() } : {}) }),
+      });
+      if (!res.ok) throw new Error(((await res.json()) as { error?: string }).error || 'failed');
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const btn = 'rounded-md px-4 py-2 text-xs font-semibold transition-colors disabled:opacity-50';
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button type="button" onClick={() => mark('done')} disabled={busy !== null} className={`${btn} bg-ql-bar text-ql-inverse hover:bg-ql-ink`}>
+        {busy === 'done' ? '…' : 'Done'}
+      </button>
+      <button type="button" onClick={() => mark('dropped')} disabled={busy !== null} className={`${btn} border border-ql-border bg-ql-surface text-ql-ink hover:bg-ql-surface2`}>
+        {busy === 'dropped' ? '…' : 'Dropped'}
+      </button>
+      {error && <span className="text-[10px] text-ql-alert">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/src/app/org/[slug]/desk/page.tsx
+++ b/apps/web/src/app/org/[slug]/desk/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from 'next/navigation';
 import { isActSlug } from '@/lib/services/fast-local-org';
 import { getOneDesk, deskHorizon, type DeskRecord, type DeskHorizon } from '@/lib/services/act-one-desk';
 import { DeskMarkButtons } from './desk-mark-buttons';
+import { DeskObligationButtons } from './desk-obligation-buttons';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,18 +17,18 @@ export async function generateMetadata() {
 
 const KIND_STYLE: Record<DeskRecord['kind'], string> = {
   funder: 'bg-ql-kind-funder', grant: 'bg-ql-kind-grant', buyer: 'bg-ql-kind-buyer',
-  money: 'bg-ql-kind-money', commitment: 'bg-ql-kind-commitment',
+  money: 'bg-ql-kind-money', obligation: 'bg-ql-kind-obligation', person: 'bg-ql-kind-person',
 };
 
-/** Plain words for the record kinds — the internal names (money/commitment)
- * confused the one human this desk serves (Ben, 2026-08-05 review). */
+/** Plain words for the record kinds — the internal names confused the one
+ * human this desk serves (Ben, 2026-08-05 review). */
 const KIND_FILTER_LABEL: Record<DeskRecord['kind'], string> = {
-  money: 'Money owed to us', commitment: 'Committed work',
+  money: 'Money owed to us', obligation: 'We owe', person: 'People',
   funder: 'Funders', grant: 'Grant rounds', buyer: 'Buyers',
 };
 
 const KIND_CHIP_LABEL: Record<DeskRecord['kind'], string> = {
-  money: 'owed', commitment: 'work', funder: 'funder', grant: 'round', buyer: 'buyer',
+  money: 'owed', obligation: 'we owe', person: 'person', funder: 'funder', grant: 'round', buyer: 'buyer',
 };
 
 const HORIZON_LABEL: Record<DeskHorizon, string> = {
@@ -56,13 +57,15 @@ export default async function OneDeskPage({ params, searchParams }: {
   const { slug } = await params;
   if (!isActSlug(slug)) notFound();
   const sp = await searchParams;
-  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer', 'money', 'commitment'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
+  const kind = typeof sp.kind === 'string' && ['funder', 'grant', 'buyer', 'money', 'obligation', 'person'].includes(sp.kind) ? (sp.kind as DeskRecord['kind']) : null;
   const project = typeof sp.project === 'string' ? sp.project : null;
 
   const { active: all, handled, orgProfileId, target } = await getOneDesk(slug);
   const money = (n: number) => (n >= 1e6 ? `$${(n / 1e6).toFixed(1)}M` : `$${Math.round(n / 1e3)}K`);
-  const asks = all.filter((r) => !r.isDecision);
+  const asks = all.filter((r) => !r.isDecision && r.kind !== 'obligation' && r.kind !== 'person');
   const decisions = all.filter((r) => r.isDecision);
+  const owedCount = all.filter((r) => r.kind === 'obligation').length;
+  const peopleCount = all.filter((r) => r.kind === 'person').length;
   const projects = [...new Set(all.map((r) => r.project))].sort();
   const pool = all.filter((r) => (!kind || r.kind === kind) && (!project || r.project === project));
   const selected = (typeof sp.rec === 'string' ? pool.find((r) => r.id === sp.rec) : null) ?? pool[0] ?? null;
@@ -92,7 +95,7 @@ export default async function OneDeskPage({ params, searchParams }: {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <div className="font-ql-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-ql-accent">
-              {asks.length} asks · {decisions.length} decisions due{handled.length > 0 ? ` · ${handled.length} handled today` : ''}
+              {asks.length} asks · {decisions.length} decisions due · {owedCount} owed · {peopleCount} people{handled.length > 0 ? ` · ${handled.length} handled today` : ''}
               {kind ? (
                 <>
                   {' · showing '}{KIND_FILTER_LABEL[kind].toLowerCase()}{' '}
@@ -145,15 +148,31 @@ export default async function OneDeskPage({ params, searchParams }: {
                     className={`flex items-center gap-2.5 border-t border-ql-border/60 px-4 py-2.5 text-sm first:border-t-0 ${selected?.id === r.id ? 'bg-ql-warm' : 'hover:bg-ql-surface2'}`}
                   >
                     <KindChip k={r.kind} />
-                    <span className="min-w-0 flex-1 truncate font-semibold">{r.name}</span>
+                    <span className="min-w-0 flex-1 truncate font-semibold">
+                      {r.name}
+                      {r.kind === 'person' && <span className="font-normal text-ql-text2"> · {r.next}</span>}
+                    </span>
                     {r.isDecision && <span className="rounded-full border border-ql-accent px-2 py-0.5 font-ql-mono text-[8.5px] font-semibold uppercase tracking-[0.08em] text-ql-accent">decide</span>}
+                    {r.kind === 'obligation' && r.owedTo && <span className="font-ql-mono text-[10px] text-ql-muted">→ {r.owedTo}</span>}
+                    {r.kind === 'person' && r.via && <span className="text-[10px] italic text-ql-muted">via {r.via}</span>}
                     {r.amount && <span className="font-ql-mono text-[11px] font-semibold">{r.amount}</span>}
                     <Due d={r.dueDays} />
                   </Link>
                 ))}
               </div>
             ))}
-            {pool.length === 0 ? <div className="px-4 py-10 text-center text-sm text-ql-text2">Nothing matches this filter.</div> : null}
+            {pool.length === 0 ? (
+              <div className="px-4 py-10 text-center text-sm text-ql-text2">
+                {all.length === 0 ? (
+                  <>
+                    Desk clear.{' '}
+                    <Link href={`/org/${slug}/goods/we-owe`} className="underline hover:text-ql-ink">obligations later</Link>
+                    {' · '}
+                    <Link href={`/org/${slug}/people`} className="underline hover:text-ql-ink">people cultivated</Link>
+                  </>
+                ) : 'Nothing matches this filter.'}
+              </div>
+            ) : null}
           </div>
 
           <div className="rounded-lg border border-ql-border bg-ql-surface p-7">
@@ -166,7 +185,16 @@ export default async function OneDeskPage({ params, searchParams }: {
                 <h2 className="mt-2.5 font-ql-display text-3xl font-semibold leading-tight">{selected.name}</h2>
                 <div className="mt-2 flex items-center gap-3">
                   {selected.amount && <span className="font-ql-mono text-sm font-semibold">{selected.amount}</span>}
+                  {selected.kind === 'obligation' && selected.owedTo && (
+                    <span className="font-ql-mono text-[11px] text-ql-muted">owed to {selected.owedTo}</span>
+                  )}
+                  {selected.kind === 'person' && selected.via && (
+                    <span className="text-xs italic text-ql-text2">via {selected.via}</span>
+                  )}
                   <Due d={selected.dueDays} />
+                  {selected.kind === 'person' && selected.lastSyncedAt && (Date.now() - new Date(selected.lastSyncedAt).getTime()) > 86_400_000 && (
+                    <span className="rounded border border-ql-alert px-1.5 py-0.5 font-ql-mono text-[9px] uppercase text-ql-alert">stale sync</span>
+                  )}
                 </div>
                 <div className="mt-5 rounded-md bg-ql-warm px-4 py-3">
                   <div className="font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-accent">Next move</div>
@@ -174,7 +202,12 @@ export default async function OneDeskPage({ params, searchParams }: {
                 </div>
                 {orgProfileId ? (
                   <div className="mt-5">
-                    <DeskMarkButtons orgProfileId={orgProfileId} actionId={selected.id} title={selected.name} detail={selected.next} />
+                    {selected.kind === 'obligation' && selected.obligationId ? (
+                      // Terminal states only (#147) — an Obligation discharges, it isn't "handled".
+                      <DeskObligationButtons orgProfileId={orgProfileId} obligationId={selected.obligationId} owedTo={selected.owedTo ?? 'funder'} />
+                    ) : (
+                      <DeskMarkButtons orgProfileId={orgProfileId} actionId={selected.id} title={selected.name} detail={selected.next} />
+                    )}
                   </div>
                 ) : null}
                 <div className="mt-4 flex flex-wrap gap-2">
@@ -185,7 +218,7 @@ export default async function OneDeskPage({ params, searchParams }: {
                   )}
                   {selected.workHref && (
                     <Link href={selected.workHref} className="rounded-md border border-ql-border bg-ql-surface px-4 py-2 text-xs font-semibold text-ql-ink hover:bg-ql-surface2">
-                      Open full workspace →
+                      {selected.kind === 'obligation' ? 'Open in delivery workspace →' : selected.kind === 'person' ? 'Open person →' : 'Open full workspace →'}
                     </Link>
                   )}
                 </div>

--- a/apps/web/src/lib/services/act-desk-people.ts
+++ b/apps/web/src/lib/services/act-desk-people.ts
@@ -1,0 +1,62 @@
+// Desk feed for cultivated People (CONTEXT.md: Person; ADR 0002 — GHL owns
+// the state, surfaces read the Supabase mirror, never GHL live). Eligibility
+// per #152: next action / watch review-by ≤ 7 days away or past.
+//
+// The mirror table (`act_people`) ships with the /people surface build
+// (#154). Until it exists this feed returns [] — the desk renders honestly
+// with zero person rows rather than faking any.
+import { getServiceSupabase } from '@/lib/supabase';
+
+export type DeskPerson = {
+  id: string;
+  name: string;
+  /** Next action / watch text, plain words. */
+  nextAction: string;
+  /** Days until review-by; negative = past. Always dated (enforced at minting). */
+  dueDays: number;
+  /** Warm-via holder; null when warmth is direct. */
+  via: string | null;
+  warmth: string | null;
+  ghlContactId: string | null;
+  lastSyncedAt: string | null;
+};
+
+type Row = {
+  id: string;
+  name: string;
+  next_action: string | null;
+  review_by: string | null;
+  warm_via: string | null;
+  warmth: string | null;
+  ghl_contact_id: string | null;
+  last_synced_at: string | null;
+};
+
+export async function getDeskPeople(orgProfileId: string): Promise<DeskPerson[]> {
+  const db = getServiceSupabase();
+  const { data, error } = await db
+    .from('act_people')
+    .select('id, name, next_action, review_by, warm_via, warmth, ghl_contact_id, last_synced_at')
+    .eq('org_profile_id', orgProfileId);
+  if (error) return []; // mirror not built yet (#154)
+
+  const out: DeskPerson[] = [];
+  for (const r of (data ?? []) as Row[]) {
+    if (!r.review_by || !r.next_action) continue;
+    const t = new Date(`${r.review_by}T00:00:00`).getTime();
+    if (Number.isNaN(t)) continue;
+    const dueDays = Math.ceil((t - Date.now()) / 86_400_000);
+    if (dueDays > 7) continue;
+    out.push({
+      id: r.id,
+      name: r.name,
+      nextAction: r.next_action,
+      dueDays,
+      via: r.warm_via,
+      warmth: r.warmth,
+      ghlContactId: r.ghl_contact_id,
+      lastSyncedAt: r.last_synced_at,
+    });
+  }
+  return out;
+}

--- a/apps/web/src/lib/services/act-one-desk.ts
+++ b/apps/web/src/lib/services/act-one-desk.ts
@@ -4,7 +4,6 @@
 // filters, never places.
 import { getGoodsFunderScan } from '@/lib/services/goods-funder-scan';
 import { getActRelationshipLedger } from '@/lib/services/act-relationship-ledger';
-import { getOrgPipelineData } from '@/lib/services/org-pipeline-service';
 import { getOrgDailyActionStates, type ActDailyActionStatus } from '@/lib/services/act-daily-actions';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsGrantsTriage } from '@/lib/services/goods-grants-triage';
@@ -12,8 +11,12 @@ import { getGoodsBuyerPipeline } from '@/lib/services/goods-buyer-pipeline';
 import { ghlContactUrl } from '@/lib/ghl-links';
 import { actOrgHref } from '@/lib/services/act-org-record';
 import { getGoodsCapitalWorkspace } from '@/lib/services/goods-capital-workspace';
+import { getDeskObligations } from '@/lib/services/act-obligations';
+import { getDeskPeople } from '@/lib/services/act-desk-people';
 
-export type DeskRecordKind = 'funder' | 'grant' | 'buyer' | 'money' | 'commitment';
+// Five row kinds (CONTEXT.md: One Desk; widened spec #153). The legacy
+// `commitment` kind is gone — committed work IS an Obligation (#150).
+export type DeskRecordKind = 'funder' | 'grant' | 'buyer' | 'money' | 'obligation' | 'person';
 
 const PROJECT_LABELS: Record<string, string> = {
   'ACT-GD': 'Goods', 'ACT-EL': 'Empathy Ledger', 'ACT-JH': 'JusticeHub',
@@ -44,6 +47,14 @@ export type DeskRecord = {
   workHref: string | null;
   /** True when this row is a decision due (pursue or pass), not yet an Ask. */
   isDecision?: boolean;
+  /** Obligation rows: who the work is owed to. */
+  owedTo?: 'funder' | 'community';
+  obligationId?: string;
+  /** Person rows: warm-via holder (null/absent when warmth is direct). */
+  via?: string;
+  personId?: string;
+  /** Person rows: mirror sync age for the stale badge (data-trust rule). */
+  lastSyncedAt?: string | null;
 };
 
 /** The primary Target the Asks serve (CONTEXT.md: Target). */
@@ -112,28 +123,52 @@ export async function getOneDesk(slug: string): Promise<OneDeskPool> {
 
 export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {
   const profile = await getOrgProfileBySlug(slug).catch(() => null);
-  const [scan, triage, buyers, ledger, pipeline] = await Promise.all([
+  const [scan, triage, buyers, ledger, obligations, people] = await Promise.all([
     getGoodsFunderScan().catch(() => null),
     getGoodsGrantsTriage({ scope: 'closing' }).catch(() => null),
     getGoodsBuyerPipeline().catch(() => null),
     profile ? getActRelationshipLedger(slug, profile.id).catch(() => null) : null,
-    getOrgPipelineData(slug).catch(() => null),
+    profile ? getDeskObligations(profile.id).catch(() => []) : [],
+    profile ? getDeskPeople(profile.id).catch(() => []) : [],
   ]);
   const pool: DeskRecord[] = [];
-  // Committed work: human-decided pipeline cards in live stages, any project.
-  for (const card of pipeline?.cards ?? []) {
-    if (card.is_historical) continue;
-    if (!['watching', 'pursuing', 'submitted'].includes(card.decision)) continue;
+  // Obligations (ADR 0003, #152): open + (overdue | due ≤ 30d | undated).
+  // Undated pin the top of the No-date group, newest-minted first — committed
+  // work with no date must never hide (score encodes the pin: 200 - idx keeps
+  // their urgency below every fit-ranked undated Signal's).
+  const undatedRank = obligations
+    .filter((o) => o.dueDays == null)
+    .sort((a, b) => b.mintedAt.localeCompare(a.mintedAt))
+    .map((o) => o.id);
+  for (const o of obligations) {
     pool.push({
-      id: `c-${card.opportunity_id}`, kind: 'commitment',
-      project: deskProjectLabel(card.project_code),
-      name: card.opportunity_name,
-      signal: card.decision,
-      next: card.decision === 'submitted' ? 'Set owner + next action for the follow-through' : 'Plan the next concrete move',
-      dueDays: days(card.deadline), score: card.fit_score ?? 0,
-      amount: card.max_grant_amount ? `$${Math.round(card.max_grant_amount / 1000)}K` : null,
-      ghlUrl: null,
-      workHref: `/org/${slug}?view=pipeline&commitment=${encodeURIComponent(card.opportunity_id)}#pipeline`,
+      id: `o-${o.id}`, kind: 'obligation', obligationId: o.id,
+      project: deskProjectLabel(o.projectCode),
+      name: o.title,
+      signal: o.sourceAskName ? `minted from ${o.sourceAskName}` : `owed to ${o.owedTo}`,
+      next: o.nextAction || 'Set the next action',
+      dueDays: o.dueDays,
+      score: o.dueDays == null ? 200 - undatedRank.indexOf(o.id) : 0,
+      amount: null, ghlUrl: null,
+      workHref: o.projectCode === 'ACT-GD' ? `/org/${slug}/goods/we-owe` : null,
+      owedTo: o.owedTo,
+    });
+  }
+  // People (ADR 0002 mirror): cultivated humans whose next action / watch is
+  // due within 7 days or past. Empty until the #154 mirror ships.
+  for (const p of people) {
+    pool.push({
+      id: `p-${p.id}`, kind: 'person', personId: p.id,
+      project: 'ACT',
+      name: p.name,
+      signal: p.warmth ?? 'cultivated',
+      next: p.nextAction,
+      dueDays: p.dueDays, score: 0,
+      amount: null,
+      ghlUrl: ghlContactUrl(p.ghlContactId),
+      workHref: `/org/${slug}/people`,
+      via: p.via ?? undefined,
+      lastSyncedAt: p.lastSyncedAt,
     });
   }
   // Money owed: outstanding invoices become chase records — the old Today


### PR DESCRIPTION
Implements docs/specs/one-desk-widened-ux-spec.md (wayfinder #153, map #143).

## What changed
- **Kind enum**: legacy `commitment` deleted — committed work IS an Obligation (#150). `obligation` + `person` added.
- **Obligation rows**: feed from `getDeskObligations` (ADR 0003; thresholds #152 — overdue, due ≤30d, undated). Undated pin the top of the No-date group, newest-minted first. Variant B grammar: solid `we owe` chip, muted `→ funder/community` owed-to tag, no amount column. Detail pane gets **Done / Dropped** terminal buttons (community drops require a reason — existing PATCH API).
- **Person rows**: feed from the `act_people` Supabase mirror (ADR 0002). The mirror ships with #154 — until then the feed returns `[]` and the desk renders honest zeros. Row grammar: name · next-action gist, italic `via <holder>`, stale-sync badge >24h in the pane, GHL + person links.
- **Header**: `N asks · M decisions due · K owed · P people`; Target line unchanged (Obligations/People never feed Target math).
- **Rail lenses**: `Committed work` → `We owe` + `People`.
- **Empty state**: unfiltered-empty shows "Desk clear." with workspace links.

## Review note
Removing the `commitment` kind removes the pipeline-card rows (watching/pursuing/submitted) from the desk — per spec, but eyeball the preview to confirm the desk doesn't feel emptier than expected. Obligation rows appear once the first Obligation is minted (`act_obligations` is empty until the 11 Wons get terms).

## Verified
- `tsc --noEmit` clean; live render on dev 3013 shows new header counts and working desk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)