### PR TITLE
Unstarve the ACT money surface: 18 → ~1,535 opportunities, 11 working project pages

### DIFF
--- a/apps/web/src/app/org/[slug]/[projectSlug]/funding/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/funding/page.tsx
@@ -1,15 +1,99 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getProjectFundingPortfolio } from '@/lib/services/project-funding-service';
+import { getProjectApplyNow, type ApplyNowCandidate } from '@/lib/services/act-project-apply-now';
 
 export const dynamic = 'force-dynamic';
 
+function money(value: number | null): string {
+  return value == null
+    ? 'Amount not published'
+    : new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: 0 }).format(value);
+}
+
+/** The five factors behind the score, shown so the number can be argued with. */
+function FactorBar({ candidate }: { candidate: ApplyNowCandidate }) {
+  const factors = candidate.factors.filter((f) => f.score != null);
+  if (factors.length === 0) return null;
+  return (
+    <div className="mt-3 flex flex-wrap gap-1.5 font-mono text-[10px] text-[#475569]">
+      {factors.map((f) => (
+        <span key={f.label} className="rounded bg-[#f1f5f9] px-2 py-1">
+          {f.label} {f.score}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function CandidateCard({ candidate }: { candidate: ApplyNowCandidate }) {
+  return (
+    <article className="rounded-xl border border-[#dbe4df] bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        {candidate.isStrongFit ? (
+          <span className="rounded-full bg-[#dcfce7] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#166534]">Strong fit</span>
+        ) : null}
+        {candidate.wonFunder ? (
+          <span className="rounded-full bg-[#eff6ff] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#2563eb]">We have won from this funder</span>
+        ) : null}
+        {candidate.feedStatus === 'rolling' ? (
+          <span className="rounded-full bg-[#f1f5f9] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#475569]">Rolling — no deadline</span>
+        ) : null}
+      </div>
+      <h3 className="mt-3 text-lg font-black">{candidate.name}</h3>
+      <p className="mt-1 text-sm text-[#64748b]">
+        {candidate.funderName || 'Funder not recorded'}
+        {candidate.fitScore != null ? ` · fit ${candidate.fitScore}/100` : ''}
+      </p>
+      <FactorBar candidate={candidate} />
+      <dl className="mt-4 grid gap-3 border-t border-[#e2e8f0] pt-4 text-sm sm:grid-cols-3">
+        <div>
+          <dt className="text-xs text-[#64748b]">Closes</dt>
+          <dd className="mt-1 font-black">
+            {candidate.deadline
+              ? new Date(candidate.deadline).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' })
+              : 'Open ongoing'}
+          </dd>
+          {candidate.daysRemaining != null ? (
+            <dd className={`text-xs ${candidate.daysRemaining <= 14 ? 'text-[#b91c1c]' : 'text-[#1f734f]'}`}>
+              {candidate.daysRemaining} days remaining
+            </dd>
+          ) : null}
+        </div>
+        <div>
+          <dt className="text-xs text-[#64748b]">Maximum</dt>
+          <dd className="mt-1 font-black">{money(candidate.maxAmount)}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-[#64748b]">Last verified</dt>
+          <dd className="mt-1 font-black">
+            {candidate.verifiedAt ? new Date(candidate.verifiedAt).toLocaleDateString('en-AU', { day: 'numeric', month: 'short' }) : 'Not recorded'}
+          </dd>
+        </div>
+      </dl>
+      {candidate.flags.length > 0 ? (
+        <p className="mt-3 rounded-lg bg-[#fff7ed] p-3 text-xs leading-5 text-[#9a3412]">{candidate.flags.join(' · ')}</p>
+      ) : null}
+      <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold">
+        {candidate.applicationUrl ? (
+          <a href={candidate.applicationUrl} target="_blank" rel="noreferrer" className="min-h-11 rounded-lg bg-[#183426] px-3 py-3 text-white hover:bg-[#2f8f64]">Apply ↗</a>
+        ) : null}
+        {candidate.sourceUrl ? (
+          <a href={candidate.sourceUrl} target="_blank" rel="noreferrer" className="min-h-11 rounded-lg border border-[#cbd5e1] px-3 py-3 hover:border-[#2f8f64]">Official source ↗</a>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
 export default async function FundingProfilePage({ params }: { params: Promise<{ slug: string; projectSlug: string }> }) {
   const { slug, projectSlug } = await params;
-  const portfolio = await getProjectFundingPortfolio(slug);
+  const [portfolio, applyNow] = await Promise.all([
+    getProjectFundingPortfolio(slug),
+    getProjectApplyNow(projectSlug).catch(() => null),
+  ]);
   const profile = portfolio?.profiles.find(item => item.projectSlug === projectSlug);
   if (!portfolio || !profile) notFound();
-  const queue = portfolio.weeklyQueue.filter(item => item.projectCode === profile.projectCode);
 
   return (
     <main className="min-h-screen bg-[#f8fafc] px-5 py-8 text-[#0f172a] lg:px-10">
@@ -30,9 +114,35 @@ export default async function FundingProfilePage({ params }: { params: Promise<{
           {profile.unresolvedDecisions.length === 0 ? <p className="mt-4 rounded-lg bg-[#dcfce7] p-4 text-sm text-[#166534]">No unresolved profile decisions.</p> : null}
         </section>
 
-        <section className="mt-6 rounded-2xl border border-[#dbe4df] bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-black">This week</h2><p className="mt-1 text-sm text-[#64748b]">Portfolio queue opportunities currently assigned to this project.</p>
-          <div className="mt-4 grid gap-3">{queue.map(item => <article key={item.opportunityId} className="rounded-lg border border-[#e2e8f0] p-4"><div className="flex flex-col gap-2 sm:flex-row sm:justify-between"><div><h3 className="font-black">{item.opportunityName}</h3><p className="mt-1 text-sm text-[#64748b]">{item.funderName} · project score {item.recommendationScore ?? item.fitScore}</p></div><span className="text-sm font-bold text-[#1f734f]">{item.daysRemaining} days</span></div><p className="mt-3 text-sm leading-6 text-[#475569]">{item.eligibilityReason}</p>{item.hybridScore != null ? <div className="mt-3 flex flex-wrap gap-2 font-mono text-[10px] text-[#475569]"><span>hybrid {item.hybridScore.toFixed(1)}</span><span>lexical {(item.lexicalScore || 0).toFixed(2)}</span><span>semantic {(item.semanticScore || 0).toFixed(2)}</span></div> : null}</article>)}{queue.length === 0 ? <p className="rounded-lg bg-[#f8fafc] p-4 text-sm text-[#64748b]">No opportunity from this project is in the five-place portfolio queue this week.</p> : null}</div>
+        <section className="mt-6">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-black">Apply now</h2>
+              <p className="mt-1 text-sm text-[#64748b]">
+                Dated rounds for this project, soonest first.
+                {applyNow ? ` ${applyNow.totalConsidered} verified opportunities considered.` : ''}
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3">
+            {applyNow?.dated.map((candidate) => <CandidateCard key={candidate.opportunityId} candidate={candidate} />)}
+            {!applyNow?.dated.length ? (
+              <p className="rounded-lg bg-[#f8fafc] p-4 text-sm text-[#64748b]">
+                No dated round is currently open for this project. Rolling programs below have no deadline and can be approached any time.
+              </p>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-black">Always open</h2>
+          <p className="mt-1 text-sm text-[#64748b]">Rolling programs with no published deadline, ranked by fit rather than urgency.</p>
+          <div className="mt-4 grid gap-3">
+            {applyNow?.rolling.map((candidate) => <CandidateCard key={candidate.opportunityId} candidate={candidate} />)}
+            {!applyNow?.rolling.length ? (
+              <p className="rounded-lg bg-[#f8fafc] p-4 text-sm text-[#64748b]">No rolling programs matched this project yet.</p>
+            ) : null}
+          </div>
         </section>
       </div>
     </main>

--- a/apps/web/src/app/org/[slug]/[projectSlug]/funding/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/funding/page.tsx
@@ -26,12 +26,19 @@ function FactorBar({ candidate }: { candidate: ApplyNowCandidate }) {
   );
 }
 
-function CandidateCard({ candidate }: { candidate: ApplyNowCandidate }) {
+function CandidateCard({ candidate, showBestAvailable }: { candidate: ApplyNowCandidate; showBestAvailable?: boolean }) {
   return (
     <article className="rounded-xl border border-[#dbe4df] bg-white p-5 shadow-sm">
       <div className="flex flex-wrap items-center gap-2">
         {candidate.isStrongFit ? (
           <span className="rounded-full bg-[#dcfce7] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#166534]">Strong fit</span>
+        ) : null}
+        {/* Relative, and labelled as such. "Strong fit" is an absolute claim about
+            the round; this only says it is the best this project has. */}
+        {showBestAvailable && !candidate.isStrongFit && (candidate.projectRank ?? 99) <= 3 ? (
+          <span className="rounded-full bg-[#f1f5f9] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#475569]">
+            Best available · #{candidate.projectRank}
+          </span>
         ) : null}
         {candidate.wonFunder ? (
           <span className="rounded-full bg-[#eff6ff] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#2563eb]">We have won from this funder</span>
@@ -122,10 +129,20 @@ export default async function FundingProfilePage({ params }: { params: Promise<{
                 Dated rounds for this project, soonest first.
                 {applyNow ? ` ${applyNow.totalConsidered} verified opportunities considered.` : ''}
               </p>
+              {/* An absence of highlights reads as "we found nothing", which is not
+                  what it means. Say what it does mean. */}
+              {applyNow?.noStrongFits ? (
+                <p className="mt-3 max-w-3xl rounded-lg bg-[#f1f5f9] p-3 text-xs leading-5 text-[#475569]">
+                  Nothing here clears the portfolio-wide strong-fit bar, so these are ranked
+                  best-available for this project rather than flagged as strong. The rounds are real
+                  and current; they score lower on theme, geography or eligibility than rounds the
+                  bar was set for. Worth reading, worth a judgement call, not worth assuming.
+                </p>
+              ) : null}
             </div>
           </div>
           <div className="mt-4 grid gap-3">
-            {applyNow?.dated.map((candidate) => <CandidateCard key={candidate.opportunityId} candidate={candidate} />)}
+            {applyNow?.dated.map((candidate) => <CandidateCard key={candidate.opportunityId} candidate={candidate} showBestAvailable={applyNow.noStrongFits} />)}
             {!applyNow?.dated.length ? (
               <p className="rounded-lg bg-[#f8fafc] p-4 text-sm text-[#64748b]">
                 No dated round is currently open for this project. Rolling programs below have no deadline and can be approached any time.
@@ -138,7 +155,7 @@ export default async function FundingProfilePage({ params }: { params: Promise<{
           <h2 className="text-xl font-black">Always open</h2>
           <p className="mt-1 text-sm text-[#64748b]">Rolling programs with no published deadline, ranked by fit rather than urgency.</p>
           <div className="mt-4 grid gap-3">
-            {applyNow?.rolling.map((candidate) => <CandidateCard key={candidate.opportunityId} candidate={candidate} />)}
+            {applyNow?.rolling.map((candidate) => <CandidateCard key={candidate.opportunityId} candidate={candidate} showBestAvailable={applyNow.noStrongFits} />)}
             {!applyNow?.rolling.length ? (
               <p className="rounded-lg bg-[#f8fafc] p-4 text-sm text-[#64748b]">No rolling programs matched this project yet.</p>
             ) : null}

--- a/apps/web/src/app/org/[slug]/[projectSlug]/funding/page.tsx
+++ b/apps/web/src/app/org/[slug]/[projectSlug]/funding/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getProjectFundingPortfolio } from '@/lib/services/project-funding-service';
-import { getProjectApplyNow, type ApplyNowCandidate } from '@/lib/services/act-project-apply-now';
+import { getProjectApplyNow, FUNDING_ROUTE_NOTE, type ApplyNowCandidate } from '@/lib/services/act-project-apply-now';
 
 export const dynamic = 'force-dynamic';
 
@@ -113,6 +113,35 @@ export default async function FundingProfilePage({ params }: { params: Promise<{
           </div>
           <dl className="mt-7 grid gap-3 sm:grid-cols-3"><div className="rounded-xl bg-[#f1f8f5] p-4"><dt className="text-xs text-[#64748b]">Applicant entities</dt><dd className="mt-1 text-2xl font-black">{profile.entities}</dd></div><div className="rounded-xl bg-[#eff6ff] p-4"><dt className="text-xs text-[#64748b]">Funding blocks</dt><dd className="mt-1 text-2xl font-black">{profile.fundingBlocks}</dd></div><div className="rounded-xl bg-[#f8fafc] p-4"><dt className="text-xs text-[#64748b]">Geographies</dt><dd className="mt-1 text-2xl font-black">{profile.geographies.length}</dd></div></dl>
         </div>
+
+        {/* Route first. Where grants are not the plan, an empty list below is the
+            expected result — saying so stops it reading as a discovery failure and
+            stops anyone "fixing" it by loosening the matcher. */}
+        {applyNow?.fundingRoute && applyNow.fundingRoute !== 'grants' && applyNow.fundingRoute !== 'mixed' ? (
+          <section className="mt-6 rounded-2xl border border-[#cbd5e1] bg-[#f8fafc] p-6">
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#475569]">
+              How this project is funded · {applyNow.fundingRoute}
+            </p>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-[#334155]">
+              {FUNDING_ROUTE_NOTE[applyNow.fundingRoute as keyof typeof FUNDING_ROUTE_NOTE]}
+            </p>
+          </section>
+        ) : null}
+
+        {/* The recommender's own open question. Better it asks than guesses — a
+            fabricated ranking is what made the last queue untrustworthy. */}
+        {applyNow?.nextQuestion ? (
+          <section className="mt-6 rounded-2xl border border-[#b8d2c5] bg-[#183426] p-6 text-white">
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[#b7e4cc]">
+              Blocking a confident ranking
+            </p>
+            <p className="mt-2 max-w-3xl text-base leading-7">{applyNow.nextQuestion}</p>
+            <p className="mt-3 text-xs leading-5 text-[#dbe9e1]">
+              Until this is answered the ranking below is a best guess on partial information.
+              Answer it in the project registry and the next run will rank on it.
+            </p>
+          </section>
+        ) : null}
 
         <section className="mt-6 rounded-2xl border border-[#dbe4df] bg-white p-6 shadow-sm">
           <h2 className="text-xl font-black">What must be resolved</h2>

--- a/apps/web/src/lib/services/act-one-desk.ts
+++ b/apps/web/src/lib/services/act-one-desk.ts
@@ -2,7 +2,7 @@
 // merged into a single deadline-first ranked queue. Born from the /prototype-one
 // session (2026-08-05): Ben picked the split-desk shape with project and type as
 // filters, never places.
-import { getGoodsFunderScan } from '@/lib/services/goods-funder-scan';
+import { getFunderScan } from '@/lib/services/goods-funder-scan';
 import { getActRelationshipLedger } from '@/lib/services/act-relationship-ledger';
 import { getOrgDailyActionStates, type ActDailyActionStatus } from '@/lib/services/act-daily-actions';
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
@@ -124,7 +124,10 @@ export async function getOneDesk(slug: string): Promise<OneDeskPool> {
 export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {
   const profile = await getOrgProfileBySlug(slug).catch(() => null);
   const [scan, triage, buyers, ledger, obligations, people] = await Promise.all([
-    getGoodsFunderScan().catch(() => null),
+    // Portfolio-wide, not Goods-only (audit 2026-08-07): Goods had 10 high-fit
+    // funders and the only surface, while Empathy Ledger had 99 and PICC 84 with
+    // none. Passing no slug scans every ACT project.
+    getFunderScan().catch(() => null),
     getGoodsGrantsTriage({ scope: 'closing' }).catch(() => null),
     getGoodsBuyerPipeline().catch(() => null),
     profile ? getActRelationshipLedger(slug, profile.id).catch(() => null) : null,
@@ -191,10 +194,15 @@ export async function getOneDeskPool(slug: string): Promise<DeskRecord[]> {
   for (const r of scan?.rows ?? []) {
     if (!r.stage || ['parked', 'declined'].includes(r.stage)) continue;
     const inGhl = r.ghlWarmth !== 'not_in_ghl';
-    if (!inGhl && (r.fitScore ?? 0) < 85) continue;
+    // Grade A only for undecided funders: recorded grants on file. The old gate
+    // was fit >= 85, which admitted 286 rows ranked on placeholder giving values
+    // and is most of why 1,005 matches sat untouched at "saved".
+    if (!inGhl && r.evidenceGrade !== 'A') continue;
     pool.push({
-      id: `f-${r.id}`, kind: 'funder', project: 'Goods', name: r.name,
-      signal: inGhl ? r.ghlWarmth : `fit ${r.fitScore} · not yet an Ask`,
+      id: `f-${r.id}`, kind: 'funder',
+      project: r.projectName ?? 'ACT',
+      name: r.name,
+      signal: inGhl ? r.ghlWarmth : 'recorded grants on file · not yet an Ask',
       next: inGhl ? (r.nextStep || 'Set a next step') : 'Decide: pursue (mint the Ask in GHL) or pass',
       dueDays: null,
       score: r.fitScore ?? 0, amount: null, ghlUrl: ghlContactUrl(r.ghlContactId),

--- a/apps/web/src/lib/services/act-project-apply-now.ts
+++ b/apps/web/src/lib/services/act-project-apply-now.ts
@@ -41,10 +41,31 @@ export interface ApplyNowCandidate {
   flags: string[];
 }
 
+/** How the project is actually funded. Anything but 'grants' means an empty
+ *  grant list is the expected result, not a discovery failure. */
+export type FundingRoute = 'grants' | 'buyers' | 'overhead' | 'earned' | 'mixed';
+
+export const FUNDING_ROUTE_NOTE: Record<Exclude<FundingRoute, 'grants' | 'mixed'>, string> = {
+  buyers:
+    'This project is funded by buyers, not grant rounds — free open registry for everyone, paid evidence and tender tools for buyers. Two candidate grants exist in the whole corpus, so an empty list here is the strategy working, not a gap.',
+  overhead:
+    'This is studio overhead — governance, operating model, cross-cutting infrastructure. Grants rarely fund overhead, and only 20 capacity-building or core-cost rounds exist across the corpus. Expect this list to stay short.',
+  earned:
+    'This project is funded by earned revenue rather than grant rounds. Anything below is opportunistic, not the plan.',
+};
+
 export interface ProjectApplyNow {
   projectSlug: string;
   projectCode: string | null;
   projectLabel: string | null;
+  /** Recorded route; null when the project has no registry row yet. */
+  fundingRoute: FundingRoute | null;
+  /**
+   * The question blocking a confident ranking, written by whoever knows the
+   * project. Surfaced instead of guessing past it — the recommender saying
+   * "I cannot rank these until you answer X" beats a fabricated score.
+   */
+  nextQuestion: string | null;
   dated: ApplyNowCandidate[];
   rolling: ApplyNowCandidate[];
   totalConsidered: number;
@@ -108,18 +129,24 @@ export async function getProjectApplyNow(projectSlug: string): Promise<ProjectAp
 
   const { data: registry } = await db
     .from('act_grant_recommendation_projects')
-    .select('project_code, project_label')
+    .select('project_code, project_label, primary_funding_route, next_question')
     .eq('org_project_id', (project as { id: string }).id)
     .maybeSingle();
+  const reg = registry as {
+    project_code?: string; project_label?: string;
+    primary_funding_route?: FundingRoute; next_question?: string;
+  } | null;
 
   // A project with no registry row simply has no recommendations yet — an empty
   // page is the honest answer, not a 404.
-  const projectCode = (registry as { project_code?: string } | null)?.project_code ?? null;
+  const projectCode = reg?.project_code ?? null;
   if (!projectCode) {
     return {
       projectSlug,
       projectCode: null,
       projectLabel: null,
+      fundingRoute: null,
+      nextQuestion: null,
       dated: [],
       rolling: [],
       totalConsidered: 0,
@@ -147,7 +174,9 @@ export async function getProjectApplyNow(projectSlug: string): Promise<ProjectAp
   return {
     projectSlug,
     projectCode,
-    projectLabel: (registry as { project_label?: string } | null)?.project_label ?? null,
+    projectLabel: reg?.project_label ?? null,
+    fundingRoute: reg?.primary_funding_route ?? null,
+    nextQuestion: reg?.next_question ?? null,
     // Dated rounds rank by urgency — a closing deadline is the actionable signal.
     dated: unique
       .filter((c) => c.feedStatus === 'apply_now')

--- a/apps/web/src/lib/services/act-project-apply-now.ts
+++ b/apps/web/src/lib/services/act-project-apply-now.ts
@@ -28,7 +28,10 @@ export interface ApplyNowCandidate {
   minAmount: number | null;
   maxAmount: number | null;
   fitScore: number | null;
+  /** Absolute claim: this round is a good match on its merits. */
   isStrongFit: boolean;
+  /** Relative position within this project's own list. Never a quality claim. */
+  projectRank: number | null;
   /** The five factors behind the score, so the number is inspectable. */
   factors: { label: string; score: number | null }[];
   sourceUrl: string | null;
@@ -45,6 +48,14 @@ export interface ProjectApplyNow {
   dated: ApplyNowCandidate[];
   rolling: ApplyNowCandidate[];
   totalConsidered: number;
+  /**
+   * True when nothing in this project's list clears the portfolio-wide strong-fit
+   * bar. The list is still real — Contained's Touring and Travel Fund and Visit
+   * Victoria Regional Events ($500K) score 40 against a bar of 55 — so the page
+   * says "best available for this project" rather than showing an unexplained
+   * absence of highlights.
+   */
+  noStrongFits: boolean;
 }
 
 const PER_LANE_LIMIT = 10;
@@ -68,6 +79,7 @@ function toCandidate(r: Record<string, unknown>): ApplyNowCandidate {
     maxAmount: (r.max_grant_amount as number | null) ?? null,
     fitScore: (r.fit_score as number | null) ?? null,
     isStrongFit: Boolean(r.is_strong_fit),
+    projectRank: (r.project_rank as number | null) ?? null,
     factors: [
       { label: 'Theme', score: (r.theme_score as number | null) ?? null },
       { label: 'Geography', score: (r.geography_score as number | null) ?? null },
@@ -111,6 +123,7 @@ export async function getProjectApplyNow(projectSlug: string): Promise<ProjectAp
       dated: [],
       rolling: [],
       totalConsidered: 0,
+      noStrongFits: true,
     };
   }
 
@@ -146,5 +159,6 @@ export async function getProjectApplyNow(projectSlug: string): Promise<ProjectAp
       .sort((a, b) => (b.fitScore ?? 0) - (a.fitScore ?? 0))
       .slice(0, PER_LANE_LIMIT),
     totalConsidered: unique.length,
+    noStrongFits: unique.length > 0 && !unique.some((c) => c.isStrongFit),
   };
 }

--- a/apps/web/src/lib/services/act-project-apply-now.ts
+++ b/apps/web/src/lib/services/act-project-apply-now.ts
@@ -1,0 +1,150 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Per-project "Apply now" — the ten candidates Phase 1 specified for
+ * `/org/act/{project}/funding`.
+ *
+ * The page previously filtered the portfolio-wide five-place queue by project.
+ * With eleven projects and five places, at least six project pages were
+ * structurally guaranteed to render "no opportunity this week", forever. This
+ * reads the project's own ranked list instead.
+ *
+ * Rows come from `act_grant_recommendations_current`, which carries an
+ * explainable five-factor breakdown rather than one opaque score, and now
+ * exposes `feed_status` so dated rounds rank by urgency and rolling programs
+ * rank by fit. Joined through `act_grant_recommendation_projects.org_project_id`
+ * — the canonical link, not the historical `project_code` string.
+ */
+
+export type ApplyNowFeedStatus = 'apply_now' | 'rolling';
+
+export interface ApplyNowCandidate {
+  opportunityId: string;
+  name: string;
+  funderName: string | null;
+  feedStatus: ApplyNowFeedStatus;
+  deadline: string | null;
+  daysRemaining: number | null;
+  minAmount: number | null;
+  maxAmount: number | null;
+  fitScore: number | null;
+  isStrongFit: boolean;
+  /** The five factors behind the score, so the number is inspectable. */
+  factors: { label: string; score: number | null }[];
+  sourceUrl: string | null;
+  applicationUrl: string | null;
+  verifiedAt: string | null;
+  wonFunder: boolean;
+  flags: string[];
+}
+
+export interface ProjectApplyNow {
+  projectSlug: string;
+  projectCode: string | null;
+  projectLabel: string | null;
+  dated: ApplyNowCandidate[];
+  rolling: ApplyNowCandidate[];
+  totalConsidered: number;
+}
+
+const PER_LANE_LIMIT = 10;
+
+function daysUntil(deadline: string | null): number | null {
+  if (!deadline) return null;
+  const ms = new Date(deadline).getTime() - Date.now();
+  return Math.round(ms / 86_400_000);
+}
+
+function toCandidate(r: Record<string, unknown>): ApplyNowCandidate {
+  const deadline = (r.deadline as string | null) ?? null;
+  return {
+    opportunityId: String(r.opportunity_id),
+    name: (r.opportunity_name as string) ?? '(unnamed opportunity)',
+    funderName: (r.funder_name as string | null) ?? null,
+    feedStatus: (r.feed_status as ApplyNowFeedStatus) ?? 'rolling',
+    deadline,
+    daysRemaining: daysUntil(deadline),
+    minAmount: (r.min_grant_amount as number | null) ?? null,
+    maxAmount: (r.max_grant_amount as number | null) ?? null,
+    fitScore: (r.fit_score as number | null) ?? null,
+    isStrongFit: Boolean(r.is_strong_fit),
+    factors: [
+      { label: 'Theme', score: (r.theme_score as number | null) ?? null },
+      { label: 'Geography', score: (r.geography_score as number | null) ?? null },
+      { label: 'Eligibility', score: (r.eligibility_score as number | null) ?? null },
+      { label: 'Timing', score: (r.timing_score as number | null) ?? null },
+      { label: 'Track record', score: (r.track_record_score as number | null) ?? null },
+    ],
+    sourceUrl: (r.source_url as string | null) ?? null,
+    applicationUrl: (r.application_url as string | null) ?? null,
+    verifiedAt: (r.verified_at as string | null) ?? null,
+    wonFunder: Boolean(r.won_funder),
+    flags: (r.flags as string[] | null) ?? [],
+  };
+}
+
+export async function getProjectApplyNow(projectSlug: string): Promise<ProjectApplyNow | null> {
+  const db = getServiceSupabase();
+
+  const { data: project } = await db
+    .from('org_projects')
+    .select('id, slug, org_profiles!inner(slug)')
+    .eq('slug', projectSlug)
+    .eq('org_profiles.slug', 'act')
+    .maybeSingle();
+  if (!project) return null;
+
+  const { data: registry } = await db
+    .from('act_grant_recommendation_projects')
+    .select('project_code, project_label')
+    .eq('org_project_id', (project as { id: string }).id)
+    .maybeSingle();
+
+  // A project with no registry row simply has no recommendations yet — an empty
+  // page is the honest answer, not a 404.
+  const projectCode = (registry as { project_code?: string } | null)?.project_code ?? null;
+  if (!projectCode) {
+    return {
+      projectSlug,
+      projectCode: null,
+      projectLabel: null,
+      dated: [],
+      rolling: [],
+      totalConsidered: 0,
+    };
+  }
+
+  const { data, error } = await db
+    .from('act_grant_recommendations_current')
+    .select('*')
+    .eq('project_code', projectCode)
+    .order('fit_score', { ascending: false, nullsFirst: false })
+    .limit(400);
+  if (error) throw new Error(`apply-now: ${error.message}`);
+
+  const rows = (data ?? []).map(toCandidate);
+  // One opportunity can appear more than once in the source pool; keep the best.
+  const seen = new Map<string, ApplyNowCandidate>();
+  for (const c of rows) {
+    const prior = seen.get(c.opportunityId);
+    if (!prior || (c.fitScore ?? 0) > (prior.fitScore ?? 0)) seen.set(c.opportunityId, c);
+  }
+  const unique = [...seen.values()];
+
+  return {
+    projectSlug,
+    projectCode,
+    projectLabel: (registry as { project_label?: string } | null)?.project_label ?? null,
+    // Dated rounds rank by urgency — a closing deadline is the actionable signal.
+    dated: unique
+      .filter((c) => c.feedStatus === 'apply_now')
+      .sort((a, b) => (a.daysRemaining ?? 1e9) - (b.daysRemaining ?? 1e9))
+      .slice(0, PER_LANE_LIMIT),
+    // Rolling programs have no clock, so fit is the only ordering that means anything.
+    rolling: unique
+      .filter((c) => c.feedStatus === 'rolling')
+      .sort((a, b) => (b.fitScore ?? 0) - (a.fitScore ?? 0))
+      .slice(0, PER_LANE_LIMIT),
+    totalConsidered: unique.length,
+  };
+}

--- a/apps/web/src/lib/services/goods-funder-scan.ts
+++ b/apps/web/src/lib/services/goods-funder-scan.ts
@@ -9,6 +9,10 @@ export type GhlWarmth = 'hot' | 'warm' | 'steady' | 'cooling' | 'cold' | 'not_in
 export interface FunderScanRow {
   id: string;
   name: string;
+  projectSlug: string | null;
+  projectName: string | null;
+  /** A = recorded grants on file · B = DGR or verified giving · C = theme overlap only. */
+  evidenceGrade: 'A' | 'B' | 'C' | null;
   stage: string | null;
   fitScore: number | null;
   fitSummary: string | null;
@@ -58,27 +62,47 @@ export interface FunderScanResult {
 
 const UNWORKED = new Set(['saved', 'parked']);
 
-export async function getGoodsFunderScan(): Promise<FunderScanResult> {
+/**
+ * Funder scan for one ACT project, or the whole portfolio when no slug is given.
+ *
+ * This was pinned to `goods` by a single `.eq()`, which is why Goods owned the
+ * only funder surface while Empathy Ledger (99 high-fit) and PICC (84) had none.
+ * Ordering is by `evidence_grade` first: A = recorded grants on file, B = DGR or
+ * a verified giving figure, C = theme overlap only. `fit_score` is a secondary
+ * sort because it was inflated by placeholder giving values on 85% of the
+ * foundations table (audit 2026-08-07).
+ */
+export async function getFunderScan(projectSlug?: string): Promise<FunderScanResult> {
   const db = getServiceSupabase();
-  const { data, error } = await db
+  let query = db
     .from('org_project_foundations')
-    .select('id, stage, fit_score, fit_summary, next_step, ghl_contact_id, ghl_contact_email, ghl_tags, ghl_synced_at, foundations(name, total_giving_annual), org_projects!inner(slug)')
-    .eq('org_projects.slug', 'goods')
+    .select('id, stage, fit_score, fit_summary, next_step, evidence_grade, ghl_contact_id, ghl_contact_email, ghl_tags, ghl_synced_at, foundations(name, total_giving_annual), org_projects!inner(slug, name)');
+  if (projectSlug) query = query.eq('org_projects.slug', projectSlug);
+  const { data, error } = await query
+    .order('evidence_grade', { ascending: true, nullsFirst: false })
     .order('fit_score', { ascending: false, nullsFirst: false })
     .limit(500);
   if (error) throw new Error(`funder scan: ${error.message}`);
 
   const rows: FunderScanRow[] = (data || []).map((r: Record<string, unknown>) => {
     const f = r.foundations as { name?: string; total_giving_annual?: number } | null;
+    const p = r.org_projects as { slug?: string; name?: string } | null;
     const tags = (r.ghl_tags as string[] | null) || [];
+    // The stored figure is a placeholder on 85% of rows (25,000 / 100,000 /
+    // 500,000). Surface null rather than a number nobody can stand behind.
+    const giving = f?.total_giving_annual ?? null;
+    const PLACEHOLDER_GIVING = new Set([25000, 100000, 500000]);
     return {
       id: r.id as string,
       name: f?.name ?? '(unknown foundation)',
+      projectSlug: p?.slug ?? null,
+      projectName: p?.name ?? null,
+      evidenceGrade: (r.evidence_grade as FunderScanRow['evidenceGrade']) ?? null,
       stage: (r.stage as string | null) ?? null,
       fitScore: (r.fit_score as number | null) ?? null,
       fitSummary: (r.fit_summary as string | null) ?? null,
       nextStep: (r.next_step as string | null) ?? null,
-      givingAnnual: f?.total_giving_annual ?? null,
+      givingAnnual: giving != null && PLACEHOLDER_GIVING.has(giving) ? null : giving,
       ghlWarmth: warmthFromTags(r.ghl_synced_at ? tags : null),
       ghlContactId: (r.ghl_contact_id as string | null) ?? null,
       ghlEmail: (r.ghl_contact_email as string | null) ?? null,
@@ -97,7 +121,14 @@ export async function getGoodsFunderScan(): Promise<FunderScanResult> {
       byWarmth,
       synced: rows.filter((r) => r.ghlSyncedAt).length,
       warmButUnworked: rows.filter((r) => (r.ghlWarmth === 'hot' || r.ghlWarmth === 'warm') && (!r.stage || UNWORKED.has(r.stage))),
-      hotButUnpushed: rows.filter((r) => r.ghlWarmth === 'not_in_ghl' && (r.fitScore ?? 0) >= 85),
+      // Was `fitScore >= 85`, which surfaced 286 rows ranked on placeholder money.
+      // Evidence grade A means recorded grants on file — provable, not inferred.
+      hotButUnpushed: rows.filter((r) => r.ghlWarmth === 'not_in_ghl' && r.evidenceGrade === 'A'),
     },
   };
+}
+
+/** Goods-scoped view, kept for the Goods funder-scan page. */
+export function getGoodsFunderScan(): Promise<FunderScanResult> {
+  return getFunderScan('goods');
 }

--- a/docs/strategy/act-money-surface-audit-2026-08-07.md
+++ b/docs/strategy/act-money-surface-audit-2026-08-07.md
@@ -288,3 +288,52 @@ which is a billing action, not a code one.
 **The one open action: the Anthropic API key is out of credit.** No new opportunity can
 reach `open_grant` until it is topped up, so 344 is a ceiling rather than a floor.
 5,436 rows are backlogged; roughly $0.55 of Haiku clears them.
+
+---
+
+## Final state (2026-08-07, end of session)
+
+The classifier backlog is cleared and the feed is rebuilt.
+
+| | morning | now |
+|---|---|---|
+| Opportunities the ACT engine can see | 18 | **1,535** |
+| Feed status | 34 apply_now · 662 quarantined | **387 apply_now · 1,572 rolling** · 633 quarantined |
+| Unclassified backlog | 5,436 (dead classifier) | **23** |
+| Strong fits, portfolio-wide | 7 | **63** |
+| Projects with a working funding page | 0 | 11 |
+
+2,662 rows classified in 66 minutes on Gemini 2.5 Flash's free tier at no cost —
+1,193 open_grant, 830 award, 373 invitation_only, 165 policy_framework,
+80 partnership, 21 placeholder. 23 errors, 25 held below the confidence threshold.
+
+Strong fits fell from 185 to 63 on purpose. The old flag fired at `fit_score >= 55`,
+which did not discriminate — a $1,000 computer grant and a $1M Paul Ramsay round
+scored identically. The bar now also requires a geography signal, a grant of
+$50,000 or more, or a funder ACT has won from before.
+
+PICC's list is the test case worth reading: Building Early Education Fund's ACCO
+grant opportunity ($3M), Paul Ramsay First Nations Targeted Round ($500K), Just
+Futures ($1M, fit 78), Yadha Muru City-Country Partnerships ($6.7M). Those are
+the right rounds for a Palm Island Aboriginal community organisation.
+
+### Two defects remain, both visible in that list
+
+**Near-duplicate programs survive dedup.** Paul Ramsay's Just Futures appears
+three times under three names — "Just Futures", "Just Futures (New Open Grant
+Round to Help Prevent Contact with the Justice System)", "Just Futures: National
+Open Grant Round". Dedup keys on exact (name, funder); these need fuzzy matching
+on the funder plus a name stem.
+
+**Geography still leaks.** Victorian and NSW-only programs reach PICC, a
+Queensland organisation — the Aboriginal Justice Agreement Bail and Remand
+program, Environmental Restoration NSW, Geelong Community Foundation. The
+`geography_score` exists but only adds points; it never excludes.
+
+### Open, unchanged
+
+- Four projects still have zero strong fits: Gold.Phone, CivicGraph, Contained,
+  ACT Core. Their theme keywords are thin, which is a content problem, not a
+  pipeline one.
+- `project_funding_profiles.next_question` remains unwired.
+- `/org/act/funding` still has no inbound links.

--- a/docs/strategy/act-money-surface-audit-2026-08-07.md
+++ b/docs/strategy/act-money-surface-audit-2026-08-07.md
@@ -1,0 +1,233 @@
+# ACT money surface — audit against Phase 1
+
+**Status:** audit · **Date:** 7 August 2026 · **Audits:** `phase-1-project-funding-operating-system.md` (3 Aug 2026)
+
+Not a new plan. Phase 1 already decided the right thing four days ago: open ACT, pick any project,
+get a small list of verified, actionable funding routes. This is the measurement of what shipped,
+what didn't, and the one data defect that will make Phase 1 fail even when fully built.
+
+Scope note: this is ACT's internal money surface, not the SE registry product. `buyer-wedge.md`
+does not gate it.
+
+Every figure below was queried directly against `tednluwflfhxyucgwigh` on 2026-08-07.
+
+---
+
+## The finding
+
+Finding grants is not the problem. There are five parallel discovery engines, one project wired to
+them, and a ranking built on invented money.
+
+### The measured inversion
+
+| Project | Funders ≥85 fit | In GHL | Ever touched | Pipeline rows | Last pipeline touch |
+|---|---|---|---|---|---|
+| Empathy Ledger | 99 | 0 | 1 | 4 | 2026-07-31 |
+| PICC | 84 | 0 | 0 | 8 | 2026-07-31 |
+| Farm | 44 | 0 | 0 | 32 | 2026-05-31 |
+| JusticeHub | 43 | 0 | 2 | 6 | 2026-07-31 |
+| Goods | **10** | **17** | **3** | 22 | 2026-08-01 |
+| Harvest | 6 | 0 | 0 | 14 | 2026-05-22 |
+| ALMA, CivicGraph, Contained, Elders Room, Station Precinct | 0 | 0 | 0 | 0 | never |
+
+**The project with the fewest high-fit funders owns the entire apparatus.** Goods has 10 high-fit
+funders and all 17 GHL contacts. Empathy Ledger and PICC have 183 between them and no surface at all.
+
+Five of eleven projects are invisible to the money machine entirely.
+
+### Where the Goods monopoly is written
+
+Three places, all small:
+
+- `apps/web/src/lib/services/act-one-desk.ts` — lines 179, 196, 212, 224 hardcode
+  `project: 'Goods'` on every money kind (`money`, `funder`, `grant`, `buyer`).
+- `apps/web/src/lib/services/goods-funder-scan.ts:66` — `.eq('org_projects.slug', 'goods')`.
+  One line. The service is otherwise general.
+- `act-workspace-shell.tsx:311` — the rail's "Money in" tree (Foundations · Funder Scan · Grants ·
+  Money) exists only inside `GOODS_RAIL_SECTIONS`.
+
+`goods_relevance_score` is a per-project column on the shared `grant_opportunities` table. It cannot
+scale past one project without eleven columns.
+
+---
+
+## Why the queue is ignored
+
+1,005 of 1,063 foundation matches sit at `saved`, untouched. This is not laziness. The queue is
+untrustworthy, and that judgment is correct.
+
+Of the 286 matches scoring ≥85:
+
+- **276 carry the identical template summary** `[auto-matched] themes: … · home-state funder ·
+  gives ~$500,000/yr`.
+- **The giving figures are placeholders.** `foundations.total_giving_annual` behind those matches
+  clusters on three round values — 500,000 (×48), 25,000 (×44), 100,000 (×23), null (×8) — with
+  exactly **two** real computed figures in the set. The fit summary then reprints the placeholder
+  as justification.
+- **Only 10 distinct fit_score values across 286 rows.** That is a bucket, not a ranking.
+- **Duplicate funders count as separate matches.** WCCT Southern / Northern / Central Sub-Regional
+  Trust plus Western Cape Communities Trust — one funder, four rows, all scored 100.
+- **Category errors.** Bravehearts Foundation — a program-delivering child-protection charity, not a
+  grantmaker — is matched to Empathy Ledger at fit 100.
+- **1,063 of 1,063 have a "why". 19 have a next step. 11 have a next touch date.**
+
+The engine explains why it matched and never says what to do, and the money it ranks on is invented.
+
+This is the failure mode already recorded in memory as `feedback_data_quality_before_scoring`:
+math on bad data dresses up noise as signal.
+
+---
+
+## Phase 1: what shipped
+
+### The two registries diverged — the plan's explicit prohibition
+
+> "The recommendation registry must reference canonical project IDs rather than acting as a second
+> project registry." — Phase 1
+
+It is acting as a second project registry.
+
+| | Codes |
+|---|---|
+| `org_projects` | ACT-EL, ACT-FM, ACT-GD, ACT-HV, ACT-JH, ACT-JH-AL, ACT-JH-CG, ACT-JH-CT, ACT-PI, ACT-PI-ER, ACT-PI-SP |
+| `act_grant_recommendations_current` | ACT-EL, ACT-FM, ACT-GD, ACT-HV, ACT-JH, ACT-PI, ACT-CORE, ACT-CS, ACT-GP, ACT-CN, ACT-MY |
+| **Overlap** | 6 |
+
+Consequences:
+
+- **90 recommendations (5 codes × 18) are recomputed daily and can never reach a project page** —
+  ACT-CORE, ACT-CS, ACT-GP (Gold.Phone), ACT-CN, ACT-MY (Mounty Yarns) have no `org_projects` row.
+- **5 real projects get nothing** — alma, civicgraph, contained, elders-room, station-precinct have
+  no recommendations.
+- **The same project has two codes.** Contained is ACT-CN and ACT-JH-CT. CivicGraph is ACT-CS and
+  ACT-JH-CG.
+
+### The per-project funding page is a stub with a structural guarantee of emptiness
+
+`/org/act/{project}/funding` is 40 lines. Phase 1 committed five sections; two shipped
+(unresolved decisions, this-week queue). Missing: Funding need, Apply now, Source health.
+
+Worse, "this week" filters the **portfolio-wide five-place queue** by project
+(`project-funding-service.ts:120,179` — `limit = 5`). Five places across eleven projects means **at
+least six project funding pages permanently render "No opportunity from this project is in the
+five-place portfolio queue this week."**
+
+Phase 1 specified a per-project **Apply now: maximum ten verified candidates**. That was never
+built. The page shows a filtered portfolio queue instead of its own list.
+
+### Orphaned surfaces
+
+- `/org/act/funding` — the portfolio desk. **Zero inbound links anywhere in the codebase.**
+- `/org/act/pipeline` — 125 rows, not on the rail.
+- `/ops/grant-recommendations` — the only surface for the 11-project engine. Linked from `/home`,
+  global `nav.tsx` and `/reports/grant-frontier` — **the CivicGraph ops side. Zero links from the
+  ACT rail.** The multi-project engine's UI lives outside the workspace Ben works in.
+
+The rail comment at `act-workspace-shell.tsx:93-97` records the 2026-08-05 decision that Money,
+Funding and Pipeline left the rail and "stay reachable by URL". In practice that means unreachable.
+
+---
+
+## The substrate is better than the surface
+
+Worth stating plainly, because it changes what the work is:
+
+- **100% embedding coverage** — 25,872 of 25,879 grants, all 4,463 open ones, refreshed today.
+  Semantic matching infrastructure is built and current.
+- **`act_grant_recommendations_current` is the right engine.** Eleven project codes, recomputed
+  today, and a genuinely explainable model: `theme_score`, `geography_score`, `eligibility_score`,
+  `timing_score`, `track_record_score`, `won_funder`, `verification_status`, `tag_density_penalised`.
+  Far better than `goods_relevance_score`'s single number.
+- **A real track record exists.** 89 recorded decisions: 62 passed, 26 won, 1 watching — wins
+  spanning 2025-02 to 2026-05 across 9 project codes. `track_record_score` already consumes it.
+- **`project_funding_profiles` has all 11 projects** and an unused `next_question` column.
+
+What is missing is not intelligence. It is trust and routing.
+
+### The number that should be on the wall
+
+**348.** That is how many grants close in the next 60 days across the entire open pool of 4,463.
+Across eleven projects, roughly 32 each. A human-sized queue.
+
+Every surface currently shows 25,879 and makes Ben do the narrowing.
+
+---
+
+## What trycompai/crm actually gives us
+
+The reference is unusually on-point for this specific failure. Four moves to take, one to refuse.
+
+**1. "Nothing about a person is guessed." Tools report observations, never confidence scores.**
+> "No tool accepts a confidence score, because a model asked to grade its own certainty will, and
+> it will be wrong."
+
+`fit_score` is a model grading its own certainty, and it is wrong — 286 rows at ≥85 with two real
+giving figures between them. Replace the number with named observations: *"ACNC AIS lists $X to Y
+purposes in FY24"*, *"has funded 3 orgs in your LGA"*, *"DGR Item 1 — Butterfly can receipt"*.
+A row either carries evidence or it does not appear.
+
+**2. Strong evidence updates records; weak evidence becomes a human-reviewed suggestion.**
+The 1,005 `saved` rows are weak signals wrongly written as records. Demote them to a suggestions
+tray that costs nothing to ignore. Promote only rows with a verified giving figure and verified
+grantmaker status.
+
+**3. `schedule_recheck` — the agent books its own follow-up, visibly.**
+19 next steps and 11 next-touch dates across 1,063 rows is the whole gap. Every promoted row should
+arrive with a dated next move already on it.
+
+**4. The Agent tab: reasoning, discarded leads, and unanswered questions.**
+"Unanswered questions" is the missing primitive. The recommender should be able to say *"I cannot
+rank Empathy Ledger funders until you tell me whether it can receipt through Butterfly"* instead of
+emitting 99 confidently wrong matches. `project_funding_profiles.next_question` already exists for
+this and is unused in the flow.
+
+**Refuse: the autonomous always-on agent daemon.** ACT's problem is not suggestion throughput —
+suggestions already outnumber decisions 1,005 to 13. More autonomous generation makes it worse.
+Take the epistemics, leave the daemon.
+
+---
+
+## Order of work
+
+Sequenced by money unlocked per unit of effort. **Step 2 must land before step 3**, or step 3
+industrialises the noise.
+
+**1. Reconcile the two project registries.** Make `act_grant_recommendations_current` join on
+canonical `org_projects.id`. Resolve the duplicate codes (Contained: ACT-CN vs ACT-JH-CT;
+CivicGraph: ACT-CS vs ACT-JH-CG). Decide whether Gold.Phone, Mounty Yarns and ACT Core become
+`org_projects` rows or are dropped. Unstrands 90 daily recommendations. Cheapest fix here.
+
+**2. Gate on verified money before anything reaches a desk.** A funder may not be promoted unless:
+its giving figure traces to a real ACNC/AIS filing (not 500,000 / 25,000 / 100,000); it is a
+grantmaker, not a program charity; and it is not a duplicate trust of a funder already listed.
+On today's data this cuts 286 to a double-digit number. **That is the correct outcome** — ten
+funders Ben believes beat 286 he does not.
+
+**3. Delete the Goods hardcode.** Four literals in `act-one-desk.ts`, one `.eq()` in
+`goods-funder-scan.ts`, and lift "Money in" out of `GOODS_RAIL_SECTIONS`. Once step 2 has cleaned
+the pool, this exposes Empathy Ledger's and PICC's funders to the desk Ben already uses every day.
+
+**4. Build the per-project "Apply now" ten.** Replace the filtered portfolio-five on
+`/org/act/{project}/funding` with the project's own ranked ten, from
+`act_grant_recommendations_current`. Removes the guaranteed-empty page for six projects.
+
+**5. Retire the losers.** `goods_relevance_score` (cannot scale past one project). Either put
+`/org/act/funding` on the rail or delete it — a zero-inbound-link page is not a surface. Bring
+`/ops/grant-recommendations` into the ACT workspace or link it from the rail.
+
+**6. Give the recommender a mouth.** Wire `project_funding_profiles.next_question` so unresolvable
+eligibility (DGR route? which entity? auspice via Butterfly?) surfaces as a question to Ben rather
+than a fabricated match.
+
+**7. Decide the five dark projects.** ALMA, CivicGraph, Contained, Elders Room and Station Precinct
+have no profile, no funders, no pipeline. Give each a funding profile, or mark them explicitly
+not-fundraising so the portfolio view stops implying coverage it does not have.
+
+---
+
+## Provenance
+
+All figures queried 2026-08-07 against project `tednluwflfhxyucgwigh` via `scripts/gsql.mjs`.
+Tables: `org_projects`, `org_profiles`, `org_project_foundations`, `org_pipeline`, `foundations`,
+`grant_opportunities`, `act_grant_recommendations_current`, `act_grant_recommendation_decisions`,
+`project_funding_profiles`. Code claims verified by reading the named files and line numbers.

--- a/docs/strategy/act-money-surface-audit-2026-08-07.md
+++ b/docs/strategy/act-money-surface-audit-2026-08-07.md
@@ -13,6 +13,41 @@ Every figure below was queried directly against `tednluwflfhxyucgwigh` on 2026-0
 
 ---
 
+## Progress (same day)
+
+Two commits landed on `fix/act-grant-feed-status-filter`. The grants half of the diagnosis below
+is largely addressed; the philanthropy/foundations half and the registry split are not.
+
+| | before | after |
+|---|---|---|
+| Opportunities the ACT engine can see | 18 | **344** |
+| Feed status | 34 apply_now · 662 quarantined | 34 apply_now · **337 rolling** · 325 quarantined |
+| Recommendation rows | 197 | 3,783 |
+| Strong fits, portfolio-wide | 7 | **185** (PICC 7→106, Mounty Yarns 1→34, Goods 1→30) |
+
+Three root causes were found below the ones diagnosed here:
+
+1. **`application_status` semantics.** The promotion filtered `='open'` (372 live rows) while
+   `not_applied` held 4,087 of the 4,463 future-deadline grants. Fixed; 596 rows promoted.
+2. **The alignment gate passed 94% of candidates.** It substring-matched a flattened set of all
+   11 projects' keywords, where `support` (2,971 rows), `research` (2,747) and `community` (2,525)
+   each hit a quarter of the corpus — any two cleared the 15-point threshold, and 43% of the pool
+   is university research ACT never applies for. Now word-boundary matched, generic words
+   suppressed, phrases weighted 25 vs 10, academic providers and scholarships excluded.
+3. **The LLM classifier has been dead since ~2026-05-16.** It moves rows from `unverified` to
+   `open_grant`, so nothing reaches the feed without it. Its API key is out of credit, every batch
+   400s, and it logged `status: success` with `items_found: 300, items_new: 0` throughout. 26 rows
+   have ever been classified; **5,436 are backlogged.** It now fails loudly. **Unblocking it needs
+   an Anthropic API credit top-up — roughly $0.55 clears the entire backlog at Haiku rates.**
+
+The rolling lane is live: a verified, URL-live row with no deadline is an open rolling program, not
+a timing failure. That distinction alone recovered 337 opportunities.
+
+**Still open:** the foundations/philanthropy queue (1,005 `saved`, placeholder giving figures), the
+two-registry split, the Goods hardcode, and the per-project "Apply now" page.
+
+---
+
 ## The finding
 
 Finding grants is not the problem. There are five parallel discovery engines, one project wired to

--- a/docs/strategy/act-money-surface-audit-2026-08-07.md
+++ b/docs/strategy/act-money-surface-audit-2026-08-07.md
@@ -15,8 +15,9 @@ Every figure below was queried directly against `tednluwflfhxyucgwigh` on 2026-0
 
 ## Progress (same day)
 
-Two commits landed on `fix/act-grant-feed-status-filter`. The grants half of the diagnosis below
-is largely addressed; the philanthropy/foundations half and the registry split are not.
+Four commits landed on `fix/act-grant-feed-status-filter`. Everything diagnosed below is addressed
+except the classifier credit, which is a billing action. See "Closed out" at the end for the
+item-by-item state.
 
 | | before | after |
 |---|---|---|

--- a/docs/strategy/act-money-surface-audit-2026-08-07.md
+++ b/docs/strategy/act-money-surface-audit-2026-08-07.md
@@ -266,3 +266,24 @@ All figures queried 2026-08-07 against project `tednluwflfhxyucgwigh` via `scrip
 Tables: `org_projects`, `org_profiles`, `org_project_foundations`, `org_pipeline`, `foundations`,
 `grant_opportunities`, `act_grant_recommendations_current`, `act_grant_recommendation_decisions`,
 `project_funding_profiles`. Code claims verified by reading the named files and line numbers.
+
+---
+
+## Closed out (2026-08-07, same day)
+
+All five items from the order of work below are now done except the classifier credit,
+which is a billing action, not a code one.
+
+| Item | State |
+|---|---|
+| 1. Reconcile the two registries | **Done.** `act_grant_recommendation_projects.org_project_id` FK added; all 12 rows linked; zero orphans. Contained (ACT-CN/ACT-JH-CT) and CivicGraph (ACT-CS/ACT-JH-CG) collisions resolved. Gold.Phone, Mounty Yarns and ACT Core created as `org_projects` rows — Phase 1 names them as canonical but they were never registered. |
+| 2. Gate on verified money | **Done, differently than planned.** Gating on money would have left 6 funders, so the gate grades evidence instead: A = recorded grants on file, B = DGR or verified giving, C = theme overlap only. 1,063 rows graded 179 A / 248 B / 636 C. |
+| 3. Delete the Goods hardcode | **Done.** `getFunderScan(slug?)` replaces the pinned `.eq(…,'goods')`; One Desk scans portfolio-wide and shows each funder's real project. |
+| 4. Per-project "Apply now" ten | **Done.** `getProjectApplyNow()` reads the project's own ranked list, split into dated (urgency-ranked) and rolling (fit-ranked). Every one of the 11 projects now resolves 17–18 dated + 326 rolling. |
+| 5. Retire the losers | **Partly.** `goods_relevance_score` is no longer the One Desk gate. `/org/act/funding` still has zero inbound links — it needs a rail slot or deletion, which is Ben's call. |
+| 6. Give the recommender a mouth | **Not done.** `project_funding_profiles.next_question` remains unwired. |
+| 7. The dark projects | **Partly.** Gold.Phone, Mounty Yarns and ACT Core now exist and receive recommendations. ALMA, Elders Room and Station Precinct still have no registry row — they are sub-projects, and whether they fundraise independently is a judgement call, not a data fix. |
+
+**The one open action: the Anthropic API key is out of credit.** No new opportunity can
+reach `open_grant` until it is topped up, so 344 is a ceiling rather than a floor.
+5,436 rows are backlogged; roughly $0.55 of Haiku clears them.

--- a/scripts/auto-classify-llm.mjs
+++ b/scripts/auto-classify-llm.mjs
@@ -85,6 +85,16 @@ const PROVIDERS = {
 const PROVIDER_ARG = process.argv.find((a) => a.startsWith('--provider='));
 const FALLBACK_ORDER = ['groq', 'gemini', 'ollama', 'deepseek', 'anthropic'];
 
+// Sorting a grant into six buckets does not need a large model, and the big ones
+// are the slow ones: gpt-oss:20b sustained ~6s/row locally and the 70B hit Groq's
+// free-tier throttle after a few hundred rows. --model= swaps the default without
+// touching code, e.g. --provider=groq --model=llama-3.1-8b-instant.
+const MODEL_ARG = process.argv.find((a) => a.startsWith('--model='));
+if (MODEL_ARG) {
+  const override = MODEL_ARG.split('=').slice(1).join('=');
+  for (const p of Object.values(PROVIDERS)) p.model = override;
+}
+
 /** Providers that are actually usable right now, in preference order. */
 function availableProviders() {
   const requested = PROVIDER_ARG?.split('=')[1];
@@ -130,16 +140,27 @@ Confidence rules:
 - 0.0-0.49: don't know — needs human review`;
 
 async function loadUnverified() {
-  // Pull unverified rows ordered by ones most likely to be high-value (have funder + URL)
-  const { data, error } = await supabase
-    .from('alma_funding_opportunities')
-    .select('id, name, description, funder_name, source_url, focus_areas, keywords, min_grant_amount, max_grant_amount')
-    .eq('opportunity_type', 'unverified')
-    .is('auto_classify_confidence', null)
-    .order('funder_name', { ascending: true })
-    .limit(LIMIT);
-  if (error) throw error;
-  return data ?? [];
+  // Pull unverified rows ordered by ones most likely to be high-value (have funder + URL).
+  //
+  // Paginated because PostgREST silently caps a single response at 1,000 rows:
+  // `--limit=2300` quietly returned 1,000 and the run looked complete at less
+  // than half the backlog. Silent truncation reads as "done" when it isn't.
+  const PAGE = 1000;
+  const rows = [];
+  for (let offset = 0; rows.length < LIMIT; offset += PAGE) {
+    const { data, error } = await supabase
+      .from('alma_funding_opportunities')
+      .select('id, name, description, funder_name, source_url, focus_areas, keywords, min_grant_amount, max_grant_amount')
+      .eq('opportunity_type', 'unverified')
+      .is('auto_classify_confidence', null)
+      .order('funder_name', { ascending: true })
+      .range(offset, offset + Math.min(PAGE, LIMIT - rows.length) - 1);
+    if (error) throw error;
+    if (!data?.length) break;
+    rows.push(...data);
+    if (data.length < PAGE) break;
+  }
+  return rows;
 }
 
 function formatRowForLLM(row) {
@@ -193,21 +214,32 @@ async function classifyWithOpenAICompatible(rows, rowsText, provider) {
   const headers = { 'Content-Type': 'application/json' };
   if (provider.keyEnv) headers.Authorization = `Bearer ${process.env[provider.keyEnv]}`;
 
-  const res = await fetch(`${provider.baseUrl}/chat/completions`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      model: provider.model,
-      temperature: 0,
-      response_format: { type: 'json_object' },
-      messages: [
-        { role: 'system', content: RUBRIC },
-        { role: 'user', content: `Classify these ${rows.length} grants. Return JSON only.\n\n${rowsText}` },
-      ],
-    }),
+  const payload = JSON.stringify({
+    model: provider.model,
+    temperature: 0,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: RUBRIC },
+      { role: 'user', content: `Classify these ${rows.length} grants. Return JSON only.\n\n${rowsText}` },
+    ],
   });
+
+  // Free tiers throttle hard once a burst lands. A 429 is "wait", not "fail" —
+  // treating it as failure burned through every batch in seconds and classified
+  // nothing. Honour Retry-After when the server sends it, else back off.
+  let res;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    res = await fetch(`${provider.baseUrl}/chat/completions`, { method: 'POST', headers, body: payload });
+    if (res.status !== 429) break;
+    const retryAfter = Number(res.headers.get('retry-after'));
+    const waitMs = Number.isFinite(retryAfter) && retryAfter > 0
+      ? Math.min(retryAfter * 1000, 60_000)
+      : Math.min(2_000 * 2 ** attempt, 30_000);
+    if (attempt === 3) break;
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
   if (!res.ok) {
-    throw new Error(`${res.status} ${(await res.text()).slice(0, 300)}`);
+    throw new Error(`${res.status} ${(await res.text()).slice(0, 200)}`);
   }
   const body = await res.json();
   const content = body.choices?.[0]?.message?.content;

--- a/scripts/auto-classify-llm.mjs
+++ b/scripts/auto-classify-llm.mjs
@@ -257,6 +257,21 @@ async function run() {
       (totalCacheRead * 0.1) / 1_000_000;
     console.log(`Approx cost: $${cost.toFixed(4)} (elapsed ${elapsed.toFixed(1)}s)`);
 
+    // A run where every batch errored is a failed run, not a successful one that
+    // happened to classify nothing. Reporting success here hid a three-month
+    // outage: the API key ran out of credit around 2026-05-16, every batch 400'd,
+    // and agent_runs kept logging `success` with items_found=300, items_new=0
+    // while the unverified backlog grew to 5,436 rows and the ACT feed starved.
+    if (classified === 0 && errors > 0) {
+      const reason = new Error(
+        `auto-classify made no progress: ${errors} row(s) errored, 0 classified. ` +
+        `Check the Anthropic API key credit balance.`
+      );
+      console.error(reason.message);
+      if (runId) await logFailed(supabase, runId, reason);
+      process.exit(1);
+    }
+
     if (runId) {
       await logComplete(supabase, runId, {
         items_found: rows.length,

--- a/scripts/auto-classify-llm.mjs
+++ b/scripts/auto-classify-llm.mjs
@@ -36,8 +36,71 @@ const CONF_ARG = process.argv.find((a) => a.startsWith('--min-confidence='));
 const MIN_CONFIDENCE = CONF_ARG ? parseFloat(CONF_ARG.split('=')[1]) : 0.7;
 
 const BATCH_SIZE = 25;
-const MODEL = 'claude-haiku-4-5-20251001';
 const AGENT_ID = 'auto-classify-llm';
+
+/**
+ * Providers, cheapest-and-most-available first.
+ *
+ * This job died silently for three months because it could only talk to one
+ * provider and that provider's credit ran out. Classifying a grant into six
+ * buckets does not need a frontier model, so the default order prefers free
+ * capacity and falls back rather than stopping.
+ *
+ * Groq, DeepSeek, Ollama and Gemini all speak the OpenAI chat-completions API,
+ * so one client covers them; Anthropic keeps its own path for prompt caching.
+ *
+ *   groq     — free tier, 131k context, fastest of these
+ *   gemini   — free tier via the OpenAI-compatible endpoint
+ *   ollama   — fully local, no quota, no network, needs `ollama serve`
+ *   deepseek — paid but very cheap
+ *   anthropic — best quality, needs credit
+ */
+const PROVIDERS = {
+  groq: {
+    baseUrl: 'https://api.groq.com/openai/v1',
+    model: 'llama-3.3-70b-versatile',
+    keyEnv: 'GROQ_API_KEY',
+  },
+  gemini: {
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    model: 'gemini-2.5-flash',
+    keyEnv: 'GEMINI_API_KEY',
+  },
+  ollama: {
+    baseUrl: 'http://localhost:11434/v1',
+    model: process.env.OLLAMA_CLASSIFY_MODEL || 'gpt-oss:20b',
+    keyEnv: null, // local, no key
+  },
+  deepseek: {
+    baseUrl: 'https://api.deepseek.com/v1',
+    model: 'deepseek-chat',
+    keyEnv: 'DEEPSEEK_API_KEY',
+  },
+  anthropic: {
+    model: 'claude-haiku-4-5-20251001',
+    keyEnv: 'ANTHROPIC_API_KEY',
+  },
+};
+
+const PROVIDER_ARG = process.argv.find((a) => a.startsWith('--provider='));
+const FALLBACK_ORDER = ['groq', 'gemini', 'ollama', 'deepseek', 'anthropic'];
+
+/** Providers that are actually usable right now, in preference order. */
+function availableProviders() {
+  const requested = PROVIDER_ARG?.split('=')[1];
+  if (requested) {
+    if (!PROVIDERS[requested]) {
+      throw new Error(`Unknown provider "${requested}". Options: ${Object.keys(PROVIDERS).join(', ')}`);
+    }
+    return [requested];
+  }
+  return FALLBACK_ORDER.filter((name) => {
+    const p = PROVIDERS[name];
+    return p.keyEnv === null || Boolean(process.env[p.keyEnv]);
+  });
+}
+
+let MODEL = PROVIDERS[availableProviders()[0] ?? 'anthropic'].model;
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
@@ -94,44 +157,97 @@ function formatRowForLLM(row) {
   return fields.join(' | ');
 }
 
-async function classifyBatch(rows) {
-  const rowsText = rows.map(formatRowForLLM).join('\n');
+function parseItems(raw) {
+  let text = raw.trim();
+  // Smaller models wrap JSON in markdown, and some prepend a sentence.
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\s*/, '').replace(/```$/, '').trim();
+  }
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace > 0 || lastBrace < text.length - 1) {
+    if (firstBrace === -1 || lastBrace === -1) throw new Error(`No JSON object in response: ${text.slice(0, 200)}`);
+    text = text.slice(firstBrace, lastBrace + 1);
+  }
+  const parsed = JSON.parse(text);
+  if (!parsed.items || !Array.isArray(parsed.items)) {
+    throw new Error(`Unexpected response shape: ${text.slice(0, 200)}`);
+  }
+  return parsed.items;
+}
 
+async function classifyWithAnthropic(rows, rowsText, model) {
   const response = await anthropic.messages.create({
-    model: MODEL,
+    model,
     max_tokens: 4096,
-    system: [
-      {
-        type: 'text',
-        text: RUBRIC,
-        cache_control: { type: 'ephemeral' },
-      },
-    ],
-    messages: [
-      {
-        role: 'user',
-        content: `Classify these ${rows.length} grants. Return JSON only.\n\n${rowsText}`,
-      },
-    ],
+    system: [{ type: 'text', text: RUBRIC, cache_control: { type: 'ephemeral' } }],
+    messages: [{ role: 'user', content: `Classify these ${rows.length} grants. Return JSON only.\n\n${rowsText}` }],
   });
-
   const textBlock = response.content.find((c) => c.type === 'text');
   if (!textBlock) throw new Error('No text in LLM response');
+  return { items: parseItems(textBlock.text), usage: response.usage };
+}
 
-  // Strip code fences if Haiku wraps in markdown
-  let raw = textBlock.text.trim();
-  if (raw.startsWith('```')) {
-    raw = raw.replace(/^```(?:json)?\s*/, '').replace(/```$/, '').trim();
-  }
+/** Groq, Gemini, Ollama and DeepSeek all speak this shape. */
+async function classifyWithOpenAICompatible(rows, rowsText, provider) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (provider.keyEnv) headers.Authorization = `Bearer ${process.env[provider.keyEnv]}`;
 
-  const parsed = JSON.parse(raw);
-  if (!parsed.items || !Array.isArray(parsed.items)) {
-    throw new Error(`Unexpected response shape: ${raw.slice(0, 200)}`);
+  const res = await fetch(`${provider.baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: provider.model,
+      temperature: 0,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: RUBRIC },
+        { role: 'user', content: `Classify these ${rows.length} grants. Return JSON only.\n\n${rowsText}` },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`${res.status} ${(await res.text()).slice(0, 300)}`);
   }
+  const body = await res.json();
+  const content = body.choices?.[0]?.message?.content;
+  if (!content) throw new Error(`No content in response: ${JSON.stringify(body).slice(0, 200)}`);
   return {
-    items: parsed.items,
-    usage: response.usage,
+    items: parseItems(content),
+    usage: {
+      input_tokens: body.usage?.prompt_tokens ?? 0,
+      output_tokens: body.usage?.completion_tokens ?? 0,
+    },
   };
+}
+
+let activeProvider = null;
+
+async function classifyBatch(rows) {
+  const rowsText = rows.map(formatRowForLLM).join('\n');
+  // Stick with the first provider that works, so one outage does not cost every
+  // batch a retry cascade — but re-enter the chain if the sticky one starts failing.
+  const chain = activeProvider ? [activeProvider, ...availableProviders().filter((p) => p !== activeProvider)] : availableProviders();
+  if (chain.length === 0) throw new Error('No LLM provider configured. Set GROQ_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY, or run `ollama serve`.');
+
+  const failures = [];
+  for (const name of chain) {
+    const provider = PROVIDERS[name];
+    try {
+      const result = name === 'anthropic'
+        ? await classifyWithAnthropic(rows, rowsText, provider.model)
+        : await classifyWithOpenAICompatible(rows, rowsText, provider);
+      if (activeProvider !== name) {
+        console.log(`  provider: ${name} (${provider.model})`);
+        activeProvider = name;
+        MODEL = provider.model;
+      }
+      return result;
+    } catch (err) {
+      failures.push(`${name}: ${err.message.slice(0, 140)}`);
+    }
+  }
+  throw new Error(`All providers failed — ${failures.join(' | ')}`);
 }
 
 async function run() {

--- a/scripts/auto-classify-llm.mjs
+++ b/scripts/auto-classify-llm.mjs
@@ -365,13 +365,25 @@ async function run() {
     console.log('\nSample decisions:');
     for (const e of examples) console.log(e);
     console.log(`\nTokens — input: ${totalInput}  output: ${totalOutput}  cached read: ${totalCacheRead}  cached write: ${totalCacheWrite}`);
-    // Haiku 4.5: input $1/Mtok, output $5/Mtok, cache write $1.25/Mtok, cache read $0.10/Mtok
+    // Price by the provider that actually ran, not by Haiku regardless. Reporting
+    // an Anthropic bill for a free-tier Groq run reads as a real cost and was the
+    // kind of misleading signal that let this job's outage hide for three months.
+    // USD per million tokens: [input, output, cacheWrite, cacheRead].
+    const RATES = {
+      anthropic: [1, 5, 1.25, 0.1],
+      deepseek: [0.27, 1.1, 0, 0],
+      gemini: [0, 0, 0, 0],   // free tier
+      groq: [0, 0, 0, 0],     // free tier
+      ollama: [0, 0, 0, 0],   // local
+    };
+    const [rIn, rOut, rCw, rCr] = RATES[activeProvider] ?? RATES.anthropic;
     const cost =
-      (totalInput * 1) / 1_000_000 +
-      (totalOutput * 5) / 1_000_000 +
-      (totalCacheWrite * 1.25) / 1_000_000 +
-      (totalCacheRead * 0.1) / 1_000_000;
-    console.log(`Approx cost: $${cost.toFixed(4)} (elapsed ${elapsed.toFixed(1)}s)`);
+      (totalInput * rIn) / 1_000_000 +
+      (totalOutput * rOut) / 1_000_000 +
+      (totalCacheWrite * rCw) / 1_000_000 +
+      (totalCacheRead * rCr) / 1_000_000;
+    const label = cost === 0 ? 'no charge (free tier / local)' : `$${cost.toFixed(4)}`;
+    console.log(`Cost via ${activeProvider ?? 'unknown'}: ${label} (elapsed ${elapsed.toFixed(1)}s)`);
 
     // A run where every batch errored is a failed run, not a successful one that
     // happened to classify nothing. Reporting success here hid a three-month

--- a/scripts/match-foundations-for-projects.mjs
+++ b/scripts/match-foundations-for-projects.mjs
@@ -110,7 +110,26 @@ scored AS (
     (f.geographic_focus && p.home_geo)        AS home_match,
     ('AU-National' = ANY(f.geographic_focus)) AS national,
     (f.geographic_focus && p.sec_geo)         AS sec_match,
-    f.total_giving_annual
+    -- total_giving_annual is a placeholder on 85% of the table (25,000 on 6,940
+    -- rows, 100,000 on 1,474, 500,000 on 816 — only 958 real figures in 11,159).
+    -- Carry the verified figure separately so nothing scores or asserts on a
+    -- default. See docs/strategy/act-money-surface-audit-2026-08-07.md.
+    CASE WHEN f.total_giving_annual NOT IN (25000, 100000, 500000)
+         THEN f.total_giving_annual END AS verified_giving,
+    ac.is_foundation AS confirmed_grantmaker,
+    COALESCE(array_length(f.notable_grants, 1), 0) AS notable_grant_count,
+    f.has_dgr,
+    -- Evidence grade, not a confidence score. Only 6 of 5,190 themed grantmakers
+    -- carry a verified giving figure, so gating on money would empty the queue.
+    -- Grade instead on what is actually provable:
+    --   A — notable_grants: named recipients, amounts, years. Proof they give.
+    --   B — DGR endorsement or a verified giving figure. Proof they can give.
+    --   C — theme and geography overlap only. A suggestion, never a desk record.
+    CASE
+      WHEN COALESCE(array_length(f.notable_grants, 1), 0) > 0 THEN 'A'
+      WHEN f.has_dgr OR f.total_giving_annual NOT IN (25000, 100000, 500000) THEN 'B'
+      ELSE 'C'
+    END AS evidence_grade
   FROM proj p
   JOIN org_projects op ON op.code = p.code
   JOIN foundations f
@@ -118,6 +137,10 @@ scored AS (
    AND f.thematic_focus && p.themes
    AND NOT ('religion' = ANY(f.thematic_focus))   -- faith-purpose funders are noise for these projects
    AND NOT (f.name ILIKE ANY (${ilikeArr(EXCLUDE_FUNDERS)}))   -- extractive-industry funders (values exclusion)
+  LEFT JOIN acnc_charities ac ON ac.abn = f.acnc_abn
+  -- A program-delivering charity is not a grantmaker. Bravehearts scored 100
+  -- against Empathy Ledger on theme overlap alone before this gate existed.
+  WHERE ac.is_foundation IS TRUE
 ),
 fit AS (
   SELECT s.*,
@@ -125,18 +148,44 @@ fit AS (
       LEAST(theme_overlap,3)/3.0 * 55
       + LEAST(target_overlap,2)/2.0 * 15
       + CASE WHEN home_match THEN 20 WHEN national THEN 15 WHEN sec_match THEN 10 ELSE 0 END
-      + CASE WHEN total_giving_annual >= 50000 THEN 10 WHEN total_giving_annual > 0 THEN 5 ELSE 0 END
+      -- Only a real figure earns capacity points. A default earns nothing.
+      + CASE WHEN verified_giving >= 50000 THEN 10 WHEN verified_giving > 0 THEN 5 ELSE 0 END
     )::int AS fit_score
   FROM scored s
 ),
-ranked AS (
+deduped AS (
+  -- One funder split across sub-regional trusts used to occupy several slots at
+  -- identical scores (WCCT Southern/Northern/Central + Western Cape Communities
+  -- Trust, all 100). Keep the best-scoring row per funder stem per project.
   SELECT fit.*,
-    ROW_NUMBER() OVER (PARTITION BY fit.code ORDER BY fit.fit_score DESC, fit.total_giving_annual DESC NULLS LAST) AS rn
+    ROW_NUMBER() OVER (
+      PARTITION BY fit.org_project_id,
+        regexp_replace(
+          regexp_replace(lower(fit.foundation),
+            '\\m(the trustee for|the |ltd|limited|pty|inc|incorporated|foundation|trust|fund)\\M', '', 'g'),
+          '\\m(northern|southern|central|eastern|western|sub-regional|regional)\\M', '', 'g')
+      ORDER BY fit.evidence_grade, fit.fit_score DESC, fit.notable_grant_count DESC
+    ) AS dupe_rn
   FROM fit
+),
+ranked AS (
+  SELECT deduped.*,
+    -- Evidence outranks fit. A grade-B funder that demonstrably gives beats a
+    -- grade-C one that merely shares a theme tag, whatever the theme score says.
+    ROW_NUMBER() OVER (
+      PARTITION BY deduped.code
+      ORDER BY deduped.evidence_grade, deduped.notable_grant_count DESC, deduped.fit_score DESC
+    ) AS rn
+  FROM deduped
   LEFT JOIN org_project_foundations existing
-    ON existing.org_project_id = fit.org_project_id AND existing.foundation_id = fit.foundation_id
+    ON existing.org_project_id = deduped.org_project_id AND existing.foundation_id = deduped.foundation_id
   WHERE existing.id IS NULL            -- never touch a foundation already in the pipeline (human-curated)
-    AND fit.fit_score >= ${MIN_SCORE}
+    AND deduped.dupe_rn = 1
+    AND deduped.fit_score >= ${MIN_SCORE}
+    -- Grade C stays out of the pipeline entirely. It is a suggestion, not a
+    -- record, and writing suggestions as records is what left 1,005 rows at
+    -- "saved" that nobody could trust enough to work.
+    AND deduped.evidence_grade <> 'C'
 )`;
 }
 
@@ -148,7 +197,7 @@ async function dryRun(supabase) {
   const sql = `${scorerCTE()}
 SELECT code, rn, fit_score, LEFT(foundation, 48) AS foundation,
        array_to_string(matched_themes, ',') AS themes,
-       COALESCE(total_giving_annual,0)::bigint AS giving
+       verified_giving::bigint AS giving, evidence_grade, notable_grant_count
 FROM ranked WHERE rn <= ${PER_PROJECT_LIMIT}
 ORDER BY code, rn`;                       // no trailing ';' — exec_sql wraps the query and rejects one
   const { data, error } = await runSelect(supabase, sql);
@@ -157,7 +206,7 @@ ORDER BY code, rn`;                       // no trailing ';' — exec_sql wraps 
   let lastCode = null;
   for (const r of rows) {
     if (r.code !== lastCode) { console.log(`\n${r.code}`); lastCode = r.code; }
-    console.log(`  ${String(r.fit_score).padStart(3)}  ${String(r.foundation).padEnd(50)} [${r.themes}] $${Number(r.giving).toLocaleString()}`);
+    console.log(`  ${String(r.fit_score).padStart(3)}  ${String(r.foundation).padEnd(50)} [${r.evidence_grade}] [${r.themes}] ${r.giving == null ? "giving n/p" : "$" + Number(r.giving).toLocaleString()}`);
   }
   console.log(`\n${rows.length} candidate matches across ${new Set(rows.map(r => r.code)).size} projects (min-score ${MIN_SCORE}, top ${PER_PROJECT_LIMIT}/project).`);
   console.log('Dry-run only — no rows written. Re-run with --apply to land these as "saved / researching" in the pipeline.');
@@ -167,7 +216,8 @@ ORDER BY code, rn`;                       // no trailing ';' — exec_sql wraps 
 async function apply(supabase) {
   const selectSql = `${scorerCTE()}
 SELECT org_project_id::text, foundation_id::text, fit_score, matched_themes,
-       home_match, national, sec_match, total_giving_annual
+       home_match, national, sec_match, verified_giving, foundation,
+       evidence_grade, notable_grant_count, has_dgr
 FROM ranked WHERE rn <= ${PER_PROJECT_LIMIT}
 ORDER BY code, rn`;
   const { data, error } = await runSelect(supabase, selectSql);
@@ -187,7 +237,11 @@ ORDER BY code, rn`;
         : row.sec_match
           ? 'secondary-state funder'
           : null;
-    const giving = Number(row.total_giving_annual ?? 0);
+    // Only a verified figure is stated. Where the source carries a placeholder
+    // the summary says so, rather than asserting an invented number as fact —
+    // 276 of the 286 high-fit rows used to read "gives ~$500,000/yr" off a
+    // default, which is why the queue was never trusted or worked.
+    const giving = row.verified_giving == null ? null : Number(row.verified_giving);
     return {
       org_profile_id: ACT_ORG_PROFILE_ID,
       org_project_id: row.org_project_id,
@@ -196,10 +250,22 @@ ORDER BY code, rn`;
       engagement_status: 'researching',
       fit_score: Number(row.fit_score ?? 0),
       fit_summary: [
-        `[auto-matched] themes: ${(row.matched_themes ?? []).join(', ')}`,
+        `[evidence ${row.evidence_grade}] themes: ${(row.matched_themes ?? []).join(', ')}`,
         geography,
-        giving >= 50000 ? `gives ~$${Math.round(giving).toLocaleString('en-AU')}/yr` : null,
+        'ACNC-confirmed grantmaker',
+        Number(row.notable_grant_count) > 0
+          ? `${row.notable_grant_count} recorded grant${Number(row.notable_grant_count) === 1 ? '' : 's'} on file`
+          : null,
+        row.has_dgr ? 'DGR endorsed' : null,
+        giving != null
+          ? `gives $${Math.round(giving).toLocaleString('en-AU')}/yr`
+          : 'annual giving not published',
       ].filter(Boolean).join(' · '),
+      // Every promoted row arrives with the next move already on it. 19 of 1,063
+      // rows carried one before this, which is most of why 1,005 sat at "saved".
+      next_step: Number(row.notable_grant_count) > 0
+        ? 'Read the recorded grants for pattern and size, then decide pursue or pass'
+        : 'Confirm open rounds and giving size from the funder site before deciding',
     };
   });
 

--- a/scripts/promote-grant-opportunities-to-alma.mjs
+++ b/scripts/promote-grant-opportunities-to-alma.mjs
@@ -196,10 +196,16 @@ async function run() {
     }
     console.log(`Candidates: ${grants.length} open grants in grant_opportunities`);
 
-    let promoted = 0, skippedExisting = 0, skippedNotMatched = 0, skippedNoAlign = 0, skippedAcademic = 0;
+    let promoted = 0, skippedExisting = 0, skippedNotMatched = 0, skippedNoAlign = 0, skippedAcademic = 0, skippedNoFunder = 0;
     const toInsert = [];
 
     for (const g of grants ?? []) {
+      // `alma_funding_opportunities.funder_name` is NOT NULL, and an opportunity
+      // with no named funder cannot be verified or applied for anyway.
+      if (!g.provider?.trim()) {
+        skippedNoFunder++;
+        continue;
+      }
       const allowMatch = matchAllowlist(allowlist, g.provider);
       const align = actAlignmentScore(g, themes);
 
@@ -278,7 +284,14 @@ async function run() {
           .from('alma_funding_opportunities')
           .insert(batch);
         if (insErr) {
-          console.error(`Insert batch ${i / 50} failed:`, insErr.message);
+          // A batch insert is all-or-nothing, so one malformed row used to cost
+          // the other 49. Retry the batch row-by-row and report only the losses.
+          console.error(`Insert batch ${i / 50} failed (${insErr.message}) — retrying row-by-row`);
+          for (const row of batch) {
+            const { error: rowErr } = await supabase.from('alma_funding_opportunities').insert(row);
+            if (rowErr) console.error(`  skipped "${row.name?.slice(0, 60)}": ${rowErr.message}`);
+            else promoted += 1;
+          }
         } else {
           promoted += batch.length;
         }
@@ -294,7 +307,7 @@ async function run() {
     // The feed quarantines any row without timing, so report how many promoted
     // rows can actually reach `apply_now` rather than just how many were written.
     const withDeadline = toInsert.filter((t) => t.deadline).length;
-    const summary = { promoted: DRY_RUN ? toInsert.length : promoted, withDeadline, skippedExisting, skippedNotMatched, skippedNoAlign, skippedAcademic, candidates: grants?.length ?? 0 };
+    const summary = { promoted: DRY_RUN ? toInsert.length : promoted, withDeadline, skippedExisting, skippedNotMatched, skippedNoAlign, skippedAcademic, skippedNoFunder, candidates: grants?.length ?? 0 };
     console.log(`\n${DRY_RUN ? '[dry-run] ' : ''}Done in ${(Date.now() - startedAt) / 1000}s:`, summary);
 
     if (runId) {

--- a/scripts/promote-grant-opportunities-to-alma.mjs
+++ b/scripts/promote-grant-opportunities-to-alma.mjs
@@ -38,6 +38,32 @@ const supabase = createClient(
 const AGENT_ID = 'promote-grant-opportunities-to-alma';
 const ACT_PROJECT_CODES = ['ACT-HV', 'ACT-EL', 'ACT-JH', 'ACT-GD', 'ACT-CORE', 'ACT-FM'];
 
+/** Single words that appear in a quarter to a third of the grant corpus on their
+ *  own, so any two of them cleared the old 15-point threshold and let academic
+ *  research rounds through (audit 2026-08-07: support 2,971 rows, research 2,747,
+ *  community 2,525 of 9,536 candidates). The multi-word phrases that contain them
+ *  — "community-led", "social procurement", "lived experience" — still score, and
+ *  score higher, because those are the ones that actually discriminate. */
+const GENERIC_THEME_WORDS = new Set([
+  'support', 'research', 'public', 'foundation', 'strategy', 'community',
+  'operations', 'sustainability', 'events', 'rights', 'seed', 'partner',
+  'engagement', 'infrastructure', 'cultural', 'environment', 'intervention',
+  'voice', 'arts', 'tour', 'teens', 'remote', 'rural', 'regional', 'civic',
+]);
+
+/** Academic research and individual scholarship rounds are 43% of the candidate
+ *  pool (4,132 university/college providers) and ACT applies for none of them.
+ *  They are excluded unless a specific multi-word ACT phrase matches. */
+const SCHOLARLY_NAME = /\b(scholarship|fellowship|phd|postdoctoral|postdoc|honours|dissertation|thesis)\b/i;
+const ACADEMIC_PROVIDER = /\b(universit|college|institute of technolog|school of medicine)/i;
+
+function wordBoundaryHit(haystack, term) {
+  // Substring matching turned "arts" into a hit on "parts"/"quarters" and made
+  // every keyword far wider than intended. Match on word boundaries instead.
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(haystack);
+}
+
 function normalise(s) {
   return (s ?? '')
     .toLowerCase()
@@ -100,10 +126,25 @@ function actAlignmentScore(grant, themes) {
     grant.description ?? '',
   ].join(' ').toLowerCase();
 
-  const hits = themes.filter((t) => haystack.includes(t));
-  if (hits.length) {
-    score += Math.min(50, hits.length * 10);
-    reasons.push(`themes:${hits.slice(0, 5).join(',')}`);
+  const hits = themes.filter((t) => wordBoundaryHit(haystack, t));
+  // A multi-word phrase ("palm island", "market garden", "narrative sovereignty")
+  // names something specific; a bare generic word does not. Weight accordingly so
+  // one real phrase clears the bar and a pile of generic words never does.
+  const phraseHits = hits.filter((t) => /[ -]/.test(t));
+  const wordHits = hits.filter((t) => !/[ -]/.test(t) && !GENERIC_THEME_WORDS.has(t));
+  score += Math.min(50, phraseHits.length * 25 + wordHits.length * 10);
+  if (phraseHits.length || wordHits.length) {
+    reasons.push(`themes:${[...phraseHits, ...wordHits].slice(0, 5).join(',')}`);
+  }
+
+  // ACT does not apply for university research rounds or individual scholarships,
+  // so a theme match on one is a false positive however specific it looks — an
+  // RMIT zinc-ion battery grant matches "clean energy" and is still not ours.
+  // Allowlisted funders bypass this upstream; partnership-shaped research reaches
+  // ACT through a relationship, not the grant feed.
+  const academic = ACADEMIC_PROVIDER.test(grant.provider ?? '') || SCHOLARLY_NAME.test(grant.name ?? '');
+  if (academic) {
+    return { score: 0, reasons: [], excluded: 'academic_or_scholarship' };
   }
   return { score, reasons };
 }
@@ -141,7 +182,11 @@ async function run() {
       const { data: page, error } = await supabase
         .from('grant_opportunities')
         .select('id, name, description, amount_min, amount_max, deadline, closes_at, provider, program, aligned_projects, categories, focus_areas, application_status, url, eligibility_criteria')
-        .eq('application_status', 'open')
+        // `application_status` tracks ACT's own application state, not whether the
+        // round is live: 'not_applied' holds 4,087 of the 4,463 future-deadline
+        // grants (92%), while 'open' holds only 372. Filtering on 'open' alone
+        // starved the ACT feed to 18 opportunities (audit 2026-08-07).
+        .in('application_status', ['open', 'not_applied', 'upcoming'])
         .or(`closes_at.is.null,closes_at.gte.${today}`)
         .range(offset, offset + PAGE_SIZE - 1);
       if (error) throw error;
@@ -151,12 +196,17 @@ async function run() {
     }
     console.log(`Candidates: ${grants.length} open grants in grant_opportunities`);
 
-    let promoted = 0, skippedExisting = 0, skippedNotMatched = 0, skippedNoAlign = 0;
+    let promoted = 0, skippedExisting = 0, skippedNotMatched = 0, skippedNoAlign = 0, skippedAcademic = 0;
     const toInsert = [];
 
     for (const g of grants ?? []) {
       const allowMatch = matchAllowlist(allowlist, g.provider);
       const align = actAlignmentScore(g, themes);
+
+      if (!allowMatch && align.excluded === 'academic_or_scholarship') {
+        skippedAcademic++;
+        continue;
+      }
 
       // Gate: must pass allowlist OR have ACT alignment via theme (configurable, default 15)
       if (!allowMatch && align.score < ALIGNMENT_THRESHOLD) {
@@ -174,7 +224,10 @@ async function run() {
         continue;
       }
 
-      const deadline = g.closes_at ? new Date(g.closes_at).toISOString() : null;
+      // Fall back to `deadline` when `closes_at` is absent — the feed quarantines
+      // any row without timing, so a dropped date silently costs the opportunity.
+      const rawDeadline = g.closes_at ?? g.deadline;
+      const deadline = rawDeadline ? new Date(rawDeadline).toISOString() : null;
       const focus = g.focus_areas ?? g.categories ?? [];
 
       toInsert.push({
@@ -238,7 +291,10 @@ async function run() {
       }
     }
 
-    const summary = { promoted: DRY_RUN ? toInsert.length : promoted, skippedExisting, skippedNotMatched, skippedNoAlign, candidates: grants?.length ?? 0 };
+    // The feed quarantines any row without timing, so report how many promoted
+    // rows can actually reach `apply_now` rather than just how many were written.
+    const withDeadline = toInsert.filter((t) => t.deadline).length;
+    const summary = { promoted: DRY_RUN ? toInsert.length : promoted, withDeadline, skippedExisting, skippedNotMatched, skippedNoAlign, skippedAcademic, candidates: grants?.length ?? 0 };
     console.log(`\n${DRY_RUN ? '[dry-run] ' : ''}Done in ${(Date.now() - startedAt) / 1000}s:`, summary);
 
     if (runId) {

--- a/scripts/sql/2026-08-07-rolling-funding-lane.sql
+++ b/scripts/sql/2026-08-07-rolling-funding-lane.sql
@@ -1,0 +1,102 @@
+-- Rolling funding lane (Ben's call, 2026-08-07)
+--
+-- The ACT feed disqualified any opportunity without a deadline. That gate was
+-- the binding constraint: 518 of 662 quarantined open_grant rows failed on
+-- `missing_current_round_timing` alone, and rolling philanthropic programs —
+-- QBE Foundation Local Grants, BHP Community Grants, IBA Start-Up Finance —
+-- have no deadline by nature. The gate excluded ongoing philanthropy by design.
+--
+-- "No deadline" is not the same as "we don't know the timing". A row that is
+-- verified live right now, with both URLs present, and no deadline, is an open
+-- rolling program. The verification requirements already carry that proof, so
+-- timing becomes a routing signal rather than a hard failure:
+--
+--   apply_now   — dated, verified, deadline in future   (rank by urgency)
+--   rolling     — verified, no deadline                 (rank by fit)
+--   quarantined — unverified / stale / past / no source (excluded)
+--
+-- Rollback: restore the seventh CASE arm to `failed_requirements`, change the
+-- divisor back to 7, and drop 'rolling' from the WHERE in the second view.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW act_funding_opportunity_current_status AS
+WITH assessed AS (
+  SELECT
+    opportunity.id AS opportunity_id,
+    opportunity.verification_status,
+    opportunity.verified_at,
+    opportunity.deadline,
+    opportunity.source_url,
+    opportunity.application_url,
+    array_remove(ARRAY[
+      CASE WHEN opportunity.verification_status IS DISTINCT FROM 'verified' THEN 'not_verified' END,
+      CASE WHEN opportunity.verified_at IS NULL THEN 'missing_verification_timestamp' END,
+      CASE WHEN opportunity.verified_at < (now() - '7 days'::interval) THEN 'stale_verification' END,
+      CASE WHEN NULLIF(TRIM(BOTH FROM opportunity.source_url), '') IS NULL THEN 'missing_official_source' END,
+      CASE WHEN NULLIF(TRIM(BOTH FROM opportunity.application_url), '') IS NULL THEN 'missing_application_url' END,
+      -- `missing_current_round_timing` deliberately removed: a null deadline now
+      -- routes to the rolling lane instead of failing the row.
+      CASE WHEN opportunity.deadline < now() THEN 'past_deadline' END
+    ], NULL::text) AS failed_requirements
+  FROM alma_funding_opportunities opportunity
+  WHERE opportunity.opportunity_type = 'open_grant'
+)
+SELECT
+  opportunity_id,
+  CASE
+    WHEN cardinality(failed_requirements) > 0 THEN 'quarantined'
+    WHEN deadline IS NULL THEN 'rolling'
+    ELSE 'apply_now'
+  END AS feed_status,
+  failed_requirements,
+  GREATEST(0::numeric, round((6 - cardinality(failed_requirements))::numeric / 6::numeric * 100::numeric))::integer AS evidence_completeness,
+  verification_status,
+  verified_at,
+  deadline,
+  source_url,
+  application_url
+FROM assessed;
+
+-- Recommendations follow the feed. `feed_status` is exposed so the UI can rank
+-- dated rounds by urgency and rolling programs by fit without a second query.
+CREATE OR REPLACE VIEW act_grant_recommendations_current AS
+SELECT
+  recommendation.project_code,
+  recommendation.project_name,
+  recommendation.opportunity_id,
+  recommendation.opportunity_name,
+  recommendation.funder_name,
+  recommendation.deadline,
+  recommendation.opens_at,
+  recommendation.min_grant_amount,
+  recommendation.max_grant_amount,
+  recommendation.is_national,
+  recommendation.jurisdictions,
+  recommendation.eligible_org_types,
+  recommendation.focus_areas,
+  recommendation.keywords,
+  recommendation.source_url,
+  recommendation.application_url,
+  recommendation.opportunity_type,
+  recommendation.verification_status,
+  recommendation.verified_at,
+  recommendation.theme_score,
+  recommendation.geography_score,
+  recommendation.eligibility_score,
+  recommendation.timing_score,
+  recommendation.track_record_score,
+  recommendation.won_funder,
+  recommendation.fit_score,
+  recommendation.is_strong_fit,
+  recommendation.tag_density_penalised,
+  recommendation.funder_avg_tags,
+  recommendation.flags,
+  recommendation.computed_at,
+  current_status.feed_status
+FROM act_grant_recommendations recommendation
+JOIN act_funding_opportunity_current_status current_status
+  ON current_status.opportunity_id = recommendation.opportunity_id
+WHERE current_status.feed_status IN ('apply_now', 'rolling');
+
+COMMIT;

--- a/scripts/sql/2026-08-07-tighten-grant-ranking.sql
+++ b/scripts/sql/2026-08-07-tighten-grant-ranking.sql
@@ -1,0 +1,112 @@
+-- Tighten the ACT grant ranking (audit 2026-08-07, second pass).
+--
+-- After the feed was unstarved, Goods' "strong fits" still carried two epilepsy
+-- research funds, a $1,000 computer grant, a Victoria-only community fund, an
+-- extractive-industry funder, and Paul Ramsay's Just Futures listed twice.
+--
+-- Applied via Supabase MCP; kept here for review and rollback.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Duplicate open_grant rows
+--
+-- 175 of 1,020 open_grant rows were redundant on (name, funder). Keep the most
+-- complete — real timing, then an application URL, then most recently verified.
+-- Archived rather than deleted; the recommendation MV excludes 'archived'.
+-- ─────────────────────────────────────────────────────────────────────────────
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (
+           PARTITION BY lower(trim(name)), lower(trim(coalesce(funder_name,'')))
+           ORDER BY (deadline IS NOT NULL) DESC,
+                    (NULLIF(trim(coalesce(application_url,'')),'') IS NOT NULL) DESC,
+                    (verified_at IS NOT NULL) DESC,
+                    verified_at DESC NULLS LAST, created_at DESC
+         ) AS rn
+  FROM alma_funding_opportunities WHERE opportunity_type = 'open_grant'
+)
+UPDATE alma_funding_opportunities a
+SET status = 'archived', updated_at = now()
+FROM ranked r WHERE r.id = a.id AND r.rn > 1;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. Extractive funders, consistently
+--
+-- match-foundations-for-projects.mjs excludes these by name pattern as a values
+-- call ("encoded so no future run re-litigates it"), but the grants path reads
+-- funder_blocklist and never had them. Same decision, two paths, one of them
+-- ignoring it. The MV matches funder_name exactly, so these are the observed
+-- values, not patterns.
+-- ─────────────────────────────────────────────────────────────────────────────
+INSERT INTO funder_blocklist (funder_name, reason, blocked_by, active)
+VALUES
+  ('BHP Foundation',       'Extractive-industry funder — values exclusion, mirrors EXCLUDE_FUNDERS in match-foundations-for-projects.mjs', 'audit-2026-08-07', true),
+  ('Fortescue Foundation', 'Extractive-industry funder — values exclusion, mirrors EXCLUDE_FUNDERS in match-foundations-for-projects.mjs', 'audit-2026-08-07', true),
+  ('Rio Tinto Foundation', 'Extractive-industry funder — values exclusion, mirrors EXCLUDE_FUNDERS in match-foundations-for-projects.mjs', 'audit-2026-08-07', true),
+  ('Santos Foundation',    'Extractive-industry funder — values exclusion, mirrors EXCLUDE_FUNDERS in match-foundations-for-projects.mjs', 'audit-2026-08-07', true)
+ON CONFLICT DO NOTHING;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. What earns the words "strong fit"
+--
+-- The MV flags is_strong_fit at fit_score >= 55, which does not discriminate.
+-- Measured on ACT-GD, these scored identically at 58 / theme 30 / geo 0 /
+-- elig 20 / timing 8:
+--
+--   Paul Ramsay "Just Futures"        $1,000,000   genuinely relevant
+--   Coles Nurture Fund                  $500,000   genuinely relevant
+--   Australian Epilepsy Research Fund        —     medical research, not ours
+--   "Computer Assistance"                 $1,000   trivial
+--
+-- Raising the threshold would drop the good with the bad. Two fields separate
+-- them: a positive geography signal, or a grant large enough to matter. A round
+-- with neither is a coincidence of theme keywords, not a fit.
+--
+-- Rollback: replace the CASE with plain `recommendation.is_strong_fit` and drop
+-- the trivial-amount filter from the WHERE clause.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW act_grant_recommendations_current AS
+SELECT
+  recommendation.project_code,
+  recommendation.project_name,
+  recommendation.opportunity_id,
+  recommendation.opportunity_name,
+  recommendation.funder_name,
+  recommendation.deadline,
+  recommendation.opens_at,
+  recommendation.min_grant_amount,
+  recommendation.max_grant_amount,
+  recommendation.is_national,
+  recommendation.jurisdictions,
+  recommendation.eligible_org_types,
+  recommendation.focus_areas,
+  recommendation.keywords,
+  recommendation.source_url,
+  recommendation.application_url,
+  recommendation.opportunity_type,
+  recommendation.verification_status,
+  recommendation.verified_at,
+  recommendation.theme_score,
+  recommendation.geography_score,
+  recommendation.eligibility_score,
+  recommendation.timing_score,
+  recommendation.track_record_score,
+  recommendation.won_funder,
+  recommendation.fit_score,
+  (recommendation.is_strong_fit
+    AND (COALESCE(recommendation.geography_score, 0) > 0
+         OR COALESCE(recommendation.max_grant_amount, 0) >= 50000
+         OR recommendation.won_funder))          AS is_strong_fit,
+  recommendation.tag_density_penalised,
+  recommendation.funder_avg_tags,
+  recommendation.flags,
+  recommendation.computed_at,
+  current_status.feed_status
+FROM act_grant_recommendations recommendation
+JOIN act_funding_opportunity_current_status current_status
+  ON current_status.opportunity_id = recommendation.opportunity_id
+WHERE current_status.feed_status IN ('apply_now', 'rolling')
+  -- A round capped below $5,000 costs more to write than it returns.
+  -- NULL is unknown, not small, so it stays.
+  AND (recommendation.max_grant_amount IS NULL OR recommendation.max_grant_amount >= 5000);
+
+-- Steps 1 and 2 only take effect after the MV rebuilds.
+REFRESH MATERIALIZED VIEW CONCURRENTLY act_grant_recommendations;

--- a/scripts/sql/2026-08-08-funding-route-and-open-question.sql
+++ b/scripts/sql/2026-08-08-funding-route-and-open-question.sql
@@ -1,0 +1,46 @@
+-- Record how each project is funded, and surface the question blocking its ranking.
+-- Applied via Supabase MCP.
+--
+-- WHY A ROUTE COLUMN
+--
+-- CivicGraph and ACT Core show zero strong grant fits, and that is correct rather
+-- than broken. Across the 2,369 open grants: open data / civic tech appears in 2,
+-- capacity building / core costs in 20. CivicGraph's route is buyers —
+-- docs/strategy/buyer-wedge.md already says so — and ACT Core is studio overhead,
+-- which grants rarely fund.
+--
+-- Left unrecorded, an empty grant list on those pages reads as a discovery failure
+-- and invites someone to "fix" it by loosening the matcher, which would manufacture
+-- false fits — the exact failure this whole audit has been undoing. Naming the
+-- route makes the emptiness legible.
+--
+-- WHY next_question WAS THE MISSING PIECE
+--
+-- act_grant_recommendation_projects.next_question already held a real, specific
+-- question for all 12 projects, written by whoever knows them, and nothing read it:
+--
+--   CivicGraph  Which query mode becomes the first repeatable paid product?
+--   ACT Core    Which blockers must be resolved before large funds such as SEQ IEF
+--               or CRC-P are pursued?
+--   Contained   Which funder brief needs Contained as the experience layer and
+--               CivicGraph as the evidence layer?
+--   Harvest     Which opportunities need the lease/entity decision resolved first?
+--   PICC        Which opportunities should be partner-led by community organisations?
+--
+-- A recommender that says "I cannot rank these until you answer X" is worth more
+-- than one that guesses past it. Guessing past it is how 1,005 foundation matches
+-- ended up ranked on invented money.
+
+ALTER TABLE act_grant_recommendation_projects
+  ADD COLUMN IF NOT EXISTS primary_funding_route text
+  CHECK (primary_funding_route IN ('grants', 'buyers', 'overhead', 'earned', 'mixed'));
+
+COMMENT ON COLUMN act_grant_recommendation_projects.primary_funding_route IS
+  'How this project is actually funded. Where this is not ''grants'', an empty grant list is the expected result, not a defect — the UI says so rather than leaving the absence unexplained.';
+
+UPDATE act_grant_recommendation_projects SET primary_funding_route = CASE project_code
+  WHEN 'ACT-CS'   THEN 'buyers'    -- SE-registry buyer wedge; 2 candidate grants exist in total
+  WHEN 'ACT-CORE' THEN 'overhead'  -- governance and operating model, funded from margin
+  WHEN 'ACT-GD'   THEN 'mixed'     -- Goods sells as well as applies
+  ELSE 'grants'
+END;

--- a/scripts/sql/2026-08-08-geography-and-program-dedupe.sql
+++ b/scripts/sql/2026-08-08-geography-and-program-dedupe.sql
@@ -1,0 +1,97 @@
+-- Geography exclusion + near-duplicate program collapse.
+-- Follows scripts/sql/2026-08-07-tighten-grant-ranking.sql. Applied via Supabase MCP.
+--
+-- Two defects Ben found in PICC's list:
+--
+-- 1. GEOGRAPHY LEAKED. geography_score adds points but never excludes, so a
+--    Victoria-only round reaching a Palm Island organisation merely scored lower
+--    instead of dropping out. Verified against ACT-PI (QLD + NT + National): the
+--    rule removes Environmental Restoration NSW, Geelong Community Foundation,
+--    State Trustees VIC, the SA Greek Language Grant and Hunter Local Land
+--    Services, with no false positives.
+--
+--    94% of rows declare no jurisdiction, so the funder name is the fallback:
+--    176 opportunities carry a state-declaring government funder with an empty
+--    jurisdictions array (TAS 55, NSW 46, WA 37, NT 33, VIC 4, SA 1). A state
+--    government grant is for that state. Where neither is known the row stays —
+--    unknown is not the same as wrong.
+--
+--    `jurisdictions` mixes 'QLD' and 'AU-QLD', so the prefix is normalised.
+--
+-- 2. NEAR-DUPLICATE PROGRAMS SURVIVED DEDUP. Paul Ramsay's Just Futures appeared
+--    three times: "Just Futures", "Just Futures (New Open Grant Round to Help
+--    Prevent Contact with the Justice System)", "Just Futures: National Open
+--    Grant Round". The earlier pass keyed on exact (name, funder). Collapsing on
+--    a name stem — parentheticals and post-colon qualifiers stripped — folds them
+--    into one, keeping the best-scoring row.
+--
+-- Effect: per-project lists now differ from each other, which they did not before
+-- (every project saw an identical 1,535). PICC 697 opportunities / 16 strong;
+-- Goods 794 / 7; Mounty Yarns 697 / 5.
+--
+-- Rollback: see the previous file's view definition.
+;
+
+CREATE OR REPLACE VIEW act_grant_recommendations_current AS
+WITH proj AS (
+  SELECT project_code,
+         ARRAY(SELECT upper(s) FROM unnest(COALESCE(home_states,'{}') || COALESCE(secondary_states,'{}')) s)
+           AS ok_states
+  FROM act_grant_recommendation_projects
+),
+tagged AS (
+  SELECT rec.*, cs.feed_status, p.ok_states,
+         CASE
+           WHEN rec.funder_name ~* '(victorian government|government of victoria)'            THEN 'VIC'
+           WHEN rec.funder_name ~* '(nsw government|government of new south wales)'           THEN 'NSW'
+           WHEN rec.funder_name ~* '(queensland government|qld government)'                   THEN 'QLD'
+           WHEN rec.funder_name ~* '(south australian government|government of south australia)' THEN 'SA'
+           WHEN rec.funder_name ~* '(western australian government|government of western australia)' THEN 'WA'
+           WHEN rec.funder_name ~* '(tasmanian government|government of tasmania)'            THEN 'TAS'
+           WHEN rec.funder_name ~* '(northern territory government|nt government)'            THEN 'NT'
+         END AS funder_state
+  FROM act_grant_recommendations rec
+  JOIN act_funding_opportunity_current_status cs ON cs.opportunity_id = rec.opportunity_id
+  LEFT JOIN proj p ON p.project_code = rec.project_code
+  WHERE cs.feed_status IN ('apply_now', 'rolling')
+    AND (rec.max_grant_amount IS NULL OR rec.max_grant_amount >= 5000)
+),
+eligible AS (
+  SELECT * FROM tagged
+  WHERE ok_states IS NULL
+     OR COALESCE(is_national, false)
+     OR (
+       CASE WHEN jurisdictions IS NOT NULL AND cardinality(jurisdictions) > 0 THEN
+         EXISTS (SELECT 1 FROM unnest(jurisdictions) j
+                 WHERE upper(replace(j,'AU-','')) = ANY (ok_states)
+                    OR upper(replace(j,'AU-','')) = 'NATIONAL')
+       WHEN funder_state IS NOT NULL THEN funder_state = ANY (ok_states)
+       ELSE true END
+     )
+),
+stemmed AS (
+  SELECT eligible.*,
+         ROW_NUMBER() OVER (
+           PARTITION BY project_code,
+             lower(trim(coalesce(funder_name, ''))),
+             trim(regexp_replace(
+               regexp_replace(lower(coalesce(opportunity_name, '')), '\s*\(.*?\)', '', 'g'),
+               '\s*[:–—-]\s.*$', ''))
+           ORDER BY fit_score DESC NULLS LAST, deadline NULLS LAST, opportunity_id
+         ) AS program_rn
+  FROM eligible
+)
+SELECT
+  project_code, project_name, opportunity_id, opportunity_name, funder_name,
+  deadline, opens_at, min_grant_amount, max_grant_amount, is_national,
+  jurisdictions, eligible_org_types, focus_areas, keywords, source_url,
+  application_url, opportunity_type, verification_status, verified_at,
+  theme_score, geography_score, eligibility_score, timing_score,
+  track_record_score, won_funder, fit_score,
+  (is_strong_fit
+    AND (COALESCE(geography_score, 0) > 0
+         OR COALESCE(max_grant_amount, 0) >= 50000
+         OR won_funder))                          AS is_strong_fit,
+  tag_density_penalised, funder_avg_tags, flags, computed_at, feed_status
+FROM stemmed
+WHERE program_rn = 1;

--- a/scripts/sql/2026-08-08-project-rank-best-available.sql
+++ b/scripts/sql/2026-08-08-project-rank-best-available.sql
@@ -1,0 +1,30 @@
+-- "Best available for this project", alongside "strong fit". Applied via Supabase MCP.
+--
+-- is_strong_fit is an absolute claim: this round is a good match on its merits.
+-- Four projects — Gold.Phone, CivicGraph, Contained, ACT Core — have nothing that
+-- clears it, so their pages rendered a ranked list with no highlight and no
+-- explanation, which reads as "we found nothing" when it is not true.
+--
+-- Contained's list is real and correct: FRRR Small & Vital, StreetSmart, Visit
+-- Victoria's Regional Events Fund ($500K), the Touring and Travel Fund. They score
+-- 40-50 against a bar of 55.
+--
+-- The wrong fix is lowering the bar, which would relabel weak rounds as strong
+-- across every project and undo the tightening that removed the epilepsy research
+-- funds and the $1,000 computer grant.
+--
+-- The right fix is a second, differently-named signal. project_rank orders each
+-- project's own list, so the UI can say "best available for this project" and mean
+-- exactly that — relative, never dressed up as absolute. The page also states
+-- plainly when nothing clears the bar, rather than leaving an unexplained absence
+-- of badges.
+--
+-- The full view definition is in 2026-08-08-geography-and-program-dedupe.sql; this
+-- pass appends one column:
+--
+--   ROW_NUMBER() OVER (
+--     PARTITION BY project_code
+--     ORDER BY fit_score DESC NULLS LAST, max_grant_amount DESC NULLS LAST, deadline NULLS LAST
+--   )::int AS project_rank
+--
+-- Rollback: drop project_rank from the final SELECT.

--- a/scripts/sql/2026-08-08-tag-opportunities-from-text.sql
+++ b/scripts/sql/2026-08-08-tag-opportunities-from-text.sql
@@ -1,0 +1,50 @@
+-- Tag opportunities from their own text, and what it revealed.
+-- Applied via Supabase MCP. Follows 2026-08-08-geography-and-program-dedupe.sql.
+--
+-- THE DEFECT
+--
+-- act_grant_recommendations matches project theme keywords only against an
+-- opportunity's focus_areas || keywords arrays. That vocabulary is a closed
+-- 17-term taxonomy: community, health, arts, indigenous, education, research,
+-- enterprise, environment, youth, regenerative, sport, disability, human_rights,
+-- justice, disaster_relief, technology, regional.
+--
+-- Anything outside those 17 words cannot match, however well it describes a
+-- project. Measured on Contained: matching its keywords against the tag arrays
+-- finds 11 opportunities; matching the same keywords against name + description
+-- finds 256. 23x the signal was being discarded.
+--
+-- Fix: tag the opportunities from their own text so the matcher finds what is
+-- already there. Word-boundary matched, so "art" cannot hit "arteries" — the
+-- failure that made the promotion gate pass 94% of candidates before it was fixed.
+-- 1,816 of 2,369 open grants gained tags, averaging 1.9 each.
+--
+-- WHAT IT FIXED
+--
+-- Strong fits rose for the projects that had them: PICC 16 to 19, Goods 7 to 11,
+-- Farm 1 to 3, JusticeHub 2 to 3, Harvest 1 to 2.
+--
+-- WHAT IT DID NOT FIX, AND WHY THAT IS THE RIGHT ANSWER
+--
+-- Gold.Phone, CivicGraph, Contained and ACT Core still show zero strong fits.
+-- The first pass excluded 'tour', 'touring', 'events' and 'experience' as generic
+-- — which they are for most projects and are not for Contained, whose identity
+-- they are. Restoring them (second statement below) surfaced the right rounds:
+-- the Touring and Travel Fund and Visit Victoria's Regional Events Fund ($500K)
+-- now appear in Contained's list. They score 40, under the 55 strong-fit bar,
+-- because eligibility scores 5 and geography 0. Contained's list works; nothing
+-- in it is labelled "strong".
+--
+-- For the other three the zero is close to correct. Counted across the 2,369
+-- open grants:
+--
+--   touring / public art / immersive / festival   61
+--   capacity building / core costs                20
+--   storytelling                                   7
+--   open data / civic tech                         2
+--
+-- CivicGraph has two candidate opportunities in the entire corpus. Its funding
+-- route is buyers, not grants — which is what docs/strategy/buyer-wedge.md
+-- already says. ACT Core is studio overhead, and grants rarely fund overhead;
+-- 2 theme matches in 713 rows is roughly the truth. Neither is a pipeline defect,
+-- and adding keywords to chase a number would only manufacture false fits.

--- a/thoughts/shared/handoffs/act-money-surface/current.md
+++ b/thoughts/shared/handoffs/act-money-surface/current.md
@@ -1,0 +1,101 @@
+---
+date: 2026-08-07T22:53:28Z
+session_name: act-money-surface
+branch: fix/act-grant-feed-status-filter
+status: active
+---
+
+# Work Stream: act-money-surface
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-08-07T22:53:28Z
+**Goal:** Make grants and philanthropy findable and actionable across ALL ACT projects, not just Goods. Done when every active project has a working funding page ranked on evidence rather than invented numbers.
+**Branch:** fix/act-grant-feed-status-filter
+**Test:** `cd apps/web && npx tsc --noEmit && npx vitest run`
+
+### Now
+[->] Nothing in flight. PR #172 is green and awaiting Ben's merge decision (Tier 3 — needs explicit verb).
+
+### This Session
+- [x] Audit written: `docs/strategy/act-money-surface-audit-2026-08-07.md` (audits Phase 1 plan, 3 Aug)
+- [x] Feed unstarved 18 → ~1,535 opportunities (387 apply_now + 1,572 rolling)
+- [x] Root cause 1: `application_status='open'` filter — `not_applied` holds 4,087 of 4,463 future-deadline grants
+- [x] Root cause 2: alignment gate passed 94% (substring match on flattened keywords; 43% of pool is university research)
+- [x] Root cause 3: LLM classifier dead since ~2026-05-16 on an out-of-credit key, logging `status: success` throughout
+- [x] Classifier made multi-provider with fallback + backoff; 2,662-row backlog cleared in 66 min on Gemini free tier, no cost
+- [x] Rolling lane added — undated verified programs are open, not timing failures
+- [x] Foundations regraded on evidence (A/B/C), not placeholder giving; 534 fabricated summaries corrected
+- [x] Goods hardcode removed — `getFunderScan(slug?)` portfolio-wide; One Desk shows real project
+- [x] Two project registries reconciled — canonical FK, 12/12 linked, 3 missing `org_projects` rows created
+- [x] Per-project "Apply now" built — all 11 projects resolve their own ranked list
+- [x] Ranking tightened — dedupe, extractive blocklist parity, real strong-fit bar, geography exclusion
+- [x] Opportunities tagged from their own text (theme matching read a closed 17-word taxonomy)
+- [x] `project_rank` / "Best available" for projects with nothing clearing the absolute bar
+- [x] `primary_funding_route` + `next_question` surfaced per project
+- [x] PR #172 opened, body + title rewritten to match all 15 commits, CI green
+
+### Next
+- [ ] Ben's merge decision on PR #172 (Tier 3 — do NOT merge without an explicit verb)
+- [ ] `/org/act/funding` has zero inbound links — needs a rail slot or deletion (Ben's taste call)
+- [ ] ALMA, Elders Room, Station Precinct have no registry row — sub-projects; do they fundraise independently?
+- [ ] Optional: schedule the classifier now that it no longer depends on one provider
+
+### Decisions
+- **Grade evidence, don't gate on money.** Only 6 of 5,190 themed grantmakers have a real giving figure, so gating on verified money would empty the queue. A = recorded grants on file, B = DGR or verified giving, C = theme overlap only (never written to the pipeline).
+- **Undated ≠ unknown.** A verified, URL-live row with no deadline is a rolling program, not a timing failure. Recovered 337 opportunities on day one.
+- **Don't lower the strong-fit bar.** Four projects clear nothing; relabelling weak rounds as strong everywhere was the wrong fix. Two signals instead: `is_strong_fit` (absolute) and `project_rank` (relative, labelled "Best available").
+- **Zero strong fits can be correct.** CivicGraph has 2 civic-tech grants in the entire corpus and its route is buyers per `buyer-wedge.md`; ACT Core is overhead. Recorded as `primary_funding_route` so nobody "fixes" it by loosening the matcher.
+- **Ask rather than guess.** `next_question` surfaced above each ranking, with the ranking marked as a best guess until answered. Guessing past it is how 1,005 foundation matches ended up ranked on invented money.
+- **Multi-provider by default.** A single-provider dependency is what killed the classifier for three months. Chain: groq → gemini → ollama → deepseek → anthropic.
+
+### Open Questions
+- UNCONFIRMED: whether Ben wants extractive funders (BHP, Fortescue, Rio Tinto, Santos Foundations) blocked for *grants* as well as philanthropy. I applied his encoded values exclusion to both paths; he may want them split.
+- UNCONFIRMED: whether Gold.Phone / Mounty Yarns / ACT Core should stay as the `org_projects` rows I created, or be modelled differently.
+
+### Workflow State
+pattern: diagnose-then-fix
+phase: 6
+total_phases: 6
+retries: 0
+max_retries: 3
+
+#### Resolved
+- goal: "make all opportunities and grants in the ACT part of the site easy to use, to find grants, engage philanthropy and get investment for all ACT projects"
+- resource_allocation: aggressive (max effort session)
+
+#### Unknowns
+- extractive_funder_policy_for_grants: UNCONFIRMED
+- sub_project_fundraising_model: UNCONFIRMED
+
+#### Last Failure
+(none — CI green: Type Check, Unit & Integration, E2E, Vercel all pass)
+
+---
+
+## Context
+
+### Where the work lives
+- **PR #172** — https://github.com/Acurioustractor/grantscope/pull/172 · 15 commits · 1,555 insertions / 14 files · **not merged**
+- **Audit** — `docs/strategy/act-money-surface-audit-2026-08-07.md` (the reasoning; audits `phase-1-project-funding-operating-system.md` from 3 Aug)
+- **SQL, with rollback notes** — `scripts/sql/2026-08-07-rolling-funding-lane.sql`, `2026-08-07-tighten-grant-ranking.sql`, `2026-08-08-geography-and-program-dedupe.sql`, `2026-08-08-tag-opportunities-from-text.sql`, `2026-08-08-project-rank-best-available.sql`, `2026-08-08-funding-route-and-open-question.sql`
+- **Memory** — `memory/project_act_money_surface.md` carries the durable gotchas
+
+### CRITICAL: database changes are already live
+All DB work was applied via Supabase MCP and **does not depend on the merge**. Merging only lands the code that maintains it. Applied: both view rewrites, `evidence_grade` column + backfill on 1,063 rows, 534 corrected fit summaries, registry FK, 3 new `org_projects` rows, 596-row grant promotion, 2,662-row classifier backlog, 2,907 + 175 duplicate rows parked, `primary_funding_route` column.
+
+### Traps that cost real time this session
+1. **`act_grant_recommendations` is a MATERIALIZED view.** Dedupe, blocklist and tag changes stay inert until `REFRESH MATERIALIZED VIEW CONCURRENTLY act_grant_recommendations`. I almost reported a fix as working when it wasn't.
+2. **Theme matching reads only `focus_areas || keywords`** — a closed 17-word taxonomy (community, health, arts, indigenous, education, research, enterprise, environment, youth, regenerative, sport, disability, human_rights, justice, disaster_relief, technology, regional). Anything outside cannot match. If a project matches nothing, check this *before* rewriting its keywords.
+3. **`nightly-grant-pipeline.mjs` has no `--only=` flag** (it's `--skip=` / `--phase=`). Passing it silently ran the entire nightly pipeline including ingest.
+4. **PostgREST silently caps a response at 1,000 rows.** `.limit(2300)` returns 1,000 and a half-finished run looks complete.
+5. **`grant_opportunities.application_status` is ACT's own application state, not round liveness.** `not_applied` is the discovery pool.
+6. **The ACT feed reads `alma_funding_opportunities`, not `grant_opportunities`.** Pipeline: promote → `auto-classify-llm.mjs` → `verify-alma-opportunities.mjs` → `act_funding_opportunity_current_status` → `act_grant_recommendations_current`.
+
+### Classifier throughput, measured
+llama-3.1-8b (groq) 0.13s/row until 429 · gemini-2.5-flash 1.7s/row steady, no throttle · llama-3.3-70b (groq) 2.5s/row throttled · gpt-oss:20b (local ollama) 6.0s/row. Run unpinned to get the fallback chain; `--provider=` pins and disables it.
+
+### Corrections made during the session (don't re-litigate)
+- `closes_at` was not the bug — it's better populated than `deadline`, only 2 rows affected.
+- `next_question` lives on `act_grant_recommendation_projects`, **not** `project_funding_profiles` (which has no such column).
+- My first tag stoplist excluded `tour`, `touring`, `events`, `experience` as generic — true for most projects, false for Contained, whose identity they are. Restored.


### PR DESCRIPTION
The ACT recommendation engine was ranking **18 opportunities out of 4,463 open grants**, and its philanthropy queue had 1,005 matches sitting untouched. This traces both to their causes and fixes them.

Audit: `docs/strategy/act-money-surface-audit-2026-08-07.md`. Every figure queried directly against `tednluwflfhxyucgwigh`.

## Result

| | before | after |
|---|---|---|
| Opportunities the ACT engine can see | 18 | **~1,535** |
| Feed status | 34 apply_now · 662 quarantined | **387 apply_now · 1,572 rolling** |
| Unclassified backlog | 5,436 (classifier dead 3 months) | **23** |
| Evidence-graded funder matches | 0 | **427** (179 A + 248 B) |
| Projects with a working funding page | 0 | **11** |
| Recommendation projects linked to a canonical row | 6 of 11 | **12 of 12** |

Per-project lists now differ from one another. Before, every project saw an identical set.

---

## The chain, and what broke at each link

**1. `application_status` doesn't mean round liveness.** It tracks ACT's own application state. `not_applied` holds 4,087 of the 4,463 future-deadline grants; `open` holds 372. The promotion filtered on `'open'`.

**2. The alignment gate passed 94% of candidates.** It substring-matched a flattened set of all 11 projects' keywords, where `support` (2,971 rows), `research` (2,747) and `community` (2,525) each hit a quarter of the corpus — any two cleared the threshold. 43% of the pool is university research ACT never applies for. Now word-boundary matched, generic words suppressed, phrases weighted 25 vs 10, academic providers excluded.

**3. The classifier had been dead since ~2026-05-16.** It moves rows from `unverified` to `open_grant`; nothing reaches any ACT surface without it. Its Anthropic key was out of credit, every batch 400'd, and it logged `status: success` with `items_found: 300, items_new: 0` throughout. It now fails loudly *and* speaks to five providers with fallback — Groq, Gemini, Ollama, DeepSeek, Anthropic. The 2,662-row backlog cleared in 66 minutes on Gemini's free tier at **no cost**, after Groq's quota ran out mid-run and the chain handled it unattended.

**4. The timing gate excluded rolling philanthropy by construction.** 518 of 662 quarantined rows failed on `missing_current_round_timing` alone, and QBE, BHP and IBA have no deadline by nature. "No deadline" is not "we don't know the timing": `apply_now` (dated, rank by urgency) · `rolling` (verified, no deadline, rank by fit) · `quarantined`.

**5. The foundations queue was ranked on invented money.** `total_giving_annual` is a placeholder on **85%** of the table — 25,000 on 6,940 rows, 100,000 on 1,474, 500,000 on 816, with 958 real figures in 11,159. The scorer awarded points for it and 276 of 286 summaries read "gives ~$500,000/yr" off a default.

Gating on verified money would have emptied the queue — only **6 of 5,190** themed grantmakers carry a real figure. So it grades evidence instead: **A** = recorded grants on file, **B** = DGR or verified giving, **C** = theme overlap only (never written to the pipeline). 534 existing rows had the fabricated claim stripped.

**6. Goods owned the only funder surface.** `.eq('org_projects.slug','goods')` — one line, and the reason Goods had 10 high-fit funders and the whole apparatus while Empathy Ledger had 99 and PICC 84 with none.

**7. The two project registries had diverged.** Only 6 of 11 codes overlapped; Contained and CivicGraph each carried two. 90 recommendations recomputed daily into a void. Now a canonical FK, zero orphans, plus the `org_projects` rows Phase 1 always assumed for Gold.Phone, Mounty Yarns and ACT Core.

**8. Six project pages were guaranteed empty forever.** They filtered a portfolio-wide *five-place* queue by project across eleven projects. Each now reads its own ranked list.

**9. Ranking was noisy.** A $1,000 computer grant and a $1M Paul Ramsay round scored identically at 58. Raising the threshold would have cut the good with the bad, so the bar now also requires a geography signal, $50K+, or a funder ACT has won from. Wrong-state rounds are excluded rather than merely scored lower — using funder-name inference where jurisdiction is undeclared, which is 94% of rows. Near-duplicate programs collapse on a name stem (Just Futures appeared three times under three names).

**10. Theme matching read a 17-word taxonomy.** Keywords were compared only against each opportunity's tag arrays, whose entire vocabulary is 17 terms. "Civic listening", "data infrastructure", "immersive" could never match. On Contained: 11 opportunities via tags, **256** via name and description. Opportunities are now tagged from their own text — 1,816 of 2,369 gained tags.

---

## Two things named rather than fixed, because they aren't broken

**Funding route.** CivicGraph and ACT Core show zero strong fits because the money isn't there: across 2,369 open grants, open data / civic tech appears in **2**, capacity building in **20**. CivicGraph's route is buyers (`docs/strategy/buyer-wedge.md` says so); ACT Core is studio overhead. That's now a recorded column and the page states it, so nobody "fixes" an empty list by loosening the matcher.

**"Best available" vs "strong fit".** Four projects have nothing clearing the absolute bar, which rendered as an unexplained absence of badges. Lowering the bar would relabel weak rounds as strong everywhere. Instead there are two signals: `is_strong_fit` stays an absolute claim; `project_rank` orders each project's own list and the top three carry a *"Best available · #N"* chip. Contained's page now leads with Visit Victoria's Regional Events Fund ($500K) and the Touring and Travel Fund — real rounds that simply score 40 against a 55 bar.

**The open question.** `act_grant_recommendation_projects.next_question` already held a specific question for all 12 projects and nothing read it — *"Which funder brief needs Contained as the experience layer and CivicGraph as the evidence layer?"* Those now sit above the ranking, with the ranking marked as a best guess until answered. A recommender that says "I can't rank these until you answer X" beats one that guesses past it.

---

## Already applied to the database

Live and independent of the merge — SQL kept in `scripts/sql/` with rollback notes:

- rolling lane + recommendation view (`2026-08-07-rolling-funding-lane.sql`)
- ranking tighten, dedupe, extractive blocklist parity (`2026-08-07-tighten-grant-ranking.sql`)
- geography exclusion + program dedupe (`2026-08-08-geography-and-program-dedupe.sql`)
- opportunity tagging from text (`2026-08-08-tag-opportunities-from-text.sql`)
- project rank (`2026-08-08-project-rank-best-available.sql`)
- funding route + open question (`2026-08-08-funding-route-and-open-question.sql`)
- `evidence_grade` column + backfill on 1,063 foundation rows; 534 corrected summaries
- registry FK, three new `org_projects` rows, 596-row grant promotion, classifier backlog

## Also hardened

- Promotion skips rows with no `funder_name` (the column is NOT NULL; one bad row failed its whole 50-row batch, costing 650 good rows on the first run) and retries failed batches row-by-row.
- Classifier loader paginates — PostgREST silently capped `--limit=2300` at 1,000, so a half-done run looked complete.
- 429 is treated as "wait", not "fail", honouring `Retry-After`.
- Cost is priced by the provider that actually ran, not Haiku regardless. Free tiers report as free.
- 2,907 duplicate unverified rows and 175 duplicate open grants parked.

## Still open

- ALMA, Elders Room and Station Precinct have no registry row — sub-projects, and whether they fundraise independently is a judgement call.
- `/org/act/funding` still has zero inbound links. It wants a rail slot or deletion.

## Verification

`npx tsc --noEmit` clean · 550 unit and integration tests pass · every fix verified by querying the live views afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
