### PR TITLE
feat(asks): artefact_url annotation — Notion draft linked to its GHL Ask (#162)

### DIFF
--- a/.claude/skills/make-the-ask/SKILL.md
+++ b/.claude/skills/make-the-ask/SKILL.md
@@ -68,6 +68,18 @@ become the other. Reference run: "Ask — Balnaves Foundation — 2026-08". The
 repo copy under `thoughts/shared/drafts/` is working scratch; Notion is where
 production lives once the draft survives grounding.
 
+**Final parking step — link the artefact to its Ask (wayfinder #162).** If the
+Ask is already a GHL card, record the Notion page URL against it so the desk
+can show "Open draft in Notion ↗":
+
+```bash
+node --env-file=.env scripts/set-ask-artefact.mjs <ghl_opportunity_id> <notion_page_url> --name "Ask — [Funder] — [YYYY-MM]"
+```
+
+Supabase-side annotation only (`act_ask_artefacts`), never a GHL field. If the
+Ask is still a Signal (no GHL card yet), skip this — run it once the card
+exists.
+
 ### 7. Set the next action (GHL)
 The Ask's state lives in GHL. If it's already a card: update next action to
 "review + submit EOI" with Ben as owner (Tier 2: one-line confirm first). If

--- a/apps/web/src/lib/services/act-ask-artefacts.ts
+++ b/apps/web/src/lib/services/act-ask-artefacts.ts
@@ -1,0 +1,51 @@
+// Ask artefact links — the Notion-page URL annotation on a GHL Ask
+// (wayfinder #162, docs/specs/grants-notion-handoff-spec.md). Supabase-side
+// only, keyed on the GHL opportunity id; /make-the-ask writes it via
+// scripts/set-ask-artefact.mjs when it parks the page. An Ask with no row is
+// normal — never treat absence as a mismatch.
+import { getServiceSupabase } from '@/lib/supabase';
+
+export type AskArtefact = {
+  ghlOpportunityId: string;
+  orgProfileId: string;
+  artefactUrl: string;
+  askName: string | null;
+  setBy: string | null;
+  setAt: string;
+};
+
+type Row = {
+  ghl_opportunity_id: string;
+  org_profile_id: string;
+  artefact_url: string;
+  ask_name: string | null;
+  set_by: string | null;
+  set_at: string;
+};
+
+function fromRow(r: Row): AskArtefact {
+  return {
+    ghlOpportunityId: r.ghl_opportunity_id,
+    orgProfileId: r.org_profile_id,
+    artefactUrl: r.artefact_url,
+    askName: r.ask_name,
+    setBy: r.set_by,
+    setAt: r.set_at,
+  };
+}
+
+/** Artefact URLs for a set of Asks, keyed by GHL opportunity id. */
+export async function getAskArtefacts(
+  orgProfileId: string,
+  ghlOpportunityIds: string[]
+): Promise<Map<string, AskArtefact>> {
+  if (ghlOpportunityIds.length === 0) return new Map();
+  const db = getServiceSupabase();
+  const { data, error } = await db
+    .from('act_ask_artefacts')
+    .select('*')
+    .eq('org_profile_id', orgProfileId)
+    .in('ghl_opportunity_id', ghlOpportunityIds);
+  if (error) throw new Error(`act_ask_artefacts read failed: ${error.message}`);
+  return new Map(((data ?? []) as Row[]).map((r) => [r.ghl_opportunity_id, fromRow(r)]));
+}

--- a/scripts/set-ask-artefact.mjs
+++ b/scripts/set-ask-artefact.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * set-ask-artefact — link a parked Notion artefact to its GHL Ask
+ * (wayfinder #162). The /make-the-ask skill's final parking step.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/set-ask-artefact.mjs <ghl_opportunity_id> <notion_url> [--name "Ask — Funder — YYYY-MM"]
+ *   node --env-file=.env scripts/set-ask-artefact.mjs <ghl_opportunity_id> --clear
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const ACT_ORG_PROFILE_ID = '8b6160a1-7eea-4bd2-8404-71c196381de0';
+
+const args = process.argv.slice(2);
+const [oppId, url] = args;
+const clear = args.includes('--clear');
+const nameIdx = args.indexOf('--name');
+const askName = nameIdx >= 0 ? args[nameIdx + 1] : null;
+
+if (!oppId || (!clear && !/^https:\/\//.test(url ?? ''))) {
+  console.error('usage: set-ask-artefact.mjs <ghl_opportunity_id> <https-url> [--name "..."] | <ghl_opportunity_id> --clear');
+  process.exit(1);
+}
+
+const db = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+if (clear) {
+  const { error } = await db.from('act_ask_artefacts').delete().eq('ghl_opportunity_id', oppId);
+  if (error) { console.error(`clear failed: ${error.message}`); process.exit(1); }
+  console.log(`cleared artefact link for ${oppId}`);
+} else {
+  const { error } = await db.from('act_ask_artefacts').upsert({
+    ghl_opportunity_id: oppId,
+    org_profile_id: ACT_ORG_PROFILE_ID,
+    artefact_url: url,
+    ask_name: askName,
+    set_by: 'make-the-ask',
+    set_at: new Date().toISOString(),
+  });
+  if (error) { console.error(`upsert failed: ${error.message}`); process.exit(1); }
+  console.log(`linked ${oppId} → ${url}`);
+}

--- a/supabase/migrations/20260807090000_act_ask_artefacts.sql
+++ b/supabase/migrations/20260807090000_act_ask_artefacts.sql
@@ -1,0 +1,24 @@
+-- Ask artefact links (wayfinder #162, docs/specs/grants-notion-handoff-spec.md):
+-- the one new piece of state closing the desk → GHL → Notion loop. Keyed on
+-- the GHL opportunity id (ADR 0001: Asks live in GHL); Supabase-side only,
+-- never a GHL field. /make-the-ask sets it when it parks the Notion page.
+-- Absence is NOT a mismatch — plenty of Asks need no document.
+
+create table if not exists act_ask_artefacts (
+  ghl_opportunity_id text primary key,
+  org_profile_id uuid not null references org_profiles(id),
+  artefact_url text not null,
+  ask_name text,
+  set_by text,
+  set_at timestamptz not null default now()
+);
+
+create index if not exists act_ask_artefacts_org_idx
+  on act_ask_artefacts (org_profile_id);
+
+alter table act_ask_artefacts enable row level security;
+-- No anon/authenticated policies: service-role only, same posture as act_people.
+
+-- psql-created tables don't inherit Supabase default grants (2026-08-06 gotcha);
+-- without this the service-role client silently reads an empty table.
+grant all on act_ask_artefacts to service_role;


### PR DESCRIPTION
Closes the desk → GHL → Notion loop from the grants→Notion handoff spec (wayfinder #162, `docs/specs/grants-notion-handoff-spec.md`).

## What
- **`act_ask_artefacts`** migration — one row per Ask that has a parked Notion draft, keyed on the GHL opportunity id. Service-role-only RLS posture, explicit `GRANT ... TO service_role` (the psql-created-table gotcha). Supabase-side annotation only, never a GHL field.
- **`act-ask-artefacts.ts`** service — batch read keyed by opportunity ids, ready for the desk Ask detail pane's "Open draft in Notion ↗" once PR #164 lands (small follow-up, kept off this PR to avoid branch conflicts).
- **`scripts/set-ask-artefact.mjs`** — the `/make-the-ask` final parking step (upsert + `--clear`); skill step 6 updated to run it after parking the page.

## Deliberate non-rule
An Ask at "In conversation" or beyond with no artefact_url is NOT a mismatch — no nag path exists in that direction. Only the forward link (parked page → URL set) is enforced.

## Not yet done
- Migration not applied to prod (Tier 3 — nothing reads the table until this ships, order flexible)
- Desk pane link — follow-up after #164 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)