### PR TITLE
Community↔Obligation tagging: the write path for 'what do we owe Barkly' (#159)

### DIFF
--- a/apps/web/src/app/api/org/[orgProfileId]/obligations/route.ts
+++ b/apps/web/src/app/api/org/[orgProfileId]/obligations/route.ts
@@ -43,6 +43,7 @@ export async function POST(request: NextRequest, { params }: Params) {
       source_ask_name: text(body.source_ask_name, 300),
       promised_to: text(body.promised_to, 300),
       artefact_url: text(body.artefact_url, 800),
+      community_id: text(body.community_id, 60),
       minted_by: auth.userId,
     })
     .select('id')
@@ -97,6 +98,8 @@ export async function PATCH(request: NextRequest, { params }: Params) {
     if (key in body) patch[key] = text(body[key], limit);
   }
   if ('due_date' in body) patch.due_date = isoDate(body.due_date);
+  // Community tag (ADR 0004) — null untags; the FK rejects unknown ids.
+  if ('community_id' in body) patch.community_id = text(body.community_id, 60);
   if ('owed_to' in body) {
     const owedTo = OWED_TO.find((t) => t === body.owed_to);
     if (!owedTo) return NextResponse.json({ error: 'owed_to must be funder or community' }, { status: 400 });

--- a/apps/web/src/app/org/[slug]/goods/we-owe/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/we-owe/page.tsx
@@ -8,8 +8,9 @@ import { notFound } from 'next/navigation';
 import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getObligationPool, type Obligation } from '@/lib/services/act-obligations';
+import { getServiceSupabase } from '@/lib/supabase';
 import { GoodsWorkspaceHeader } from '../_components/goods-capital-ui';
-import { MintObligationForm, ObligationStateButtons } from './we-owe-actions';
+import { MintObligationForm, ObligationStateButtons, ObligationCommunityPicker } from './we-owe-actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -47,6 +48,14 @@ export default async function GoodsWeOwePage({ params, searchParams }: {
   const sp = await searchParams;
 
   const pool = await getObligationPool(profile.id, GOODS_PROJECT_CODE);
+  // Community tag options (ADR 0004: hand-minted, expected size 5–15 — the
+  // whole list ships to the client pickers). #165's service owns the record
+  // pages; this stays a plain lookup to avoid a cross-branch file.
+  const { data: communityRows } = await getServiceSupabase()
+    .from('act_communities')
+    .select('id, name')
+    .order('name');
+  const communities = (communityRows ?? []) as Array<{ id: string; name: string }>;
   const selected = (typeof sp.rec === 'string' ? [...pool.open, ...pool.closed].find((o) => o.id === sp.rec) : null) ?? pool.open[0] ?? null;
   const base = `/org/${slug}/goods/we-owe`;
 
@@ -70,7 +79,7 @@ export default async function GoodsWeOwePage({ params, searchParams }: {
       />
       <div className="mx-auto max-w-[1760px] px-4 py-6">
         <div className="mb-4">
-          <MintObligationForm orgProfileId={profile.id} projectCode={GOODS_PROJECT_CODE} />
+          <MintObligationForm orgProfileId={profile.id} projectCode={GOODS_PROJECT_CODE} communities={communities} />
         </div>
 
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
@@ -88,6 +97,9 @@ export default async function GoodsWeOwePage({ params, searchParams }: {
                   >
                     <span className="bg-bauhaus-black px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest text-white">we owe</span>
                     <span className="min-w-0 flex-1 truncate font-bold">{o.title}</span>
+                    {o.communityName ? (
+                      <span className="hidden border-2 border-bauhaus-black px-1.5 py-0.5 text-[9px] font-black uppercase tracking-widest md:inline">{o.communityName}</span>
+                    ) : null}
                     <OwedToTag t={o.owedTo} />
                     <Due d={o.dueDays} />
                   </Link>
@@ -145,6 +157,18 @@ export default async function GoodsWeOwePage({ params, searchParams }: {
                     Open artefact ↗
                   </a>
                 ) : null}
+                <div className="mt-4">
+                  <ObligationCommunityPicker
+                    orgProfileId={profile.id}
+                    obligationId={selected.id}
+                    communityId={selected.communityId}
+                    communityName={selected.communityName}
+                    communitySlug={selected.communitySlug}
+                    orgSlug={slug}
+                    communities={communities}
+                    readOnly={selected.state !== 'open'}
+                  />
+                </div>
                 {selected.state === 'open' ? (
                   <div className="mt-5">
                     <ObligationStateButtons orgProfileId={profile.id} obligationId={selected.id} owedTo={selected.owedTo} />

--- a/apps/web/src/app/org/[slug]/goods/we-owe/we-owe-actions.tsx
+++ b/apps/web/src/app/org/[slug]/goods/we-owe/we-owe-actions.tsx
@@ -71,12 +71,85 @@ export function ObligationStateButtons({ orgProfileId, obligationId, owedTo }: {
   );
 }
 
-export function MintObligationForm({ orgProfileId, projectCode }: { orgProfileId: string; projectCode: string }) {
+type CommunityOption = { id: string; name: string };
+
+/** Community tag on an Obligation (ADR 0004) — set, change, or clear.
+ * owed-to-community first, but any Obligation can carry the tag. */
+export function ObligationCommunityPicker({ orgProfileId, obligationId, communityId, communityName, communitySlug, orgSlug, communities, readOnly }: {
+  orgProfileId: string;
+  obligationId: string;
+  communityId: string | null;
+  communityName: string | null;
+  communitySlug: string | null;
+  orgSlug: string;
+  communities: CommunityOption[];
+  readOnly: boolean;
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function set(value: string | null) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/${orgProfileId}/obligations`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: obligationId, community_id: value }),
+      });
+      if (!res.ok) throw new Error(((await res.json()) as { error?: string }).error || 'failed');
+      setEditing(false);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className={label}>Community</span>
+      {editing ? (
+        <>
+          <select
+            className="border-2 border-bauhaus-black bg-white px-2 py-1.5 text-xs"
+            defaultValue={communityId ?? ''}
+            disabled={busy}
+            onChange={(e) => set(e.target.value || null)}
+          >
+            <option value="">— none —</option>
+            {communities.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+          <button type="button" className="text-xs font-bold underline" onClick={() => setEditing(false)}>cancel</button>
+        </>
+      ) : communityName ? (
+        <>
+          <a href={`/org/${orgSlug}/communities/${communitySlug}`} className="border-2 border-bauhaus-black px-2 py-0.5 text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-yellow/40">
+            {communityName}
+          </a>
+          {!readOnly && (
+            <button type="button" className="text-xs font-bold underline" onClick={() => setEditing(true)}>change</button>
+          )}
+        </>
+      ) : !readOnly ? (
+        <button type="button" className="text-xs font-bold underline" onClick={() => setEditing(true)}>+ tag a community</button>
+      ) : (
+        <span className="text-xs text-neutral-500">—</span>
+      )}
+      {error && <span className="text-xs font-bold text-bauhaus-red">{error}</span>}
+    </div>
+  );
+}
+
+export function MintObligationForm({ orgProfileId, projectCode, communities }: { orgProfileId: string; projectCode: string; communities: CommunityOption[] }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [form, setForm] = useState({ title: '', owed_to: 'community', due_date: '', next_action: '', promised_to: '', owner: '' });
+  const [form, setForm] = useState({ title: '', owed_to: 'community', due_date: '', next_action: '', promised_to: '', owner: '', community_id: '' });
 
   async function submit() {
     setBusy(true);
@@ -93,10 +166,11 @@ export function MintObligationForm({ orgProfileId, projectCode }: { orgProfileId
           next_action: form.next_action || undefined,
           promised_to: form.promised_to || undefined,
           owner: form.owner || undefined,
+          community_id: form.community_id || undefined,
         }),
       });
       if (!res.ok) throw new Error(((await res.json()) as { error?: string }).error || 'failed');
-      setForm({ title: '', owed_to: 'community', due_date: '', next_action: '', promised_to: '', owner: '' });
+      setForm({ title: '', owed_to: 'community', due_date: '', next_action: '', promised_to: '', owner: '', community_id: '' });
       setOpen(false);
       router.refresh();
     } catch (e) {
@@ -134,9 +208,18 @@ export function MintObligationForm({ orgProfileId, projectCode }: { orgProfileId
           <input type="date" className={field} value={form.due_date} onChange={(e) => setForm({ ...form, due_date: e.target.value })} />
         </div>
       </div>
-      <div>
-        <span className={label}>Promised to (optional)</span>
-        <input className={field} value={form.promised_to} onChange={(e) => setForm({ ...form, promised_to: e.target.value })} placeholder="Who did we promise?" />
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <span className={label}>Promised to (optional)</span>
+          <input className={field} value={form.promised_to} onChange={(e) => setForm({ ...form, promised_to: e.target.value })} placeholder="Who did we promise?" />
+        </div>
+        <div>
+          <span className={label}>Community (optional)</span>
+          <select className={field} value={form.community_id} onChange={(e) => setForm({ ...form, community_id: e.target.value })}>
+            <option value="">— none —</option>
+            {communities.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+        </div>
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>

--- a/apps/web/src/lib/services/act-obligations.ts
+++ b/apps/web/src/lib/services/act-obligations.ts
@@ -25,6 +25,10 @@ export type Obligation = {
   dropReason: string | null;
   mintedAt: string;
   dischargedAt: string | null;
+  /** Community this is owed to/tagged with (ADR 0004) — null = untagged. */
+  communityId: string | null;
+  communityName: string | null;
+  communitySlug: string | null;
 };
 
 export type ObligationPool = {
@@ -51,6 +55,8 @@ type Row = {
   drop_reason: string | null;
   minted_at: string;
   discharged_at: string | null;
+  community_id?: string | null;
+  act_communities?: { name: string; slug: string } | null;
 };
 
 function dueDays(iso: string | null): number | null {
@@ -78,6 +84,9 @@ function fromRow(r: Row): Obligation {
     dropReason: r.drop_reason,
     mintedAt: r.minted_at,
     dischargedAt: r.discharged_at,
+    communityId: r.community_id ?? null,
+    communityName: r.act_communities?.name ?? null,
+    communitySlug: r.act_communities?.slug ?? null,
   };
 }
 
@@ -86,7 +95,7 @@ export async function getObligationPool(orgProfileId: string, projectCode: strin
   const db = getServiceSupabase();
   const { data, error } = await db
     .from('act_obligations')
-    .select('*')
+    .select('*, act_communities(name, slug)')
     .eq('org_profile_id', orgProfileId)
     .eq('project_code', projectCode)
     .order('minted_at', { ascending: false });


### PR DESCRIPTION
PR #165 shipped the Community record pages and the \`act_obligations.community_id\` column (live in prod, 3 communities seeded). This adds the missing write path — until now nothing could actually tag an Obligation with a Community, so the community page's "What we owe" pane could never fill.

## What's here
- **Service**: \`getObligationPool\` joins \`act_communities\` — Obligations carry \`communityId/Name/Slug\`.
- **API**: \`community_id\` accepted on mint (POST) and edit (PATCH); \`null\` untags; the FK rejects unknown ids.
- **We-owe UI** (Bauhaus, matching the tab):
  - Community select in the "+ We owe something" mint form (optional, defaults to none).
  - Community chip on list rows.
  - Detail pane picker: \`+ tag a community\` / change / clear; the tag links to \`/org/act/communities/[slug]\`.
- Per the #159 spec, owed-to-community Obligations are the primary case but **any** Obligation can carry the tag.

No migration — the column and tables already exist in prod. Composes with #165 (read side) and feeds the triage sitting: when Ben mints obligations for the 11 live Wons, they can be community-tagged at mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)