### PR TITLE
feat(engagement): Community records + digest preview screens (#159, #160)

### DIFF
--- a/apps/web/src/app/org/[slug]/communities/[community]/page.tsx
+++ b/apps/web/src/app/org/[slug]/communities/[community]/page.tsx
@@ -1,0 +1,135 @@
+// One Community record — a read surface composed of existing state (spec
+// docs/specs/community-records-spec.md): who we know there, what we owe,
+// what's live, last touch. Communities never mint desk rows.
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import { getCommunityRecord } from '@/lib/services/act-communities';
+
+export const dynamic = 'force-dynamic';
+
+const LINK_LABEL: Record<string, string> = {
+  'in': 'based here',
+  'distributes-into': 'channel into here',
+  'anchored-in': 'anchored here',
+};
+
+function Due({ d }: { d: number | null }) {
+  if (d == null) return <span className="font-ql-mono text-[10px] text-ql-muted">no date</span>;
+  if (d < 0) return <span className="font-ql-mono text-[10px] font-semibold text-ql-alert">{-d}d overdue</span>;
+  return <span className="font-ql-mono text-[10px] font-medium text-ql-ink">{d}d</span>;
+}
+
+export default async function CommunityRecordPage({ params }: { params: Promise<{ slug: string; community: string }> }) {
+  const { slug, community } = await params;
+  if (!isActSlug(slug)) notFound();
+  const profile = await getOrgProfileBySlug(slug).catch(() => null);
+  const record = profile ? await getCommunityRecord(profile.id, community) : null;
+  if (!record) notFound();
+
+  const people = record.links.filter((l) => l.subjectType === 'person');
+  const orgs = record.links.filter((l) => l.subjectType === 'org');
+  const paneTitle = 'font-ql-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-ql-accent';
+
+  return (
+    <main className="min-h-screen bg-ql-surface2 p-6 text-ql-ink">
+      <div className="mx-auto max-w-[1100px]">
+        <Link href={`/org/${slug}/communities`} className="font-ql-mono text-[10px] uppercase tracking-[0.12em] text-ql-muted hover:text-ql-ink">
+          ← Communities
+        </Link>
+        <div className="mt-2 flex flex-wrap items-baseline gap-3">
+          <h1 className="font-ql-display text-4xl font-semibold">{record.name}</h1>
+          {record.lastTouch && (
+            <span className="font-ql-mono text-[10px] text-ql-muted">
+              last touch {new Date(record.lastTouch).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' })}
+            </span>
+          )}
+        </div>
+        {record.notes && <p className="mt-1.5 max-w-[70ch] text-sm text-ql-text2">{record.notes}</p>}
+
+        <div className="mt-5 grid gap-4 md:grid-cols-2">
+          {/* Pane 1 — who we know there */}
+          <section className="rounded-lg border border-ql-border bg-ql-surface p-5">
+            <h2 className={paneTitle}>Who we know there</h2>
+            <div className="mt-3 space-y-2">
+              {orgs.map((l) => (
+                <div key={l.id} className="flex items-baseline gap-2 text-sm">
+                  <span className="font-semibold">{l.subjectRef}</span>
+                  <span className="text-[11px] text-ql-text2">{LINK_LABEL[l.linkType]}</span>
+                  {l.warmth && <span className="ml-auto font-ql-mono text-[10px] text-ql-moss">{l.warmth}</span>}
+                </div>
+              ))}
+              {people.map((l) => (
+                <div key={l.id} className="flex items-baseline gap-2 text-sm">
+                  <span className="font-semibold">{l.subjectRef}</span>
+                  <span className="text-[11px] italic text-ql-text2">{LINK_LABEL[l.linkType]}</span>
+                </div>
+              ))}
+              {record.links.length === 0 && <p className="text-sm text-ql-text2">No connections recorded yet.</p>}
+            </div>
+          </section>
+
+          {/* Pane 2 — what we owe */}
+          <section className="rounded-lg border border-ql-border bg-ql-surface p-5">
+            <h2 className={paneTitle}>What we owe</h2>
+            <div className="mt-3 space-y-2">
+              {record.obligations.map((o) => (
+                <div key={o.id} className="flex items-baseline gap-2 text-sm">
+                  <span className="min-w-0 flex-1 truncate font-semibold">{o.title}</span>
+                  <span className="font-ql-mono text-[10px] text-ql-muted">→ {o.owedTo}</span>
+                  <Due d={o.dueDays} />
+                </div>
+              ))}
+              {record.obligations.length === 0 && <p className="text-sm text-ql-text2">Nothing owed here right now.</p>}
+            </div>
+          </section>
+
+          {/* Pane 3 — what's live */}
+          <section className="rounded-lg border border-ql-border bg-ql-surface p-5">
+            <h2 className={paneTitle}>What&apos;s live</h2>
+            <div className="mt-3 space-y-2">
+              {record.channels.map((l) => (
+                <div key={l.id} className="flex items-baseline gap-2 text-sm">
+                  <span className="font-semibold">{l.subjectRef}</span>
+                  <span className="text-[11px] text-ql-text2">live channel</span>
+                  {l.warmth && <span className="ml-auto font-ql-mono text-[10px] text-ql-moss">{l.warmth}</span>}
+                </div>
+              ))}
+              {record.channels.length === 0 && <p className="text-sm text-ql-text2">No live Channels into this place yet.</p>}
+            </div>
+          </section>
+
+          {/* Pane 4 — the record itself */}
+          <section className="rounded-lg border border-ql-border bg-ql-surface p-5">
+            <h2 className={paneTitle}>Record</h2>
+            <dl className="mt-3 space-y-1.5 text-sm">
+              <div className="flex gap-2">
+                <dt className="text-ql-text2">Minted</dt>
+                <dd className="font-ql-mono text-[11px]">
+                  {new Date(record.mintedAt).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' })}
+                  {record.mintedBy ? ` · ${record.mintedBy}` : ''}
+                </dd>
+              </div>
+              {Array.isArray(record.geo.postcodes) && record.geo.postcodes.length > 0 && (
+                <div className="flex gap-2">
+                  <dt className="text-ql-text2">Postcodes</dt>
+                  <dd className="font-ql-mono text-[11px]">{(record.geo.postcodes as string[]).join(', ')}</dd>
+                </div>
+              )}
+              {Array.isArray(record.geo.lga_codes) && record.geo.lga_codes.length > 0 && (
+                <div className="flex gap-2">
+                  <dt className="text-ql-text2">LGAs</dt>
+                  <dd className="font-ql-mono text-[11px]">{(record.geo.lga_codes as string[]).join(', ')}</dd>
+                </div>
+              )}
+            </dl>
+            <p className="mt-3 text-[11px] leading-5 text-ql-muted">
+              Geo codes are annotations, never identity. This record exists because someone decided ACT is engaged here.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/org/[slug]/communities/page.tsx
+++ b/apps/web/src/app/org/[slug]/communities/page.tsx
@@ -1,0 +1,59 @@
+// Communities — the places ACT is deliberately engaged with (CONTEXT.md:
+// Community; docs/specs/community-records-spec.md). Hand-minted list, 5–15
+// records. Skin: Quiet Ledger.
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import { getCommunities } from '@/lib/services/act-communities';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  return { title: 'Communities — CivicGraph' };
+}
+
+export default async function CommunitiesPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  if (!isActSlug(slug)) notFound();
+  const profile = await getOrgProfileBySlug(slug).catch(() => null);
+  const communities = profile ? await getCommunities(profile.id) : [];
+
+  return (
+    <main className="min-h-screen bg-ql-surface2 p-6 text-ql-ink">
+      <div className="mx-auto max-w-[900px]">
+        <div className="font-ql-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-ql-accent">
+          {communities.length} communities · hand-minted
+        </div>
+        <h1 className="mt-1 font-ql-display text-4xl font-semibold">Communities</h1>
+        <p className="mt-1.5 text-sm text-ql-text2">
+          Places ACT is deliberately engaged with. A Community is minted by decision, never by a dataset.
+        </p>
+
+        <div className="mt-5 rounded-lg border border-ql-border bg-ql-surface">
+          {communities.map((c) => (
+            <Link
+              key={c.id}
+              href={`/org/${slug}/communities/${c.slug}`}
+              className="flex items-center gap-3 border-t border-ql-border/60 px-5 py-3.5 first:border-t-0 hover:bg-ql-surface2"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="font-ql-display text-lg font-semibold">{c.name}</span>
+                {c.notes && <span className="ml-2 truncate text-sm text-ql-text2">{c.notes}</span>}
+              </span>
+              {c.openObligations > 0 && (
+                <span className="font-ql-mono text-[10px] font-semibold text-ql-alert">{c.openObligations} owed</span>
+              )}
+              <span className="font-ql-mono text-[10px] text-ql-muted">{c.linkCount} connections</span>
+            </Link>
+          ))}
+          {communities.length === 0 && (
+            <div className="px-5 py-10 text-center text-sm text-ql-text2">
+              No Communities minted yet. Minting is a decision that ACT is engaged with a place — it happens here, deliberately, not from a dataset.
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/org/[slug]/digest-preview/page.tsx
+++ b/apps/web/src/app/org/[slug]/digest-preview/page.tsx
@@ -1,0 +1,91 @@
+// Digest preview — renders today's would-be email digest from the same
+// services the desk reads (docs/specs/grants-digest-spec.md), so the content
+// and shape get reviewed before any send infrastructure exists. This page is
+// the read channel's mock-up; it never sends anything.
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import { getOneDeskPool, type DeskRecord } from '@/lib/services/act-one-desk';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  return { title: 'Digest preview — CivicGraph' };
+}
+
+function Row({ r, slug }: { r: DeskRecord; slug: string }) {
+  return (
+    <div className="flex items-baseline gap-2 border-t border-ql-border/60 py-2 text-sm first:border-t-0">
+      <span className="font-ql-mono text-[9px] uppercase text-ql-muted">{r.project}</span>
+      <Link href={`/org/${slug}/desk?rec=${encodeURIComponent(r.id)}`} className="min-w-0 flex-1 truncate font-semibold hover:underline">
+        {r.name}
+      </Link>
+      <span className="hidden max-w-[40%] truncate text-[11px] text-ql-text2 sm:block">{r.next}</span>
+      {r.dueDays != null && (
+        <span className={`font-ql-mono text-[10px] font-semibold ${r.dueDays < 0 ? 'text-ql-alert' : 'text-ql-ink'}`}>
+          {r.dueDays < 0 ? `${-r.dueDays}d overdue` : `${r.dueDays}d`}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default async function DigestPreviewPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  if (!isActSlug(slug)) notFound();
+  const pool = await getOneDeskPool(slug);
+
+  // Section 1 — new decisions due. The real digest diffs against digest_log
+  // ("since last digest"); the preview shows everything currently in the
+  // decision window so the shape can be judged.
+  const decisions = pool.filter((r) => r.isDecision);
+  // Section 2 — going due / overdue: desk rows in the urgent window (≤ 7d or past).
+  const goingDue = pool.filter((r) => !r.isDecision && r.dueDays != null && r.dueDays <= 7);
+
+  const subject = `CivicGraph desk digest — ${decisions.length} decision${decisions.length === 1 ? '' : 's'} due, ${goingDue.length} going due`;
+
+  return (
+    <main className="min-h-screen bg-ql-surface2 p-6 text-ql-ink">
+      <div className="mx-auto max-w-[760px]">
+        <div className="font-ql-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-ql-accent">
+          Preview — nothing is sent from this page
+        </div>
+        <h1 className="mt-1 font-ql-display text-3xl font-semibold">Desk digest</h1>
+        <p className="mt-1 text-sm text-ql-text2">
+          Daily 07:00 Brisbane, delta-only (Monday heartbeat sends regardless). Everything here is on the desk; the digest is a pull-back-in, never a second queue.
+        </p>
+
+        <div className="mt-5 rounded-lg border border-ql-border bg-ql-surface p-6">
+          <div className="border-b border-ql-border pb-3">
+            <div className="font-ql-mono text-[9px] uppercase tracking-[0.12em] text-ql-muted">Subject</div>
+            <div className="mt-0.5 text-sm font-semibold">{subject}</div>
+          </div>
+
+          <section className="mt-4">
+            <h2 className="font-ql-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-ql-accent">
+              New decisions due · {decisions.length}
+            </h2>
+            <div className="mt-2">
+              {decisions.slice(0, 15).map((r) => <Row key={r.id} r={r} slug={slug} />)}
+              {decisions.length === 0 && <p className="py-2 text-sm text-ql-text2">Nothing new crossed the thresholds.</p>}
+            </div>
+          </section>
+
+          <section className="mt-5">
+            <h2 className="font-ql-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-ql-accent">
+              Going due / overdue · {goingDue.length}
+            </h2>
+            <div className="mt-2">
+              {goingDue.slice(0, 15).map((r) => <Row key={r.id} r={r} slug={slug} />)}
+              {goingDue.length === 0 && <p className="py-2 text-sm text-ql-text2">Nothing entering the urgent window.</p>}
+            </div>
+          </section>
+
+          <div className="mt-5 border-t border-ql-border pt-3 text-[11px] text-ql-muted">
+            Open the desk for the full queue → <Link href={`/org/${slug}/desk`} className="underline hover:text-ql-ink">/org/{slug}/desk</Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/services/act-communities.ts
+++ b/apps/web/src/lib/services/act-communities.ts
@@ -1,0 +1,154 @@
+// Community records — places ACT is deliberately engaged with (CONTEXT.md;
+// docs/specs/community-records-spec.md; ADR 0004). Supabase-native, human-
+// minted, expected list size 5–15. The record page is a read surface composed
+// of existing state: who we know there, what we owe, what's live, last touch.
+import { getServiceSupabase } from '@/lib/supabase';
+import type { Obligation } from '@/lib/services/act-obligations';
+
+export type CommunityLinkType = 'in' | 'distributes-into' | 'anchored-in';
+
+export type CommunityLink = {
+  id: string;
+  subjectType: 'org' | 'person';
+  subjectRef: string;
+  linkType: CommunityLinkType;
+  /** Org links: relationship warmth from goods_relationships when known. */
+  warmth: string | null;
+  lastTouch: string | null;
+};
+
+export type Community = {
+  id: string;
+  name: string;
+  slug: string;
+  notes: string | null;
+  geo: Record<string, unknown>;
+  mintedBy: string | null;
+  mintedAt: string;
+};
+
+export type CommunityRecord = Community & {
+  /** Pane 1 — who we know there. */
+  links: CommunityLink[];
+  /** Pane 2 — what we owe (open Obligations tagged to this Community). */
+  obligations: Obligation[];
+  /** Pane 3 — what's live: the distributes-into links are the Channels. */
+  channels: CommunityLink[];
+  /** Pane 4 — derived max last-touch across the record's state. */
+  lastTouch: string | null;
+};
+
+type CommunityRow = {
+  id: string;
+  name: string;
+  slug: string;
+  notes: string | null;
+  geo: Record<string, unknown>;
+  minted_by: string | null;
+  minted_at: string;
+};
+
+function fromRow(r: CommunityRow): Community {
+  return { id: r.id, name: r.name, slug: r.slug, notes: r.notes, geo: r.geo ?? {}, mintedBy: r.minted_by, mintedAt: r.minted_at };
+}
+
+export async function getCommunities(orgProfileId: string): Promise<Array<Community & { linkCount: number; openObligations: number }>> {
+  const db = getServiceSupabase();
+  const { data, error } = await db
+    .from('act_communities')
+    .select('id, name, slug, notes, geo, minted_by, minted_at')
+    .eq('org_profile_id', orgProfileId)
+    .order('name');
+  if (error) return []; // table not migrated yet
+  const communities = ((data ?? []) as CommunityRow[]).map(fromRow);
+  if (communities.length === 0) return [];
+
+  const ids = communities.map((c) => c.id);
+  const [links, obligations] = await Promise.all([
+    db.from('act_community_links').select('community_id').in('community_id', ids),
+    db.from('act_obligations').select('community_id').eq('state', 'open').in('community_id', ids),
+  ]);
+  const linkCounts = new Map<string, number>();
+  for (const l of (links.data ?? []) as Array<{ community_id: string }>) linkCounts.set(l.community_id, (linkCounts.get(l.community_id) ?? 0) + 1);
+  const oblCounts = new Map<string, number>();
+  for (const o of (obligations.data ?? []) as Array<{ community_id: string }>) oblCounts.set(o.community_id, (oblCounts.get(o.community_id) ?? 0) + 1);
+
+  return communities.map((c) => ({ ...c, linkCount: linkCounts.get(c.id) ?? 0, openObligations: oblCounts.get(c.id) ?? 0 }));
+}
+
+export async function getCommunityRecord(orgProfileId: string, slug: string): Promise<CommunityRecord | null> {
+  const db = getServiceSupabase();
+  const { data, error } = await db
+    .from('act_communities')
+    .select('id, name, slug, notes, geo, minted_by, minted_at')
+    .eq('org_profile_id', orgProfileId)
+    .eq('slug', slug)
+    .maybeSingle();
+  if (error || !data) return null;
+  const community = fromRow(data as CommunityRow);
+
+  const [linkRes, oblRes] = await Promise.all([
+    db.from('act_community_links').select('id, subject_type, subject_ref, link_type').eq('community_id', community.id).order('link_type'),
+    db.from('act_obligations').select('*').eq('community_id', community.id).order('due_date', { ascending: true, nullsFirst: false }),
+  ]);
+
+  const linkRows = (linkRes.data ?? []) as Array<{ id: string; subject_type: 'org' | 'person'; subject_ref: string; link_type: CommunityLinkType }>;
+
+  // Org warmth annotation from the Goods relationship registry (best-effort;
+  // absence is honest — not every linked Org is in the registry).
+  const orgNames = linkRows.filter((l) => l.subject_type === 'org').map((l) => l.subject_ref);
+  const warmthByOrg = new Map<string, { warmth: string | null; lastTouch: string | null }>();
+  if (orgNames.length > 0) {
+    const { data: rels } = await db
+      .from('goods_relationships')
+      .select('display_name, warmth_display, last_touch_at')
+      .in('display_name', orgNames);
+    for (const r of (rels ?? []) as Array<{ display_name: string; warmth_display: string | null; last_touch_at: string | null }>) {
+      warmthByOrg.set(r.display_name, { warmth: r.warmth_display, lastTouch: r.last_touch_at });
+    }
+  }
+
+  const links: CommunityLink[] = linkRows.map((l) => ({
+    id: l.id,
+    subjectType: l.subject_type,
+    subjectRef: l.subject_ref,
+    linkType: l.link_type,
+    warmth: warmthByOrg.get(l.subject_ref)?.warmth ?? null,
+    lastTouch: warmthByOrg.get(l.subject_ref)?.lastTouch ?? null,
+  }));
+
+  type OblRow = Parameters<typeof mapObligation>[0];
+  const obligations = ((oblRes.data ?? []) as OblRow[]).map(mapObligation);
+
+  const touches = [
+    ...links.map((l) => l.lastTouch),
+    ...obligations.map((o) => o.dischargedAt ?? o.mintedAt),
+  ].filter((t): t is string => Boolean(t)).sort();
+
+  return {
+    ...community,
+    links,
+    obligations: obligations.filter((o) => o.state === 'open'),
+    channels: links.filter((l) => l.linkType === 'distributes-into'),
+    lastTouch: touches[touches.length - 1] ?? null,
+  };
+}
+
+function mapObligation(r: {
+  id: string; org_profile_id: string; project_code: string; title: string;
+  owed_to: 'funder' | 'community'; state: 'open' | 'done' | 'dropped';
+  next_action: string | null; due_date: string | null; owner: string | null;
+  source_ask_ghl_id: string | null; source_ask_name: string | null;
+  promised_to: string | null; artefact_url: string | null; drop_reason: string | null;
+  minted_at: string; discharged_at: string | null;
+}): Obligation {
+  const t = r.due_date ? new Date(`${r.due_date}T00:00:00`).getTime() : NaN;
+  return {
+    id: r.id, orgProfileId: r.org_profile_id, projectCode: r.project_code,
+    title: r.title, owedTo: r.owed_to, state: r.state, nextAction: r.next_action,
+    dueDate: r.due_date, dueDays: Number.isNaN(t) ? null : Math.ceil((t - Date.now()) / 86_400_000),
+    owner: r.owner, sourceAskGhlId: r.source_ask_ghl_id, sourceAskName: r.source_ask_name,
+    promisedTo: r.promised_to, artefactUrl: r.artefact_url, dropReason: r.drop_reason,
+    mintedAt: r.minted_at, dischargedAt: r.discharged_at,
+  };
+}

--- a/supabase/migrations/20260806150000_act_communities.sql
+++ b/supabase/migrations/20260806150000_act_communities.sql
@@ -1,0 +1,40 @@
+-- Community records: places ACT is deliberately engaged with (CONTEXT.md;
+-- docs/specs/community-records-spec.md; ADR 0004). Supabase-native, human-
+-- minted, name-as-identity. Geo codes and goods_communities rows attach as
+-- annotations in `geo`, never as the key.
+
+create table if not exists act_communities (
+  id uuid primary key default gen_random_uuid(),
+  org_profile_id uuid not null references org_profiles(id),
+  name text not null,
+  slug text not null,
+  notes text,
+  -- Annotations only: { lga_codes: [], postcodes: [], goods_community_ids: [] }
+  geo jsonb not null default '{}',
+  minted_by text,
+  minted_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_profile_id, slug)
+);
+
+-- Typed edges: hub, not hierarchy (nothing is required to have a Community).
+create table if not exists act_community_links (
+  id uuid primary key default gen_random_uuid(),
+  community_id uuid not null references act_communities(id) on delete cascade,
+  subject_type text not null check (subject_type in ('org', 'person')),
+  -- Org name (goods_relationships key) or Person GHL contact id.
+  subject_ref text not null,
+  link_type text not null check (link_type in ('in', 'distributes-into', 'anchored-in')),
+  created_at timestamptz not null default now(),
+  unique (community_id, subject_type, subject_ref, link_type)
+);
+
+-- "What do we owe Barkly" — the highest-value join (#159).
+alter table act_obligations add column if not exists community_id uuid references act_communities(id);
+
+create index if not exists act_obligations_community_idx on act_obligations (community_id) where community_id is not null;
+
+alter table act_communities enable row level security;
+alter table act_community_links enable row level security;
+-- Service-role only, same posture as act_obligations.

--- a/supabase/migrations/20260806151000_act_communities_seed.sql
+++ b/supabase/migrations/20260806151000_act_communities_seed.sql
@@ -1,0 +1,14 @@
+-- Seed the three Communities Ben named in the #158 charting session
+-- (2026-08-06) — these are his minting decisions, recorded, not dataset rows.
+-- Idempotent on (org_profile_id, slug).
+
+insert into act_communities (org_profile_id, name, slug, notes, minted_by)
+select o.id, v.name, v.slug, v.notes, 'ben-charting-2026-08-06'
+from org_profiles o,
+  (values
+    ('Barkly', 'barkly', 'Tennant Creek and the Barkly region — Goods channels and delivery relationships.'),
+    ('Urapuntja (Utopia)', 'utopia', 'Utopia homelands, Alyawarre and Anmatyerre country.'),
+    ('Bwgcolman (Palm Island)', 'palm-island', 'Palm Island community.')
+  ) as v(name, slug, notes)
+where o.slug = 'act'
+on conflict (org_profile_id, slug) do nothing;


### PR DESCRIPTION
First reviewable screens from the #158 engagement layer. Specs: docs/specs/community-records-spec.md (ADR 0004) + docs/specs/grants-digest-spec.md.

## Screens to review (on the Vercel preview)
- **/org/act/communities** — the hand-minted Community list (Barkly, Urapuntja (Utopia), Bwgcolman (Palm Island) are live in prod — migration + seed applied)
- **/org/act/communities/barkly** — the four-pane record: who we know there (warmth annotated from goods_relationships), what we owe (obligations tagged via the new community_id), what's live (channel edges), record/minting facts
- **/org/act/digest-preview** — today's would-be digest email rendered from the same services the desk reads: subject line, 'new decisions due', 'going due/overdue'. Nothing sends from this page.

## Data
- `act_communities` + `act_community_links` (typed edges: in / distributes-into / anchored-in) + nullable `act_obligations.community_id` — **already applied to prod** with the 3-row seed (Ben authorized, 2026-08-06). Deliberately separate from the 1,542-row `goods_communities` dataset — that's evidence, not Community records.
- Panes degrade honestly: no connections/obligations tagged yet → plain empty lines.

## Verified
- tsc --noEmit clean; migration + seed applied via Supabase MCP and rows confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)