### PR TITLE
Make the place pages tell the truth about money and geography

### DIFF
--- a/apps/web/src/app/place/far-west-coast/page.tsx
+++ b/apps/web/src/app/place/far-west-coast/page.tsx
@@ -1,0 +1,240 @@
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+import { getPostcodeFundingPicture } from '@/lib/services/place-intelligence';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Where the money goes: the Far West Coast — CivicGraph',
+  description:
+    'Public money reaching organisations on the Far West Coast of South Australia: Ceduna, Koonibba, Scotdesco, Yalata and Oak Valley.',
+};
+
+function money(value: number): string {
+  if (!value) return '$0';
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toLocaleString('en-AU', { maximumFractionDigits: 1 })}M`;
+  }
+  return `$${Math.round(value).toLocaleString('en-AU')}`;
+}
+
+/**
+ * The five communities, and who holds the paperwork for each.
+ *
+ * This column exists because the data kept trying to hide it. Yalata Anangu
+ * Aboriginal Corporation's registered office is in Ceduna. So is Oak Valley's.
+ * Every automated way of placing an organisation - postcode, registered
+ * address, postal locality - therefore files their money under Ceduna. The
+ * communities are 200km and 700km away.
+ */
+const COMMUNITIES = [
+  { name: 'Ceduna', council: 'District Council of Ceduna', note: 'The regional centre. Most services for the coast are run from here.' },
+  { name: 'Koonibba', council: 'District Council of Ceduna', note: 'About 40km west of Ceduna. Its own corporation, its own store.' },
+  { name: 'Scotdesco', council: 'Unincorporated SA', note: 'At Bookabie, on the coast west of Ceduna.' },
+  { name: 'Yalata', council: 'Unincorporated SA', note: 'About 200km west. Its corporation is registered at an address in Ceduna.' },
+  { name: 'Oak Valley', council: 'Maralinga Tjarutja', note: 'About 700km north-west, on the Maralinga Tjarutja lands. Its corporation is also registered in Ceduna.' },
+];
+
+export default async function FarWestCoastPage() {
+  const supabase = getServiceSupabase();
+
+  const [ceduna5690, streaky5680, crimeResult, unplacedResult] = await Promise.all([
+    getPostcodeFundingPicture('5690').catch(() => null),
+    getPostcodeFundingPicture('5680').catch(() => null),
+    supabase
+      .from('crime_stats_lga')
+      .select('lga_name, offence_group, incidents, year_period')
+      .eq('state', 'SA')
+      .in('lga_name', ['Ceduna', 'Maralinga Tjarutja', 'Streaky Bay'])
+      .eq('offence_group', 'Total'),
+    supabase
+      .from('gs_entities')
+      .select('id', { count: 'exact', head: true })
+      .eq('postcode', '5690')
+      .eq('lga_source', 'unresolved_multi_lga_postcode'),
+  ]);
+
+  const crime = (crimeResult.data || []) as Array<{ lga_name: string; incidents: number; year_period: string }>;
+  const crimePeriod = crime[0]?.year_period ?? null;
+  const unplaced = unplacedResult.count ?? 0;
+
+  const committed = (ceduna5690?.activeValue ?? 0) + (streaky5680?.activeValue ?? 0);
+  const ending = (ceduna5690?.endingWithin24mValue ?? 0) + (streaky5680?.endingWithin24mValue ?? 0);
+  const agreements = (ceduna5690?.activeAwards ?? 0) + (streaky5680?.activeAwards ?? 0);
+  const orgs = (ceduna5690?.recipients ?? 0) + (streaky5680?.recipients ?? 0);
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
+      <header className="border-b-4 border-bauhaus-black bg-white px-5 py-10 lg:px-10">
+        <div className="mx-auto max-w-6xl">
+          <p className="font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-red">
+            Where the money goes
+          </p>
+          <h1 className="mt-3 text-4xl font-black uppercase tracking-tight lg:text-5xl">
+            The Far West Coast
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7">
+            Wirangu country, and the country of the communities along the coast west of it. Public
+            money reaching organisations at Ceduna, Koonibba, Scotdesco, Yalata and Oak Valley.
+            Every figure here comes from a public register and can be checked. Where we cannot tell
+            you something, the page says so instead of guessing.
+          </p>
+        </div>
+      </header>
+
+      <div className="mx-auto grid max-w-6xl gap-10 px-5 py-10 lg:px-10">
+        <section aria-labelledby="money-title">
+          <h2 id="money-title" className="text-xl font-black uppercase tracking-widest">
+            What is committed now
+          </h2>
+          <div className="mt-5 grid grid-cols-2 gap-px border-4 border-bauhaus-black bg-bauhaus-black lg:grid-cols-4">
+            {[
+              { label: 'Committed now', value: money(committed), tone: 'text-bauhaus-black' },
+              { label: 'Ends within 24 months', value: money(ending), tone: 'text-bauhaus-red' },
+              { label: 'Live agreements', value: String(agreements), tone: 'text-bauhaus-black' },
+              { label: 'Organisations', value: String(orgs), tone: 'text-bauhaus-black' },
+            ].map((stat) => (
+              <div key={stat.label} className="bg-white p-5">
+                <div className={`text-3xl font-black ${stat.tone}`}>{stat.value}</div>
+                <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 max-w-3xl text-sm leading-6">
+            Federal grant agreements held by organisations registered in postcodes 5690 and 5680,
+            counted from GrantConnect. Values are whole-of-agreement, not annual. The second figure
+            is the part of it whose agreement ends inside two years, which is the only part anyone
+            can do much about right now.
+          </p>
+        </section>
+
+        <section aria-labelledby="hub-title" className="border-4 border-bauhaus-black bg-white p-6">
+          <h2 id="hub-title" className="text-xl font-black uppercase tracking-widest">
+            Read the place names carefully
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-6">
+            The communities out along the coast are administered from Ceduna. Yalata Anangu
+            Aboriginal Corporation is registered at an address in Ceduna, 200km from Yalata. Oak
+            Valley&rsquo;s corporation is registered in Ceduna too, 700km from Oak Valley. The
+            postcode, 5690, covers all of it, and so does the postal locality.
+          </p>
+          <p className="mt-3 max-w-3xl text-sm leading-6">
+            That means every automatic way of working out where an organisation sits &mdash; its
+            postcode, its registered address, the town on its mail &mdash; points at Ceduna. Money
+            intended for the outstations gets counted as Ceduna&rsquo;s. It is not that anyone is
+            hiding it; it is that the registers only record where the paperwork lives, and out here
+            the paperwork lives in town.
+          </p>
+          <p className="mt-3 max-w-3xl text-sm leading-6">
+            So treat the totals above as the coast&rsquo;s, not Ceduna&rsquo;s. Splitting them by
+            community needs someone who knows which organisation serves where, and that is not a
+            thing a register can tell you.
+          </p>
+        </section>
+
+        <section aria-labelledby="communities-title">
+          <h2 id="communities-title" className="text-xl font-black uppercase tracking-widest">
+            The five communities
+          </h2>
+          <div className="mt-5 overflow-x-auto border-4 border-bauhaus-black bg-white">
+            <table className="w-full min-w-[40rem] text-left text-sm">
+              <thead className="border-b-4 border-bauhaus-black">
+                <tr>
+                  <th className="p-4 text-[10px] font-black uppercase tracking-widest">Community</th>
+                  <th className="p-4 text-[10px] font-black uppercase tracking-widest">Council area</th>
+                  <th className="p-4 text-[10px] font-black uppercase tracking-widest">Note</th>
+                </tr>
+              </thead>
+              <tbody>
+                {COMMUNITIES.map((community) => (
+                  <tr key={community.name} className="border-b-2 border-bauhaus-black/10 last:border-b-0">
+                    <td className="p-4 font-black">{community.name}</td>
+                    <td className="p-4">{community.council}</td>
+                    <td className="p-4 text-bauhaus-muted">{community.note}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-4 max-w-3xl text-sm leading-6">
+            Council areas come from the ABS statistical geography. Three councils cover these five
+            communities, which is why a single figure for &ldquo;the Ceduna area&rdquo; is usually
+            answering a different question than the one being asked.
+          </p>
+        </section>
+
+        {crime.length > 0 && (
+          <section aria-labelledby="crime-title">
+            <h2 id="crime-title" className="text-xl font-black uppercase tracking-widest">
+              Reported offences by council
+            </h2>
+            <div className="mt-5 grid gap-px border-4 border-bauhaus-black bg-bauhaus-black sm:grid-cols-3">
+              {crime
+                .slice()
+                .sort((a, b) => b.incidents - a.incidents)
+                .map((row) => (
+                  <div key={row.lga_name} className="bg-white p-5">
+                    <div className="text-3xl font-black">{row.incidents.toLocaleString('en-AU')}</div>
+                    <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">
+                      {row.lga_name}
+                    </div>
+                  </div>
+                ))}
+            </div>
+            <p className="mt-4 max-w-3xl text-sm leading-6">
+              All reported offences{crimePeriod ? `, ${crimePeriod}` : ''}, from SA Police, counted
+              by the suburb where the offence was reported.
+            </p>
+            <p className="mt-3 max-w-3xl text-sm leading-6">
+              Until August 2026 this page would have shown 905 offences against Maralinga Tjarutja,
+              because our own pipeline rolled every offence in postcode 5690 up to a single council
+              and picked that one. Oak Valley, the community actually in Maralinga Tjarutja,
+              reported eight offences that year. The error was ours and it is fixed; the numbers
+              above are counted by suburb.
+            </p>
+          </section>
+        )}
+
+        <section aria-labelledby="gaps-title" className="border-4 border-bauhaus-red bg-white p-6">
+          <h2 id="gaps-title" className="text-xl font-black uppercase tracking-widest text-bauhaus-red">
+            What this page cannot tell you
+          </h2>
+          <ul className="mt-3 max-w-3xl list-disc space-y-2 pl-5 text-sm leading-6">
+            <li>
+              <strong>Which community each dollar reaches.</strong> Federal grants are counted
+              against the organisation&rsquo;s registered address, and out here that address is
+              usually in Ceduna regardless of where the work happens.
+            </li>
+            {unplaced > 0 && (
+              <li>
+                <strong>{unplaced} organisations in postcode 5690 have no council recorded.</strong>{' '}
+                They sit in a postcode covering three, and nothing we hold says which. They are
+                marked unplaced rather than assigned to a guess.
+              </li>
+            )}
+            <li>
+              <strong>Whether Ceduna&rsquo;s justice reinvestment work is funded.</strong> It appears
+              in our evidence layer as a community-endorsed initiative with no funding record
+              anywhere. Two other South Australian sites hold federal justice reinvestment money to
+              2029. Ceduna holds none that we can see, which may mean it is funded through a channel
+              we do not capture.
+            </li>
+            <li>
+              <strong>Anything about how any of this is going.</strong> These are agreements and
+              incident counts. They are not outcomes, and they are not the community&rsquo;s account
+              of itself.
+            </li>
+          </ul>
+        </section>
+
+        <section className="text-sm leading-6">
+          <Link href="/places/5690" className="font-black uppercase tracking-widest text-bauhaus-blue underline">
+            Postcode 5690 in detail &rarr;
+          </Link>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/places/[postcode]/page.tsx
+++ b/apps/web/src/app/places/[postcode]/page.tsx
@@ -1011,6 +1011,16 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
             </Section>
           )}
 
+          {/* Crime figures withheld: the council they would be labelled with is
+              not one we can stand behind for this postcode. Saying so beats an
+              empty space, which reads as a place with no crime data at all. */}
+          {dataLayers.crime?.withheld_reason && (
+            <Section title="Crime &amp; Safety">
+              <p className="text-xs text-bauhaus-black font-bold mb-2">Withheld for this postcode.</p>
+              <p className="text-xs text-bauhaus-muted leading-relaxed">{dataLayers.crime.withheld_reason}</p>
+            </Section>
+          )}
+
           {/* Crime & Safety */}
           {dataLayers.crime && dataLayers.crime.offences.length > 0 && (
             <Section title={`Crime & Safety — ${dataLayers.crime.lga_name} LGA`}>

--- a/apps/web/src/app/places/[postcode]/page.tsx
+++ b/apps/web/src/app/places/[postcode]/page.tsx
@@ -3,6 +3,7 @@ import { safeOptionalData } from '@/lib/optional-data';
 import { createGovernedProofService } from '@/lib/governed-proof/service';
 import { getProofPack } from '@/lib/governed-proof/presentation';
 import { getPlaceBrief } from '@/lib/services/place-brief-service';
+import { getPostcodeFundingPicture } from '@/lib/services/place-intelligence';
 import { getPlaceDataLayers } from '@/lib/services/place-data-service';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
@@ -381,9 +382,12 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
 
   // Place Brief — EL transcripts + ALMA interventions + alignment score
   // Place Data Layers — crime, schools, NDIS participants, DSS payments
-  const [placeBrief, dataLayers] = await Promise.all([
+  // Federal grants held by organisations registered here. Separate from the
+  // gs_relationships totals above, which do not carry GrantConnect at all.
+  const [placeBrief, dataLayers, federalFunding] = await Promise.all([
     getPlaceBrief(supabase, postcode, geo.locality, geo.state),
     getPlaceDataLayers(supabase, postcode, geo.lga_name, geo.lga_code, geo.state),
+    getPostcodeFundingPicture(postcode).catch(() => null),
   ]);
 
   // Filter grants relevant to this area (by state match or national scope)
@@ -490,9 +494,17 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
           <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Entities</div>
           <div className="text-2xl font-black text-bauhaus-black">{entityList.length}</div>
         </div>
+        {/* The headline carries the federal committed figure where we have it.
+            totalFunding comes from gs_relationships, which has no GrantConnect
+            in it, so on a place like Ceduna it under-reports by roughly 30x and
+            was the most prominent wrong number on the page. */}
         <div className="p-4 border-b-2 sm:border-b-0 sm:border-r-2 border-bauhaus-black/10">
-          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Total Funding</div>
-          <div className="text-2xl font-black text-bauhaus-black">{formatMoney(totalFunding)}</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">
+            {federalFunding ? 'Federal Committed' : 'Total Funding'}
+          </div>
+          <div className="text-2xl font-black text-bauhaus-black">
+            {formatMoney(federalFunding ? federalFunding.activeValue : totalFunding)}
+          </div>
         </div>
         <div className="p-4 border-r-2 border-bauhaus-black/10">
           <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Community-Controlled</div>
@@ -594,6 +606,50 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main Content */}
         <div className="lg:col-span-2">
+          {/* Federal grants held by organisations registered here. This leads
+              because it is the largest real number on the page: the block below
+              reads gs_relationships, which does not carry GrantConnect. */}
+          {federalFunding && (
+            <Section title="Federal Grants Held Here">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+                <div>
+                  <div className="text-xl font-black text-bauhaus-black">{formatMoney(federalFunding.activeValue)}</div>
+                  <div className="text-[10px] text-bauhaus-muted font-medium uppercase tracking-widest">Committed now</div>
+                </div>
+                <div>
+                  <div className="text-xl font-black text-bauhaus-red">{formatMoney(federalFunding.endingWithin24mValue)}</div>
+                  <div className="text-[10px] text-bauhaus-muted font-medium uppercase tracking-widest">Ends within 24 months</div>
+                </div>
+                <div>
+                  <div className="text-xl font-black text-bauhaus-black">{federalFunding.activeAwards}</div>
+                  <div className="text-[10px] text-bauhaus-muted font-medium uppercase tracking-widest">Live agreements</div>
+                </div>
+                <div>
+                  <div className="text-xl font-black text-bauhaus-black">{federalFunding.recipients}</div>
+                  <div className="text-[10px] text-bauhaus-muted font-medium uppercase tracking-widest">Organisations</div>
+                </div>
+              </div>
+              {federalFunding.topPrograms.length > 0 && (
+                <div className="space-y-0 mb-4">
+                  {federalFunding.topPrograms.map((p, i) => (
+                    <div key={i} className="flex items-center justify-between py-2 border-b-2 border-bauhaus-black/5 last:border-b-0">
+                      <div className="flex-1 min-w-0">
+                        <div className="font-bold text-bauhaus-black text-sm truncate">{p.program}</div>
+                        <div className="text-[11px] text-bauhaus-muted font-medium truncate">{p.agency} &middot; {p.awards} award{p.awards === 1 ? '' : 's'}</div>
+                      </div>
+                      <div className="font-black text-bauhaus-black ml-4">{formatMoney(p.value)}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <p className="text-[11px] text-bauhaus-muted font-medium leading-relaxed">
+                GrantConnect awards, counted by the recipient&rsquo;s registered address.
+                {' '}{federalFunding.awards} award{federalFunding.awards === 1 ? '' : 's'} totalling {formatMoney(federalFunding.lifetimeValue)} since 2015; only {federalFunding.withDeliveryPostcode} publish a delivery location.
+                An organisation registered here may deliver elsewhere, and work delivered here may be run from a city. Values are whole-of-agreement, not annual.
+              </p>
+            </Section>
+          )}
+
           {/* Top Recipients */}
           {topRecipients.length > 0 && (
             <Section title="Top Funded Entities">

--- a/apps/web/src/app/places/[postcode]/page.tsx
+++ b/apps/web/src/app/places/[postcode]/page.tsx
@@ -95,7 +95,10 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
       .select('postcode, locality, state, remoteness_2021, sa2_code, sa2_name, sa3_name, lga_name, lga_code')
       .eq('postcode', postcode)
       .not('state', 'is', null)
-      .limit(1),
+      // Every locality, not one. A postcode can span several councils and the
+      // page needs to know that before it labels itself with one of them.
+      .order('locality')
+      .limit(200),
     supabase
       .from('seifa_2021')
       .select('decile_national, score')
@@ -124,7 +127,22 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
 
   if (!geoData?.length) notFound();
 
-  const geo = geoData[0];
+  // geoData[0] is whatever the planner returned first, which named postcode
+  // 5690 after BOOKABIE. Prefer the locality that shares its name with one of
+  // the postcode's councils: regional service towns are almost always the seat
+  // of the council named after them, so 5690 resolves to CEDUNA.
+  const geoRows = geoData as Array<{ locality: string | null; lga_name: string | null; [k: string]: unknown }>;
+  const lgaNames = new Set(
+    geoRows.map(row => (row.lga_name || '').trim().toLowerCase()).filter(Boolean)
+  );
+  const geo = (geoRows.find(row => lgaNames.has((row.locality || '').trim().toLowerCase())) ?? geoRows[0]) as typeof geoData[number];
+
+  // Every distinct council this postcode touches. One label is a coin toss when
+  // a postcode spans several, and 5690 spans four.
+  const spannedLgas = Array.from(
+    new Set(geoRows.map(row => (row.lga_name || '').trim()).filter(Boolean))
+  ).sort();
+
   const stateCode = typeof geo.state === 'string' && geo.state.trim().length > 0 ? geo.state : null;
   const placeTitle = stateCode ? `${geo.locality || postcode}, ${stateCode}` : (geo.locality || postcode);
   const socialEnterprisesHref = stateCode ? `/social-enterprises?state=${encodeURIComponent(stateCode)}` : '/social-enterprises';
@@ -456,9 +474,9 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
               SEIFA Decile {seifa.decile_national}/10
             </span>
           )}
-          {geo.lga_name && (
+          {spannedLgas.length > 0 && (
             <span className="text-[11px] font-black px-2.5 py-1 border-2 border-bauhaus-blue/30 bg-blue-50 text-bauhaus-blue uppercase tracking-widest">
-              LGA: {geo.lga_name}
+              {spannedLgas.length === 1 ? `LGA: ${spannedLgas[0]}` : `${spannedLgas.length} LGAs: ${spannedLgas.join(' · ')}`}
             </span>
           )}
           {geo.sa2_code && (
@@ -510,8 +528,13 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
           <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">Community-Controlled</div>
           <div className="text-2xl font-black text-bauhaus-black">{communityControlledCount}</div>
         </div>
+        {/* Sits beside a GrantConnect headline but is computed from
+            gs_relationships, a different and much smaller base. Labelled so the
+            two are not read as numerator and denominator of each other. */}
         <div className="p-4">
-          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">CC Funding Share</div>
+          <div className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest mb-1">
+            CC Share {federalFunding ? '(excl. federal)' : ''}
+          </div>
           <div className={`text-2xl font-black ${communityControlledShare < 30 ? 'text-bauhaus-red' : communityControlledShare < 60 ? 'text-orange-600' : 'text-money'}`}>
             {communityControlledShare}%
           </div>

--- a/apps/web/src/lib/services/place-data-service.ts
+++ b/apps/web/src/lib/services/place-data-service.ts
@@ -17,6 +17,8 @@ export interface CrimeSummary {
     ten_year_trend_pct: number | null;
   }>;
   year_period: string | null;
+  /** Set when the figures are withheld because the council cannot be trusted. */
+  withheld_reason?: string;
 }
 
 export interface SchoolProfile {
@@ -62,16 +64,79 @@ function stripLgaSuffix(lgaName: string): string {
   return lgaName.replace(/\s*\(.*?\)\s*$/, '').trim();
 }
 
+/**
+ * Can offences reported in this postcode honestly be labelled with this council?
+ *
+ * crime_stats_lga is built by aggregating SAPOL's suburb-level counts up to an
+ * LGA through postcode_geo, which holds one council per postcode and takes the
+ * first it sees. Postcode 5690 spans three, so every offence reported in Ceduna
+ * township is currently filed against Maralinga Tjarutja, a community of a few
+ * hundred people: 905 offences and 336 assaults that did not happen there.
+ *
+ * ABS ASGS is the authority and we already hold it in abs_locality_lga. Until
+ * postcode_geo is rebuilt from it, refuse to label a crime figure with a council
+ * where ABS disagrees or where the postcode genuinely spans several. Attributing
+ * a town's offences to a small community is not a rounding error, and a place
+ * page is read by the people being counted.
+ */
+async function getLgaAttribution(
+  db: SupabaseClient,
+  postcode: string,
+  lgaName: string | null,
+): Promise<{ safe: boolean; reason: string | null }> {
+  if (!lgaName) return { safe: false, reason: null };
+  if (!/^\d{4}$/.test(postcode)) return { safe: false, reason: null };
+
+  const { data } = await db.rpc('exec_sql', {
+    query: `SELECT DISTINCT a.lga_name
+              FROM postcode_geo p
+              JOIN abs_locality_lga a ON upper(a.locality) = upper(p.locality)
+             WHERE p.postcode = '${postcode}'`,
+  });
+  const absLgas = (Array.isArray(data) ? data : [])
+    .map(row => String((row as Record<string, unknown>).lga_name ?? ''))
+    .filter(Boolean);
+
+  // No ABS coverage for these localities: no basis to contradict, so allow.
+  if (absLgas.length === 0) return { safe: true, reason: null };
+
+  const claimed = stripLgaSuffix(lgaName);
+  if (absLgas.length > 1) {
+    return {
+      safe: false,
+      reason: `Postcode ${postcode} spans ${absLgas.length} council areas (${absLgas.slice(0, 4).join(', ')}). Police counts here are recorded by suburb and rolled up to a single council, so we cannot say which of them a figure belongs to.`,
+    };
+  }
+  if (absLgas[0] !== claimed) {
+    return {
+      safe: false,
+      reason: `Our postcode-to-council mapping puts ${postcode} in ${claimed}, but the ABS records it as ${absLgas[0]}. Crime figures are withheld until that disagreement is resolved.`,
+    };
+  }
+  return { safe: true, reason: null };
+}
+
 // ── Query functions ────────────────────────────────────────────────────
 
 async function getCrimeStats(
   db: SupabaseClient,
+  postcode: string,
   lgaName: string | null,
   state: string | null,
 ): Promise<CrimeSummary | null> {
   if (!lgaName || !state) return null;
 
   const cleanLga = stripLgaSuffix(lgaName);
+
+  // Checked before the numbers are fetched, not after. A suppressed figure that
+  // still travels in the RSC payload has not been suppressed.
+  const attribution = await getLgaAttribution(db, postcode, lgaName);
+  if (!attribution.safe) {
+    return attribution.reason
+      ? { lga_name: cleanLga, offences: [], year_period: null, withheld_reason: attribution.reason }
+      : null;
+  }
+
   const { data } = await db.rpc('exec_sql', {
     query: `SELECT offence_group, SUM(incidents) as total_incidents,
               AVG(rate_per_100k) as rate_per_100k,
@@ -231,7 +296,7 @@ export async function getPlaceDataLayers(
   state: string | null,
 ): Promise<PlaceDataLayers> {
   const [crime, schools, ndis_participants, dss_payments] = await Promise.all([
-    getCrimeStats(db, lgaName, state).catch(() => null),
+    getCrimeStats(db, postcode, lgaName, state).catch(() => null),
     getSchools(db, postcode).catch(() => []),
     getNdisParticipants(db, lgaCode, lgaName).catch(() => null),
     getDssPayments(db, postcode, lgaCode).catch(() => []),

--- a/apps/web/src/lib/services/place-intelligence.ts
+++ b/apps/web/src/lib/services/place-intelligence.ts
@@ -71,15 +71,52 @@ interface RawProfile {
   philanthropic_grants: number;
 }
 
-const AREA_ORDER = [
-  'alice-springs',
-  'barkly',
-  'macdonnell',
-  'central-desert',
-  // Last, because it is the residue rather than a place: organisations whose
-  // council we still cannot record.
-  'remote-unplaced',
-];
+/**
+ * A region this service can describe.
+ *
+ * These were hardcoded to Central Australia. They are configuration now because
+ * the same shape holds anywhere: a set of council areas, optionally a postcode
+ * whose organisations have no council area at all, and labels that use the
+ * names people there actually use.
+ */
+export interface PlaceRegion {
+  key: string;
+  lgaNames: string[];
+  states: string[];
+  /** Organisations here cannot be placed in a council area at all. */
+  unplaced: { postcode: string; state: string } | null;
+  labels: Record<string, { label: string; note: string | null }>;
+}
+
+export const PLACE_REGIONS: Record<string, PlaceRegion> = {
+  'central-australia': {
+    key: 'central-australia',
+    lgaNames: ['Alice Springs', 'Barkly', 'MacDonnell', 'Central Desert', 'Anangu Pitjantjatjara Yankunytjatjara'],
+    states: ['NT', 'SA'],
+    unplaced: { postcode: '0872', state: 'NT' },
+    labels: {
+      'Alice Springs': { label: 'Mparntwe (Alice Springs)', note: null },
+      Barkly: { label: 'Barkly, including Tennant Creek', note: 'Includes Tennant Creek, Ali Curung and Ampilatwatja in the Utopia homelands.' },
+      MacDonnell: { label: 'MacDonnell', note: 'Includes Papunya, Hermannsburg and Areyonga.' },
+      'Central Desert': { label: 'Central Desert', note: 'Includes Yuendumu and Atitjere.' },
+      'Anangu Pitjantjatjara Yankunytjatjara': { label: 'APY Lands (South Australia)', note: 'Iwantja, Mimili, Kaltjiti and Pukatja. Their grants are delivered into postcode 0872, which spans seven councils, so most cannot be placed here.' },
+    },
+  },
+  // Wirangu country and the Far West Coast. Both council areas are listed
+  // because postcode 5690 maps every locality in it, Ceduna township included,
+  // to Maralinga Tjarutja. Reading only one of them loses most of the region.
+  'far-west-coast': {
+    key: 'far-west-coast',
+    lgaNames: ['Ceduna', 'Maralinga Tjarutja', 'Streaky Bay'],
+    states: ['SA'],
+    unplaced: null,
+    labels: {
+      Ceduna: { label: 'Ceduna (District Council)', note: 'Holds far fewer organisations than the town does, because postcode 5690 attributes most of them to Maralinga Tjarutja.' },
+      'Maralinga Tjarutja': { label: 'Maralinga Tjarutja', note: 'Carries Oak Valley, and also most Ceduna township organisations through the postcode 5690 mapping. Read it as the Far West Coast rather than as the Maralinga Tjarutja lands alone.' },
+      'Streaky Bay': { label: 'Streaky Bay', note: null },
+    },
+  },
+};
 
 function num(value: number | string | null): number {
   if (value === null) return 0;
@@ -87,8 +124,12 @@ function num(value: number | string | null): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-export const getCentralAustraliaIntelligence = cache(
-  async function getCentralAustraliaIntelligence(): Promise<PlaceIntelligence> {
+export const getPlaceIntelligence = cache(
+  async function getPlaceIntelligence(regionKey: string): Promise<PlaceIntelligence> {
+    const region = PLACE_REGIONS[regionKey];
+    if (!region) {
+      throw new Error(`Unknown place region: ${regionKey}`);
+    }
     const db = getServiceSupabase();
 
     const [snapshotResult, orgsResult, gapResult, deregisteredResult] = await Promise.all([
@@ -102,8 +143,8 @@ export const getCentralAustraliaIntelligence = cache(
       // grants are $202.8M.
       db.from('mv_lga_place_profile')
         .select('lga_name, state, remoteness, avg_irsd_decile, org_count, community_controlled, without_abn, caring_for_country, employers, contract_count, contract_value_lifetime, contract_value_24m, grants_delivered, grants_delivered_value, local_retention_pct, philanthropic_funders, philanthropic_grants')
-        .in('lga_name', ['Alice Springs', 'Barkly', 'MacDonnell', 'Central Desert', 'Anangu Pitjantjatjara Yankunytjatjara'])
-        .in('state', ['NT', 'SA']),
+        .in('lga_name', region.lgaNames)
+        .in('state', region.states),
       // The homelands organisations, named. They have no council area, so the
       // only honest way to show them is by name — and all of them, not a
       // slice. An alphabetical cap truncates mid-list and quietly drops the
@@ -113,43 +154,41 @@ export const getCentralAustraliaIntelligence = cache(
       // corporation as a current community organisation misrepresents the
       // community it belonged to, and the first version of this page did
       // exactly that for 57 of them.
-      db.from('gs_entities')
-        .select('canonical_name, entity_type, is_community_controlled')
-        .eq('state', 'NT')
-        .eq('postcode', '0872')
-        .or('is_community_controlled.eq.true,entity_type.eq.indigenous_corp')
-        .or('oric_status.is.null,oric_status.neq.Deregistered')
-        .order('canonical_name')
-        .limit(300),
-      db.from('geo_resolution_gaps')
-        .select('postcode, required_source, affected_entities, affected_community_controlled')
-        .eq('postcode', '0872')
-        .maybeSingle(),
-      db.from('gs_entities')
-        .select('id', { count: 'exact', head: true })
-        .eq('state', 'NT')
-        .eq('postcode', '0872')
-        .or('is_community_controlled.eq.true,entity_type.eq.indigenous_corp')
-        .eq('oric_status', 'Deregistered'),
+      region.unplaced
+        ? db.from('gs_entities')
+            .select('canonical_name, entity_type, is_community_controlled')
+            .eq('state', region.unplaced.state)
+            .eq('postcode', region.unplaced.postcode)
+            .or('is_community_controlled.eq.true,entity_type.eq.indigenous_corp')
+            .or('oric_status.is.null,oric_status.neq.Deregistered')
+            .order('canonical_name')
+            .limit(300)
+        : Promise.resolve({ data: [], error: null }),
+      region.unplaced
+        ? db.from('geo_resolution_gaps')
+            .select('postcode, required_source, affected_entities, affected_community_controlled')
+            .eq('postcode', region.unplaced.postcode)
+            .maybeSingle()
+        : Promise.resolve({ data: null, error: null }),
+      region.unplaced
+        ? db.from('gs_entities')
+            .select('id', { count: 'exact', head: true })
+            .eq('state', region.unplaced.state)
+            .eq('postcode', region.unplaced.postcode)
+            .or('is_community_controlled.eq.true,entity_type.eq.indigenous_corp')
+            .eq('oric_status', 'Deregistered')
+        : Promise.resolve({ count: 0, error: null }),
     ]);
 
     if (snapshotResult.error) {
       throw new Error(`Place snapshot unavailable: ${snapshotResult.error.message}`);
     }
 
-    const LABELS: Record<string, { label: string; note: string | null }> = {
-      'Alice Springs': { label: 'Mparntwe (Alice Springs)', note: null },
-      Barkly: { label: 'Barkly, including Tennant Creek', note: 'Includes Tennant Creek, Ali Curung and Ampilatwatja in the Utopia homelands.' },
-      MacDonnell: { label: 'MacDonnell', note: 'Includes Papunya, Hermannsburg and Areyonga.' },
-      'Central Desert': { label: 'Central Desert', note: 'Includes Yuendumu and Atitjere.' },
-      'Anangu Pitjantjatjara Yankunytjatjara': { label: 'APY Lands (South Australia)', note: 'Iwantja, Mimili, Kaltjiti and Pukatja. Their grants are delivered into postcode 0872, which spans seven councils, so most cannot be placed here.' },
-    };
-
     const areas = ((snapshotResult.data || []) as RawProfile[])
       .map(row => ({
         areaKey: row.lga_name,
-        areaLabel: LABELS[row.lga_name]?.label ?? row.lga_name,
-        areaNote: LABELS[row.lga_name]?.note ?? null,
+        areaLabel: region.labels[row.lga_name]?.label ?? row.lga_name,
+        areaNote: region.labels[row.lga_name]?.note ?? null,
         remoteness: row.remoteness,
         irsdDecile: num(row.avg_irsd_decile),
         orgCount: row.org_count,
@@ -185,14 +224,17 @@ export const getCentralAustraliaIntelligence = cache(
     // the agencies funding Indigenous affairs and social services publish a
     // delivery location on almost nothing, so a map of delivered grants shows a
     // small and unrepresentative slice.
+    const quoted = (values: string[]) => values.map(value => `'${value.replace(/'/g, "''")}'`).join(',');
+    const unplacedClause = region.unplaced
+      ? ` OR e.postcode = '${region.unplaced.postcode.replace(/'/g, "''")}'`
+      : '';
     const coverageResult = await db.rpc('exec_sql', {
       query: `SELECT round(sum(ga.value_aud) FILTER (WHERE ga.delivery_postcode IS NOT NULL)/1e6,1) AS known_m,
                      round(sum(ga.value_aud) FILTER (WHERE ga.delivery_postcode IS NULL)/1e6,1) AS unknown_m
                 FROM grantconnect_awards ga
                 JOIN gs_entities e ON e.id = ga.gs_entity_id
-               WHERE e.state IN ('NT','SA')
-                 AND (e.lga_name IN ('Alice Springs','Barkly','MacDonnell','Central Desert','Anangu Pitjantjatjara Yankunytjatjara')
-                      OR e.postcode = '0872')`,
+               WHERE e.state IN (${quoted(region.states)})
+                 AND (e.lga_name IN (${quoted(region.lgaNames)})${unplacedClause})`,
     });
     const covRow = Array.isArray(coverageResult.data) ? coverageResult.data[0] as Record<string, unknown> : null;
     const knownM = num((covRow?.known_m as number | string | null) ?? null);
@@ -216,6 +258,113 @@ export const getCentralAustraliaIntelligence = cache(
         : null,
       deregisteredExcluded: deregisteredResult.error ? 0 : (deregisteredResult.count ?? 0),
       deliveryCoverage: coverage,
+    };
+  },
+);
+
+export function getCentralAustraliaIntelligence(): Promise<PlaceIntelligence> {
+  return getPlaceIntelligence('central-australia');
+}
+
+/**
+ * Federal grants held by organisations registered in a postcode.
+ *
+ * The place pages previously read funding from gs_relationships, which does not
+ * carry GrantConnect. For Ceduna that showed $7.5M against $215.3M of federal
+ * money currently committed to organisations based there, so the page reported
+ * roughly three cents in the dollar and read as a place nobody funds.
+ *
+ * This is keyed on the recipient's registered address, not delivery location.
+ * Only 41 of 346 awards in postcode 5690 publish a delivery postcode, so a
+ * delivery-keyed figure omits seven awards in eight. Registered address has its
+ * own bias in the other direction: an organisation registered here may deliver
+ * elsewhere, and a service delivered here may be run from Adelaide. Both
+ * caveats travel to the page rather than sitting in this comment.
+ */
+export interface PostcodeFundingPicture {
+  postcode: string;
+  awards: number;
+  recipients: number;
+  lifetimeValue: number;
+  activeAwards: number;
+  activeValue: number;
+  /** Committed money whose agreement ends inside two years. The renewal window. */
+  endingWithin24mValue: number;
+  /** Awards that publish a delivery location, out of the total. */
+  withDeliveryPostcode: number;
+  topPrograms: Array<{ agency: string; program: string; awards: number; value: number }>;
+  endingSoon: Array<{ recipient: string; agency: string; program: string; value: number; endDate: string }>;
+}
+
+export const getPostcodeFundingPicture = cache(
+  async function getPostcodeFundingPicture(postcode: string): Promise<PostcodeFundingPicture | null> {
+    if (!/^\d{4}$/.test(postcode)) return null;
+    const db = getServiceSupabase();
+
+    const [totals, programs, ending] = await Promise.all([
+      db.rpc('exec_sql', {
+        query: `SELECT count(*) AS awards,
+                       count(DISTINCT ga.recipient_abn) AS recipients,
+                       coalesce(sum(ga.value_aud),0) AS lifetime_value,
+                       count(*) FILTER (WHERE ga.end_date >= current_date) AS active_awards,
+                       coalesce(sum(ga.value_aud) FILTER (WHERE ga.end_date >= current_date),0) AS active_value,
+                       coalesce(sum(ga.value_aud) FILTER (WHERE ga.end_date >= current_date
+                                                            AND ga.end_date < current_date + interval '24 months'),0) AS ending_24m_value,
+                       count(*) FILTER (WHERE ga.delivery_postcode IS NOT NULL) AS with_delivery_pc
+                  FROM grantconnect_awards ga
+                  JOIN gs_entities e ON e.id = ga.gs_entity_id
+                 WHERE e.postcode = '${postcode}'`,
+      }),
+      db.rpc('exec_sql', {
+        query: `SELECT ga.agency, ga.grant_program AS program, count(*) AS awards, coalesce(sum(ga.value_aud),0) AS value
+                  FROM grantconnect_awards ga
+                  JOIN gs_entities e ON e.id = ga.gs_entity_id
+                 WHERE e.postcode = '${postcode}' AND ga.grant_program IS NOT NULL
+                 GROUP BY 1,2 ORDER BY value DESC LIMIT 8`,
+      }),
+      db.rpc('exec_sql', {
+        query: `SELECT ga.recipient_name AS recipient, ga.agency, ga.grant_program AS program,
+                       coalesce(ga.value_aud,0) AS value, ga.end_date::text AS end_date
+                  FROM grantconnect_awards ga
+                  JOIN gs_entities e ON e.id = ga.gs_entity_id
+                 WHERE e.postcode = '${postcode}'
+                   AND ga.end_date >= current_date
+                   AND ga.end_date < current_date + interval '24 months'
+                 ORDER BY ga.value_aud DESC NULLS LAST LIMIT 10`,
+      }),
+    ]);
+
+    const row = Array.isArray(totals.data) ? totals.data[0] as Record<string, unknown> : null;
+    if (!row || num(row.awards as number | string | null) === 0) return null;
+
+    return {
+      postcode,
+      awards: num(row.awards as number | string | null),
+      recipients: num(row.recipients as number | string | null),
+      lifetimeValue: num(row.lifetime_value as number | string | null),
+      activeAwards: num(row.active_awards as number | string | null),
+      activeValue: num(row.active_value as number | string | null),
+      endingWithin24mValue: num(row.ending_24m_value as number | string | null),
+      withDeliveryPostcode: num(row.with_delivery_pc as number | string | null),
+      topPrograms: (Array.isArray(programs.data) ? programs.data : []).map(entry => {
+        const record = entry as Record<string, unknown>;
+        return {
+          agency: String(record.agency ?? ''),
+          program: String(record.program ?? ''),
+          awards: num(record.awards as number | string | null),
+          value: num(record.value as number | string | null),
+        };
+      }),
+      endingSoon: (Array.isArray(ending.data) ? ending.data : []).map(entry => {
+        const record = entry as Record<string, unknown>;
+        return {
+          recipient: String(record.recipient ?? ''),
+          agency: String(record.agency ?? ''),
+          program: String(record.program ?? ''),
+          value: num(record.value as number | string | null),
+          endDate: String(record.end_date ?? ''),
+        };
+      }),
     };
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3435 @@
+{
+  "name": "grantscope",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grantscope",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@supabase/supabase-js": "^2.49.1",
+        "cheerio": "^1.2.0",
+        "csv-parse": "^5.6.0",
+        "next": "^15.1.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "xlsx": "^0.18.5"
+      },
+      "devDependencies": {
+        "dotenv": "^17.3.1",
+        "playwright": "^1.58.2",
+        "tsx": "^4.21.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.23.tgz",
+      "integrity": "sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.23.tgz",
+      "integrity": "sha512-SrEwOROH/rhA03F59hHtdhgtfZMWGzr5duDBWgRQt2rS3mJhqMKOcnNx6txOd0/i3E3D3uFKYFvyHsEiwQxzag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.23.tgz",
+      "integrity": "sha512-f0FpFbG2EhDCuptBGcfrLcYMDuQAhe6m1QA4VVfXFrIBoFXvXt/olGbBkYkloKlXQtmhuzvtdYyuu/6zf07GIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.23.tgz",
+      "integrity": "sha512-WlNtfepUXKX2u2ZsJZ8c3c8+tJSRZqsYzoMwLOY72A8ucKCCgxgNhiePA3qzFYahVWrwcQd8jOeJmBinc+VFVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.23.tgz",
+      "integrity": "sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.23.tgz",
+      "integrity": "sha512-vzefI32mi6VMk96RaTAyxApgfGbiFzQBXVsekEjsDv1fr48mlABTWx0sUYhaYCBHWqCalxmz3DxbxFcbFvzNtw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.23.tgz",
+      "integrity": "sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.23.tgz",
+      "integrity": "sha512-Wc29KFOdT7XBcII3Vtmw7aoU8Uk3Mes/FNJfhFeSHdYBFJWMcR/DsI8U9BCPUhq/uycsUVuqSKGthW15tLsigA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.23.tgz",
+      "integrity": "sha512-/C7wRW4fa9s/PKA18zGPPpVmx8ycgVpP8yOxro4gzGTzjPJdscbAP3ODeFvgiIovxD176Z2J/SXO9t8PJKHLeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.112.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.112.2.tgz",
+      "integrity": "sha512-l1InCp4j98d09LZ6+RgubgF4eVPGBGXcLEhFusLg1qUCHJ2IEkYu5FohKK+eaFmIOwEk0kqG/j/lycw5e15mcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.112.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.112.2.tgz",
+      "integrity": "sha512-oMuSWN0ERmrG9S6kOM0bwhHmESGVl3kMtkZl2dNCU/r89hMiziX4GfD1omNo9QcBDele4N0GwSZ7hdbpuiA35A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.112.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.112.2.tgz",
+      "integrity": "sha512-ewhhtRny/HFRGhUTTg/PsqIatsl8OhW8Eha/Tz4S+SRAXBnuhKei9ZpsQTgL/3XcH9UEwuPQyQgQ9itq7nRQeg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.112.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.112.2.tgz",
+      "integrity": "sha512-cd9/CEUJ6Go13FxtfiuC5rYELJtuQzVzTXlGG+XjSppjDS+anq+xo++WQe7ZRUNTuHOCeyKRwmx9Hw/OQJ04ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.112.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.112.2.tgz",
+      "integrity": "sha512-6jyBq/J1iXOHNpbjCZS7gFcDk49iM1MCJUVkDl71gLd/+XnLDzpUBs8icGebtwiHpl4kVszxIRDYAosbF4Rsig==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.112.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.112.2.tgz",
+      "integrity": "sha512-UyI1epU9B4X51HvNpkmlwTdF20fEcz2vyvrcDKVzFN4jZN41f5iQRqsiIQjAY5OVJD6ljqA/1g9JQeOTvFHpkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.112.2",
+        "@supabase/functions-js": "2.112.2",
+        "@supabase/postgrest-js": "2.112.2",
+        "@supabase/realtime-js": "2.112.2",
+        "@supabase/storage-js": "2.112.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.23.tgz",
+      "integrity": "sha512-Gvd2WKgvxIXCGotxcI1im/Uf3rS3J3oZGw0g/uskg6AVBZhyE3aAbujkYWzS3xLmEPEtTLfkaVQUKK0KMTSIkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.23",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.23",
+        "@next/swc-darwin-x64": "15.5.23",
+        "@next/swc-linux-arm64-gnu": "15.5.23",
+        "@next/swc-linux-arm64-musl": "15.5.23",
+        "@next/swc-linux-x64-gnu": "15.5.23",
+        "@next/swc-linux-x64-musl": "15.5.23",
+        "@next/swc-win32-arm64-msvc": "15.5.23",
+        "@next/swc-win32-x64-msvc": "15.5.23",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/scripts/fetch-oric-addresses.mjs
+++ b/scripts/fetch-oric-addresses.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Fetch registered-office localities for ORIC corporations from the public register.
+ *
+ * Why this exists: 64,801 gs_entities have no council, because they sit in a
+ * postcode spanning several and we hold no locality for them. Neither
+ * abr_registry nor oric_corporations stores one (postcode and state only), and
+ * the ABR bulk extract does not publish street addresses at all. That leaves
+ * every ORIC corporation unplaceable, including Ceduna Aboriginal Corporation,
+ * Koonibba, Yalata, Scotdesco and Oak Valley.
+ *
+ * The ORIC public register does publish it, per corporation, on the page we
+ * already store in oric_corporations.oric_url. "39 McKenzie Street, CEDUNA, SA
+ * 5690" gives us CEDUNA, which maps to exactly one council in ABS ASGS.
+ *
+ * Restraint is deliberate. A previous note in geo_resolution_gaps records that
+ * ORIC will not release addresses in bulk and discourages custom requests, so
+ * this reads the same public pages a person would, one at a time, slowly, and
+ * only for corporations you ask for. It is not a crawler for the whole register.
+ * Default concurrency is 1 and there is a fixed delay between requests.
+ *
+ * Usage:
+ *   node --env-file=.env scripts/fetch-oric-addresses.mjs --abn=65255759096,33876790225
+ *   node --env-file=.env scripts/fetch-oric-addresses.mjs --postcode=5690
+ *   node --env-file=.env scripts/fetch-oric-addresses.mjs --postcode=5690 --apply
+ *
+ * Without --apply it prints what it found and writes nothing.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const args = process.argv.slice(2);
+const arg = (name) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : null;
+};
+const APPLY = args.includes('--apply');
+const ABNS = (arg('abn') || '').split(',').map((s) => s.trim()).filter(Boolean);
+const POSTCODE = arg('postcode');
+const LIMIT = Number(arg('limit') || 50);
+const DELAY_MS = Number(arg('delay') || 2000);
+
+if (!ABNS.length && !POSTCODE) {
+  console.error('Need --abn=... or --postcode=.... Refusing to walk the whole register.');
+  process.exit(1);
+}
+
+const db = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+let query = db
+  .from('oric_corporations')
+  .select('icn, name, abn, state, postcode, oric_url, status')
+  .eq('status', 'Registered')
+  .not('oric_url', 'is', null)
+  .limit(LIMIT);
+query = ABNS.length ? query.in('abn', ABNS) : query.eq('postcode', POSTCODE);
+
+const { data: corps, error } = await query;
+if (error) {
+  console.error('Lookup failed:', error.message);
+  process.exit(1);
+}
+if (!corps?.length) {
+  console.log('No registered corporations matched.');
+  process.exit(0);
+}
+
+// Localities genuinely belonging to each postcode in play.
+const validByPostcode = new Map();
+for (const pc of [...new Set(corps.map(c => c.postcode).filter(Boolean))]) {
+  const { data: rows } = await db.from('postcode_geo').select('locality').eq('postcode', pc).limit(200);
+  validByPostcode.set(pc, new Set((rows || []).map(r => (r.locality || '').trim().toUpperCase())));
+}
+
+console.log(`${corps.length} corporation(s) to look up, ${DELAY_MS}ms apart\n`);
+
+// Every ABS locality in play, longest first so BOOKABIE wins over BOOK and
+// "OAK VALLEY" wins over "OAK". Loaded once; the register pages are read
+// against it rather than against a guess about address shape.
+// Paged. PostgREST caps a response at 1,000 rows regardless of .limit(), and
+// silently: the first version of this asked for 20,000 of the 16,631 rows, got
+// 1,000, and quietly failed to recognise YALATA as a place.
+const absLocalities = [];
+for (let from = 0; ; from += 1000) {
+  const { data: page } = await db
+    .from('abs_locality_lga')
+    .select('locality, state_name')
+    .range(from, from + 999);
+  if (!page?.length) break;
+  absLocalities.push(...page);
+  if (page.length < 1000) break;
+}
+const STATE_NAMES = {
+  ACT: 'Australian Capital Territory', NSW: 'New South Wales', NT: 'Northern Territory',
+  QLD: 'Queensland', SA: 'South Australia', TAS: 'Tasmania', VIC: 'Victoria', WA: 'Western Australia',
+};
+const localitiesByState = new Map();
+for (const row of absLocalities || []) {
+  const list = localitiesByState.get(row.state_name) || [];
+  list.push(row.locality.replace(/\s*\([A-Z]{2,3}\)\s*$/, '').trim().toUpperCase());
+  localitiesByState.set(row.state_name, list);
+}
+for (const [key, list] of localitiesByState) {
+  localitiesByState.set(key, [...new Set(list)].sort((a, b) => b.length - a.length));
+}
+
+/**
+ * The locality slot is not the community.
+ *
+ * Yalata Anangu Aboriginal Corporation's registered office reads
+ * "C/-Yalata Community Eyre Highway, CEDUNA, SA 5690". CEDUNA is the postal
+ * locality for the whole of 5690; Yalata is 200km west of it and ABS puts it in
+ * Unincorporated SA. Reading the slot would file Yalata's money under District
+ * Council of Ceduna, which is the same hub-credit distortion this work exists
+ * to remove, just arriving by a new route.
+ *
+ * So scan the whole address for any ABS locality and prefer one that is not the
+ * postal locality, because a community named in the street line is a stronger
+ * signal about where an organisation sits than the sorting label at the end.
+ * Return both so the caller can see when they disagree.
+ */
+function localitiesFromAddress(address, state, postcode, validHere) {
+  if (!address) return { postal: null, specific: null };
+  const cleaned = address.replace(/\s+/g, ' ').replace(/,\s*AUSTRALIA\s*$/i, '').trim().toUpperCase();
+
+  const slotMatch = cleaned.match(new RegExp(`,\\s*([^,]+?)\\s*,\\s*${state}\\s+${postcode}\\s*$`, 'i'));
+  let postal = slotMatch ? slotMatch[1].trim() : null;
+  if (postal && /^(PO BOX|GPO BOX|LOCKED BAG)/i.test(postal)) postal = null;
+
+  // Only accept a community named in the street line if it is genuinely a
+  // locality of this postcode. Without that constraint "Eyre Highway" matches
+  // the locality EYRE and "Laura Bay" matches LAURA BAY, and Scotdesco moves
+  // from a correct BOOKABIE to a wrong EYRE. Street names collide with place
+  // names constantly; the postcode is what tells them apart.
+  const known = (localitiesByState.get(STATE_NAMES[state]) || []).filter(name => validHere.has(name));
+  const head = postal ? cleaned.slice(0, cleaned.lastIndexOf(postal)) : cleaned;
+  const specific = known.find(name =>
+    name !== postal && new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(head)
+  ) || null;
+
+  return { postal: postal || null, specific };
+}
+
+const results = [];
+for (const corp of corps) {
+  try {
+    const response = await fetch(corp.oric_url, {
+      headers: { 'User-Agent': 'CivicGraph/1.0 (civicgraph.app; public register lookup)' },
+    });
+    if (!response.ok) {
+      results.push({ ...corp, locality: null, note: `HTTP ${response.status}` });
+    } else {
+      const html = await response.text();
+      const text = html.replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ');
+      // Greedy on purpose. Non-greedy captures only ", CEDUNA, SA 5690" and the
+      // street line holding the community name never reaches the parser.
+      const addressPattern = new RegExp(`[^.;]{0,140},\\s*${corp.state}\\s+${corp.postcode}`, 'gi');
+      const candidates = text.match(addressPattern) || [];
+      let postal = null;
+      let specific = null;
+      for (const candidate of candidates) {
+        const parsed = localitiesFromAddress(candidate, corp.state, corp.postcode, validByPostcode.get(corp.postcode) || new Set());
+        postal = postal || parsed.postal;
+        specific = specific || parsed.specific;
+        if (specific) break;
+      }
+      const locality = specific || postal;
+      results.push({
+        ...corp,
+        locality,
+        postal,
+        specific,
+        note: !locality ? 'no locality parsed'
+          : specific && postal && specific !== postal ? `community line beats postal (${postal})`
+          : 'postal locality only',
+      });
+    }
+  } catch (err) {
+    results.push({ ...corp, locality: null, note: err.message });
+  }
+  console.log(`  ${(results.at(-1).locality || '—').padEnd(14)} ${corp.name} — ${results.at(-1).note}`);
+  await new Promise((r) => setTimeout(r, DELAY_MS));
+}
+
+const found = results.filter((r) => r.locality);
+console.log(`\n${found.length}/${results.length} localities parsed`);
+
+if (!APPLY) {
+  console.log('\nDry run. Re-run with --apply to write gs_entities.lga_name.');
+  process.exit(0);
+}
+
+// Resolve locality -> council through ABS, and only where ABS is unambiguous.
+let written = 0;
+for (const row of found) {
+  const { data: lga } = await db
+    .from('abs_locality_lga')
+    .select('lga_name, lga_code, lga_count')
+    .ilike('locality', row.locality)
+    .eq('lga_count', 1);
+  if (!lga || lga.length !== 1) {
+    console.log(`  skip ${row.name}: ${row.locality} is not unambiguous in ABS`);
+    continue;
+  }
+  const { error: updateError } = await db
+    .from('gs_entities')
+    .update({
+      lga_name: lga[0].lga_name,
+      lga_code: lga[0].lga_code,
+      lga_source: 'oric_register_address+abs_asgs',
+    })
+    .eq('abn', row.abn);
+  if (updateError) console.log(`  FAILED ${row.name}: ${updateError.message}`);
+  else {
+    written += 1;
+    console.log(`  ${row.name} -> ${lga[0].lga_name}`);
+  }
+}
+console.log(`\n${written} entities placed.`);

--- a/scripts/ingest-crime-sa.mjs
+++ b/scripts/ingest-crime-sa.mjs
@@ -1,23 +1,43 @@
 #!/usr/bin/env node
 /**
- * Ingest South Australia crime data into crime_stats_lga.
+ * Ingest South Australia crime data into crime_stats_lga, keyed on suburb.
  *
- * Source: SA Police (SAPOL) reported crime statistics
- *   - CSV with suburb/postcode-level offence counts (daily granularity)
- *   - Aggregated to LGA level via postcode_geo lookup
+ * Source: SA Police reported crime statistics, published per suburb.
+ *   https://data.sa.gov.au/data/dataset/crime-statistics
+ *
+ * WHY THIS WAS REWRITTEN
+ *
+ * The previous version aggregated to LGA through postcode_geo, which stored one
+ * council per postcode and took whichever it saw first. Postcode 5690 spans
+ * four councils, so every offence reported anywhere in it was filed against
+ * Maralinga Tjarutja: 905 offences and 336 assaults attributed to a community of
+ * a few hundred people. Oak Valley, the community actually in Maralinga
+ * Tjarutja, reported 8 offences in 2024-25. Ceduna township reported 649.
+ *
+ * SAPOL publishes the suburb. It always did. The old script parsed it and then
+ * threw it away in favour of the postcode. This one uses it, resolving suburb to
+ * council through abs_locality_lga (ABS ASGS Ed3 SAL_2021 + LGA_2025).
+ *
+ * WHAT IT REFUSES TO DO
+ *
+ * Where ABS puts a locality in more than one council, the offences are not
+ * assigned. They are counted, reported at the end, and left out. A number
+ * attributed to the wrong community is worse than a number we admit we cannot
+ * place, and this whole rewrite exists because of what the guess cost.
  *
  * Usage:
- *   node --env-file=.env scripts/ingest-crime-sa.mjs [path-to-csv]
+ *   node --env-file=.env scripts/ingest-crime-sa.mjs <path-to-csv>            # dry run
+ *   node --env-file=.env scripts/ingest-crime-sa.mjs <path-to-csv> --apply
  */
 
 import { readFileSync } from 'fs';
 import { createClient } from '@supabase/supabase-js';
 
-const CSV_PATH = process.argv[2] || '/tmp/sa-crime-2024-25.csv';
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const CSV_PATH = args.find((a) => !a.startsWith('--')) || '/tmp/sa-crime-2024-25.csv';
+const PERIOD = args.find((a) => a.startsWith('--period='))?.split('=')[1] || 'July 2024 - June 2025';
 
-// ---------------------------------------------------------------------------
-// Map SA offence Level 2 descriptions to normalised groups/types
-// ---------------------------------------------------------------------------
 const OFFENCE_MAP = {
   'HOMICIDE AND RELATED OFFENCES':          { group: 'Homicide', type: 'Homicide & related' },
   'ACTS INTENDED TO CAUSE INJURY':          { group: 'Assault', type: 'Assault & related' },
@@ -32,211 +52,120 @@ const OFFENCE_MAP = {
   'OTHER OFFENCES AGAINST PROPERTY':        { group: 'Other offences', type: 'Other property offences' },
 };
 
-// ---------------------------------------------------------------------------
-// Parse CSV (simple — no quoted commas in this dataset)
-// ---------------------------------------------------------------------------
-console.log(`Reading ${CSV_PATH}...`);
-const raw = readFileSync(CSV_PATH, 'utf-8');
-const lines = raw.trim().split('\n');
-const headers = lines[0].split(',');
-console.log(`Headers: ${headers.join(' | ')}`);
-console.log(`Data rows: ${lines.length - 1}`);
+const db = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
 
-// Parse rows: Reported Date, Suburb, Postcode, Level1, Level2, Level3, Count
-const records = [];
-for (let i = 1; i < lines.length; i++) {
-  const parts = lines[i].split(',');
-  if (parts.length < 7) continue;
-  records.push({
-    date: parts[0],
-    suburb: parts[1],
-    postcode: parts[2],
-    level1: parts[3],
-    level2: parts[4],
-    level3: parts[5],
-    count: parseInt(parts[6]) || 0,
-  });
+// Suburb -> council, SA only, and only where ABS gives exactly one answer.
+// Paged: PostgREST caps a response at 1,000 rows whatever .limit() says.
+const absRows = [];
+for (let from = 0; ; from += 1000) {
+  const { data: page, error } = await db
+    .from('abs_locality_lga')
+    .select('locality, lga_name, lga_count')
+    .eq('state_name', 'South Australia')
+    .range(from, from + 999);
+  if (error) { console.error('ABS lookup failed:', error.message); process.exit(1); }
+  if (!page?.length) break;
+  absRows.push(...page);
+  if (page.length < 1000) break;
 }
-console.log(`Parsed ${records.length} records`);
 
-// Determine year period from date range
-const dates = records.map(r => {
-  const [d, m, y] = r.date.split('/');
-  return new Date(`${y}-${m}-${d}`);
-}).sort((a, b) => a - b);
-const startDate = dates[0];
-const endDate = dates[dates.length - 1];
-const yearPeriod = `July ${startDate.getFullYear()} - June ${endDate.getFullYear()}`;
-console.log(`Period: ${yearPeriod}`);
+const suburbToLga = new Map();
+const ambiguous = new Set();
+for (const row of absRows) {
+  const key = row.locality.replace(/\s*\([A-Z]{2,3}\)\s*$/, '').trim().toUpperCase();
+  if (row.lga_count === 1) suburbToLga.set(key, row.lga_name);
+  else ambiguous.add(key);
+}
+console.log(`ABS: ${suburbToLga.size} SA suburbs resolve to one council, ${ambiguous.size} straddle several`);
 
 // ---------------------------------------------------------------------------
-// Load postcode→LGA mapping from Supabase
-// ---------------------------------------------------------------------------
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-if (!supabaseUrl || !supabaseKey) {
-  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+const raw = readFileSync(CSV_PATH, 'utf-8').trim().split('\n');
+const headers = raw[0].split(',').map((h) => h.trim());
+const col = {
+  suburb: headers.indexOf('Suburb - Incident'),
+  level2: headers.indexOf('Offence Level 2 Description'),
+  count: headers.indexOf('Offence count'),
+};
+if (Object.values(col).some((i) => i < 0)) {
+  console.error(`Unexpected columns: ${headers.join(' | ')}`);
   process.exit(1);
 }
-const supabase = createClient(supabaseUrl, supabaseKey);
+console.log(`Reading ${CSV_PATH}: ${raw.length - 1} rows\n`);
 
-console.log('\nLoading SA postcode→LGA mapping...');
-const { data: postcodeRows, error: pgErr } = await supabase
-  .from('postcode_geo')
-  .select('postcode, lga_name')
-  .eq('state', 'SA')
-  .not('lga_name', 'is', null);
+const tally = new Map();          // "LGA|group|type" -> incidents
+const lgaTotals = new Map();
+let placed = 0, unplacedAmbiguous = 0, unplacedUnknown = 0, unmappedOffence = 0;
+const unknownSuburbs = new Map();
 
-if (pgErr) {
-  console.error('Error loading postcode_geo:', pgErr.message);
-  process.exit(1);
-}
+for (let i = 1; i < raw.length; i++) {
+  const parts = raw[i].split(',');
+  const suburb = (parts[col.suburb] || '').trim().toUpperCase();
+  const level2 = (parts[col.level2] || '').trim().toUpperCase();
+  const count = parseInt(parts[col.count] || '0', 10) || 0;
+  if (!suburb || !count) continue;
 
-// Build postcode→LGA map (some postcodes span multiple LGAs — take first)
-const postcodeLga = new Map();
-for (const row of postcodeRows) {
-  if (!postcodeLga.has(row.postcode)) {
-    postcodeLga.set(row.postcode, row.lga_name);
-  }
-}
-console.log(`Postcode→LGA mappings: ${postcodeLga.size}`);
+  const mapping = OFFENCE_MAP[level2];
+  if (!mapping) { unmappedOffence += count; continue; }
 
-// ---------------------------------------------------------------------------
-// Aggregate: postcode → LGA, Level 2 → normalised offence group/type
-// ---------------------------------------------------------------------------
-const lgaOffenceMap = new Map(); // key: "LGA|group|type" -> incidents
-let unmappedPostcodes = 0;
-let unmappedOffences = 0;
-const unmappedPostcodeSet = new Set();
-
-for (const rec of records) {
-  const lga = postcodeLga.get(rec.postcode);
+  const lga = suburbToLga.get(suburb);
   if (!lga) {
-    unmappedPostcodes++;
-    unmappedPostcodeSet.add(rec.postcode);
+    if (ambiguous.has(suburb)) unplacedAmbiguous += count;
+    else { unplacedUnknown += count; unknownSuburbs.set(suburb, (unknownSuburbs.get(suburb) || 0) + count); }
     continue;
   }
 
-  const mapping = OFFENCE_MAP[rec.level2];
-  if (!mapping) {
-    unmappedOffences++;
-    continue;
-  }
-
+  placed += count;
   const key = `${lga}|${mapping.group}|${mapping.type}`;
-  lgaOffenceMap.set(key, (lgaOffenceMap.get(key) || 0) + rec.count);
+  tally.set(key, (tally.get(key) || 0) + count);
+  lgaTotals.set(lga, (lgaTotals.get(lga) || 0) + count);
 }
 
-console.log(`\nUnmapped postcodes: ${unmappedPostcodes} records (${unmappedPostcodeSet.size} unique postcodes)`);
-if (unmappedPostcodeSet.size > 0 && unmappedPostcodeSet.size <= 20) {
-  console.log(`  Postcodes: ${[...unmappedPostcodeSet].sort().join(', ')}`);
+const rows = [];
+for (const [key, incidents] of tally) {
+  const [lga_name, offence_group, offence_type] = key.split('|');
+  rows.push({ lga_name, state: 'SA', offence_group, offence_type, year_period: PERIOD, incidents, source: 'SAPOL' });
 }
-console.log(`Unmapped offence types: ${unmappedOffences} records`);
-
-// Build insert rows
-const insertRows = [];
-const lgaNames = new Set();
-const lgaTotals = new Map(); // LGA → total incidents
-
-for (const [key, incidents] of lgaOffenceMap) {
-  const [lga, group, type] = key.split('|');
-  if (incidents === 0) continue;
-
-  lgaNames.add(lga);
-  lgaTotals.set(lga, (lgaTotals.get(lga) || 0) + incidents);
-
-  insertRows.push({
-    lga_name: lga,
-    state: 'SA',
-    offence_group: group,
-    offence_type: type,
-    year_period: yearPeriod,
-    incidents,
-    rate_per_100k: null, // SAPOL CSV doesn't include population rates
-    source: 'SAPOL',
-  });
+for (const [lga_name, incidents] of lgaTotals) {
+  rows.push({ lga_name, state: 'SA', offence_group: 'Total', offence_type: 'All offences', year_period: PERIOD, incidents, source: 'SAPOL' });
 }
 
-// Add total row per LGA
-for (const [lga, total] of lgaTotals) {
-  insertRows.push({
-    lga_name: lga,
-    state: 'SA',
-    offence_group: 'Total',
-    offence_type: 'All offences',
-    year_period: yearPeriod,
-    incidents: total,
-    rate_per_100k: null,
-    source: 'SAPOL',
-  });
+const total = placed + unplacedAmbiguous + unplacedUnknown + unmappedOffence;
+console.log(`Placed:              ${placed} offences across ${lgaTotals.size} councils`);
+console.log(`Unplaced, ambiguous: ${unplacedAmbiguous}  (suburb straddles councils in ABS)`);
+console.log(`Unplaced, unknown:   ${unplacedUnknown}  (suburb not in ABS)`);
+console.log(`Offence not mapped:  ${unmappedOffence}`);
+console.log(`Total in file:       ${total}  (${((100 * placed) / total).toFixed(1)}% placed)\n`);
+
+if (unknownSuburbs.size) {
+  const worst = [...unknownSuburbs.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+  console.log('Largest unrecognised suburbs:');
+  for (const [name, n] of worst) console.log(`  ${String(n).padStart(6)}  ${name}`);
+  console.log();
 }
 
-console.log(`\nLGAs found: ${lgaNames.size}`);
-console.log(`Total rows to insert: ${insertRows.length}`);
+console.log('Far West check:');
+for (const name of ['Ceduna', 'Maralinga Tjarutja', 'Streaky Bay']) {
+  console.log(`  ${name.padEnd(20)} ${lgaTotals.get(name) ?? 0}`);
+}
+console.log();
 
-// ---------------------------------------------------------------------------
-// Delete existing SA data for this period (idempotent re-runs)
-// ---------------------------------------------------------------------------
-console.log(`\nDeleting existing SA/SAPOL data for period "${yearPeriod}"...`);
-const { error: delErr } = await supabase
+if (!APPLY) {
+  console.log(`Dry run: ${rows.length} rows ready. Re-run with --apply to replace SA rows for "${PERIOD}".`);
+  process.exit(0);
+}
+
+const { error: delError } = await db
   .from('crime_stats_lga')
   .delete()
   .eq('state', 'SA')
-  .eq('source', 'SAPOL')
-  .eq('year_period', yearPeriod);
+  .eq('year_period', PERIOD);
+if (delError) { console.error('Delete failed:', delError.message); process.exit(1); }
 
-if (delErr) {
-  console.error('Delete error:', delErr.message);
-} else {
-  console.log('  Deleted existing rows (if any)');
+for (let i = 0; i < rows.length; i += 500) {
+  const { error: insError } = await db.from('crime_stats_lga').insert(rows.slice(i, i + 500));
+  if (insError) { console.error('Insert failed:', insError.message); process.exit(1); }
 }
-
-// Insert in batches of 500
-const BATCH_SIZE = 500;
-let inserted = 0;
-let errors = 0;
-
-for (let i = 0; i < insertRows.length; i += BATCH_SIZE) {
-  const batch = insertRows.slice(i, i + BATCH_SIZE);
-  const { error: insertErr } = await supabase
-    .from('crime_stats_lga')
-    .insert(batch);
-
-  if (insertErr) {
-    console.error(`  Batch ${Math.floor(i / BATCH_SIZE) + 1} error:`, insertErr.message);
-    errors++;
-  } else {
-    inserted += batch.length;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Report
-// ---------------------------------------------------------------------------
-console.log('\n=== INGEST REPORT ===');
-console.log(`Source: SA Police (SAPOL)`);
-console.log(`Period: ${yearPeriod}`);
-console.log(`LGAs: ${lgaNames.size}`);
-console.log(`Rows inserted: ${inserted}`);
-console.log(`Batch errors: ${errors}`);
-
-// Sample data
-console.log('\n=== SAMPLE DATA (first 10 rows) ===');
-for (const row of insertRows.slice(0, 10)) {
-  console.log(`  ${row.lga_name} | ${row.offence_group} | ${row.offence_type} | incidents=${row.incidents}`);
-}
-
-// Top LGAs by total incidents
-const totals = insertRows.filter(r => r.offence_group === 'Total');
-totals.sort((a, b) => b.incidents - a.incidents);
-console.log('\n=== TOP 15 LGAs BY TOTAL INCIDENTS ===');
-for (const row of totals.slice(0, 15)) {
-  console.log(`  ${row.lga_name}: ${row.incidents.toLocaleString()}`);
-}
-
-// Bottom 5 LGAs
-totals.sort((a, b) => a.incidents - b.incidents);
-console.log('\n=== BOTTOM 5 LGAs BY TOTAL INCIDENTS ===');
-for (const row of totals.slice(0, 5)) {
-  console.log(`  ${row.lga_name}: ${row.incidents.toLocaleString()}`);
-}
+console.log(`Wrote ${rows.length} rows for ${PERIOD}.`);

--- a/supabase/migrations/20260808120000_rebuild_postcode_geo_lga_from_abs.sql
+++ b/supabase/migrations/20260808120000_rebuild_postcode_geo_lga_from_abs.sql
@@ -1,0 +1,64 @@
+-- Rebuild postcode_geo.lga_name / lga_code from ABS ASGS.
+--
+-- postcode_geo stored one council per postcode and, where a postcode spanned
+-- several, kept whichever was seen first. Postcode 5690 spans three, so every
+-- locality in it, Ceduna township and Koonibba included, was recorded as
+-- Maralinga Tjarutja. Anything keyed on that column inherited the error:
+-- crime_stats_lga filed 905 offences and 336 assaults reported in Ceduna
+-- against a community of a few hundred people, and mv_funding_by_lga credited
+-- Ceduna's organisations to the wrong council.
+--
+-- abs_locality_lga (ABS ASGS Ed3 SAL_2021_AUST + LGA_2025_AUST) is the
+-- authority and was already in the database. This aligns postcode_geo to it.
+--
+-- Scope and deliberate limits:
+--   * Locality level, not postcode level. That is the whole point: CEDUNA and
+--     OAK VALLEY share postcode 5690 and belong to different councils.
+--   * Only where ABS is unambiguous (lga_count = 1 and one row per
+--     locality+state). Localities that genuinely straddle councils are left
+--     untouched rather than guessed at.
+--   * Joined on locality AND state. Locality names repeat across states, and
+--     matching on name alone fans out and misassigns.
+--
+-- Does NOT touch gs_entities.lga_name, which carries the same error but can
+-- only be resolved by postcode and so cannot be fixed this way for any
+-- multi-council postcode. Tracked separately.
+--
+-- Reversible: prior values are copied to postcode_geo_lga_backup_20260808.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS postcode_geo_lga_backup_20260808 AS
+SELECT postcode, locality, state, lga_name, lga_code
+FROM postcode_geo;
+
+WITH state_codes(state_name, code) AS (
+  VALUES ('Australian Capital Territory','ACT'),
+         ('New South Wales','NSW'),
+         ('Northern Territory','NT'),
+         ('Queensland','QLD'),
+         ('South Australia','SA'),
+         ('Tasmania','TAS'),
+         ('Victoria','VIC'),
+         ('Western Australia','WA')
+),
+unambiguous AS (
+  SELECT upper(a.locality) AS loc,
+         s.code            AS state,
+         min(a.lga_name)   AS lga_name,
+         min(a.lga_code)   AS lga_code
+    FROM abs_locality_lga a
+    JOIN state_codes s ON s.state_name = a.state_name
+   WHERE a.lga_count = 1
+   GROUP BY 1, 2
+  HAVING count(*) = 1
+)
+UPDATE postcode_geo p
+   SET lga_name = u.lga_name,
+       lga_code = u.lga_code
+  FROM unambiguous u
+ WHERE u.loc = upper(p.locality)
+   AND u.state = p.state
+   AND p.lga_name IS DISTINCT FROM u.lga_name;
+
+COMMIT;

--- a/supabase/migrations/20260808130000_resolve_or_null_entity_lga.sql
+++ b/supabase/migrations/20260808130000_resolve_or_null_entity_lga.sql
@@ -7,39 +7,42 @@
 -- locality table but not this column, because entities carry a postcode and no
 -- locality, so there is nothing here to rebuild from.
 --
--- Two passes, in this order:
---
 --   Pass 1, resolve. Where the entity is an ACNC-registered charity, its
 --   town_city is a locality, and that locality maps to exactly one council in
 --   ABS ASGS, use it. Stamped lga_source = 'acnc_town_city+abs_asgs'.
 --
 --   Pass 2, null. Everything else in a multi-council postcode loses its
---   lga_name. A postcode-derived council in a postcode that spans several is a
+--   lga_name. A postcode-derived council in a postcode spanning several is a
 --   guess wearing the costume of a fact, and the Ceduna case shows the guess
 --   lands on the smallest community in the postcode. Stamped lga_source =
---   'unresolved_multi_lga_postcode' so the nulls are legible rather than
---   looking like missing data, and recorded in geo_resolution_gaps the same way
+--   'unresolved_multi_lga_postcode' so the nulls read as recorded ignorance
+--   rather than missing data, and logged in geo_resolution_gaps the same way
 --   postcode 0872 already is.
 --
--- Entities in single-council postcodes are not touched by either pass.
+-- Entities in single-council postcodes are untouched by both passes.
 --
--- ALTERNATIVE, if nulling proves too blunt: replace pass 2's null with a
--- lga_source stamp alone, keeping lga_name and letting consumers filter on
--- provenance. That preserves the rollups at the cost of leaving a wrong value
--- in place for anything that does not check lga_source. Nulling was chosen
--- because most consumers will not check.
+-- RUN SHAPE. The first version wrapped everything in one transaction. It got
+-- through pass 1 and died in pass 2 after five minutes, rolling back all of it:
+-- a ~68,000 row UPDATE holds its locks too long for the pooler. This version
+-- runs in autocommit with real staging tables instead of temp ones, and chunks
+-- pass 2 into batches that commit as they go. Safe to re-run: every phase is
+-- idempotent and pass 2 resumes where it stopped, because a row it has already
+-- nulled no longer matches its own WHERE clause.
 --
 -- Reversible: prior values in gs_entities_lga_backup_20260808.
 
-BEGIN;
+SET statement_timeout = '15min';
 
+-- Phase 0. Backup, committed on its own so a later failure cannot discard it.
 CREATE TABLE IF NOT EXISTS gs_entities_lga_backup_20260808 AS
 SELECT id, abn, postcode, state, lga_name, lga_code, lga_source
 FROM gs_entities;
 
--- Pre-materialised with indexes. The equivalent inline subqueries plan as a
--- nested loop over a Materialize node and do not finish.
-CREATE TEMP TABLE _unamb ON COMMIT DROP AS
+-- Phase 1. Staging. Real tables, not temp: they must outlive each batch commit.
+-- Pre-materialised and indexed because the inline equivalents plan as a nested
+-- loop over a Materialize node and do not finish.
+DROP TABLE IF EXISTS stg_lga_unamb;
+CREATE UNLOGGED TABLE stg_lga_unamb AS
 WITH state_codes(state_name, code) AS (
   VALUES ('Australian Capital Territory','ACT'),
          ('New South Wales','NSW'),
@@ -59,47 +62,70 @@ SELECT upper(a.locality) AS loc,
  WHERE a.lga_count = 1
  GROUP BY 1, 2
 HAVING count(*) = 1;
-CREATE INDEX ON _unamb (loc, state);
-ANALYZE _unamb;
+CREATE INDEX ON stg_lga_unamb (loc, state);
+ANALYZE stg_lga_unamb;
 
-CREATE TEMP TABLE _multi ON COMMIT DROP AS
+DROP TABLE IF EXISTS stg_lga_multi;
+CREATE UNLOGGED TABLE stg_lga_multi AS
 SELECT p.postcode, p.state
   FROM postcode_geo p
   JOIN abs_locality_lga a ON upper(a.locality) = upper(p.locality)
  GROUP BY p.postcode, p.state
 HAVING count(DISTINCT a.lga_name) > 1;
-CREATE INDEX ON _multi (postcode, state);
-ANALYZE _multi;
+CREATE INDEX ON stg_lga_multi (postcode, state);
+ANALYZE stg_lga_multi;
 
 -- ACNC abn is unique among rows carrying a town_city, so this cannot fan out.
-CREATE TEMP TABLE _resolved ON COMMIT DROP AS
+DROP TABLE IF EXISTS stg_lga_resolved;
+CREATE UNLOGGED TABLE stg_lga_resolved AS
 SELECT e.id, u.lga_name, u.lga_code
   FROM gs_entities e
-  JOIN _multi m ON m.postcode = e.postcode AND m.state = e.state
+  JOIN stg_lga_multi m ON m.postcode = e.postcode AND m.state = e.state
   JOIN acnc_charities c ON c.abn = e.abn AND c.town_city IS NOT NULL
-  JOIN _unamb u ON u.loc = upper(c.town_city) AND u.state = e.state;
-CREATE INDEX ON _resolved (id);
-ANALYZE _resolved;
+  JOIN stg_lga_unamb u ON u.loc = upper(c.town_city) AND u.state = e.state;
+CREATE INDEX ON stg_lga_resolved (id);
+ANALYZE stg_lga_resolved;
 
--- Pass 1
+-- Phase 2. Resolve. Measured at 7,538 rows and seconds of work.
 UPDATE gs_entities e
    SET lga_name = r.lga_name,
        lga_code = r.lga_code,
        lga_source = 'acnc_town_city+abs_asgs'
-  FROM _resolved r
- WHERE r.id = e.id;
+  FROM stg_lga_resolved r
+ WHERE r.id = e.id
+   AND e.lga_source IS DISTINCT FROM 'acnc_town_city+abs_asgs';
 
--- Pass 2
-UPDATE gs_entities e
-   SET lga_name = NULL,
-       lga_code = NULL,
-       lga_source = 'unresolved_multi_lga_postcode'
-  FROM _multi m
- WHERE m.postcode = e.postcode
-   AND m.state = e.state
-   AND e.lga_name IS NOT NULL
-   AND NOT EXISTS (SELECT 1 FROM _resolved r WHERE r.id = e.id);
+-- Phase 3. Null, in committed batches. The WHERE excludes rows already nulled,
+-- so each pass shrinks the remaining set and a re-run picks up mid-way.
+DO $$
+DECLARE
+  batch int;
+  total int := 0;
+BEGIN
+  LOOP
+    UPDATE gs_entities e
+       SET lga_name = NULL,
+           lga_code = NULL,
+           lga_source = 'unresolved_multi_lga_postcode'
+     WHERE e.id IN (
+       SELECT e2.id
+         FROM gs_entities e2
+         JOIN stg_lga_multi m ON m.postcode = e2.postcode AND m.state = e2.state
+         LEFT JOIN stg_lga_resolved r ON r.id = e2.id
+        WHERE e2.lga_name IS NOT NULL
+          AND r.id IS NULL
+        LIMIT 5000
+     );
+    GET DIAGNOSTICS batch = ROW_COUNT;
+    EXIT WHEN batch = 0;
+    total := total + batch;
+    COMMIT;
+    RAISE NOTICE 'nulled % this batch, % so far', batch, total;
+  END LOOP;
+  RAISE NOTICE 'pass 2 complete: % rows nulled', total;
+END $$;
 
+-- Phase 4. Record what we could not place, so the gap is a task and not a shrug.
 INSERT INTO geo_resolution_gaps
   (postcode, issue, affected_entities, affected_community_controlled, required_source, detected_at)
 SELECT e.postcode,
@@ -127,4 +153,6 @@ BEGIN
   RAISE NOTICE 'open geo_resolution_gaps:  %', gaps_n;
 END $$;
 
-COMMIT;
+DROP TABLE IF EXISTS stg_lga_resolved;
+DROP TABLE IF EXISTS stg_lga_multi;
+DROP TABLE IF EXISTS stg_lga_unamb;

--- a/supabase/migrations/20260808130000_resolve_or_null_entity_lga.sql
+++ b/supabase/migrations/20260808130000_resolve_or_null_entity_lga.sql
@@ -1,0 +1,130 @@
+-- Place gs_entities in a council where we can, and admit we cannot where we can't.
+--
+-- gs_entities.lga_name was derived from postcode. Postcode 5690 spans four
+-- councils, so all 97 Ceduna-region organisations were stamped Maralinga
+-- Tjarutja, and mv_funding_by_lga credited a town's funding to a community of
+-- a few hundred people. Rebuilding postcode_geo (20260808120000) fixed the
+-- locality table but not this column, because entities carry a postcode and no
+-- locality, so there is nothing here to rebuild from.
+--
+-- Two passes, in this order:
+--
+--   Pass 1, resolve. Where the entity is an ACNC-registered charity, its
+--   town_city is a locality, and that locality maps to exactly one council in
+--   ABS ASGS, use it. Stamped lga_source = 'acnc_town_city+abs_asgs'.
+--
+--   Pass 2, null. Everything else in a multi-council postcode loses its
+--   lga_name. A postcode-derived council in a postcode that spans several is a
+--   guess wearing the costume of a fact, and the Ceduna case shows the guess
+--   lands on the smallest community in the postcode. Stamped lga_source =
+--   'unresolved_multi_lga_postcode' so the nulls are legible rather than
+--   looking like missing data, and recorded in geo_resolution_gaps the same way
+--   postcode 0872 already is.
+--
+-- Entities in single-council postcodes are not touched by either pass.
+--
+-- ALTERNATIVE, if nulling proves too blunt: replace pass 2's null with a
+-- lga_source stamp alone, keeping lga_name and letting consumers filter on
+-- provenance. That preserves the rollups at the cost of leaving a wrong value
+-- in place for anything that does not check lga_source. Nulling was chosen
+-- because most consumers will not check.
+--
+-- Reversible: prior values in gs_entities_lga_backup_20260808.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS gs_entities_lga_backup_20260808 AS
+SELECT id, abn, postcode, state, lga_name, lga_code, lga_source
+FROM gs_entities;
+
+-- Pre-materialised with indexes. The equivalent inline subqueries plan as a
+-- nested loop over a Materialize node and do not finish.
+CREATE TEMP TABLE _unamb ON COMMIT DROP AS
+WITH state_codes(state_name, code) AS (
+  VALUES ('Australian Capital Territory','ACT'),
+         ('New South Wales','NSW'),
+         ('Northern Territory','NT'),
+         ('Queensland','QLD'),
+         ('South Australia','SA'),
+         ('Tasmania','TAS'),
+         ('Victoria','VIC'),
+         ('Western Australia','WA')
+)
+SELECT upper(a.locality) AS loc,
+       s.code            AS state,
+       min(a.lga_name)   AS lga_name,
+       min(a.lga_code)   AS lga_code
+  FROM abs_locality_lga a
+  JOIN state_codes s ON s.state_name = a.state_name
+ WHERE a.lga_count = 1
+ GROUP BY 1, 2
+HAVING count(*) = 1;
+CREATE INDEX ON _unamb (loc, state);
+ANALYZE _unamb;
+
+CREATE TEMP TABLE _multi ON COMMIT DROP AS
+SELECT p.postcode, p.state
+  FROM postcode_geo p
+  JOIN abs_locality_lga a ON upper(a.locality) = upper(p.locality)
+ GROUP BY p.postcode, p.state
+HAVING count(DISTINCT a.lga_name) > 1;
+CREATE INDEX ON _multi (postcode, state);
+ANALYZE _multi;
+
+-- ACNC abn is unique among rows carrying a town_city, so this cannot fan out.
+CREATE TEMP TABLE _resolved ON COMMIT DROP AS
+SELECT e.id, u.lga_name, u.lga_code
+  FROM gs_entities e
+  JOIN _multi m ON m.postcode = e.postcode AND m.state = e.state
+  JOIN acnc_charities c ON c.abn = e.abn AND c.town_city IS NOT NULL
+  JOIN _unamb u ON u.loc = upper(c.town_city) AND u.state = e.state;
+CREATE INDEX ON _resolved (id);
+ANALYZE _resolved;
+
+-- Pass 1
+UPDATE gs_entities e
+   SET lga_name = r.lga_name,
+       lga_code = r.lga_code,
+       lga_source = 'acnc_town_city+abs_asgs'
+  FROM _resolved r
+ WHERE r.id = e.id;
+
+-- Pass 2
+UPDATE gs_entities e
+   SET lga_name = NULL,
+       lga_code = NULL,
+       lga_source = 'unresolved_multi_lga_postcode'
+  FROM _multi m
+ WHERE m.postcode = e.postcode
+   AND m.state = e.state
+   AND e.lga_name IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM _resolved r WHERE r.id = e.id);
+
+INSERT INTO geo_resolution_gaps
+  (postcode, issue, affected_entities, affected_community_controlled, required_source, detected_at)
+SELECT e.postcode,
+       'Postcode spans multiple council areas and the entity record carries no locality',
+       count(*),
+       count(*) FILTER (WHERE e.is_community_controlled),
+       'A street address or locality per entity, from ABR or ORIC. Neither currently stores one: both hold postcode and state only.',
+       now()
+  FROM gs_entities e
+ WHERE e.lga_source = 'unresolved_multi_lga_postcode'
+ GROUP BY e.postcode
+ON CONFLICT (postcode, issue) DO UPDATE
+   SET affected_entities = EXCLUDED.affected_entities,
+       affected_community_controlled = EXCLUDED.affected_community_controlled,
+       detected_at = EXCLUDED.detected_at;
+
+DO $$
+DECLARE resolved_n int; nulled_n int; gaps_n int;
+BEGIN
+  SELECT count(*) INTO resolved_n FROM gs_entities WHERE lga_source = 'acnc_town_city+abs_asgs';
+  SELECT count(*) INTO nulled_n   FROM gs_entities WHERE lga_source = 'unresolved_multi_lga_postcode';
+  SELECT count(*) INTO gaps_n     FROM geo_resolution_gaps WHERE resolved_at IS NULL;
+  RAISE NOTICE 'resolved by ACNC locality: %', resolved_n;
+  RAISE NOTICE 'nulled as unplaceable:     %', nulled_n;
+  RAISE NOTICE 'open geo_resolution_gaps:  %', gaps_n;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Ceduna's place page said the region held **\$7.5M**. It holds **\$215.3M** in current federal commitments. Separately, it showed 336 assaults against a community of a few hundred people that did not happen there. Both were our bugs.

## What changed

**Place pages read GrantConnect.** `/places/[postcode]` took its funding from `gs_relationships`, which carries no GrantConnect at all. New `getPostcodeFundingPicture` keys on the recipient's registered address, because only 41 of 346 awards in postcode 5690 publish a delivery location and delivery-keying drops seven awards in eight. Registered address has the opposite bias, so both caveats render on the page rather than living in a comment. Surfaces "ends within 24 months" (\$148.3M for 5690) because committed money is only leverage when you know its renewal date.

**`place-intelligence` generalised** off its hardcoded Central Australia filter into a `PLACE_REGIONS` registry. `getCentralAustraliaIntelligence()` is now a wrapper, so `/place/central-australia` is unchanged.

**Crime figures withheld where the council is wrong.** `crime_stats_lga` rolls SAPOL's suburb counts up to an LGA through `postcode_geo`, which stored one council per postcode and took the first it saw. Postcode 5690 spans four. `getLgaAttribution` checks ABS ASGS before fetching, so suppressed figures never reach the RSC payload, and the section explains itself rather than vanishing.

**Two migrations, both applied and verified.**

| | Result |
|---|---|
| `postcode_geo` rebuilt from ABS | 4,126 rows, 729 postcodes |
| Entities resolved via ACNC locality | 7,538 |
| Entities nulled as unplaceable | 64,801 |
| `geo_resolution_gaps` recorded | 598 |

Ceduna's rollup went from 6 entities / \$42,871 to **23 / \$3,581,161**. Maralinga Tjarutja's phantom 97 entities and \$7.45M are gone: every one was a misattribution.

## Deliberate trade-offs

- **The nulls are recorded ignorance, not missing data.** Check `lga_source` before reading a null LGA as absent. Rejected the softer "stamp provenance, keep the value" variant because most consumers will not check.
- **A targeted "null only if the council is not in the ABS set" rule was rejected** — it would not have caught Ceduna, since Maralinga Tjarutja is a valid council for 5690.
- **Crime suppressed on ~31.8% of postcodes.** Those genuinely span councils. Re-ingesting SA crime by suburb would cut this.

## Not verified

`/places/5690` has not been rendered. Browse tools cannot read this app in dev or prod, so this is verified by SQL, tsc and 541 passing tests only. Needs eyes on the preview.

Backups: `postcode_geo_lga_backup_20260808`, `gs_entities_lga_backup_20260808`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)