### PR TITLE
Give the funding desk a rail slot

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -90,10 +90,15 @@ export function ActWorkspaceShell({
     // The one cross-project noun (ADR 0002): cultivated humans, org-wide.
     { label: 'People', hint: 'Who we cultivate', href: `/org/${slug}/people`, active: pathname.startsWith(`/org/${slug}/people`) },
     { label: 'Curiosity', hint: 'New leads', href: rootHref(slug, 'opportunities', 'opportunities'), active: onOrgRoot && (view === 'opportunities' || view === 'triage') },
-    // Rail cut to the spine (Ben, 2026-08-05): Action, Art, Money, Sources,
-    // Research and Funding all left the rail. Art = the Harvest project, which
-    // the project list already carries; the rest stay reachable by URL
-    // (?view=pipeline, ?view=money, ?view=evidence, /research, /funding).
+    // Funding came back 2026-08-08 (Ben). It was cut on 2026-08-05 because the
+    // feed held 18 opportunities and the room had nothing in it. The feed now
+    // backs ~1,535 across all 11 projects, so the portfolio-wide decision queue
+    // is worth a door. Curiosity is raw leads; this is the ranked five.
+    { label: 'Funding', hint: 'Money worth chasing', href: `/org/${slug}/funding`, active: pathname.startsWith(`/org/${slug}/funding`) },
+    // Rail otherwise stays cut to the spine (Ben, 2026-08-05): Action, Art,
+    // Money, Sources and Research left and have not come back. Art = the Harvest
+    // project, which the project list already carries; the rest stay reachable
+    // by URL (?view=pipeline, ?view=money, ?view=evidence, /research).
   ];
   const utilityLinks = [
     {
@@ -182,7 +187,7 @@ export function ActWorkspaceShell({
                 />
               ) : null}
               <MobileWorkspaceLink href={`/org/${slug}/explore`} label="Atlas" active={pathname.startsWith(`/org/${slug}/explore`)} />
-              {workModes.slice(0, 4).map((mode) => <MobileWorkspaceLink key={mode.label} {...mode} />)}
+              {workModes.map((mode) => <MobileWorkspaceLink key={mode.label} {...mode} />)}
               <MobileWorkspaceLink href={rootHref(slug, 'money', 'money')} label="Money" active={onOrgRoot && view === 'money'} />
               <MobileWorkspaceLink href={rootHref(slug, 'evidence', 'systems')} label="Sources" active={onOrgRoot && view === 'evidence'} />
               <MobileWorkspaceLink href={`/org/${slug}/research`} label="Research" active={pathname.startsWith(`/org/${slug}/research`)} />

--- a/apps/web/tests/e2e/act-field-desk.spec.ts
+++ b/apps/web/tests/e2e/act-field-desk.spec.ts
@@ -352,8 +352,9 @@ test.describe('ACT Field Desk pilot workflow', () => {
     await expect(sidebar.getByRole('link', { name: 'Listen' })).toHaveCount(0);
     // Action retired from the rail — One Desk owns committed work (kind=commitment).
     await expect(sidebar.getByRole('link', { name: 'Action', exact: true })).toHaveCount(0);
-    // Funding retired 2026-08-05 — Curiosity + the desk absorbed the ritual.
-    await expect(sidebar.getByRole('link', { name: /^Funding/ })).toHaveCount(0);
+    // Funding returned 2026-08-08 — the feed went from 18 opportunities to
+    // ~1,535, so the portfolio-wide decision queue is a room again.
+    await expect(sidebar.getByRole('link', { name: /^Funding/ })).toBeVisible();
     await expect(sidebar.getByRole('link', { name: 'Curiosity' })).toBeVisible();
     await sidebar.getByRole('link', { name: 'Orgs' }).click();
     await expect(page).toHaveURL(/\/org\/act\/orgs/);

--- a/apps/web/tests/e2e/act-field-desk.spec.ts
+++ b/apps/web/tests/e2e/act-field-desk.spec.ts
@@ -351,10 +351,18 @@ test.describe('ACT Field Desk pilot workflow', () => {
     const sidebar = page.getByTestId('act-desk-sidebar');
     await expect(sidebar.getByRole('link', { name: 'Listen' })).toHaveCount(0);
     // Action retired from the rail — One Desk owns committed work (kind=commitment).
-    await expect(sidebar.getByRole('link', { name: 'Action', exact: true })).toHaveCount(0);
+    // Not exact: true — the rail numbers its rooms, so an exact whole-string
+    // match on "Action" could never fire and the guard was vacuous.
+    await expect(sidebar.getByRole('link', { name: 'Action' })).toHaveCount(0);
     // Funding returned 2026-08-08 — the feed went from 18 opportunities to
     // ~1,535, so the portfolio-wide decision queue is a room again.
-    await expect(sidebar.getByRole('link', { name: /^Funding/ })).toBeVisible();
+    // Substring, not /^Funding/: the rail prefixes each room with its number,
+    // so the accessible name is "05 Funding Money worth chasing" and an
+    // anchored regex can never match. The absence assertion this replaces was
+    // passing vacuously for that reason — it never guarded anything.
+    const fundingRoom = sidebar.getByRole('link', { name: /Funding/ });
+    await expect(fundingRoom).toBeVisible();
+    await expect(fundingRoom).toHaveAttribute('href', '/org/act/funding');
     await expect(sidebar.getByRole('link', { name: 'Curiosity' })).toBeVisible();
     await sidebar.getByRole('link', { name: 'Orgs' }).click();
     await expect(page).toHaveURL(/\/org\/act\/orgs/);

--- a/docs/strategy/act-money-surface-audit-2026-08-07.md
+++ b/docs/strategy/act-money-surface-audit-2026-08-07.md
@@ -337,3 +337,40 @@ program, Environmental Restoration NSW, Geelong Community Foundation. The
   pipeline one.
 - `project_funding_profiles.next_question` remains unwired.
 - `/org/act/funding` still has no inbound links.
+
+---
+
+## Ben's calls (2026-08-08)
+
+Four judgement questions the audit could not answer for itself. Answered, so
+nobody re-opens them.
+
+**Extractive funders stay blocked on both paths.** BHP, Fortescue, Rio Tinto and
+Santos are excluded from grant rounds as well as philanthropy. The exclusion is a
+values decision about whose money ACT takes, not a claim about the quality of the
+round, so it does not care which door the money comes through. Do not split the
+paths.
+
+**`/org/act/funding` gets a rail slot.** It was cut from the rail on 2026-08-05
+when the feed held 18 opportunities and the room was empty. The feed now backs
+~1,535 across 11 projects, so the portfolio-wide decision queue earns a door.
+Curiosity stays the raw-leads room; Funding is the ranked five. The rest of the
+2026-08-05 cut stands.
+
+**ALMA, Elders Room and Station Precinct fundraise through a parent.** They are
+programs inside another project, not fundraising units. No `org_projects` rows,
+no funding pages, and their money shows on the parent's page. Their absence from
+the registry is now a recorded decision, not a gap to be closed. Item 7 is
+closed on this basis.
+
+**Gold.Phone, Mounty Yarns and ACT Core stay as registry rows.** Created during
+the 2026-08-07 session because Phase 1 names them as canonical. Reviewed and
+kept.
+
+### Closed since
+
+- `project_funding_profiles.next_question` is wired. It renders above the
+  ranking on `/org/{slug}/{project}/funding`, with the ranking marked a best
+  guess until the question is answered.
+- `/org/act/funding` now has an inbound link: rail room 05, "Funding · Money
+  worth chasing".

--- a/thoughts/shared/handoffs/act-money-surface/current.md
+++ b/thoughts/shared/handoffs/act-money-surface/current.md
@@ -9,13 +9,13 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-07T22:53:28Z
+**Updated:** 2026-08-08T00:05:00Z
 **Goal:** Make grants and philanthropy findable and actionable across ALL ACT projects, not just Goods. Done when every active project has a working funding page ranked on evidence rather than invented numbers.
-**Branch:** fix/act-grant-feed-status-filter
+**Branch:** feat/funding-rail-slot (PR #172 merged to main as 17acf23)
 **Test:** `cd apps/web && npx tsc --noEmit && npx vitest run`
 
 ### Now
-[->] Nothing in flight. PR #172 is green and awaiting Ben's merge decision (Tier 3 — needs explicit verb).
+[->] PR #173 (funding rail slot) is green and awaiting Ben's merge decision (Tier 3 — needs explicit verb). PR #172 is MERGED.
 
 ### This Session
 - [x] Audit written: `docs/strategy/act-money-surface-audit-2026-08-07.md` (audits Phase 1 plan, 3 Aug)
@@ -34,12 +34,16 @@ status: active
 - [x] `project_rank` / "Best available" for projects with nothing clearing the absolute bar
 - [x] `primary_funding_route` + `next_question` surfaced per project
 - [x] PR #172 opened, body + title rewritten to match all 15 commits, CI green
+- [x] **PR #172 MERGED** to main as 17acf23 (Ben, 2026-08-08)
+- [x] All four open judgement calls answered by Ben and recorded in the audit
+- [x] `/org/act/funding` given rail room 05 — "Funding · Money worth chasing"
+- [x] Found + fixed two vacuous E2E rail guards (anchored/exact matchers can never match a numbered room)
+- [x] PR #173 opened for the rail slot, CI green
 
 ### Next
-- [ ] Ben's merge decision on PR #172 (Tier 3 — do NOT merge without an explicit verb)
-- [ ] `/org/act/funding` has zero inbound links — needs a rail slot or deletion (Ben's taste call)
-- [ ] ALMA, Elders Room, Station Precinct have no registry row — sub-projects; do they fundraise independently?
+- [ ] Ben's merge decision on PR #173 (Tier 3 — do NOT merge without an explicit verb)
 - [ ] Optional: schedule the classifier now that it no longer depends on one provider
+- [ ] Content problem, not pipeline: Gold.Phone, CivicGraph, Contained and ACT Core have thin theme keywords, which is why they clear zero strong fits
 
 ### Decisions
 - **Grade evidence, don't gate on money.** Only 6 of 5,190 themed grantmakers have a real giving figure, so gating on verified money would empty the queue. A = recorded grants on file, B = DGR or verified giving, C = theme overlap only (never written to the pipeline).
@@ -50,8 +54,11 @@ status: active
 - **Multi-provider by default.** A single-provider dependency is what killed the classifier for three months. Chain: groq → gemini → ollama → deepseek → anthropic.
 
 ### Open Questions
-- UNCONFIRMED: whether Ben wants extractive funders (BHP, Fortescue, Rio Tinto, Santos Foundations) blocked for *grants* as well as philanthropy. I applied his encoded values exclusion to both paths; he may want them split.
-- UNCONFIRMED: whether Gold.Phone / Mounty Yarns / ACT Core should stay as the `org_projects` rows I created, or be modelled differently.
+All four resolved by Ben on 2026-08-08. Recorded in `docs/strategy/act-money-surface-audit-2026-08-07.md` under "Ben's calls (2026-08-08)".
+- RESOLVED: extractive funders (BHP, Fortescue, Rio Tinto, Santos) stay blocked on **both** paths, grants and philanthropy. It is a values decision about whose money ACT takes, so it does not care which door the money comes through. Do not split.
+- RESOLVED: Gold.Phone / Mounty Yarns / ACT Core **stay** as `org_projects` rows.
+- RESOLVED: ALMA / Elders Room / Station Precinct **fundraise through a parent**. No rows, no funding pages; their money shows on the parent's page. Absence from the registry is now a decision, not a gap to close.
+- RESOLVED: `/org/act/funding` **gets a rail slot** rather than deletion. Note this reverses the 2026-08-05 cut, knowingly: the room was cut when the feed held 18 opportunities and is back now it holds ~1,535. The rest of that cut stands.
 
 ### Workflow State
 pattern: diagnose-then-fix
@@ -65,8 +72,8 @@ max_retries: 3
 - resource_allocation: aggressive (max effort session)
 
 #### Unknowns
-- extractive_funder_policy_for_grants: UNCONFIRMED
-- sub_project_fundraising_model: UNCONFIRMED
+- extractive_funder_policy_for_grants: RESOLVED — blocked on both paths
+- sub_project_fundraising_model: RESOLVED — sub-projects fundraise through a parent
 
 #### Last Failure
 (none — CI green: Type Check, Unit & Integration, E2E, Vercel all pass)


### PR DESCRIPTION
`/org/act/funding` had zero inbound links. Nothing in the app navigated to it, so the portfolio-wide decision queue was reachable only by typing the URL.

It was cut from the rail on 2026-08-05, and that was the right call at the time: the feed held 18 opportunities and the room was empty. The feed now backs ~1,535 across all 11 projects, so the room has something in it. Ben's call to bring it back, 2026-08-08.

## What changed

- **Rail room 05, after Curiosity** — "Funding · Money worth chasing". Curiosity stays the raw-leads room; Funding is the ranked five. The rest of the 2026-08-05 cut stands: Action, Art, Money, Sources and Research stay off the rail and reachable by URL.
- **Mobile nav rendered `workModes.slice(0, 4)`** — a no-op at four modes, but it would have silently dropped the fifth. Renders all modes now.
- **The E2E spec asserted Funding was absent.** It now asserts it is present, with the reversal and its reason recorded in place rather than the old comment being deleted.

## Also recorded

Three judgement calls answered on resume, written into the audit so they are not re-opened:

- Extractive funders (BHP, Fortescue, Rio Tinto, Santos) stay blocked on grants as well as philanthropy. It is a values decision about whose money ACT takes, so it does not care which door the money comes through.
- ALMA, Elders Room and Station Precinct fundraise through a parent. Their absence from `org_projects` is a decision, not a gap to be closed.
- Gold.Phone, Mounty Yarns and ACT Core stay as the registry rows created on 2026-08-07.

Closes the last two "Open, unchanged" items from the 2026-08-07 audit: `next_question` is wired and rendering, and `/org/act/funding` now has an inbound link.

## Verification

`tsc --noEmit` clean, 550 unit and integration tests pass. The one thing local gates cannot check is the E2E sidebar assertion — `scrollHeight <= clientHeight`, i.e. the rail never scrolls — now that there is a fifth row. It fits at 720px by my arithmetic, but CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)