### PR TITLE
Put unplaced organisations on the map, and give councils their modal remoteness

### DIFF
--- a/apps/web/src/app/api/data/map/route.ts
+++ b/apps/web/src/app/api/data/map/route.ts
@@ -9,6 +9,7 @@ export const dynamic = 'force-dynamic';
 const limiter = rateLimit();
 
 const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'ACT', 'NT'] as const;
+const METRICS = ['desert_score', 'unplaced_share'] as const;
 
 const schema = z.object({
   state: z.string().optional(),
@@ -24,7 +25,7 @@ export async function GET(request: Request) {
   if (!parsed.success) return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 });
 
   const safeState = whitelist(parsed.data.state?.toUpperCase() ?? null, STATES, null as unknown as typeof STATES[number]);
-  const metric = parsed.data.metric || 'desert_score';
+  const metric = whitelist(parsed.data.metric ?? null, METRICS, 'desert_score');
 
   try {
     const supabase = getServiceSupabase();
@@ -33,55 +34,167 @@ export async function GET(request: Request) {
       ? `AND UPPER(state) = '${safeState}'`
       : '';
 
+    // Base grain is councils with centroids, not mv_funding_deserts rows: the
+    // councils whose organisations we cannot place are exactly the ones most
+    // likely to have no MV row (Maralinga Tjarutja has none), and an
+    // uncertainty layer that drops the most uncertain councils would be lying.
+    //
+    // Remoteness comes from the modal ABS class across the council's postcodes.
+    // mv_funding_deserts carries one row per remoteness class a council touches
+    // and picking the highest desert_score row labelled Brisbane "Remote
+    // Australia"; where several rows exist we keep the one matching the modal
+    // class and fall back to severity only when none does.
+    //
+    // Unplaced counts join postcode -> council, so an organisation in a
+    // postcode spanning three councils counts toward all three. That is the
+    // semantics, not a bug: an organisation that could be in any of them makes
+    // each council's picture less certain.
+    const undrawnPromise = supabase.rpc('exec_sql', {
+      query: `WITH no_lat AS (
+        SELECT lga_name, UPPER(state) AS state
+        FROM postcode_geo
+        WHERE lga_name IS NOT NULL ${stateClause}
+        GROUP BY 1, 2
+        HAVING count(latitude) = 0
+      ),
+      unplaced_pc AS MATERIALIZED (
+        SELECT postcode, COUNT(*) AS n
+        FROM gs_entities
+        WHERE lga_name IS NULL AND postcode IS NOT NULL
+        GROUP BY postcode
+      ),
+      cpc AS MATERIALIZED (
+        SELECT DISTINCT lga_name, UPPER(state) AS state, postcode
+        FROM postcode_geo
+        WHERE lga_name IS NOT NULL
+      ),
+      counts AS (
+        SELECT nl.lga_name, nl.state, COALESCE(SUM(u.n), 0)::int AS unplaced
+        FROM no_lat nl
+        LEFT JOIN cpc ON cpc.lga_name = nl.lga_name AND cpc.state = nl.state
+        LEFT JOIN unplaced_pc u USING (postcode)
+        GROUP BY 1, 2
+      )
+      SELECT count(*)::int AS undrawn_lgas FROM counts c
+      WHERE c.unplaced > 0 OR EXISTS (
+        SELECT 1 FROM mv_funding_deserts d
+        WHERE d.lga_name = c.lga_name AND UPPER(d.state) = c.state
+          AND d.desert_score IS NOT NULL
+      )`,
+    });
+
     const { data, error } = await supabase.rpc('exec_sql', {
       query: `WITH lga_centroids AS (
         SELECT lga_name, lga_code, UPPER(state) as state,
                AVG(latitude::float) as lat,
                AVG(longitude::float) as lng
         FROM postcode_geo
-        WHERE lga_name IS NOT NULL AND latitude IS NOT NULL
+        WHERE lga_name IS NOT NULL AND latitude IS NOT NULL ${stateClause}
         GROUP BY lga_name, lga_code, UPPER(state)
       ),
-      deduped_deserts AS (
+      modal_remoteness AS (
         SELECT DISTINCT ON (lga_name, UPPER(state))
-          lga_name, UPPER(state) as state, remoteness,
-          avg_irsd_decile, avg_irsd_score,
-          indexed_entities, community_controlled_entities,
-          total_funding_all_sources, desert_score
-        FROM mv_funding_deserts
-        WHERE desert_score IS NOT NULL ${stateClause}
-        ORDER BY lga_name, UPPER(state), desert_score DESC
+          lga_name, UPPER(state) AS state, remoteness_2021 AS remoteness
+        FROM postcode_geo
+        WHERE lga_name IS NOT NULL AND remoteness_2021 IS NOT NULL
+        GROUP BY lga_name, UPPER(state), remoteness_2021
+        ORDER BY lga_name, UPPER(state), COUNT(*) DESC
+      ),
+      deduped_deserts AS (
+        SELECT DISTINCT ON (dd.lga_name, UPPER(dd.state))
+          dd.lga_name, UPPER(dd.state) as state,
+          COALESCE(mr.remoteness, dd.remoteness) AS remoteness,
+          dd.avg_irsd_decile, dd.avg_irsd_score,
+          dd.indexed_entities, dd.community_controlled_entities,
+          dd.total_funding_all_sources, dd.desert_score
+        FROM mv_funding_deserts dd
+        LEFT JOIN modal_remoteness mr
+          ON mr.lga_name = dd.lga_name AND mr.state = UPPER(dd.state)
+        WHERE dd.desert_score IS NOT NULL
+        ORDER BY dd.lga_name, UPPER(dd.state),
+                 (dd.remoteness = mr.remoteness) DESC NULLS LAST,
+                 dd.desert_score DESC
+      ),
+      unplaced_pc AS MATERIALIZED (
+        SELECT postcode, COUNT(*) AS n
+        FROM gs_entities
+        WHERE lga_name IS NULL AND postcode IS NOT NULL
+        GROUP BY postcode
+      ),
+      council_pc AS MATERIALIZED (
+        SELECT DISTINCT lga_name, UPPER(state) AS state, postcode
+        FROM postcode_geo
+        WHERE lga_name IS NOT NULL
+      ),
+      unplaced AS MATERIALIZED (
+        SELECT cp.lga_name, cp.state, SUM(u.n)::int AS unplaced
+        FROM council_pc cp
+        JOIN unplaced_pc u USING (postcode)
+        GROUP BY 1, 2
+      ),
+      placed AS MATERIALIZED (
+        SELECT lga_name, UPPER(state) AS state, COUNT(*)::int AS placed
+        FROM gs_entities
+        WHERE lga_name IS NOT NULL
+        GROUP BY 1, 2
       )
-      SELECT dd.lga_name, dd.state, dd.remoteness,
+      SELECT lc.lga_name, lc.state, lc.lat, lc.lng, lc.lga_code,
+             COALESCE(dd.remoteness, mr.remoteness) AS remoteness,
              dd.avg_irsd_decile, dd.avg_irsd_score,
              dd.indexed_entities, dd.community_controlled_entities,
              dd.total_funding_all_sources, dd.desert_score,
-             lc.lat, lc.lng, lc.lga_code
-      FROM deduped_deserts dd
-      LEFT JOIN lga_centroids lc ON dd.lga_name = lc.lga_name AND dd.state = lc.state
-      WHERE lc.lat IS NOT NULL
-      ORDER BY dd.desert_score DESC`,
+             COALESCE(un.unplaced, 0) AS unplaced_count,
+             COALESCE(pl.placed, 0) AS placed_count,
+             CASE WHEN COALESCE(un.unplaced, 0) + COALESCE(pl.placed, 0) > 0
+                  THEN ROUND(100.0 * COALESCE(un.unplaced, 0)
+                       / (COALESCE(un.unplaced, 0) + COALESCE(pl.placed, 0)), 1)
+                  ELSE NULL END AS unplaced_share
+      FROM lga_centroids lc
+      LEFT JOIN deduped_deserts dd ON dd.lga_name = lc.lga_name AND dd.state = lc.state
+      LEFT JOIN modal_remoteness mr ON mr.lga_name = lc.lga_name AND mr.state = lc.state
+      LEFT JOIN unplaced un ON un.lga_name = lc.lga_name AND un.state = lc.state
+      LEFT JOIN placed pl ON pl.lga_name = lc.lga_name AND pl.state = lc.state
+      WHERE dd.desert_score IS NOT NULL OR COALESCE(un.unplaced, 0) > 0
+      ORDER BY dd.desert_score DESC NULLS LAST`,
     });
 
     if (error) throw error;
 
-    // Compute summary stats
+    // A council with data but no coordinates cannot be drawn. Failing to say
+    // so would present the drawable subset as the whole country.
+    const { data: undrawnData } = await undrawnPromise;
+    const undrawnLgas = Array.isArray(undrawnData) && undrawnData.length > 0
+      ? Number((undrawnData[0] as { undrawn_lgas?: number }).undrawn_lgas ?? 0)
+      : 0;
+
     const features = (data || []) as Array<{
-      lga_name: string; state: string; remoteness: string;
-      avg_irsd_decile: number; desert_score: number;
-      indexed_entities: number; community_controlled_entities: number;
-      total_funding_all_sources: number; lat: number; lng: number;
+      lga_name: string; state: string; remoteness: string | null;
+      avg_irsd_decile: number | null; desert_score: number | null;
+      indexed_entities: number | null; community_controlled_entities: number | null;
+      total_funding_all_sources: number | null; lat: number; lng: number;
+      unplaced_count: number; placed_count: number; unplaced_share: number | null;
     }>;
+
+    const desertFeatures = features.filter(f => f.desert_score !== null);
 
     const summary = {
       total_lgas: features.length,
-      severe_deserts: features.filter(f => Number(f.desert_score) > 100).length,
-      avg_desert_score: features.length > 0
-        ? (features.reduce((s, f) => s + Number(f.desert_score), 0) / features.length).toFixed(1)
+      severe_deserts: desertFeatures.filter(f => Number(f.desert_score) > 100).length,
+      avg_desert_score: desertFeatures.length > 0
+        ? (desertFeatures.reduce((s, f) => s + Number(f.desert_score), 0) / desertFeatures.length).toFixed(1)
         : '0',
-      max_desert_score: features.length > 0
-        ? Math.max(...features.map(f => Number(f.desert_score))).toFixed(1)
+      max_desert_score: desertFeatures.length > 0
+        ? Math.max(...desertFeatures.map(f => Number(f.desert_score))).toFixed(1)
         : '0',
+      // Councils where at least half the organisations that might be there
+      // cannot be placed, with enough of them that it is not small-number
+      // noise. No national total: an unplaced organisation counts toward every
+      // council sharing its postcode, so summing per-council counts would
+      // double-count. High share means every other number here is less certain.
+      high_uncertainty_lgas: features.filter(
+        f => Number(f.unplaced_share) >= 50 && Number(f.unplaced_count) >= 50
+      ).length,
+      undrawn_lgas: undrawnLgas,
     };
 
     const response = NextResponse.json({ features, summary, metric });

--- a/apps/web/src/app/map/map-view.tsx
+++ b/apps/web/src/app/map/map-view.tsx
@@ -10,22 +10,28 @@ import { money } from '@/lib/format';
 interface LgaFeature {
   lga_name: string;
   state: string;
-  remoteness: string;
-  avg_irsd_decile: number;
-  avg_irsd_score: number;
-  indexed_entities: number;
-  community_controlled_entities: number;
-  total_funding_all_sources: number;
-  desert_score: number;
+  remoteness: string | null;
+  avg_irsd_decile: number | null;
+  avg_irsd_score: number | null;
+  indexed_entities: number | null;
+  community_controlled_entities: number | null;
+  total_funding_all_sources: number | null;
+  desert_score: number | null;
+  unplaced_count: number;
+  placed_count: number;
+  unplaced_share: number | null;
   lat: number;
   lng: number;
   lga_code: string;
 }
 
+type MapMetric = 'desert_score' | 'unplaced_share';
+
 interface MapViewProps {
   features: LgaFeature[];
   selected: LgaFeature | null;
   onSelect: (f: LgaFeature) => void;
+  metric?: MapMetric;
 }
 
 const STATE_ABBREV: Record<string, string> = {
@@ -57,6 +63,54 @@ function desertOpacity(score: number): number {
   return 0.3;
 }
 
+// Share of organisations in a council's postcodes we cannot place, 0–100
+function shareColor(pct: number): string {
+  if (pct >= 75) return '#D02020';
+  if (pct >= 50) return '#E06C18';
+  if (pct >= 25) return '#F0C020';
+  if (pct >= 10) return '#4CB876';
+  return '#1040C0';
+}
+
+function shareOpacity(pct: number): number {
+  if (pct >= 75) return 0.7;
+  if (pct >= 50) return 0.6;
+  if (pct >= 25) return 0.5;
+  if (pct >= 10) return 0.4;
+  return 0.3;
+}
+
+function metricValue(f: LgaFeature, metric: MapMetric): number | null {
+  const v = metric === 'desert_score' ? f.desert_score : f.unplaced_share;
+  return v === null || v === undefined ? null : Number(v);
+}
+
+function metricColor(value: number, metric: MapMetric): string {
+  return metric === 'desert_score' ? desertColor(value) : shareColor(value);
+}
+
+function metricOpacity(value: number, metric: MapMetric): number {
+  return metric === 'desert_score' ? desertOpacity(value) : shareOpacity(value);
+}
+
+function tooltipHtml(data: LgaFeature): string {
+  const desert = data.desert_score === null
+    ? '—'
+    : `<strong>${Number(data.desert_score).toFixed(1)}</strong>`;
+  const funding = data.total_funding_all_sources === null
+    ? ''
+    : `Funding: ${money(Number(data.total_funding_all_sources))}<br/>`;
+  const entities = data.indexed_entities === null
+    ? ''
+    : `Entities: ${data.indexed_entities}${Number(data.community_controlled_entities) > 0 ? ` (${data.community_controlled_entities} CC)` : ''}<br/>`;
+  const share = data.unplaced_share === null ? '' : ` (${Number(data.unplaced_share).toFixed(0)}%)`;
+  return `<div class="text-xs">
+    <strong>${data.lga_name}</strong> (${data.state})<br/>
+    Desert Score: ${desert}<br/>
+    ${funding}${entities}Cannot place: <strong>${data.unplaced_count}</strong>${share}
+  </div>`;
+}
+
 // Fit bounds when data changes
 function FitBounds({ features }: { features: LgaFeature[] }) {
   const map = useMap();
@@ -74,7 +128,7 @@ function FitBounds({ features }: { features: LgaFeature[] }) {
   return null;
 }
 
-export default function MapView({ features, selected, onSelect }: MapViewProps) {
+export default function MapView({ features, selected, onSelect, metric = 'desert_score' }: MapViewProps) {
   const [geoData, setGeoData] = useState<FeatureCollection | null>(null);
   const [geoLoading, setGeoLoading] = useState(true);
 
@@ -111,7 +165,9 @@ export default function MapView({ features, selected, onSelect }: MapViewProps) 
       const data = desertLookup.get(`${lga_name}|${stateAbbrev}`) || desertLookup.get(lga_name);
       const isSelected = selected?.lga_name === data?.lga_name && selected?.state === data?.state;
 
-      if (!data) {
+      const value = data ? metricValue(data, metric) : null;
+
+      if (!data || value === null) {
         return {
           fillColor: '#e5e7eb',
           fillOpacity: 0.15,
@@ -121,16 +177,15 @@ export default function MapView({ features, selected, onSelect }: MapViewProps) 
         };
       }
 
-      const score = Number(data.desert_score);
       return {
-        fillColor: desertColor(score),
-        fillOpacity: isSelected ? 0.85 : desertOpacity(score),
+        fillColor: metricColor(value, metric),
+        fillOpacity: isSelected ? 0.85 : metricOpacity(value, metric),
         weight: isSelected ? 3 : 0.8,
         color: isSelected ? '#121212' : '#666',
         opacity: isSelected ? 1 : 0.4,
       };
     };
-  }, [desertLookup, selected]);
+  }, [desertLookup, selected, metric]);
 
   // Click handler for GeoJSON features
   const onEachFeature = useMemo(() => {
@@ -140,20 +195,11 @@ export default function MapView({ features, selected, onSelect }: MapViewProps) 
       const data = desertLookup.get(`${lga_name}|${stateAbbrev}`) || desertLookup.get(lga_name);
 
       if (data) {
-        (layer as L.Path).bindTooltip(
-          `<div class="text-xs">
-            <strong>${data.lga_name}</strong> (${data.state})<br/>
-            Desert Score: <strong>${Number(data.desert_score).toFixed(1)}</strong><br/>
-            Funding: ${money(Number(data.total_funding_all_sources))}<br/>
-            Entities: ${data.indexed_entities}
-            ${Number(data.community_controlled_entities) > 0 ? ` (${data.community_controlled_entities} CC)` : ''}
-          </div>`,
-          { sticky: true }
-        );
+        (layer as L.Path).bindTooltip(tooltipHtml(data), { sticky: true });
         layer.on('click', () => onSelect(data));
       } else {
         (layer as L.Path).bindTooltip(
-          `<div class="text-xs"><strong>${lga_name}</strong> (${stateAbbrev})<br/>No funding data</div>`,
+          `<div class="text-xs"><strong>${lga_name}</strong> (${stateAbbrev})<br/>No data held</div>`,
           { sticky: true }
         );
       }
@@ -173,7 +219,10 @@ export default function MapView({ features, selected, onSelect }: MapViewProps) 
   }, [features]);
 
   // Key to force GeoJSON re-render when style changes
-  const geoKey = useMemo(() => `${selected?.lga_name}-${selected?.state}-${features.length}`, [selected, features]);
+  const geoKey = useMemo(
+    () => `${selected?.lga_name}-${selected?.state}-${features.length}-${metric}`,
+    [selected, features, metric]
+  );
 
   return (
     <MapContainer
@@ -203,25 +252,22 @@ export default function MapView({ features, selected, onSelect }: MapViewProps) 
         pane="tooltipPane"
       />
 
-      {/* Fallback: CircleMarkers for LGAs not matched to boundaries */}
-      {features.filter(f => {
-        if (!geoData) return true;
-        // Show circles only if no GeoJSON loaded
-        return !geoData;
-      }).map((f, i) => {
+      {/* Fallback: CircleMarkers when no GeoJSON loaded */}
+      {features.filter(() => !geoData).map((f, i) => {
         const lat = Number(f.lat);
         const lng = Number(f.lng);
         if (isNaN(lat) || isNaN(lng)) return null;
-        const score = Number(f.desert_score);
+        const value = metricValue(f, metric);
+        if (value === null) return null;
         return (
           <CircleMarker
             key={`circle-${f.lga_name}-${f.state}-${i}`}
             center={[lat, lng]}
-            radius={Math.max(3, Math.min(Math.sqrt(score) * 1.2, 20))}
+            radius={Math.max(3, Math.min(Math.sqrt(value) * 1.2, 20))}
             pathOptions={{
-              fillColor: desertColor(score),
+              fillColor: metricColor(value, metric),
               fillOpacity: 0.7,
-              color: desertColor(score),
+              color: metricColor(value, metric),
               weight: 1,
             }}
             eventHandlers={{ click: () => onSelect(f) }}
@@ -229,7 +275,7 @@ export default function MapView({ features, selected, onSelect }: MapViewProps) 
             <Tooltip>
               <div className="text-xs">
                 <strong>{f.lga_name}</strong> ({f.state})<br />
-                Desert Score: <strong>{score.toFixed(1)}</strong>
+                {metric === 'desert_score' ? 'Desert Score' : 'Unplaced share'}: <strong>{value.toFixed(1)}{metric === 'unplaced_share' ? '%' : ''}</strong>
               </div>
             </Tooltip>
           </CircleMarker>

--- a/apps/web/src/app/map/page.tsx
+++ b/apps/web/src/app/map/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { money } from '@/lib/format';
@@ -11,13 +11,16 @@ const MapView = dynamic(() => import('./map-view'), { ssr: false });
 interface LgaFeature {
   lga_name: string;
   state: string;
-  remoteness: string;
-  avg_irsd_decile: number;
-  avg_irsd_score: number;
-  indexed_entities: number;
-  community_controlled_entities: number;
-  total_funding_all_sources: number;
-  desert_score: number;
+  remoteness: string | null;
+  avg_irsd_decile: number | null;
+  avg_irsd_score: number | null;
+  indexed_entities: number | null;
+  community_controlled_entities: number | null;
+  total_funding_all_sources: number | null;
+  desert_score: number | null;
+  unplaced_count: number;
+  placed_count: number;
+  unplaced_share: number | null;
   lat: number;
   lng: number;
   lga_code: string;
@@ -28,16 +31,34 @@ interface Summary {
   severe_deserts: number;
   avg_desert_score: string;
   max_desert_score: string;
+  high_uncertainty_lgas: number;
+  undrawn_lgas: number;
 }
+
+export type MapMetric = 'desert_score' | 'unplaced_share';
 
 const STATES = ['ALL', 'NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
 const REMOTENESS_ORDER = ['Major Cities of Australia', 'Inner Regional Australia', 'Outer Regional Australia', 'Remote Australia', 'Very Remote Australia'];
+
+const METRIC_COPY: Record<MapMetric, { title: string; description: string }> = {
+  desert_score: {
+    title: 'Funding Desert Map',
+    description:
+      'Where disadvantage is highest but funding is lowest. Each area is an LGA scored by SEIFA disadvantage vs actual funding received across all government systems.',
+  },
+  unplaced_share: {
+    title: 'Unplaced Organisations',
+    description:
+      'Organisations registered in a council’s postcodes that our records cannot tie to any council. A postcode can span several councils, so an unplaced organisation counts toward each place it might belong to. The higher the share, the less certain everything else on this map is.',
+  },
+};
 
 export default function FundingDesertMapPage() {
   const [features, setFeatures] = useState<LgaFeature[]>([]);
   const [summary, setSummary] = useState<Summary | null>(null);
   const [loading, setLoading] = useState(true);
   const [stateFilter, setStateFilter] = useState('ALL');
+  const [metric, setMetric] = useState<MapMetric>('desert_score');
   const [selected, setSelected] = useState<LgaFeature | null>(null);
   const [lgaEntities, setLgaEntities] = useState<Array<{
     gs_id: string; canonical_name: string; entity_type: string;
@@ -56,6 +77,7 @@ export default function FundingDesertMapPage() {
       .catch(() => { setLgaEntities([]); setLoadingEntities(false); });
   }, [selected]);
 
+  // The API returns both metrics in one payload; switching metric costs no fetch.
   useEffect(() => {
     setLoading(true);
     const url = stateFilter === 'ALL'
@@ -71,16 +93,17 @@ export default function FundingDesertMapPage() {
       .catch(() => setLoading(false));
   }, [stateFilter]);
 
-  // Stats by remoteness
+  // Stats by remoteness — desert stats, so only rows that carry a score
   const remotenessBuckets = useMemo(() => {
     const buckets = new Map<string, { count: number; avgDesert: number; avgFunding: number; totalEntities: number }>();
     for (const f of features) {
+      if (f.desert_score === null) continue;
       const r = f.remoteness || 'Unknown';
       const b = buckets.get(r) || { count: 0, avgDesert: 0, avgFunding: 0, totalEntities: 0 };
       b.count++;
       b.avgDesert += Number(f.desert_score);
-      b.avgFunding += Number(f.total_funding_all_sources);
-      b.totalEntities += Number(f.indexed_entities);
+      b.avgFunding += Number(f.total_funding_all_sources ?? 0);
+      b.totalEntities += Number(f.indexed_entities ?? 0);
       buckets.set(r, b);
     }
     for (const [, b] of buckets) {
@@ -94,6 +117,18 @@ export default function FundingDesertMapPage() {
         return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
       });
   }, [features]);
+
+  // Top-10 list for the active metric
+  const topFeatures = useMemo(() => {
+    if (metric === 'desert_score') {
+      return features.filter(f => f.desert_score !== null).slice(0, 10);
+    }
+    return [...features]
+      .sort((a, b) => Number(b.unplaced_count) - Number(a.unplaced_count))
+      .slice(0, 10);
+  }, [features, metric]);
+
+  const copy = METRIC_COPY[metric];
 
   return (
     <main className="min-h-screen bg-gray-50 text-bauhaus-black">
@@ -114,11 +149,10 @@ export default function FundingDesertMapPage() {
             </div>
           </div>
           <h1 className="text-3xl font-black uppercase tracking-wider">
-            Funding Desert Map
+            {copy.title}
           </h1>
           <p className="text-gray-400 text-sm mt-1 max-w-2xl">
-            Where disadvantage is highest but funding is lowest. Each circle represents an LGA
-            scored by SEIFA disadvantage vs actual funding received across all government systems.
+            {copy.description}
           </p>
         </div>
       </div>
@@ -126,32 +160,65 @@ export default function FundingDesertMapPage() {
       {/* Controls + Summary */}
       <div className="mx-auto max-w-7xl px-4 py-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
-          {/* State filter */}
-          <div className="flex items-center gap-1">
-            {STATES.map(s => (
-              <button
-                key={s}
-                onClick={() => { setStateFilter(s); setSelected(null); }}
-                className={`text-[10px] px-3 py-1.5 font-bold uppercase tracking-wider transition-all ${
-                  stateFilter === s
-                    ? 'bg-bauhaus-black text-white'
-                    : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
-                }`}
-              >
-                {s}
-              </button>
-            ))}
+          <div className="flex flex-wrap items-center gap-4">
+            {/* Metric toggle */}
+            <div className="flex items-center gap-1">
+              {([
+                ['desert_score', 'Funding deserts'],
+                ['unplaced_share', 'Unplaced orgs'],
+              ] as Array<[MapMetric, string]>).map(([m, label]) => (
+                <button
+                  key={m}
+                  onClick={() => setMetric(m)}
+                  className={`text-[10px] px-3 py-1.5 font-bold uppercase tracking-wider transition-all ${
+                    metric === m
+                      ? 'bg-bauhaus-red text-white'
+                      : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-red'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {/* State filter */}
+            <div className="flex items-center gap-1">
+              {STATES.map(s => (
+                <button
+                  key={s}
+                  onClick={() => { setStateFilter(s); setSelected(null); }}
+                  className={`text-[10px] px-3 py-1.5 font-bold uppercase tracking-wider transition-all ${
+                    stateFilter === s
+                      ? 'bg-bauhaus-black text-white'
+                      : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
           </div>
 
           {/* Summary stats */}
           {summary && (
             <div className="flex items-center gap-4 text-xs text-gray-500">
               <span><strong className="text-bauhaus-black">{summary.total_lgas}</strong> LGAs</span>
-              <span><strong className="text-bauhaus-red">{summary.severe_deserts}</strong> severe deserts</span>
-              <span>Avg score <strong className="text-bauhaus-black">{summary.avg_desert_score}</strong></span>
+              {metric === 'desert_score' ? (
+                <>
+                  <span><strong className="text-bauhaus-red">{summary.severe_deserts}</strong> severe deserts</span>
+                  <span>Avg score <strong className="text-bauhaus-black">{summary.avg_desert_score}</strong></span>
+                </>
+              ) : (
+                <span><strong className="text-bauhaus-red">{summary.high_uncertainty_lgas}</strong> mostly unplaceable</span>
+              )}
             </div>
           )}
         </div>
+        {summary && summary.undrawn_lgas > 0 && (
+          <p className="mt-2 text-xs text-gray-400">
+            {summary.undrawn_lgas} councils hold data but have no coordinates in our records, so they are not drawn here.
+          </p>
+        )}
       </div>
 
       {/* Map + Detail panel */}
@@ -169,6 +236,7 @@ export default function FundingDesertMapPage() {
                 features={features}
                 selected={selected}
                 onSelect={setSelected}
+                metric={metric}
               />
             )}
           </div>
@@ -181,19 +249,19 @@ export default function FundingDesertMapPage() {
                   <h3 className="font-black text-lg uppercase tracking-wider">{selected.lga_name}</h3>
                   <div className="flex items-center gap-2 mt-1 text-xs text-gray-400">
                     <span>{selected.state}</span>
-                    <span>{selected.remoteness}</span>
+                    <span>{selected.remoteness ?? ''}</span>
                   </div>
                   <div className="mt-4 space-y-3">
                     <div className="flex justify-between items-baseline">
                       <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Desert Score</span>
                       <span className={`text-2xl font-black ${Number(selected.desert_score) > 100 ? 'text-bauhaus-red' : 'text-bauhaus-black'}`}>
-                        {Number(selected.desert_score).toFixed(1)}
+                        {selected.desert_score === null ? '—' : Number(selected.desert_score).toFixed(1)}
                       </span>
                     </div>
                     <div className="flex justify-between items-baseline">
                       <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Total Funding</span>
                       <span className="text-lg font-black text-green-700">
-                        {money(Number(selected.total_funding_all_sources))}
+                        {selected.total_funding_all_sources === null ? '—' : money(Number(selected.total_funding_all_sources))}
                       </span>
                     </div>
                     <div className="flex justify-between items-baseline">
@@ -202,11 +270,20 @@ export default function FundingDesertMapPage() {
                     </div>
                     <div className="flex justify-between items-baseline">
                       <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Entities</span>
-                      <span className="text-lg font-black">{selected.indexed_entities}</span>
+                      <span className="text-lg font-black">{selected.indexed_entities ?? '—'}</span>
                     </div>
                     <div className="flex justify-between items-baseline">
                       <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Community Controlled</span>
-                      <span className="text-lg font-black">{selected.community_controlled_entities}</span>
+                      <span className="text-lg font-black">{selected.community_controlled_entities ?? '—'}</span>
+                    </div>
+                    <div className="flex justify-between items-baseline">
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Unplaced in its postcodes</span>
+                      <span className={`text-lg font-black ${Number(selected.unplaced_share) >= 50 ? 'text-bauhaus-red' : 'text-bauhaus-black'}`}>
+                        {selected.unplaced_count}
+                        {selected.unplaced_share !== null && (
+                          <span className="text-xs font-bold text-gray-400 ml-1.5">({Number(selected.unplaced_share).toFixed(0)}%)</span>
+                        )}
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -255,12 +332,14 @@ export default function FundingDesertMapPage() {
                   )}
                 </div>
                 <p className="text-xs text-gray-400">
-                  Desert score = disadvantage x (1 / funding). Higher = more underserved.
+                  {metric === 'desert_score'
+                    ? 'Desert score = disadvantage x (1 / funding). Higher = more underserved.'
+                    : 'Unplaced = registered in this council’s postcodes but not placeable to any council. A shared postcode counts toward every council it touches.'}
                 </p>
               </>
             ) : (
               <div className="bg-white border border-gray-200 p-4">
-                <p className="text-sm text-gray-500">Click a circle on the map to see LGA details.</p>
+                <p className="text-sm text-gray-500">Click an area on the map to see LGA details.</p>
               </div>
             )}
 
@@ -282,11 +361,13 @@ export default function FundingDesertMapPage() {
               </div>
             </div>
 
-            {/* Top 10 worst */}
+            {/* Top 10 for the active metric */}
             <div className="bg-white border border-gray-200 p-4">
-              <h3 className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-3">Worst Funding Deserts</h3>
+              <h3 className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-3">
+                {metric === 'desert_score' ? 'Worst Funding Deserts' : 'Most Unplaced Organisations'}
+              </h3>
               <div className="space-y-1.5">
-                {features.slice(0, 10).map((f, i) => (
+                {topFeatures.map((f, i) => (
                   <button
                     key={i}
                     onClick={() => setSelected(f)}
@@ -295,7 +376,16 @@ export default function FundingDesertMapPage() {
                     <span className="font-medium truncate max-w-40">{f.lga_name}</span>
                     <div className="flex items-center gap-2">
                       <span className="text-gray-400">{f.state}</span>
-                      <span className="font-mono font-bold text-bauhaus-red">{Number(f.desert_score).toFixed(0)}</span>
+                      {metric === 'desert_score' ? (
+                        <span className="font-mono font-bold text-bauhaus-red">{Number(f.desert_score).toFixed(0)}</span>
+                      ) : (
+                        <span className="font-mono font-bold text-bauhaus-red">
+                          {f.unplaced_count}
+                          {f.unplaced_share !== null && (
+                            <span className="text-gray-400 font-normal"> ({Number(f.unplaced_share).toFixed(0)}%)</span>
+                          )}
+                        </span>
+                      )}
                     </div>
                   </button>
                 ))}

--- a/apps/web/src/app/reports/reallocation-atlas/reallocation-atlas-client.tsx
+++ b/apps/web/src/app/reports/reallocation-atlas/reallocation-atlas-client.tsx
@@ -10,13 +10,16 @@ const MapView = dynamic(() => import('@/app/map/map-view'), { ssr: false });
 type LgaFeature = {
   lga_name: string;
   state: string;
-  remoteness: string;
+  remoteness: string | null;
   avg_irsd_decile: number;
   avg_irsd_score: number;
   indexed_entities: number;
   community_controlled_entities: number;
   total_funding_all_sources: number;
   desert_score: number;
+  unplaced_count: number;
+  placed_count: number;
+  unplaced_share: number | null;
   lat: number;
   lng: number;
   lga_code: string;
@@ -101,7 +104,7 @@ function priorityReasons(feature: LgaFeature | null, localCommunityCount: number
   if (feature.total_funding_all_sources <= 250_000) reasons.push('very low recorded funding base');
   if (feature.community_controlled_entities <= 2) reasons.push('thin visible community-controlled footprint');
   if (localCommunityCount > 0) reasons.push(`${localCommunityCount} community-controlled organisations already present`);
-  if (feature.remoteness.includes('Very Remote')) reasons.push('very remote logistics and service burden');
+  if ((feature.remoteness ?? '').includes('Very Remote')) reasons.push('very remote logistics and service burden');
 
   return reasons.slice(0, 4);
 }
@@ -131,7 +134,11 @@ export function ReallocationAtlasClient({ atlasData }: { atlasData: AtlasData })
       .then((res) => res.json())
       .then((data) => {
         if (ignore) return;
-        const nextFeatures = (data.features || []) as LgaFeature[];
+        // The map API now also returns councils that carry only placement
+        // uncertainty (no desert score); this page reasons about desert
+        // scores, so keep its universe to scored councils as before.
+        const nextFeatures = ((data.features || []) as Array<LgaFeature & { desert_score: number | null }>)
+          .filter((f): f is LgaFeature => f.desert_score !== null);
         setFeatures(nextFeatures);
         setSummary(data.summary || null);
         setSelected((current) => {
@@ -316,7 +323,9 @@ export function ReallocationAtlasClient({ atlasData }: { atlasData: AtlasData })
                   Loading reallocation atlas...
                 </div>
               ) : (
-                <MapView features={features} selected={selected} onSelect={setSelected} />
+                // MapView only selects from features this page passed in, so
+                // the callback value is one of our filtered, desert-scored rows.
+                <MapView features={features} selected={selected} onSelect={(f) => setSelected(f as LgaFeature)} />
               )}
             </div>
 


### PR DESCRIPTION
Independent of #176. Two items from the place-data ledger, both on `/map`.

## The one-line argument

The map coloured what we hold and said nothing about what we cannot place. For some councils the unplaceable share is the whole story, and the map is the surface where that silence was loudest.

## What changed

**A second view, "Unplaced orgs".** Colours each council by the share of organisations registered in its postcodes that our records cannot tie to any council. Verified through the same `exec_sql` path production uses:

| Council | Unplaced | Placed | Share |
|---|---|---|---|
| Maralinga Tjarutja (SA) | 76 | 0 | 100% |
| Ceduna (SA) | 126 | 23 | 85% |
| Melbourne (VIC) | 8,220 | 2,596 | 76% |
| Brisbane (QLD) | 4,828 | 15,579 | 24% |

A postcode can span several councils, so an unplaced organisation counts toward each place it might belong to. That is the semantics, not double-counting: an organisation that could be in any of three councils makes all three less certain.

**Base grain moved to councils-with-centroids.** The old grain was `mv_funding_deserts` rows, and the councils whose organisations we cannot place are exactly the ones most likely to have no MV row. An uncertainty layer that drops the most uncertain councils would be lying.

**Modal remoteness.** The old dedup took the highest `desert_score` row per council, which could label Brisbane "Remote Australia" (it has 9 such MV rows). Remoteness now comes from the modal ABS class across the council's postcodes: Brisbane reads Major Cities, Yarra Ranges Inner Regional, Maralinga Tjarutja Very Remote.

**The undrawn are named.** 113 councils hold data but no coordinates in `postcode_geo` (Sunshine Coast, Townsville, Mount Isa among the largest) and were silently missing from the map. The page now says so. Fixing their geocodes is a follow-up, not this PR.

**A planner trap, found by verification.** With a state filter, Postgres estimated one outer row and re-ran the full `gs_entities` aggregation per row as a nested loop, timing out at 8s. Heavy aggregate CTEs are now `MATERIALIZED`; both queries run under 1s for ALL and per-state.

## What did not change

- The reallocation atlas keeps its universe to desert-scored councils, behaviour identical, types synced to the wider API payload.
- The desert metric still reads `mv_funding_deserts`, which is one refresh behind; the unplaced view reads live `gs_entities` and is unaffected.
- No DB objects added or altered. The metric toggle is client-side; the API returns both measures in one payload, so switching costs no fetch.

## What to eyeball on the preview

- `/map`: toggle to Unplaced orgs; Maralinga Tjarutja and Ceduna dark in SA; Brisbane no longer Remote; the undrawn-councils line under the controls.
- `/reports/reallocation-atlas`: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)