### PR TITLE
People surface: act_people mirror + /org/act/people + minting flow (#154)

### DIFF
--- a/apps/web/src/app/api/org/[orgProfileId]/people/route.ts
+++ b/apps/web/src/app/api/org/[orgProfileId]/people/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgWriteAccess } from '../../_lib/auth';
+import { WARMTH_VALUES, ROLE_TYPES } from '@/lib/services/act-people';
+import {
+  createPersonContact,
+  setWarmthTag,
+  upsertNextActionTask,
+  completeNextActionTask,
+} from '@/lib/services/act-people-ghl';
+
+type Params = { params: Promise<{ orgProfileId: string }> };
+
+function text(v: unknown, limit = 400): string | null {
+  return typeof v === 'string' && v.trim() ? v.trim().slice(0, limit) : null;
+}
+
+function isoDate(v: unknown): string | null {
+  const s = text(v, 10);
+  return s && /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : null;
+}
+
+// Mint a Person (spec §5, ADR 0002): create/claim the GHL contact, write
+// warmth + next-action to GHL FIRST, then mirror. Mandatory at mint: warmth
+// (+ via when indirect) AND a next action with a review-by date. No inert
+// People. If the GHL write fails, nothing is mirrored — surface the error.
+export async function POST(request: NextRequest, { params }: Params) {
+  const { orgProfileId } = await params;
+  const auth = await requireOrgWriteAccess(orgProfileId);
+  if (auth instanceof NextResponse) return auth;
+
+  const body = (await request.json()) as Record<string, unknown>;
+  const name = text(body.name, 200);
+  const warmth = WARMTH_VALUES.find((w) => w === body.warmth);
+  const nextAction = text(body.next_action, 800);
+  const reviewBy = isoDate(body.review_by);
+  if (!name || !warmth || !nextAction || !reviewBy) {
+    return NextResponse.json(
+      { error: 'name, warmth, next_action and review_by are required — no inert People' },
+      { status: 400 }
+    );
+  }
+  const warmVia = text(body.warm_via, 200);
+
+  let ghlContactId = text(body.ghl_contact_id, 120); // present = claim
+  try {
+    if (!ghlContactId) {
+      ghlContactId = await createPersonContact({ name, email: text(body.email, 200) });
+    }
+    await setWarmthTag(ghlContactId, warmth);
+    const ghlTaskId = await upsertNextActionTask(ghlContactId, null, { nextAction, reviewBy, warmVia });
+
+    const { data, error } = await auth.serviceDb
+      .from('act_people')
+      .insert({
+        org_profile_id: orgProfileId,
+        ghl_contact_id: ghlContactId,
+        name,
+        warmth,
+        warm_via: warmVia,
+        next_action: nextAction,
+        review_by: reviewBy,
+        ghl_task_id: ghlTaskId,
+        minted_by: auth.userId,
+        last_synced_at: new Date().toISOString(),
+      })
+      .select('id')
+      .single();
+    if (error) {
+      const dupe = error.code === '23505';
+      return NextResponse.json(
+        { error: dupe ? 'This GHL contact is already a Person' : error.message },
+        { status: dupe ? 409 : 500 }
+      );
+    }
+
+    const roleType = ROLE_TYPES.find((r) => r === (body.role as Record<string, unknown> | undefined)?.role_type);
+    const roleOrg = text((body.role as Record<string, unknown> | undefined)?.org_name, 300);
+    if (roleType && roleOrg) {
+      await auth.serviceDb.from('act_person_roles').insert({
+        person_id: data.id,
+        role_type: roleType,
+        org_name: roleOrg,
+        org_ref: text((body.role as Record<string, unknown>).org_ref, 120),
+        created_by: auth.userId,
+      });
+    }
+    return NextResponse.json({ id: data.id, ghl_contact_id: ghlContactId });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'GHL write failed' }, { status: 502 });
+  }
+}
+
+// Edits. Relationship state (warmth, next action) goes to GHL then the
+// mirror; roles write to Supabase directly (ADR 0002 deviation 2). Owner is
+// mirror-only for now — GHL assignedTo needs a GHL user id, and the desk's
+// owner is a plain name.
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const { orgProfileId } = await params;
+  const auth = await requireOrgWriteAccess(orgProfileId);
+  if (auth instanceof NextResponse) return auth;
+
+  const body = (await request.json()) as Record<string, unknown>;
+  const id = text(body.id, 60);
+  if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 });
+
+  const { data: person, error: readError } = await auth.serviceDb
+    .from('act_people')
+    .select('id, ghl_contact_id, ghl_task_id, warm_via, next_action, review_by')
+    .eq('id', id)
+    .eq('org_profile_id', orgProfileId)
+    .maybeSingle();
+  if (readError) return NextResponse.json({ error: readError.message }, { status: 500 });
+  if (!person) return NextResponse.json({ error: 'Person not found' }, { status: 404 });
+
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+  try {
+    // Roles — Supabase-owned, no GHL involvement.
+    const addRole = body.add_role as Record<string, unknown> | undefined;
+    if (addRole) {
+      const roleType = ROLE_TYPES.find((r) => r === addRole.role_type);
+      const orgName = text(addRole.org_name, 300);
+      if (!roleType || !orgName) {
+        return NextResponse.json({ error: 'add_role needs role_type and org_name' }, { status: 400 });
+      }
+      const { error } = await auth.serviceDb.from('act_person_roles').insert({
+        person_id: id,
+        role_type: roleType,
+        org_name: orgName,
+        org_ref: text(addRole.org_ref, 120),
+        created_by: auth.userId,
+      });
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    const removeRoleId = text(body.remove_role_id, 60);
+    if (removeRoleId) {
+      await auth.serviceDb.from('act_person_roles').delete().eq('id', removeRoleId).eq('person_id', id);
+    }
+
+    // Warmth — GHL tag replace first.
+    const warmth = WARMTH_VALUES.find((w) => w === body.warmth);
+    if (warmth) {
+      await setWarmthTag(person.ghl_contact_id, warmth);
+      patch.warmth = warmth;
+    }
+    if ('warm_via' in body) patch.warm_via = text(body.warm_via, 200);
+    if ('owner' in body) patch.owner = text(body.owner, 120);
+
+    // Next action / watch. Three moves (spec §4.3, #148 — never a bare dismiss):
+    //   edit:            next_action (+ review_by) → update the GHL task
+    //   done — set next: done=true + a NEW next_action + review_by
+    //   release:         release=true → complete the task, drop to dateless tail
+    const done = body.done === true;
+    const release = body.release === true;
+    const nextAction = text(body.next_action, 800);
+    const reviewBy = isoDate(body.review_by);
+    const warmVia = ('warm_via' in body ? (patch.warm_via as string | null) : person.warm_via) ?? null;
+
+    if (release) {
+      if (person.ghl_task_id) await completeNextActionTask(person.ghl_contact_id, person.ghl_task_id);
+      patch.next_action = null;
+      patch.review_by = null;
+      patch.ghl_task_id = null;
+    } else if (done) {
+      if (!nextAction || !reviewBy) {
+        return NextResponse.json(
+          { error: 'Done requires the next action and review-by — or release explicitly' },
+          { status: 400 }
+        );
+      }
+      if (person.ghl_task_id) await completeNextActionTask(person.ghl_contact_id, person.ghl_task_id);
+      patch.ghl_task_id = await upsertNextActionTask(person.ghl_contact_id, null, { nextAction, reviewBy, warmVia });
+      patch.next_action = nextAction;
+      patch.review_by = reviewBy;
+    } else if (nextAction || reviewBy) {
+      const action = nextAction ?? (person.next_action as string | null);
+      const by = reviewBy ?? (person.review_by as string | null);
+      if (!action || !by) {
+        return NextResponse.json({ error: 'A next action needs both text and a review-by date' }, { status: 400 });
+      }
+      patch.ghl_task_id = await upsertNextActionTask(person.ghl_contact_id, person.ghl_task_id as string | null, {
+        nextAction: action,
+        reviewBy: by,
+        warmVia,
+      });
+      patch.next_action = action;
+      patch.review_by = by;
+    }
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'GHL write failed' }, { status: 502 });
+  }
+
+  patch.last_synced_at = new Date().toISOString();
+  const { error } = await auth.serviceDb.from('act_people').update(patch).eq('id', id).eq('org_profile_id', orgProfileId);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/org/[orgProfileId]/people/route.ts
+++ b/apps/web/src/app/api/org/[orgProfileId]/people/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireOrgWriteAccess } from '../../_lib/auth';
-import { WARMTH_VALUES, ROLE_TYPES } from '@/lib/services/act-people';
+import { WARMTH_VALUES, ROLE_TYPES, PROJECT_CODE_OPTIONS } from '@/lib/services/act-people';
 import {
   createPersonContact,
   setWarmthTag,
@@ -17,6 +17,12 @@ function text(v: unknown, limit = 400): string | null {
 function isoDate(v: unknown): string | null {
   const s = text(v, 10);
   return s && /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : null;
+}
+
+function projectCodes(v: unknown): string[] | null {
+  if (!Array.isArray(v)) return null;
+  const codes = v.filter((c): c is string => typeof c === 'string' && (PROJECT_CODE_OPTIONS as readonly string[]).includes(c));
+  return [...new Set(codes)];
 }
 
 // Mint a Person (spec §5, ADR 0002): create/claim the GHL contact, write
@@ -60,6 +66,7 @@ export async function POST(request: NextRequest, { params }: Params) {
         next_action: nextAction,
         review_by: reviewBy,
         ghl_task_id: ghlTaskId,
+        project_codes: projectCodes(body.project_codes) ?? [],
         minted_by: auth.userId,
         last_synced_at: new Date().toISOString(),
       })
@@ -135,6 +142,35 @@ export async function PATCH(request: NextRequest, { params }: Params) {
     const removeRoleId = text(body.remove_role_id, 60);
     if (removeRoleId) {
       await auth.serviceDb.from('act_person_roles').delete().eq('id', removeRoleId).eq('person_id', id);
+    }
+
+    // Project ties — set by humans, never derived (Ben, 2026-08-06).
+    if ('project_codes' in body) {
+      const codes = projectCodes(body.project_codes);
+      if (!codes) return NextResponse.json({ error: 'project_codes must be an array of known ACT codes' }, { status: 400 });
+      patch.project_codes = codes;
+    }
+
+    // Ask↔Person warm-via links (act_ask_warmers) — human-minted, Supabase-owned.
+    const linkAsk = body.link_ask as Record<string, unknown> | undefined;
+    if (linkAsk) {
+      const oppId = text(linkAsk.ghl_opportunity_id, 120);
+      if (!oppId) return NextResponse.json({ error: 'link_ask needs ghl_opportunity_id' }, { status: 400 });
+      const { error } = await auth.serviceDb.from('act_ask_warmers').upsert(
+        {
+          ghl_opportunity_id: oppId,
+          person_id: id,
+          org_profile_id: orgProfileId,
+          ask_name: text(linkAsk.ask_name, 300),
+          created_by: auth.userId,
+        },
+        { onConflict: 'ghl_opportunity_id,person_id' }
+      );
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    const unlinkAsk = text(body.unlink_ask, 120);
+    if (unlinkAsk) {
+      await auth.serviceDb.from('act_ask_warmers').delete().eq('ghl_opportunity_id', unlinkAsk).eq('person_id', id);
     }
 
     // Warmth — GHL tag replace first.

--- a/apps/web/src/app/api/org/[orgProfileId]/people/search/route.ts
+++ b/apps/web/src/app/api/org/[orgProfileId]/people/search/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgAccess } from '../../../_lib/auth';
+
+type Params = { params: Promise<{ orgProfileId: string }> };
+
+// Mint-modal name search (spec §5.1): the GHL contact pool (via the
+// ghl_contacts mirror — never GHL live) and CivicGraph person rows, together.
+// A GHL hit means CLAIM the contact; a CivicGraph-only hit means create.
+export async function GET(request: NextRequest, { params }: Params) {
+  const { orgProfileId } = await params;
+  const auth = await requireOrgAccess(orgProfileId);
+  if (auth instanceof NextResponse) return auth;
+
+  const q = (request.nextUrl.searchParams.get('q') ?? '').trim();
+  if (q.length < 2) return NextResponse.json({ results: [] });
+  const like = `%${q.replace(/[%_]/g, '')}%`;
+
+  const [ghl, civic, minted] = await Promise.all([
+    auth.serviceDb
+      .from('ghl_contacts')
+      .select('ghl_id, full_name, email, company_name')
+      .ilike('full_name', like)
+      .not('ghl_id', 'is', null)
+      .limit(8),
+    auth.serviceDb
+      .from('gs_entities')
+      .select('gs_id, canonical_name')
+      .eq('entity_type', 'person')
+      .ilike('canonical_name', like)
+      .limit(8),
+    auth.serviceDb.from('act_people').select('ghl_contact_id').eq('org_profile_id', orgProfileId),
+  ]);
+
+  const mintedIds = new Set((minted.data ?? []).map((m) => m.ghl_contact_id as string));
+  const results = [
+    ...(ghl.data ?? [])
+      .filter((c) => !mintedIds.has(c.ghl_id as string))
+      .map((c) => ({
+        source: 'ghl' as const,
+        ghlContactId: c.ghl_id as string,
+        name: c.full_name as string,
+        detail: [c.email, c.company_name].filter(Boolean).join(' · ') || null,
+      })),
+    ...(civic.data ?? []).map((c) => ({
+      source: 'civicgraph' as const,
+      ghlContactId: null,
+      name: c.canonical_name as string,
+      detail: `CivicGraph ${c.gs_id as string}`,
+    })),
+  ];
+  return NextResponse.json({ results });
+}

--- a/apps/web/src/app/api/org/[orgProfileId]/people/search/route.ts
+++ b/apps/web/src/app/api/org/[orgProfileId]/people/search/route.ts
@@ -15,6 +15,25 @@ export async function GET(request: NextRequest, { params }: Params) {
   if (q.length < 2) return NextResponse.json({ results: [] });
   const like = `%${q.replace(/[%_]/g, '')}%`;
 
+  // ?type=ask — search the ghl_opportunities mirror for the "warms N Asks"
+  // link picker (act_ask_warmers). Open Asks only; ADR 0001 keeps the Ask in GHL.
+  if (request.nextUrl.searchParams.get('type') === 'ask') {
+    const { data } = await auth.serviceDb
+      .from('ghl_opportunities')
+      .select('ghl_id, name, pipeline_name, stage_name, status')
+      .ilike('name', like)
+      .eq('status', 'open')
+      .limit(10);
+    return NextResponse.json({
+      results: (data ?? []).map((o) => ({
+        source: 'ask' as const,
+        ghlOpportunityId: o.ghl_id as string,
+        name: o.name as string,
+        detail: [o.pipeline_name, o.stage_name].filter(Boolean).join(' · ') || null,
+      })),
+    });
+  }
+
   const [ghl, civic, minted] = await Promise.all([
     auth.serviceDb
       .from('ghl_contacts')

--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -85,6 +85,8 @@ export function ActWorkspaceShell({
     // Listen folded into Orgs 2026-08-05 — the Org record + one list.
     // Legacy lens stays reachable at ?view=relationships (not on the rail).
     { label: 'Orgs', href: `/org/${slug}/orgs`, active: pathname.startsWith(`/org/${slug}/orgs`) },
+    // The one cross-project noun (ADR 0002): cultivated humans, org-wide.
+    { label: 'People', href: `/org/${slug}/people`, active: pathname.startsWith(`/org/${slug}/people`) },
     { label: 'Curiosity', href: rootHref(slug, 'opportunities', 'opportunities'), active: onOrgRoot && (view === 'opportunities' || view === 'triage') },
     // Rail cut to the spine (Ben, 2026-08-05): Action, Art, Money, Sources,
     // Research and Funding all left the rail. Art = the Harvest project, which

--- a/apps/web/src/app/org/[slug]/contacts/page.tsx
+++ b/apps/web/src/app/org/[slug]/contacts/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
 import {
   getOrgProfileBySlug,
   getOrgContacts,
@@ -20,6 +21,10 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function ContactsPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
+  // ACT's contacts surface is replaced by /people (spec §1, Ben 2026-08-06):
+  // un-minted contacts reappear only as minting candidates there. Delete this
+  // route for ACT (and this redirect) one release after /people ships.
+  if (isActSlug(slug)) redirect(`/org/${slug}/people`);
   const profile = await getOrgProfileBySlug(slug);
   if (!profile) notFound();
 

--- a/apps/web/src/app/org/[slug]/people/page.tsx
+++ b/apps/web/src/app/org/[slug]/people/page.tsx
@@ -17,7 +17,8 @@ import {
   type RoleType,
   type Warmth,
 } from '@/lib/services/act-people';
-import { PersonNextMove, AddRoleInline, MintPersonButton } from './people-actions';
+import { deskProjectLabel } from '@/lib/services/act-one-desk';
+import { PersonNextMove, AddRoleInline, MintPersonButton, ProjectsInline, AskLinksInline } from './people-actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -61,6 +62,7 @@ export default async function PeoplePage({ params, searchParams }: {
 
   const sp = await searchParams;
   const warmthFilter = WARMTH_VALUES.find((w) => w === sp.warmth) ?? null;
+  const projectFilter = typeof sp.project === 'string' ? sp.project : null;
   const roleFilter = ROLE_TYPES.find((r) => r === sp.role) ?? null;
   const dueOnly = sp.due === '1';
 
@@ -72,6 +74,7 @@ export default async function PeoplePage({ params, searchParams }: {
   const pool = all.filter(
     (p) =>
       (!warmthFilter || p.warmth === warmthFilter) &&
+      (!projectFilter || p.projectCodes.includes(projectFilter)) &&
       (!roleFilter || p.roles.some((r) => r.roleType === roleFilter)) &&
       (!dueOnly || p.dueDays != null)
   );
@@ -88,7 +91,7 @@ export default async function PeoplePage({ params, searchParams }: {
   const qs = (extra: Record<string, string | null>) => {
     const merged: Record<string, string> = {};
     for (const [k, v] of Object.entries({
-      warmth: warmthFilter, role: roleFilter, due: dueOnly ? '1' : null, ...extra,
+      warmth: warmthFilter, role: roleFilter, project: projectFilter, due: dueOnly ? '1' : null, ...extra,
     })) {
       if (v) merged[k] = v;
     }
@@ -142,6 +145,12 @@ export default async function PeoplePage({ params, searchParams }: {
             </Link>
           ))}
           <span className="mx-1 text-ql-border">·</span>
+          {[...new Set(all.flatMap((p) => p.projectCodes))].sort().map((c) => (
+            <Link key={c} href={qs({ project: projectFilter === c ? null : c, rec: null })} className={chip(projectFilter === c)}>
+              {deskProjectLabel(c)}
+            </Link>
+          ))}
+          <span className="mx-1 text-ql-border">·</span>
           <Link href={qs({ due: dueOnly ? null : '1', rec: null })} className={chip(dueOnly)}>
             due only
           </Link>
@@ -166,9 +175,9 @@ export default async function PeoplePage({ params, searchParams }: {
                         <span className="font-semibold">{p.name}</span>
                         {p.nextAction ? <span className="text-ql-text2"> · {p.nextAction}</span> : null}
                       </span>
-                      {p.roles.slice(0, 2).map((r) => (
-                        <span key={r.id} className="hidden rounded-full border border-ql-border px-2 py-0.5 font-ql-mono text-[8.5px] uppercase tracking-[0.06em] text-ql-text2 xl:inline">
-                          {r.orgName}
+                      {p.projectCodes.slice(0, 2).map((c) => (
+                        <span key={c} className="hidden rounded-full border border-ql-border px-2 py-0.5 font-ql-mono text-[8.5px] uppercase tracking-[0.06em] text-ql-text2 xl:inline">
+                          {deskProjectLabel(c)}
                         </span>
                       ))}
                       {p.warmVia ? <span className="hidden text-xs italic text-ql-text2 md:inline">via {p.warmVia}</span> : null}
@@ -248,6 +257,9 @@ export default async function PeoplePage({ params, searchParams }: {
                   ) : null}
                   <AddRoleInline orgProfileId={orgProfileId} personId={selected.id} />
                 </div>
+
+                <ProjectsInline orgProfileId={orgProfileId} personId={selected.id} projectCodes={selected.projectCodes} />
+                <AskLinksInline orgProfileId={orgProfileId} personId={selected.id} askLinks={selected.askLinks} />
 
                 <PersonNextMove
                   orgProfileId={orgProfileId}

--- a/apps/web/src/app/org/[slug]/people/page.tsx
+++ b/apps/web/src/app/org/[slug]/people/page.tsx
@@ -1,0 +1,292 @@
+// The People surface (spec: docs/specs/people-surface-ux-spec.md, #154).
+// Org-wide — People are the one cross-project noun. Desk-style split: list
+// left, detail right, selection via ?rec=. Skin: Quiet Ledger, same tokens
+// as One Desk. All reads hit the act_people mirror, never GHL live (ADR 0002).
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { isActSlug } from '@/lib/services/fast-local-org';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import {
+  getActPeople,
+  getMintCandidates,
+  getPersonEvidence,
+  ROLE_LABEL,
+  ROLE_TYPES,
+  WARMTH_VALUES,
+  type ActPerson,
+  type RoleType,
+  type Warmth,
+} from '@/lib/services/act-people';
+import { PersonNextMove, AddRoleInline, MintPersonButton } from './people-actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata() {
+  return { title: 'People — CivicGraph' };
+}
+
+type Horizon = 'overdue' | 'fortnight' | 'quarter' | 'undated';
+const HORIZON_LABEL: Record<Horizon, string> = {
+  overdue: 'Overdue', fortnight: 'This fortnight', quarter: 'This quarter', undated: 'No date',
+};
+
+function horizon(p: ActPerson): Horizon {
+  if (p.dueDays == null) return 'undated';
+  if (p.dueDays < 0) return 'overdue';
+  if (p.dueDays <= 14) return 'fortnight';
+  return 'quarter';
+}
+
+function Due({ d }: { d: number | null }) {
+  if (d == null) return <span className="font-ql-mono text-[10px] text-ql-muted">—</span>;
+  if (d < 0) return <span className="font-ql-mono text-[10px] font-semibold text-ql-alert">{-d}d overdue</span>;
+  if (d <= 14) return <span className="font-ql-mono text-[10px] font-semibold text-ql-alert">{d}d</span>;
+  return <span className="font-ql-mono text-[10px] font-medium text-ql-ink">{d}d</span>;
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-AU', { day: 'numeric', month: 'short' });
+}
+
+export default async function PeoplePage({ params, searchParams }: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { slug } = await params;
+  if (!isActSlug(slug)) notFound();
+  const profile = await getOrgProfileBySlug(slug).catch(() => null);
+  if (!profile) notFound();
+  const orgProfileId = profile.id;
+
+  const sp = await searchParams;
+  const warmthFilter = WARMTH_VALUES.find((w) => w === sp.warmth) ?? null;
+  const roleFilter = ROLE_TYPES.find((r) => r === sp.role) ?? null;
+  const dueOnly = sp.due === '1';
+
+  const [all, candidates] = await Promise.all([
+    getActPeople(orgProfileId),
+    getMintCandidates(orgProfileId),
+  ]);
+
+  const pool = all.filter(
+    (p) =>
+      (!warmthFilter || p.warmth === warmthFilter) &&
+      (!roleFilter || p.roles.some((r) => r.roleType === roleFilter)) &&
+      (!dueOnly || p.dueDays != null)
+  );
+  const selected = (typeof sp.rec === 'string' ? pool.find((p) => p.id === sp.rec) : null) ?? pool[0] ?? null;
+  const evidence = selected ? await getPersonEvidence(selected.name) : null;
+
+  const dueThisWeek = all.filter((p) => p.dueDays != null && p.dueDays >= 0 && p.dueDays <= 7).length;
+  const overdue = all.filter((p) => p.dueDays != null && p.dueDays < 0).length;
+  const syncedTimes = all.map((p) => (p.lastSyncedAt ? new Date(p.lastSyncedAt).getTime() : 0));
+  const newestSync = syncedTimes.length ? Math.max(...syncedTimes) : null;
+  const allStale = all.length > 0 && all.every((p) => p.stale);
+
+  const base = `/org/${slug}/people`;
+  const qs = (extra: Record<string, string | null>) => {
+    const merged: Record<string, string> = {};
+    for (const [k, v] of Object.entries({
+      warmth: warmthFilter, role: roleFilter, due: dueOnly ? '1' : null, ...extra,
+    })) {
+      if (v) merged[k] = v;
+    }
+    const s = new URLSearchParams(merged).toString();
+    return s ? `${base}?${s}` : base;
+  };
+
+  const groups: Array<{ horizon: Horizon; items: ActPerson[] }> = [];
+  for (const p of pool.slice(0, 120)) {
+    const h = horizon(p);
+    const last = groups[groups.length - 1];
+    if (last && last.horizon === h) last.items.push(p);
+    else groups.push({ horizon: h, items: [p] });
+  }
+
+  const chip = (active: boolean) =>
+    `rounded-full border px-3 py-1 text-[11px] font-medium transition-colors ${
+      active ? 'border-ql-bar bg-ql-bar text-ql-inverse' : 'border-ql-border bg-ql-surface text-ql-text2 hover:border-ql-muted'
+    }`;
+
+  return (
+    <main className="min-h-screen bg-ql-surface2 p-6 text-ql-ink">
+      <div className="mx-auto max-w-[1760px]">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="font-ql-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-ql-accent">
+              {all.length} people · {dueThisWeek} due this week · {overdue} overdue
+            </div>
+            <h1 className="mt-1 font-ql-display text-4xl font-semibold">People</h1>
+          </div>
+          <MintPersonButton orgProfileId={orgProfileId} />
+        </div>
+
+        {allStale && newestSync ? (
+          <div className="mt-4 rounded-md border border-ql-border bg-ql-warm px-4 py-2 text-xs text-ql-text2">
+            Relationship state may be stale — synced {Math.round((Date.now() - newestSync) / 3600_000)}h ago
+          </div>
+        ) : null}
+
+        {/* Rail filters (spec §3): warmth band · role type · due only. */}
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {WARMTH_VALUES.map((w) => (
+            <Link key={w} href={qs({ warmth: warmthFilter === w ? null : w, rec: null })} className={chip(warmthFilter === w)}>
+              {w}
+            </Link>
+          ))}
+          <span className="mx-1 text-ql-border">·</span>
+          {ROLE_TYPES.map((r) => (
+            <Link key={r} href={qs({ role: roleFilter === r ? null : r, rec: null })} className={chip(roleFilter === r)}>
+              {ROLE_LABEL[r]}
+            </Link>
+          ))}
+          <span className="mx-1 text-ql-border">·</span>
+          <Link href={qs({ due: dueOnly ? null : '1', rec: null })} className={chip(dueOnly)}>
+            due only
+          </Link>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
+          <div>
+            <div className="max-h-[70vh] overflow-y-auto rounded-lg border border-ql-border bg-ql-surface">
+              {groups.map((group) => (
+                <div key={group.horizon}>
+                  <div className={`sticky top-0 z-10 px-4 py-1.5 font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-inverse ${group.horizon === 'overdue' ? 'bg-ql-alert' : 'bg-ql-bar'}`}>
+                    {HORIZON_LABEL[group.horizon]} · {group.items.length}
+                  </div>
+                  {group.items.map((p) => (
+                    <Link
+                      key={p.id}
+                      href={qs({ rec: p.id })}
+                      className={`flex items-center gap-2.5 border-t border-ql-border/60 px-4 py-2.5 text-sm first:border-t-0 ${selected?.id === p.id ? 'bg-ql-warm' : 'hover:bg-ql-surface2'}`}
+                    >
+                      <span className="rounded bg-ql-bar px-1.5 py-0.5 font-ql-mono text-[8.5px] font-semibold uppercase tracking-[0.08em] text-ql-inverse">person</span>
+                      <span className="min-w-0 flex-1 truncate">
+                        <span className="font-semibold">{p.name}</span>
+                        {p.nextAction ? <span className="text-ql-text2"> · {p.nextAction}</span> : null}
+                      </span>
+                      {p.roles.slice(0, 2).map((r) => (
+                        <span key={r.id} className="hidden rounded-full border border-ql-border px-2 py-0.5 font-ql-mono text-[8.5px] uppercase tracking-[0.06em] text-ql-text2 xl:inline">
+                          {r.orgName}
+                        </span>
+                      ))}
+                      {p.warmVia ? <span className="hidden text-xs italic text-ql-text2 md:inline">via {p.warmVia}</span> : null}
+                      <Due d={p.dueDays} />
+                    </Link>
+                  ))}
+                </div>
+              ))}
+              {pool.length === 0 ? (
+                <div className="px-4 py-10 text-center text-sm text-ql-text2">
+                  {all.length === 0
+                    ? 'No People yet. A Person is a human ACT deliberately cultivates — mint the first one, or pick from the candidates below.'
+                    : 'Nothing matches this filter.'}
+                </div>
+              ) : null}
+            </div>
+
+            {/* Candidates rail (spec §5): not yet people — minting signals only. */}
+            <details className="mt-3 rounded-lg border border-ql-border bg-ql-surface" open={all.length === 0}>
+              <summary className="cursor-pointer px-4 py-2.5 font-ql-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-ql-text2">
+                Not yet people · {candidates.length}
+              </summary>
+              {candidates.map((c, i) => (
+                <div key={`${c.source}-${c.ghlContactId ?? c.name}-${i}`} className="flex items-center gap-2.5 border-t border-ql-border/60 px-4 py-2 text-sm">
+                  <span className="min-w-0 flex-1 truncate">
+                    <span className="font-medium">{c.name}</span>
+                    {c.detail ? <span className="text-ql-text2"> · {c.detail}</span> : null}
+                  </span>
+                  <span className="font-ql-mono text-[8.5px] uppercase text-ql-muted">{c.source === 'ghl' ? 'GHL' : 'contacts'}</span>
+                  <MintPersonButton orgProfileId={orgProfileId} prefill={{ name: c.name, ghlContactId: c.ghlContactId }} small />
+                </div>
+              ))}
+              {candidates.length === 0 ? <div className="border-t border-ql-border/60 px-4 py-3 text-xs text-ql-text2">No unminted candidates.</div> : null}
+            </details>
+          </div>
+
+          {/* Detail pane (spec §4). */}
+          <div className="rounded-lg border border-ql-border bg-ql-surface p-7">
+            {selected ? (
+              <>
+                <div className="flex flex-wrap items-center gap-2.5">
+                  <span className="rounded bg-ql-bar px-1.5 py-0.5 font-ql-mono text-[8.5px] font-semibold uppercase tracking-[0.08em] text-ql-inverse">person</span>
+                  {selected.warmth ? (
+                    <span className="font-ql-mono text-[9.5px] font-semibold uppercase tracking-[0.1em] text-ql-text2">{selected.warmth}</span>
+                  ) : null}
+                  {selected.warmVia ? <span className="text-xs italic text-ql-text2">via {selected.warmVia}</span> : null}
+                  {selected.stale ? (
+                    <span className="rounded-full border border-ql-alert px-2 py-0.5 font-ql-mono text-[8.5px] font-semibold uppercase text-ql-alert">stale</span>
+                  ) : null}
+                </div>
+                <h2 className="mt-2.5 font-ql-display text-3xl font-semibold leading-tight">{selected.name}</h2>
+                <p className="mt-1.5 text-xs text-ql-muted">
+                  {selected.owner ? `${selected.owner} · ` : ''}last touch {fmtDate(selected.lastTouchAt)} · synced {fmtDate(selected.lastSyncedAt)}
+                </p>
+
+                <div className="mt-5">
+                  <div className="font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-muted">Roles</div>
+                  {selected.roles.length > 0 ? (
+                    <ul className="mt-1.5 space-y-1 text-sm">
+                      {selected.roles.map((r) => (
+                        <li key={r.id}>
+                          {r.roleType === 'opens_into' ? (
+                            <span className="font-semibold text-ql-accent">opens into </span>
+                          ) : (
+                            <span className="text-ql-text2">{ROLE_LABEL[r.roleType]} </span>
+                          )}
+                          {r.orgRef?.startsWith('GS-') ? (
+                            <Link href={`/entity/${r.orgRef}`} className="font-medium underline decoration-ql-border underline-offset-2 hover:text-ql-accent">
+                              {r.orgName}
+                            </Link>
+                          ) : (
+                            <span className="font-medium">{r.orgName}</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  <AddRoleInline orgProfileId={orgProfileId} personId={selected.id} />
+                </div>
+
+                <PersonNextMove
+                  orgProfileId={orgProfileId}
+                  personId={selected.id}
+                  nextAction={selected.nextAction}
+                  reviewBy={selected.reviewBy}
+                />
+
+                {/* CivicGraph evidence — annotations, never state (spec §4.4). */}
+                <details className="mt-5 rounded-md border border-ql-border">
+                  <summary className="cursor-pointer px-4 py-2 font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-muted">
+                    CivicGraph evidence
+                  </summary>
+                  <div className="space-y-1.5 px-4 pb-3 text-xs text-ql-text2">
+                    {evidence?.influence ? (
+                      <p>{evidence.influence.boardCount} board seats · financial footprint ${Math.round(evidence.influence.financialFootprint / 1000)}K</p>
+                    ) : null}
+                    {evidence?.interlocks.map((it, i) => (
+                      <p key={i}>Shared boards ({it.sharedBoardCount}): {it.entities}</p>
+                    ))}
+                    {!evidence?.influence && (evidence?.interlocks.length ?? 0) === 0 ? <p>No CivicGraph matches for this name.</p> : null}
+                    <p className="text-ql-muted">Evidence refreshes nightly with the CivicGraph views.</p>
+                  </div>
+                </details>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {selected.ghlUrl ? (
+                    <a href={selected.ghlUrl} target="_blank" rel="noopener noreferrer" className="rounded-md border border-ql-border bg-ql-surface px-4 py-2 text-xs font-semibold text-ql-accent hover:bg-ql-surface2">
+                      Open in GHL ↗
+                    </a>
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-ql-text2">Nothing selected.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/org/[slug]/people/people-actions.tsx
+++ b/apps/web/src/app/org/[slug]/people/people-actions.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+// Client actions for the People surface: the next-move box (Done — set next /
+// Release / Edit, per #148 — never a bare dismiss), inline role add, and the
+// one minting modal (spec §5). Writes go through /api/org/[id]/people, which
+// hits GHL first and mirrors after — errors surface, never silently drop.
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const WARMTHS = ['hot', 'warm', 'steady', 'cooling', 'cold'] as const;
+const ROLES = [
+  { value: 'works_at', label: 'works at' },
+  { value: 'board_of', label: 'board of' },
+  { value: 'decides_for', label: 'decides for' },
+  { value: 'opens_into', label: 'opens into' },
+] as const;
+
+const inputCls = 'w-full rounded-md border border-ql-border bg-ql-surface px-3 py-2 text-sm text-ql-ink placeholder:text-ql-muted focus:border-ql-accent focus:outline-none';
+const btnPrimary = 'rounded-md bg-ql-bar px-4 py-2 text-xs font-semibold text-ql-inverse transition-colors hover:bg-ql-ink disabled:opacity-50';
+const btnQuiet = 'rounded-md border border-ql-border bg-ql-surface px-4 py-2 text-xs font-semibold text-ql-ink transition-colors hover:bg-ql-surface2 disabled:opacity-50';
+
+function defaultReviewBy(): string {
+  const d = new Date(Date.now() + 14 * 86_400_000);
+  return d.toISOString().slice(0, 10);
+}
+
+function usePatch(orgProfileId: string) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function patch(body: Record<string, unknown>): Promise<boolean> {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/${orgProfileId}/people`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(((await res.json()) as { error?: string }).error || 'failed');
+      router.refresh();
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed');
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+  return { patch, busy, error };
+}
+
+export function PersonNextMove({ orgProfileId, personId, nextAction, reviewBy }: {
+  orgProfileId: string;
+  personId: string;
+  nextAction: string | null;
+  reviewBy: string | null;
+}) {
+  const { patch, busy, error } = usePatch(orgProfileId);
+  const [mode, setMode] = useState<'view' | 'edit' | 'next' | 'release'>('view');
+  const [text, setText] = useState('');
+  const [date, setDate] = useState(defaultReviewBy());
+
+  useEffect(() => {
+    setMode('view');
+  }, [personId]);
+
+  async function submit() {
+    const ok = await patch(
+      mode === 'next'
+        ? { id: personId, done: true, next_action: text, review_by: date }
+        : { id: personId, next_action: text, review_by: date }
+    );
+    if (ok) setMode('view');
+  }
+
+  return (
+    <div className="mt-5 rounded-md bg-ql-warm px-4 py-3">
+      <div className="font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-accent">Next move</div>
+      {mode === 'view' ? (
+        <>
+          <p className="mt-1 text-sm font-medium leading-6">
+            {nextAction ?? 'No next action — this Person is released (dateless tail).'}
+            {reviewBy ? <span className="text-ql-text2"> · review by {reviewBy}</span> : null}
+          </p>
+          <div className="mt-2.5 flex flex-wrap gap-2">
+            <button type="button" className={btnPrimary} disabled={busy} onClick={() => { setText(''); setDate(defaultReviewBy()); setMode('next'); }}>
+              Done — set next
+            </button>
+            <button type="button" className={btnQuiet} disabled={busy} onClick={() => { setText(nextAction ?? ''); setDate(reviewBy ?? defaultReviewBy()); setMode('edit'); }}>
+              Edit
+            </button>
+            {nextAction ? (
+              <button type="button" className={btnQuiet} disabled={busy} onClick={() => setMode('release')}>
+                Release
+              </button>
+            ) : null}
+          </div>
+        </>
+      ) : mode === 'release' ? (
+        <div className="mt-2 space-y-2">
+          <p className="text-sm">Release this watch? The Person drops to the dateless tail — nothing will resurface them until you set a new next action.</p>
+          <div className="flex gap-2">
+            <button type="button" className={btnPrimary} disabled={busy} onClick={async () => { if (await patch({ id: personId, release: true })) setMode('view'); }}>
+              {busy ? '…' : 'Release'}
+            </button>
+            <button type="button" className={btnQuiet} onClick={() => setMode('view')}>Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-2 space-y-2">
+          <input className={inputCls} value={text} onChange={(e) => setText(e.target.value)} placeholder={mode === 'next' ? 'The new next action' : 'Next action'} />
+          <input className={inputCls} type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+          <div className="flex gap-2">
+            <button type="button" className={btnPrimary} disabled={busy || !text.trim() || !date} onClick={submit}>
+              {busy ? '…' : 'Save'}
+            </button>
+            <button type="button" className={btnQuiet} onClick={() => setMode('view')}>Cancel</button>
+          </div>
+        </div>
+      )}
+      {error ? <p className="mt-2 text-xs font-semibold text-ql-alert">{error}</p> : null}
+    </div>
+  );
+}
+
+export function AddRoleInline({ orgProfileId, personId }: { orgProfileId: string; personId: string }) {
+  const { patch, busy, error } = usePatch(orgProfileId);
+  const [open, setOpen] = useState(false);
+  const [roleType, setRoleType] = useState<string>('works_at');
+  const [orgName, setOrgName] = useState('');
+
+  useEffect(() => setOpen(false), [personId]);
+
+  if (!open) {
+    return (
+      <button type="button" className="mt-2 text-xs font-semibold text-ql-accent hover:underline" onClick={() => setOpen(true)}>
+        + add role
+      </button>
+    );
+  }
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2">
+      <select className="rounded-md border border-ql-border bg-ql-surface px-2 py-2 text-xs" value={roleType} onChange={(e) => setRoleType(e.target.value)}>
+        {ROLES.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
+      </select>
+      <input className="w-52 rounded-md border border-ql-border bg-ql-surface px-3 py-2 text-xs" value={orgName} onChange={(e) => setOrgName(e.target.value)} placeholder="Org name" />
+      <button
+        type="button"
+        className={btnPrimary}
+        disabled={busy || !orgName.trim()}
+        onClick={async () => {
+          if (await patch({ id: personId, add_role: { role_type: roleType, org_name: orgName } })) {
+            setOrgName('');
+            setOpen(false);
+          }
+        }}
+      >
+        {busy ? '…' : 'Add'}
+      </button>
+      <button type="button" className={btnQuiet} onClick={() => setOpen(false)}>Cancel</button>
+      {error ? <span className="text-xs font-semibold text-ql-alert">{error}</span> : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Minting (spec §5): one modal for every entry point. Mandatory at mint:
+// warmth (+ via when indirect) AND a next action with a review-by date.
+
+type SearchResult = { source: 'ghl' | 'civicgraph'; ghlContactId: string | null; name: string; detail: string | null };
+
+export function MintPersonButton({ orgProfileId, prefill, small }: {
+  orgProfileId: string;
+  prefill?: { name: string; ghlContactId: string | null };
+  small?: boolean;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [name, setName] = useState(prefill?.name ?? '');
+  const [claimedId, setClaimedId] = useState<string | null>(prefill?.ghlContactId ?? null);
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [warmth, setWarmth] = useState('warm');
+  const [warmVia, setWarmVia] = useState('');
+  const [roleType, setRoleType] = useState('');
+  const [roleOrg, setRoleOrg] = useState('');
+  const [nextAction, setNextAction] = useState('');
+  const [reviewBy, setReviewBy] = useState(defaultReviewBy());
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function onNameChange(v: string) {
+    setName(v);
+    setClaimedId(null);
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    if (v.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    searchTimer.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/org/${orgProfileId}/people/search?q=${encodeURIComponent(v.trim())}`);
+        if (res.ok) setResults(((await res.json()) as { results: SearchResult[] }).results);
+      } catch {
+        /* search is best-effort */
+      }
+    }, 250);
+  }
+
+  async function mint() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/${orgProfileId}/people`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          ghl_contact_id: claimedId,
+          warmth,
+          warm_via: warmVia.trim() || null,
+          next_action: nextAction.trim(),
+          review_by: reviewBy,
+          ...(roleType && roleOrg.trim() ? { role: { role_type: roleType, org_name: roleOrg.trim() } } : {}),
+        }),
+      });
+      const json = (await res.json()) as { id?: string; error?: string };
+      if (!res.ok) throw new Error(json.error || 'failed');
+      setOpen(false);
+      router.push(`?rec=${json.id}`);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <button type="button" className={small ? 'rounded-md border border-ql-border px-2.5 py-1 font-ql-mono text-[9px] font-semibold uppercase tracking-[0.08em] text-ql-accent hover:bg-ql-surface2' : btnPrimary} onClick={() => setOpen(true)}>
+        {small ? 'mint' : '+ Mint a person'}
+      </button>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-6 pt-[8vh]" onClick={() => !busy && setOpen(false)}>
+          <div className="w-full max-w-lg rounded-lg border border-ql-border bg-ql-surface p-6 text-ql-ink shadow-xl" onClick={(e) => e.stopPropagation()}>
+            <h3 className="font-ql-display text-xl font-semibold">Mint a person</h3>
+            <p className="mt-1 text-xs text-ql-text2">
+              Minting creates or claims the GHL contact — GHL owns the relationship state from here.
+            </p>
+
+            <div className="mt-4 space-y-3">
+              <div>
+                <input className={inputCls} value={name} onChange={(e) => onNameChange(e.target.value)} placeholder="Name — searches GHL and CivicGraph" autoFocus />
+                {claimedId ? (
+                  <p className="mt-1 text-xs text-ql-moss">Claiming existing GHL contact.</p>
+                ) : results.length > 0 ? (
+                  <div className="mt-1 max-h-40 overflow-y-auto rounded-md border border-ql-border">
+                    {results.map((r, i) => (
+                      <button
+                        key={`${r.source}-${r.ghlContactId ?? r.name}-${i}`}
+                        type="button"
+                        className="flex w-full items-center gap-2 border-t border-ql-border/60 px-3 py-1.5 text-left text-xs first:border-t-0 hover:bg-ql-surface2"
+                        onClick={() => {
+                          setName(r.name);
+                          setClaimedId(r.ghlContactId);
+                          setResults([]);
+                        }}
+                      >
+                        <span className="min-w-0 flex-1 truncate">
+                          <span className="font-medium">{r.name}</span>
+                          {r.detail ? <span className="text-ql-text2"> · {r.detail}</span> : null}
+                        </span>
+                        <span className="font-ql-mono text-[8.5px] uppercase text-ql-muted">{r.source === 'ghl' ? 'claim' : 'create'}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-1.5">
+                {WARMTHS.map((w) => (
+                  <button key={w} type="button" onClick={() => setWarmth(w)} className={`rounded-full border px-3 py-1 text-[11px] font-medium ${warmth === w ? 'border-ql-bar bg-ql-bar text-ql-inverse' : 'border-ql-border text-ql-text2 hover:border-ql-muted'}`}>
+                    {w}
+                  </button>
+                ))}
+              </div>
+              <input className={inputCls} value={warmVia} onChange={(e) => setWarmVia(e.target.value)} placeholder="Warm via (leave empty when direct)" />
+
+              <div className="flex gap-2">
+                <select className="rounded-md border border-ql-border bg-ql-surface px-2 py-2 text-xs" value={roleType} onChange={(e) => setRoleType(e.target.value)}>
+                  <option value="">role (optional)</option>
+                  {ROLES.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
+                </select>
+                <input className={inputCls} value={roleOrg} onChange={(e) => setRoleOrg(e.target.value)} placeholder="Org" disabled={!roleType} />
+              </div>
+
+              <input className={inputCls} value={nextAction} onChange={(e) => setNextAction(e.target.value)} placeholder="Next action (required)" />
+              <input className={inputCls} type="date" value={reviewBy} onChange={(e) => setReviewBy(e.target.value)} />
+            </div>
+
+            {error ? <p className="mt-3 text-xs font-semibold text-ql-alert">{error}</p> : null}
+            <div className="mt-4 flex justify-end gap-2">
+              <button type="button" className={btnQuiet} disabled={busy} onClick={() => setOpen(false)}>Cancel</button>
+              <button type="button" className={btnPrimary} disabled={busy || !name.trim() || !nextAction.trim() || !reviewBy} onClick={mint}>
+                {busy ? 'Minting…' : claimedId ? 'Claim + mint' : 'Mint'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/org/[slug]/people/people-actions.tsx
+++ b/apps/web/src/app/org/[slug]/people/people-actions.tsx
@@ -15,7 +15,18 @@ const ROLES = [
   { value: 'opens_into', label: 'opens into' },
 ] as const;
 
-const inputCls = 'w-full rounded-md border border-ql-border bg-ql-surface px-3 py-2 text-sm text-ql-ink placeholder:text-ql-muted focus:border-ql-accent focus:outline-none';
+// Mirror of PROJECT_CODE_OPTIONS + deskProjectLabel (server-side) — plain
+// words for the mint modal and detail-pane project picker.
+const PROJECTS: Array<{ code: string; label: string }> = [
+  { code: 'ACT-GD', label: 'Goods' },
+  { code: 'ACT-JH', label: 'JusticeHub' },
+  { code: 'ACT-HV', label: 'Harvest' },
+  { code: 'ACT-EL', label: 'Empathy Ledger' },
+  { code: 'ACT-PI', label: 'Palm Island' },
+  { code: 'ACT-MY', label: 'ACT' },
+];
+
+const inputCls ='w-full rounded-md border border-ql-border bg-ql-surface px-3 py-2 text-sm text-ql-ink placeholder:text-ql-muted focus:border-ql-accent focus:outline-none';
 const btnPrimary = 'rounded-md bg-ql-bar px-4 py-2 text-xs font-semibold text-ql-inverse transition-colors hover:bg-ql-ink disabled:opacity-50';
 const btnQuiet = 'rounded-md border border-ql-border bg-ql-surface px-4 py-2 text-xs font-semibold text-ql-ink transition-colors hover:bg-ql-surface2 disabled:opacity-50';
 
@@ -164,6 +175,159 @@ export function AddRoleInline({ orgProfileId, personId }: { orgProfileId: string
   );
 }
 
+function ProjectChips({ value, onToggle }: { value: string[]; onToggle: (code: string) => void }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {PROJECTS.map((p) => (
+        <button
+          key={p.code}
+          type="button"
+          onClick={() => onToggle(p.code)}
+          className={`rounded-full border px-3 py-1 text-[11px] font-medium ${value.includes(p.code) ? 'border-ql-bar bg-ql-bar text-ql-inverse' : 'border-ql-border text-ql-text2 hover:border-ql-muted'}`}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Detail-pane project ties editor — set by humans, never derived. */
+export function ProjectsInline({ orgProfileId, personId, projectCodes }: {
+  orgProfileId: string;
+  personId: string;
+  projectCodes: string[];
+}) {
+  const { patch, busy, error } = usePatch(orgProfileId);
+  const [open, setOpen] = useState(false);
+  const [codes, setCodes] = useState(projectCodes);
+
+  useEffect(() => {
+    setOpen(false);
+    setCodes(projectCodes);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [personId]);
+
+  return (
+    <div className="mt-4">
+      <div className="font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-muted">Projects</div>
+      {open ? (
+        <div className="mt-1.5 space-y-2">
+          <ProjectChips value={codes} onToggle={(c) => setCodes((v) => (v.includes(c) ? v.filter((x) => x !== c) : [...v, c]))} />
+          <div className="flex gap-2">
+            <button type="button" className={btnPrimary} disabled={busy} onClick={async () => { if (await patch({ id: personId, project_codes: codes })) setOpen(false); }}>
+              {busy ? '…' : 'Save'}
+            </button>
+            <button type="button" className={btnQuiet} onClick={() => { setCodes(projectCodes); setOpen(false); }}>Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          {projectCodes.map((c) => (
+            <span key={c} className="rounded-full border border-ql-border px-2.5 py-0.5 font-ql-mono text-[9px] uppercase tracking-[0.06em] text-ql-text2">
+              {PROJECTS.find((p) => p.code === c)?.label ?? c}
+            </span>
+          ))}
+          <button type="button" className="text-xs font-semibold text-ql-accent hover:underline" onClick={() => setOpen(true)}>
+            {projectCodes.length ? 'edit' : '+ add projects'}
+          </button>
+        </div>
+      )}
+      {error ? <p className="mt-1 text-xs font-semibold text-ql-alert">{error}</p> : null}
+    </div>
+  );
+}
+
+type AskSearchResult = { ghlOpportunityId: string; name: string; detail: string | null };
+
+/** "Warms N Asks" — human-minted Ask↔Person links (act_ask_warmers). */
+export function AskLinksInline({ orgProfileId, personId, askLinks }: {
+  orgProfileId: string;
+  personId: string;
+  askLinks: Array<{ ghlOpportunityId: string; askName: string | null }>;
+}) {
+  const { patch, busy, error } = usePatch(orgProfileId);
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState('');
+  const [results, setResults] = useState<AskSearchResult[]>([]);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setOpen(false);
+    setQ('');
+    setResults([]);
+  }, [personId]);
+
+  function onSearch(v: string) {
+    setQ(v);
+    if (timer.current) clearTimeout(timer.current);
+    if (v.trim().length < 2) return setResults([]);
+    timer.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/org/${orgProfileId}/people/search?type=ask&q=${encodeURIComponent(v.trim())}`);
+        if (res.ok) setResults(((await res.json()) as { results: AskSearchResult[] }).results);
+      } catch { /* best-effort */ }
+    }, 250);
+  }
+
+  return (
+    <div className="mt-4">
+      <div className="font-ql-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-ql-muted">
+        Warms {askLinks.length > 0 ? `${askLinks.length} ask${askLinks.length === 1 ? '' : 's'}` : ''}
+      </div>
+      {askLinks.length > 0 ? (
+        <ul className="mt-1.5 space-y-1 text-sm">
+          {askLinks.map((l) => (
+            <li key={l.ghlOpportunityId} className="flex items-center gap-2">
+              <span className="min-w-0 flex-1 truncate font-medium">{l.askName ?? l.ghlOpportunityId}</span>
+              <button type="button" className="text-xs text-ql-muted hover:text-ql-alert" disabled={busy} onClick={() => patch({ id: personId, unlink_ask: l.ghlOpportunityId })}>
+                ✕
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {open ? (
+        <div className="mt-2">
+          <input className={inputCls} value={q} onChange={(e) => onSearch(e.target.value)} placeholder="Search open Asks by name" autoFocus />
+          {results.length > 0 ? (
+            <div className="mt-1 max-h-36 overflow-y-auto rounded-md border border-ql-border">
+              {results
+                .filter((r) => !askLinks.some((l) => l.ghlOpportunityId === r.ghlOpportunityId))
+                .map((r) => (
+                  <button
+                    key={r.ghlOpportunityId}
+                    type="button"
+                    className="flex w-full items-center gap-2 border-t border-ql-border/60 px-3 py-1.5 text-left text-xs first:border-t-0 hover:bg-ql-surface2"
+                    disabled={busy}
+                    onClick={async () => {
+                      if (await patch({ id: personId, link_ask: { ghl_opportunity_id: r.ghlOpportunityId, ask_name: r.name } })) {
+                        setOpen(false);
+                        setQ('');
+                        setResults([]);
+                      }
+                    }}
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      <span className="font-medium">{r.name}</span>
+                      {r.detail ? <span className="text-ql-text2"> · {r.detail}</span> : null}
+                    </span>
+                  </button>
+                ))}
+            </div>
+          ) : null}
+          <button type="button" className="mt-1.5 text-xs font-semibold text-ql-text2 hover:underline" onClick={() => setOpen(false)}>Cancel</button>
+        </div>
+      ) : (
+        <button type="button" className="mt-1.5 text-xs font-semibold text-ql-accent hover:underline" onClick={() => setOpen(true)}>
+          + link an Ask
+        </button>
+      )}
+      {error ? <p className="mt-1 text-xs font-semibold text-ql-alert">{error}</p> : null}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Minting (spec §5): one modal for every entry point. Mandatory at mint:
 // warmth (+ via when indirect) AND a next action with a review-by date.
@@ -187,6 +351,7 @@ export function MintPersonButton({ orgProfileId, prefill, small }: {
   const [warmVia, setWarmVia] = useState('');
   const [roleType, setRoleType] = useState('');
   const [roleOrg, setRoleOrg] = useState('');
+  const [projects, setProjects] = useState<string[]>([]);
   const [nextAction, setNextAction] = useState('');
   const [reviewBy, setReviewBy] = useState(defaultReviewBy());
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -223,6 +388,7 @@ export function MintPersonButton({ orgProfileId, prefill, small }: {
           warm_via: warmVia.trim() || null,
           next_action: nextAction.trim(),
           review_by: reviewBy,
+          project_codes: projects,
           ...(roleType && roleOrg.trim() ? { role: { role_type: roleType, org_name: roleOrg.trim() } } : {}),
         }),
       });
@@ -288,6 +454,8 @@ export function MintPersonButton({ orgProfileId, prefill, small }: {
                 ))}
               </div>
               <input className={inputCls} value={warmVia} onChange={(e) => setWarmVia(e.target.value)} placeholder="Warm via (leave empty when direct)" />
+
+              <ProjectChips value={projects} onToggle={(c) => setProjects((v) => (v.includes(c) ? v.filter((x) => x !== c) : [...v, c]))} />
 
               <div className="flex gap-2">
                 <select className="rounded-md border border-ql-border bg-ql-surface px-2 py-2 text-xs" value={roleType} onChange={(e) => setRoleType(e.target.value)}>

--- a/apps/web/src/lib/services/act-people-ghl.ts
+++ b/apps/web/src/lib/services/act-people-ghl.ts
@@ -1,0 +1,110 @@
+// GHL write path for People (ADR 0002: GHL owns relationship state — warmth,
+// next action, last touch). Server-side only. Every surface write goes here
+// FIRST; the mirror updates only after GHL accepts (never mirror-only writes).
+//
+// Storage mapping (capability audit #144):
+//   warmth      → the single goods-* warmth tag (scripts/lib/ghl-tag-registry.mjs
+//                 vocabulary: exactly one, REPLACE never append)
+//   next action → a contact Task (title + dueDate); its id is kept on the
+//                 mirror row (ghl_task_id) so edits update rather than pile up
+//   warm via    → written into the task body for phone visibility; the mirror
+//                 is authoritative (GHL has no native home for it)
+
+const BASE_URL = 'https://services.leadconnectorhq.com';
+const WARMTH_TAG_PREFIX = 'goods-';
+const WARMTH_TAGS = ['goods-hot', 'goods-warm', 'goods-steady', 'goods-cooling', 'goods-cold'];
+
+async function ghlFetch(endpoint: string, options: RequestInit = {}) {
+  const apiKey = process.env.GHL_API_KEY;
+  if (!apiKey) throw new Error('GHL_API_KEY not set');
+  const res = await fetch(`${BASE_URL}${endpoint}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      Version: '2021-07-28',
+      ...options.headers,
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GHL API ${res.status}: ${text}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+/** Create a bare person contact. GHL allows name-only creation. */
+export async function createPersonContact(opts: { name: string; email?: string | null }): Promise<string> {
+  const locationId = process.env.GHL_LOCATION_ID;
+  const [firstName, ...rest] = opts.name.trim().split(/\s+/);
+  const data = await ghlFetch('/contacts/', {
+    method: 'POST',
+    body: JSON.stringify({
+      locationId,
+      firstName,
+      lastName: rest.join(' ') || undefined,
+      ...(opts.email ? { email: opts.email } : {}),
+      tags: ['record:person'],
+      source: 'civicgraph-people-mint',
+    }),
+  });
+  const id = data?.contact?.id;
+  if (!id) throw new Error('GHL contact create did not return an id');
+  return id;
+}
+
+/** Replace the contact's warmth tag (exactly one, per the tag registry). */
+export async function setWarmthTag(contactId: string, warmth: string): Promise<void> {
+  const target = `${WARMTH_TAG_PREFIX}${warmth}`;
+  const existing = await ghlFetch(`/contacts/${contactId}`);
+  const tags: string[] = existing?.contact?.tags ?? [];
+  const staleWarmth = tags.filter((t) => WARMTH_TAGS.includes(t.toLowerCase()) && t.toLowerCase() !== target);
+  if (staleWarmth.length > 0) {
+    await ghlFetch(`/contacts/${contactId}/tags`, { method: 'DELETE', body: JSON.stringify({ tags: staleWarmth }) });
+  }
+  if (!tags.some((t) => t.toLowerCase() === target)) {
+    await ghlFetch(`/contacts/${contactId}/tags`, { method: 'POST', body: JSON.stringify({ tags: [target] }) });
+  }
+}
+
+function taskBody(nextAction: string, warmVia: string | null): string {
+  return warmVia ? `${nextAction}\nvia ${warmVia}` : nextAction;
+}
+
+/** Create or update the contact task holding the next action. Returns task id. */
+export async function upsertNextActionTask(
+  contactId: string,
+  taskId: string | null,
+  opts: { nextAction: string; reviewBy: string; warmVia: string | null }
+): Promise<string> {
+  const payload = {
+    title: opts.nextAction.slice(0, 200),
+    body: taskBody(opts.nextAction, opts.warmVia),
+    dueDate: `${opts.reviewBy}T09:00:00+10:00`,
+    completed: false,
+  };
+  if (taskId) {
+    try {
+      await ghlFetch(`/contacts/${contactId}/tasks/${taskId}`, { method: 'PUT', body: JSON.stringify(payload) });
+      return taskId;
+    } catch {
+      // Task deleted/completed in GHL — fall through and create fresh.
+    }
+  }
+  const data = await ghlFetch(`/contacts/${contactId}/tasks`, { method: 'POST', body: JSON.stringify(payload) });
+  const id = data?.task?.id ?? data?.id;
+  if (!id) throw new Error('GHL task create did not return an id');
+  return id;
+}
+
+/** Mark the current next-action task done in GHL (watch completed / released). */
+export async function completeNextActionTask(contactId: string, taskId: string): Promise<void> {
+  try {
+    await ghlFetch(`/contacts/${contactId}/tasks/${taskId}/completed`, {
+      method: 'PUT',
+      body: JSON.stringify({ completed: true }),
+    });
+  } catch {
+    // Already completed or deleted in GHL — GHL wins, nothing to enforce.
+  }
+}

--- a/apps/web/src/lib/services/act-people.ts
+++ b/apps/web/src/lib/services/act-people.ts
@@ -24,6 +24,15 @@ export type PersonRole = {
   orgRef: string | null;
 };
 
+/** The ACT projects a Person can be tied to (set at mint, edited in the
+ * detail pane — never derived; Ben 2026-08-06). Labels via deskProjectLabel. */
+export const PROJECT_CODE_OPTIONS = ['ACT-GD', 'ACT-JH', 'ACT-HV', 'ACT-EL', 'ACT-PI', 'ACT-MY'] as const;
+
+export type AskLink = {
+  ghlOpportunityId: string;
+  askName: string | null;
+};
+
 export type ActPerson = {
   id: string;
   name: string;
@@ -41,6 +50,9 @@ export type ActPerson = {
   ghlContactId: string;
   ghlUrl: string | null;
   roles: PersonRole[];
+  projectCodes: string[];
+  /** Live Asks this Person warms (act_ask_warmers, human-minted links). */
+  askLinks: AskLink[];
 };
 
 const WARMTH_RANK: Record<string, number> = { hot: 0, warm: 1, steady: 2, cooling: 3, cold: 4 };
@@ -57,7 +69,7 @@ export async function getActPeople(orgProfileId: string): Promise<ActPerson[]> {
   const { data, error } = await db
     .from('act_people')
     .select(
-      'id, name, warmth, warm_via, owner, next_action, review_by, last_touch_at, last_synced_at, ghl_contact_id, act_person_roles(id, role_type, org_name, org_ref)'
+      'id, name, warmth, warm_via, owner, next_action, review_by, last_touch_at, last_synced_at, ghl_contact_id, project_codes, act_person_roles(id, role_type, org_name, org_ref), act_ask_warmers(ghl_opportunity_id, ask_name)'
     )
     .eq('org_profile_id', orgProfileId);
   if (error) return []; // mirror not migrated yet — surface renders empty, honestly
@@ -84,6 +96,11 @@ export async function getActPeople(orgProfileId: string): Promise<ActPerson[]> {
         roleType: role.role_type as RoleType,
         orgName: role.org_name as string,
         orgRef: (role.org_ref as string) ?? null,
+      })),
+      projectCodes: ((r.project_codes as string[]) ?? []).filter(Boolean),
+      askLinks: ((r.act_ask_warmers as unknown as Array<Record<string, unknown>>) ?? []).map((l) => ({
+        ghlOpportunityId: l.ghl_opportunity_id as string,
+        askName: (l.ask_name as string) ?? null,
       })),
     } satisfies ActPerson;
   });

--- a/apps/web/src/lib/services/act-people.ts
+++ b/apps/web/src/lib/services/act-people.ts
@@ -1,0 +1,208 @@
+// The People surface reads (spec: docs/specs/people-surface-ux-spec.md).
+// Everything here hits the Supabase mirror (`act_people`) or CivicGraph —
+// never GHL live (ADR 0002). Writes live in act-people-ghl.ts + the API route.
+import { getServiceSupabase } from '@/lib/supabase';
+import { ghlContactUrl } from '@/lib/ghl-links';
+
+export const WARMTH_VALUES = ['hot', 'warm', 'steady', 'cooling', 'cold'] as const;
+export type Warmth = (typeof WARMTH_VALUES)[number];
+
+export const ROLE_TYPES = ['works_at', 'board_of', 'decides_for', 'opens_into'] as const;
+export type RoleType = (typeof ROLE_TYPES)[number];
+
+export const ROLE_LABEL: Record<RoleType, string> = {
+  works_at: 'works at',
+  board_of: 'board of',
+  decides_for: 'decides for',
+  opens_into: 'opens into',
+};
+
+export type PersonRole = {
+  id: string;
+  roleType: RoleType;
+  orgName: string;
+  orgRef: string | null;
+};
+
+export type ActPerson = {
+  id: string;
+  name: string;
+  warmth: Warmth | null;
+  warmVia: string | null;
+  owner: string | null;
+  nextAction: string | null;
+  reviewBy: string | null;
+  /** Days until review-by; negative = past; null = dateless (released). */
+  dueDays: number | null;
+  lastTouchAt: string | null;
+  lastSyncedAt: string | null;
+  /** Mirrored fact older than 24h (existing data-trust rule). */
+  stale: boolean;
+  ghlContactId: string;
+  ghlUrl: string | null;
+  roles: PersonRole[];
+};
+
+const WARMTH_RANK: Record<string, number> = { hot: 0, warm: 1, steady: 2, cooling: 3, cold: 4 };
+
+function dueDays(reviewBy: string | null): number | null {
+  if (!reviewBy) return null;
+  const t = new Date(`${reviewBy}T00:00:00`).getTime();
+  if (Number.isNaN(t)) return null;
+  return Math.ceil((t - Date.now()) / 86_400_000);
+}
+
+export async function getActPeople(orgProfileId: string): Promise<ActPerson[]> {
+  const db = getServiceSupabase();
+  const { data, error } = await db
+    .from('act_people')
+    .select(
+      'id, name, warmth, warm_via, owner, next_action, review_by, last_touch_at, last_synced_at, ghl_contact_id, act_person_roles(id, role_type, org_name, org_ref)'
+    )
+    .eq('org_profile_id', orgProfileId);
+  if (error) return []; // mirror not migrated yet — surface renders empty, honestly
+
+  const now = Date.now();
+  const people = (data ?? []).map((r) => {
+    const synced = r.last_synced_at ? new Date(r.last_synced_at).getTime() : null;
+    return {
+      id: r.id as string,
+      name: r.name as string,
+      warmth: (r.warmth as Warmth) ?? null,
+      warmVia: (r.warm_via as string) ?? null,
+      owner: (r.owner as string) ?? null,
+      nextAction: (r.next_action as string) ?? null,
+      reviewBy: (r.review_by as string) ?? null,
+      dueDays: dueDays(r.review_by as string | null),
+      lastTouchAt: (r.last_touch_at as string) ?? null,
+      lastSyncedAt: (r.last_synced_at as string) ?? null,
+      stale: synced == null || now - synced > 24 * 3600_000,
+      ghlContactId: r.ghl_contact_id as string,
+      ghlUrl: ghlContactUrl(r.ghl_contact_id as string),
+      roles: ((r.act_person_roles as unknown as Array<Record<string, unknown>>) ?? []).map((role) => ({
+        id: role.id as string,
+        roleType: role.role_type as RoleType,
+        orgName: role.org_name as string,
+        orgRef: (role.org_ref as string) ?? null,
+      })),
+    } satisfies ActPerson;
+  });
+
+  // Ordering (spec §3): next-action due first — overdue, then soonest
+  // review-by, then the dateless tail sorted by warmth (warmest first).
+  people.sort((a, b) => {
+    if (a.dueDays != null && b.dueDays != null) return a.dueDays - b.dueDays;
+    if (a.dueDays != null) return -1;
+    if (b.dueDays != null) return 1;
+    return (WARMTH_RANK[a.warmth ?? ''] ?? 9) - (WARMTH_RANK[b.warmth ?? ''] ?? 9);
+  });
+  return people;
+}
+
+// ---------------------------------------------------------------------------
+// Minting candidates ("Not yet people", spec §5): GHL contacts + org_contacts
+// rows that aren't minted — one-line signals, never mixed into the list.
+
+export type MintCandidate = {
+  /** GHL contact id when the candidate already exists in GHL (→ claim). */
+  ghlContactId: string | null;
+  name: string;
+  detail: string | null;
+  source: 'ghl' | 'org_contacts';
+};
+
+export async function getMintCandidates(orgProfileId: string, limit = 25): Promise<MintCandidate[]> {
+  const db = getServiceSupabase();
+  const [minted, ghl, orgContacts] = await Promise.all([
+    db.from('act_people').select('ghl_contact_id, name').eq('org_profile_id', orgProfileId),
+    db
+      .from('ghl_contacts')
+      .select('ghl_id, full_name, first_name, last_name, company_name, tags, last_contact_date')
+      .not('full_name', 'is', null)
+      .order('last_contact_date', { ascending: false, nullsFirst: false })
+      .limit(200),
+    db
+      .from('org_contacts')
+      .select('name, role, organisation')
+      .eq('org_profile_id', orgProfileId)
+      .limit(100),
+  ]);
+
+  const mintedIds = new Set((minted.data ?? []).map((m) => m.ghl_contact_id as string));
+  const mintedNames = new Set((minted.data ?? []).map((m) => (m.name as string).toLowerCase()));
+  const out: MintCandidate[] = [];
+
+  for (const c of ghl.data ?? []) {
+    if (out.length >= limit) break;
+    const id = c.ghl_id as string | null;
+    const name = (c.full_name as string) || `${c.first_name ?? ''} ${c.last_name ?? ''}`.trim();
+    if (!id || !name || mintedIds.has(id) || mintedNames.has(name.toLowerCase())) continue;
+    // Person-shaped GHL contacts only: the record:person tag when present,
+    // else any contact with a real name that isn't tagged as an org record.
+    const tags = ((c.tags as string[]) ?? []).map((t) => t.toLowerCase());
+    if (tags.includes('record:org')) continue;
+    out.push({
+      ghlContactId: id,
+      name,
+      detail: (c.company_name as string) || null,
+      source: 'ghl',
+    });
+  }
+  for (const c of orgContacts.data ?? []) {
+    if (out.length >= limit) break;
+    const name = c.name as string;
+    if (!name || mintedNames.has(name.toLowerCase())) continue;
+    if (out.some((o) => o.name.toLowerCase() === name.toLowerCase())) continue;
+    out.push({
+      ghlContactId: null,
+      name,
+      detail: [c.role, c.organisation].filter(Boolean).join(' · ') || null,
+      source: 'org_contacts',
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CivicGraph evidence (spec §4.4): annotations, never state. Read-only, each
+// carrying its own freshness signal (the MVs refresh nightly).
+
+export type PersonEvidence = {
+  influence: { boardCount: number; financialFootprint: number } | null;
+  interlocks: Array<{ entities: string; sharedBoardCount: number }>;
+};
+
+export async function getPersonEvidence(name: string): Promise<PersonEvidence> {
+  const db = getServiceSupabase();
+  const empty: PersonEvidence = { influence: null, interlocks: [] };
+  if (!name) return empty;
+  try {
+    const [influence, interlocks] = await Promise.all([
+      db
+        .from('mv_person_influence')
+        .select('board_count, financial_footprint')
+        .ilike('person_name', name)
+        .limit(1)
+        .maybeSingle(),
+      db
+        .from('mv_board_interlocks')
+        .select('entities, shared_board_count')
+        .ilike('person_name', name)
+        .limit(5),
+    ]);
+    return {
+      influence: influence.data
+        ? {
+            boardCount: Number(influence.data.board_count ?? 0),
+            financialFootprint: Number(influence.data.financial_footprint ?? 0),
+          }
+        : null,
+      interlocks: (interlocks.data ?? []).map((r) => ({
+        entities: Array.isArray(r.entities) ? (r.entities as string[]).join(', ') : String(r.entities ?? ''),
+        sharedBoardCount: Number(r.shared_board_count ?? 0),
+      })),
+    };
+  } catch {
+    return empty;
+  }
+}

--- a/scripts/reconcile-act-people-ghl.mjs
+++ b/scripts/reconcile-act-people-ghl.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Reconcile the act_people mirror against GHL — the system of record for
+ * Person relationship state (ADR 0002). On any disagreement GHL wins silently.
+ *
+ * For each act_people row:
+ *   1. GET the GHL contact → warmth (single goods-* tag), name, last touch
+ *   2. GET the contact's tasks → the next-action task (ghl_task_id):
+ *      - due date moved in GHL      → mirror follows
+ *      - completed/deleted in GHL   → mirror clears (Person drops dateless)
+ *   3. Contact deleted in GHL       → flag loudly, leave the row (a human
+ *      decides; the mirror never deletes People on its own)
+ *   4. Stamp last_synced_at (the stale-badge clock on every surface)
+ *
+ * warm_via is NOT reconciled — the mirror is authoritative for it (GHL has
+ * no native home; it only echoes into the task body for phone visibility).
+ *
+ * Read-only against GHL. Intended for the daily reconcile pass.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/reconcile-act-people-ghl.mjs [--dry-run]
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { logStart, logComplete } from './lib/log-agent-run.mjs';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GHL_API_KEY = process.env.GHL_API_KEY;
+const GHL_BASE = 'https://services.leadconnectorhq.com';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (!SUPABASE_URL || !SUPABASE_KEY || !GHL_API_KEY) {
+  console.error('FATAL: need SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, GHL_API_KEY');
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+const WARMTH_TAGS = ['goods-hot', 'goods-warm', 'goods-steady', 'goods-cooling', 'goods-cold'];
+
+async function ghl(endpoint) {
+  const res = await fetch(`${GHL_BASE}${endpoint}`, {
+    headers: { Authorization: `Bearer ${GHL_API_KEY}`, Version: '2021-07-28' },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`GHL ${res.status} on ${endpoint}: ${await res.text()}`);
+  return res.json();
+}
+
+function warmthFromTags(tags = []) {
+  const tag = tags.find((t) => WARMTH_TAGS.includes(String(t).toLowerCase()));
+  return tag ? String(tag).toLowerCase().replace('goods-', '') : null;
+}
+
+async function main() {
+  const run = await logStart(sb, 'reconcile-act-people', 'Reconcile People mirror vs GHL');
+
+  const { data: people, error } = await sb
+    .from('act_people')
+    .select('id, name, ghl_contact_id, ghl_task_id, warmth, next_action, review_by');
+  if (error) throw new Error(`act_people read failed: ${error.message}`);
+  console.log(`${people.length} People to reconcile${DRY_RUN ? ' (dry-run)' : ''}`);
+
+  let updated = 0;
+  let missing = 0;
+  for (const p of people) {
+    try {
+      const contactRes = await ghl(`/contacts/${p.ghl_contact_id}`);
+      const contact = contactRes?.contact;
+      if (!contact) {
+        missing += 1;
+        console.warn(`MISSING IN GHL: ${p.name} (${p.ghl_contact_id}) — contact deleted? Needs a human call.`);
+        continue;
+      }
+
+      const patch = { last_synced_at: new Date().toISOString(), updated_at: new Date().toISOString() };
+      const warmth = warmthFromTags(contact.tags);
+      if (warmth && warmth !== p.warmth) patch.warmth = warmth;
+      const ghlName = [contact.firstName, contact.lastName].filter(Boolean).join(' ').trim();
+      if (ghlName && ghlName !== p.name) patch.name = ghlName;
+      const touch = contact.lastActivity || contact.dateUpdated;
+      if (touch) patch.last_touch_at = new Date(touch).toISOString();
+
+      if (p.ghl_task_id) {
+        const tasksRes = await ghl(`/contacts/${p.ghl_contact_id}/tasks`);
+        const task = (tasksRes?.tasks ?? []).find((t) => t.id === p.ghl_task_id);
+        if (!task || task.completed) {
+          // Completed or deleted on the GHL side: the watch is over. Mirror
+          // drops the Person to the dateless tail — a human sets the next one.
+          patch.next_action = null;
+          patch.review_by = null;
+          patch.ghl_task_id = null;
+        } else {
+          if (task.title && task.title !== p.next_action) patch.next_action = task.title;
+          const due = task.dueDate ? new Date(task.dueDate).toISOString().slice(0, 10) : null;
+          if (due && due !== p.review_by) patch.review_by = due;
+        }
+      }
+
+      const changes = Object.keys(patch).filter((k) => !['last_synced_at', 'updated_at'].includes(k));
+      if (changes.length > 0) {
+        updated += 1;
+        console.log(`${p.name}: ${changes.join(', ')}${DRY_RUN ? ' (skipped)' : ''}`);
+      }
+      if (!DRY_RUN) {
+        const { error: upErr } = await sb.from('act_people').update(patch).eq('id', p.id);
+        if (upErr) console.error(`  update failed for ${p.name}: ${upErr.message}`);
+      }
+    } catch (e) {
+      console.error(`  ${p.name}: ${e.message}`);
+    }
+  }
+
+  console.log(`Done: ${updated} updated, ${missing} missing in GHL, ${people.length} scanned`);
+  // logStart can return {id:null} under pooler stress — logComplete tolerates it.
+  if (run?.id) await logComplete(sb, run.id, { items_found: people.length, items_new: updated });
+  return run;
+}
+
+main().catch(async (e) => {
+  console.error(`FATAL: ${e.message}`);
+  process.exit(1);
+});

--- a/supabase/migrations/20260806120000_act_people.sql
+++ b/supabase/migrations/20260806120000_act_people.sql
@@ -1,0 +1,59 @@
+-- People: humans ACT deliberately cultivates (CONTEXT.md; ADR 0002).
+-- GHL owns existence + relationship state (warmth, next action, owner,
+-- last touch); this table is the READ MIRROR the desk and /people surface
+-- query — never GHL live. Synced by scripts/reconcile-act-people-ghl.mjs;
+-- on any disagreement GHL wins silently.
+--
+-- Not a Person without a GHL contact: minting = creating/claiming the
+-- contact, and ghl_contact_id is therefore NOT NULL + unique.
+
+create table if not exists act_people (
+  id uuid primary key default gen_random_uuid(),
+  org_profile_id uuid not null references org_profiles(id),
+  ghl_contact_id text not null unique,
+  name text not null,
+  -- One warmth value per Person (ADR 0002). Mirrors the single GHL warmth
+  -- tag (goods-hot..goods-cold) minus the prefix.
+  warmth text check (warmth in ('hot', 'warm', 'steady', 'cooling', 'cold')),
+  -- The holder when warmth is indirect ("warm via Nic"); null = direct.
+  -- Written into the GHL task body for phone visibility, but the mirror is
+  -- authoritative for this one field (GHL has no native home for it).
+  warm_via text,
+  owner text,
+  -- The next action / watch (#148). Minting always sets both; a dateless
+  -- Person exists only pre-backfill or after an explicit Release.
+  next_action text,
+  review_by date,
+  -- The GHL contact task holding the next action (write path + reconcile).
+  ghl_task_id text,
+  last_touch_at timestamptz,
+  last_synced_at timestamptz not null default now(),
+  minted_by text,
+  minted_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists act_people_pool_idx
+  on act_people (org_profile_id, review_by);
+
+-- Person↔Org roles are Supabase-owned, NOT mirrored (ADR 0002 deviation 2):
+-- ACT's structural knowledge, changed by human decision in the workspace.
+create table if not exists act_person_roles (
+  id uuid primary key default gen_random_uuid(),
+  person_id uuid not null references act_people(id) on delete cascade,
+  role_type text not null check (role_type in ('works_at', 'board_of', 'decides_for', 'opens_into')),
+  org_name text not null,
+  -- Optional link into CivicGraph (gs_id) or an org workspace slug.
+  org_ref text,
+  created_by text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists act_person_roles_person_idx
+  on act_person_roles (person_id);
+
+alter table act_people enable row level security;
+alter table act_person_roles enable row level security;
+-- No anon/authenticated policies: all access goes through the app's service
+-- role (same posture as act_obligations / the other org-workspace tables).

--- a/supabase/migrations/20260806130000_act_people_projects_ask_warmers.sql
+++ b/supabase/migrations/20260806130000_act_people_projects_ask_warmers.sql
@@ -1,0 +1,27 @@
+-- People follow-ups (Ben, 2026-08-06, PR #166 review):
+--   1. project_codes on act_people — project ties are set at mint (and edited
+--      in the detail pane), not derived; lights up the spec §3 project chips
+--      + rail filter.
+--   2. act_ask_warmers — the Ask↔Person warm-via link ("warms N Asks →",
+--      spec §4.5). Human-minted links only, never name-matched. The Ask side
+--      is a GHL opportunity id (ADR 0001: Asks live in GHL); ask_name is a
+--      display cache, refreshed opportunistically on write.
+
+alter table act_people
+  add column if not exists project_codes text[] not null default '{}';
+
+create table if not exists act_ask_warmers (
+  ghl_opportunity_id text not null,
+  person_id uuid not null references act_people(id) on delete cascade,
+  org_profile_id uuid not null references org_profiles(id),
+  ask_name text,
+  created_by text,
+  created_at timestamptz not null default now(),
+  primary key (ghl_opportunity_id, person_id)
+);
+
+create index if not exists act_ask_warmers_person_idx
+  on act_ask_warmers (person_id);
+
+alter table act_ask_warmers enable row level security;
+-- No anon/authenticated policies: service-role only, same posture as act_people.


### PR DESCRIPTION
Builds wayfinder #154 per docs/specs/people-surface-ux-spec.md (ADR 0002: Person lives in GHL, Supabase mirrors, roles Supabase-owned, CivicGraph annotates).

## What's here
- **Migration** \`supabase/migrations/20260806120000_act_people.sql\` — \`act_people\` mirror + \`act_person_roles\`. **NOT applied to prod** (Tier 3, day shift). Apply with:
  \`source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U postgres.tednluwflfhxyucgwigh -d postgres -f supabase/migrations/20260806120000_act_people.sql\`
- **Columns match PR #164's desk feed** (\`act-desk-people.ts\`) — merging both + applying the migration lights up desk person rows.
- **GHL write path**: warmth = the single \`goods-*\` tag (registry vocab, replace-never-append); next action = a contact Task whose id lives on the mirror row; warm-via echoed into the task body, mirror-authoritative. GHL first, mirror after; GHL failure = surfaced error, no mirror-only writes.
- **/org/act/people** — Quiet Ledger split (list + detail via \`?rec=\`), horizon bands (Overdue / fortnight / quarter / No date), due-first ordering with warmth-sorted dateless tail, rail filters (warmth · role type · due only), stale badges >24h, candidates rail ("Not yet people": unminted ghl_contacts + org_contacts), CivicGraph evidence (mv_person_influence + mv_board_interlocks) as a collapsed annotations section.
- **Minting modal** — one flow: name search across the GHL pool (claim) and CivicGraph persons (create), warmth + via, optional first role, required next action + review-by (default +14d). No inert People.
- **Next-move box** — Done → set next (forced), Release (explicit confirm → dateless tail), Edit. Never a bare dismiss (#148).
- **/org/act/contacts → redirects to /people** (ACT only; other orgs keep their contacts page). Delete the route one release later per spec.
- **Reconcile agent** \`scripts/reconcile-act-people-ghl.mjs\` (\`--dry-run\` supported) — GHL wins silently; task completed/deleted in GHL drops the Person dateless; contact missing in GHL is flagged loudly, never auto-deleted. Logs to agent_runs.

## Deliberate deviations / deferrals
- **Project chips + project rail filter** deferred — the mirror has no project ties yet (spec derives them from roles/next-action ties; nothing to derive from at mint time). Honest omission rather than fake chips.
- **Owner edits are mirror-only** — GHL \`assignedTo\` wants a GHL user id, the desk wants a plain name.
- **"Warms N Asks" link row** deferred — needs the Ask↔Person warm-via join.
- **warm_via is mirror-authoritative** (GHL has no native field; task body carries it for the phone).

## To go live
1. Apply the migration (above) — day shift.
2. Merge this + PR #164, then run the reconcile agent daily (candidate for the 07:00 Brisbane pass alongside the digest/bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)