### PR TITLE
Name all 721, keep corrections, draw the coordless councils

### DIFF
--- a/apps/web/src/app/api/data/map/route.ts
+++ b/apps/web/src/app/api/data/map/route.ts
@@ -49,48 +49,17 @@ export async function GET(request: Request) {
     // postcode spanning three councils counts toward all three. That is the
     // semantics, not a bug: an organisation that could be in any of them makes
     // each council's picture less certain.
-    const undrawnPromise = supabase.rpc('exec_sql', {
-      query: `WITH no_lat AS (
-        SELECT lga_name, UPPER(state) AS state
-        FROM postcode_geo
-        WHERE lga_name IS NOT NULL ${stateClause}
-        GROUP BY 1, 2
-        HAVING count(latitude) = 0
-      ),
-      unplaced_pc AS MATERIALIZED (
-        SELECT postcode, COUNT(*) AS n
-        FROM gs_entities
-        WHERE lga_name IS NULL AND postcode IS NOT NULL
-        GROUP BY postcode
-      ),
-      cpc AS MATERIALIZED (
-        SELECT DISTINCT lga_name, UPPER(state) AS state, postcode
-        FROM postcode_geo
-        WHERE lga_name IS NOT NULL
-      ),
-      counts AS (
-        SELECT nl.lga_name, nl.state, COALESCE(SUM(u.n), 0)::int AS unplaced
-        FROM no_lat nl
-        LEFT JOIN cpc ON cpc.lga_name = nl.lga_name AND cpc.state = nl.state
-        LEFT JOIN unplaced_pc u USING (postcode)
-        GROUP BY 1, 2
-      )
-      SELECT count(*)::int AS undrawn_lgas FROM counts c
-      WHERE c.unplaced > 0 OR EXISTS (
-        SELECT 1 FROM mv_funding_deserts d
-        WHERE d.lga_name = c.lga_name AND UPPER(d.state) = c.state
-          AND d.desert_score IS NOT NULL
-      )`,
-    });
-
+    // Councils without point coordinates stay in the payload with a null
+    // lat/lng: the choropleth paints them by boundary-name match, which needs
+    // no centroid. Coordinates only drive bounds-fitting and fallback markers.
     const { data, error } = await supabase.rpc('exec_sql', {
       query: `WITH lga_centroids AS (
-        SELECT lga_name, lga_code, UPPER(state) as state,
+        SELECT lga_name, MAX(lga_code) AS lga_code, UPPER(state) as state,
                AVG(latitude::float) as lat,
                AVG(longitude::float) as lng
         FROM postcode_geo
-        WHERE lga_name IS NOT NULL AND latitude IS NOT NULL ${stateClause}
-        GROUP BY lga_name, lga_code, UPPER(state)
+        WHERE lga_name IS NOT NULL ${stateClause}
+        GROUP BY lga_name, UPPER(state)
       ),
       modal_remoteness AS (
         SELECT DISTINCT ON (lga_name, UPPER(state))
@@ -160,20 +129,17 @@ export async function GET(request: Request) {
 
     if (error) throw error;
 
-    // A council with data but no coordinates cannot be drawn. Failing to say
-    // so would present the drawable subset as the whole country.
-    const { data: undrawnData } = await undrawnPromise;
-    const undrawnLgas = Array.isArray(undrawnData) && undrawnData.length > 0
-      ? Number((undrawnData[0] as { undrawn_lgas?: number }).undrawn_lgas ?? 0)
-      : 0;
-
     const features = (data || []) as Array<{
       lga_name: string; state: string; remoteness: string | null;
       avg_irsd_decile: number | null; desert_score: number | null;
       indexed_entities: number | null; community_controlled_entities: number | null;
-      total_funding_all_sources: number | null; lat: number; lng: number;
+      total_funding_all_sources: number | null; lat: number | null; lng: number | null;
       unplaced_count: number; placed_count: number; unplaced_share: number | null;
     }>;
+
+    // Councils with data but no point coordinates render only where a map
+    // boundary matches their name; the summary says how many that covers.
+    const undrawnLgas = features.filter(f => f.lat === null).length;
 
     const desertFeatures = features.filter(f => f.desert_score !== null);
 

--- a/apps/web/src/app/api/place/corrections/route.ts
+++ b/apps/web/src/app/api/place/corrections/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getServiceSupabase } from '@/lib/supabase';
+import { rateLimit } from '@/lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const limiter = rateLimit();
+
+const schema = z.object({
+  page_route: z.string().min(1).max(200),
+  lga_name: z.string().max(120).optional(),
+  message: z.string().min(3).max(4000),
+  contact: z.string().max(320).optional(),
+  // Honeypot. Real people never see this field; anything in it is a bot.
+  website: z.string().max(200).optional(),
+});
+
+export async function POST(request: Request) {
+  const limited = limiter(request);
+  if (limited) return limited;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  // Bots that fill the honeypot get a success they cannot learn from.
+  if (parsed.data.website) {
+    return NextResponse.json({ ok: true });
+  }
+
+  try {
+    const supabase = getServiceSupabase();
+    const { error } = await supabase.from('place_corrections').insert({
+      page_route: parsed.data.page_route,
+      lga_name: parsed.data.lga_name ?? null,
+      message: parsed.data.message,
+      contact: parsed.data.contact || null,
+    });
+
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('place correction insert failed:', error);
+    // The form falls back to email on this status; do not lose the correction.
+    return NextResponse.json({ error: 'Could not record the correction' }, { status: 503 });
+  }
+}

--- a/apps/web/src/app/map/map-view.tsx
+++ b/apps/web/src/app/map/map-view.tsx
@@ -20,8 +20,11 @@ interface LgaFeature {
   unplaced_count: number;
   placed_count: number;
   unplaced_share: number | null;
-  lat: number;
-  lng: number;
+  // Null when the council has no point coordinates; it still renders where a
+  // boundary matches its name. Number(null) is 0, not NaN — filter nulls
+  // before coercing or a coordless council drags bounds to the equator.
+  lat: number | null;
+  lng: number | null;
   lga_code: string;
 }
 
@@ -116,8 +119,9 @@ function FitBounds({ features }: { features: LgaFeature[] }) {
   const map = useMap();
   useEffect(() => {
     if (features.length === 0) return;
-    const lats = features.map(f => Number(f.lat)).filter(v => !isNaN(v));
-    const lngs = features.map(f => Number(f.lng)).filter(v => !isNaN(v));
+    const located = features.filter(f => f.lat != null && f.lng != null);
+    const lats = located.map(f => Number(f.lat)).filter(v => !isNaN(v));
+    const lngs = located.map(f => Number(f.lng)).filter(v => !isNaN(v));
     if (lats.length === 0) return;
     const bounds = L.latLngBounds(
       [Math.min(...lats), Math.min(...lngs)],
@@ -209,8 +213,9 @@ export default function MapView({ features, selected, onSelect, metric = 'desert
   // Compute center from features
   const center = useMemo<[number, number]>(() => {
     if (features.length === 0) return [-25.5, 134.0];
-    const lats = features.map(f => Number(f.lat)).filter(v => !isNaN(v));
-    const lngs = features.map(f => Number(f.lng)).filter(v => !isNaN(v));
+    const located = features.filter(f => f.lat != null && f.lng != null);
+    const lats = located.map(f => Number(f.lat)).filter(v => !isNaN(v));
+    const lngs = located.map(f => Number(f.lng)).filter(v => !isNaN(v));
     if (lats.length === 0) return [-25.5, 134.0];
     return [
       (Math.min(...lats) + Math.max(...lats)) / 2,
@@ -254,6 +259,7 @@ export default function MapView({ features, selected, onSelect, metric = 'desert
 
       {/* Fallback: CircleMarkers when no GeoJSON loaded */}
       {features.filter(() => !geoData).map((f, i) => {
+        if (f.lat == null || f.lng == null) return null;
         const lat = Number(f.lat);
         const lng = Number(f.lng);
         if (isNaN(lat) || isNaN(lng)) return null;

--- a/apps/web/src/app/map/page.tsx
+++ b/apps/web/src/app/map/page.tsx
@@ -21,8 +21,8 @@ interface LgaFeature {
   unplaced_count: number;
   placed_count: number;
   unplaced_share: number | null;
-  lat: number;
-  lng: number;
+  lat: number | null;
+  lng: number | null;
   lga_code: string;
 }
 
@@ -216,7 +216,7 @@ export default function FundingDesertMapPage() {
         </div>
         {summary && summary.undrawn_lgas > 0 && (
           <p className="mt-2 text-xs text-gray-400">
-            {summary.undrawn_lgas} councils hold data but have no coordinates in our records, so they are not drawn here.
+            {summary.undrawn_lgas} councils hold data but no point coordinates in our records; they appear only where a map boundary matches their name.
           </p>
         )}
       </div>

--- a/apps/web/src/app/place/correction-form.tsx
+++ b/apps/web/src/app/place/correction-form.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CorrectionFormProps {
+  pageRoute: string;
+  lgaName?: string;
+  /** Fallback if the API cannot take the correction. */
+  mailtoHref: string;
+}
+
+/**
+ * A correction still goes to a person — this form just makes sure it is not
+ * lost to a mailbox on the way. Submissions land in a review queue that a
+ * person reads; nothing on the site changes automatically.
+ */
+export function CorrectionForm({ pageRoute, lgaName, mailtoHref }: CorrectionFormProps) {
+  const [message, setMessage] = useState('');
+  const [contact, setContact] = useState('');
+  const [state, setState] = useState<'idle' | 'sending' | 'sent' | 'failed'>('idle');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (message.trim().length < 3 || state === 'sending') return;
+    setState('sending');
+    try {
+      const res = await fetch('/api/place/corrections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          page_route: pageRoute,
+          lga_name: lgaName,
+          message: message.trim(),
+          contact: contact.trim() || undefined,
+        }),
+      });
+      setState(res.ok ? 'sent' : 'failed');
+    } catch {
+      setState('failed');
+    }
+  }
+
+  if (state === 'sent') {
+    return (
+      <p className="border-4 border-bauhaus-black bg-white p-4 text-base leading-7">
+        Received. A person will read it, and if the page changes we will say what changed and why.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div>
+        <label htmlFor="correction-message" className="block text-[11px] font-black uppercase tracking-widest">
+          What we have wrong
+        </label>
+        <textarea
+          id="correction-message"
+          value={message}
+          onChange={e => setMessage(e.target.value)}
+          rows={5}
+          maxLength={4000}
+          required
+          placeholder="Which organisations belong here, which do not, or anything else this page gets wrong."
+          className="mt-2 w-full border-4 border-bauhaus-black bg-white p-3 text-base leading-7 outline-none focus:border-bauhaus-red"
+        />
+      </div>
+      <div>
+        <label htmlFor="correction-contact" className="block text-[11px] font-black uppercase tracking-widest">
+          Your name and organisation <span className="font-normal normal-case tracking-normal">(optional, so we can reply)</span>
+        </label>
+        <input
+          id="correction-contact"
+          type="text"
+          value={contact}
+          onChange={e => setContact(e.target.value)}
+          maxLength={320}
+          className="mt-2 w-full border-4 border-bauhaus-black bg-white p-3 text-base outline-none focus:border-bauhaus-red"
+        />
+      </div>
+      {/* Honeypot — hidden from people, filled by bots. */}
+      <input type="text" name="website" tabIndex={-1} autoComplete="off" aria-hidden="true" className="hidden" />
+      <div className="flex flex-wrap items-center gap-4">
+        <button
+          type="submit"
+          disabled={state === 'sending' || message.trim().length < 3}
+          className="inline-block border-4 border-bauhaus-black bg-white px-5 py-3 text-xs font-black uppercase tracking-widest disabled:opacity-50"
+        >
+          {state === 'sending' ? 'Sending…' : 'Send the correction'}
+        </button>
+        {state === 'failed' ? (
+          <p className="text-sm">
+            That did not go through.{' '}
+            <a href={mailtoHref} className="font-bold underline">
+              Email it instead
+            </a>
+            {' '}— it reaches the same person.
+          </p>
+        ) : (
+          <a href={mailtoHref} className="text-sm underline">
+            Prefer email?
+          </a>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/place/council/[slug]/page.tsx
+++ b/apps/web/src/app/place/council/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getCouncilPlaceReport } from '@/lib/services/council-place-report';
 import { getSchoolNeedSignal } from '@/lib/services/school-need-signal';
 import { SchoolNeed } from '../../school-need';
 import { PlaceContextPanel } from '../../place-context';
+import { CorrectionForm } from '../../correction-form';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,9 +24,9 @@ export default async function CouncilPage({ params }: { params: Promise<{ slug: 
   if (!report) notFound();
   const schools = await getSchoolNeedSignal(report.lgaName);
 
-  // The correction goes to a person, not a database. A public form writing
-  // straight into the register would need moderation we do not have, and the
-  // first thing a community tells us is likely to need a conversation anyway.
+  // The correction still goes to a person — the form writes to a review
+  // queue (place_corrections) that a person reads, never to the register.
+  // The mailto stays as the fallback so a failed request loses nothing.
   const correctionSubject = encodeURIComponent(`Correction: ${report.lgaName}`);
   const correctionBody = encodeURIComponent(
     `Council area: ${report.lgaName}\n` +
@@ -145,16 +146,15 @@ export default async function CouncilPage({ params }: { params: Promise<{ slug: 
             that would make this page true.
           </p>
           <p className="mt-3 max-w-3xl text-base leading-7">
-            It goes to a person, not a form. We will say what we changed and why.
+            It goes to a person, not a pipeline. We will say what we changed and why.
           </p>
-          <p className="mt-5">
-            <a
-              href={`mailto:hello@civicgraph.au?subject=${correctionSubject}&body=${correctionBody}`}
-              className="inline-block border-4 border-bauhaus-black bg-white px-5 py-3 text-xs font-black uppercase tracking-widest"
-            >
-              Send a correction
-            </a>
-          </p>
+          <div className="mt-5 max-w-3xl">
+            <CorrectionForm
+              pageRoute={`/place/council/${report.slug}`}
+              lgaName={report.lgaName}
+              mailtoHref={`mailto:hello@civicgraph.au?subject=${correctionSubject}&body=${correctionBody}`}
+            />
+          </div>
         </section>
 
         <section className="text-sm leading-6">

--- a/apps/web/src/lib/services/council-place-report.ts
+++ b/apps/web/src/lib/services/council-place-report.ts
@@ -195,7 +195,11 @@ export const getCouncilPlaceReport = cache(async function getCouncilPlaceReport(
                 WHERE lga_name='${lga}' AND entity_type='indigenous_corp') AS indigenous_corps,
               (SELECT count(*) FROM gs_entities
                 WHERE lga_name='${lga}' AND is_community_controlled) AS community_controlled,
-              (SELECT count(*) FROM crime_stats_lga WHERE lga_name='${lga}') AS crime_rows,
+              -- State-qualified: LGA names repeat across states (Bayside is
+              -- both NSW and VIC), and counting another state's rows would
+              -- claim we hold crime records for this council when we do not.
+              (SELECT count(*) FROM crime_stats_lga
+                WHERE lga_name='${lga}'${council.state ? ` AND state='${council.state.replace(/'/g, "''")}'` : ''}) AS crime_rows,
               (SELECT count(*) FROM social_enterprises se
                  JOIN gs_entities e ON e.abn = se.abn
                 WHERE e.lga_name='${lga}') AS social_enterprises`,

--- a/apps/web/src/lib/services/place-intelligence.ts
+++ b/apps/web/src/lib/services/place-intelligence.ts
@@ -543,7 +543,10 @@ export const getPlaceIntelligence = cache(
             .or('is_community_controlled.eq.true,entity_type.eq.indigenous_corp')
             .or('oric_status.is.null,oric_status.neq.Deregistered')
             .order('canonical_name')
-            .limit(300)
+            // 1000 is PostgREST's per-request ceiling, and above every current
+            // region's count (the Kimberley holds 721). If a region ever
+            // exceeds it, the page's "showing X of Y" line reports the gap.
+            .limit(1000)
         : Promise.resolve({ data: [], error: null }),
       region.unplaced
         ? db.from('geo_resolution_gaps')

--- a/migrations/2026-08-08-place-corrections.sql
+++ b/migrations/2026-08-08-place-corrections.sql
@@ -1,0 +1,27 @@
+-- Corrections to place pages, accumulated instead of lost to a mailbox.
+-- Service-role writes only: RLS is enabled with no public policies, so the
+-- only way in is the API route, and the only way out is a person reading it.
+-- Nothing publishes automatically.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-08-place-corrections.sql
+
+CREATE TABLE IF NOT EXISTS place_corrections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  page_route text NOT NULL CHECK (char_length(page_route) <= 200),
+  lga_name text CHECK (char_length(lga_name) <= 120),
+  message text NOT NULL CHECK (char_length(message) BETWEEN 3 AND 4000),
+  contact text CHECK (char_length(contact) <= 320),
+  status text NOT NULL DEFAULT 'new' CHECK (status IN ('new', 'reviewed', 'applied', 'rejected')),
+  reviewed_at timestamptz,
+  review_notes text
+);
+
+ALTER TABLE place_corrections ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_place_corrections_status
+  ON place_corrections (status, created_at DESC);
+
+COMMENT ON TABLE place_corrections IS
+  'Community corrections to place pages. Service-role writes only (RLS enabled, no public policies). Reviewed by a person; nothing publishes automatically.';

--- a/thoughts/shared/plans/place-atlas-surface.md
+++ b/thoughts/shared/plans/place-atlas-surface.md
@@ -1,0 +1,79 @@
+# The Atlas: one full-screen surface for the place data
+
+**Written:** 2026-08-08, after PRs #175/#176/#177 landed. **Status: proposal, nothing built.**
+
+## The problem it solves
+
+The place work now lives on five surfaces that do not know about each other: `/map` (boxed
+at 600px inside a container), `/place/*` (deep prose pages), `/places` (postcode gaps),
+`/reports/reallocation-atlas`, `/graph`. Each holds a piece; none can be projected in a room
+and explain itself. Ben's ask: a full-screen map that explains, all the data easy to reach,
+connected to Goods.
+
+## Shape
+
+**`/atlas` — map fills the viewport.** Everything else overlays it.
+
+1. **Layers, not pages.** Money held / money delivered / unplaced share / SEIFA / schools
+   (ICSEA) / overcrowding / crime-where-honest / renewal cliff. The layer registry is typed
+   and carries, per layer: the caveat paragraph ("what this number contains" — the five
+   misattribution mechanisms, distilled to one paragraph each), the geography it is honest
+   at, and a consent tier (see Goods below). Selecting a layer shows its caveat. The explain
+   is not a help page; it is attached to the number.
+
+2. **Place rail.** Click a council or search a place → side panel with the mini
+   place-report (the council/RegionReport data already built) and a link to the full
+   `/place/*` prose page. The prose pages stay the depth; the Atlas is the door.
+
+3. **Story mode.** A fixed sequence for a room: where money is recorded is not where it
+   lands → Utopia's $93.6M sitting in Alice Springs → the unplaced layer → the renewal
+   cliff (58–64% ending within 24 months everywhere). Five steps, each one map state +
+   one paragraph. This is the community-conversation artifact.
+
+4. **Take the data.** Per-council CSV/JSON from the panel; shareable URLs
+   (`/atlas?place=ceduna&layer=unplaced`) so a link IS the presentation; the map API
+   already returns the full payload — formalise it as the documented endpoint rather
+   than building a second one.
+
+## Goods
+
+The Goods ledger is the inverse layer and the strongest demonstration of the thesis:
+CivicGraph shows money recorded, Goods shows things delivered.
+Alice Springs: $2,441M held, 16 beds. Utopia: no council area at all, 147 beds.
+
+**Consent gates this, and the gate holds.** All three Notion rows are Publish-to-site =
+NO; Utopia consent is Not checked. So:
+
+- Build the Goods layer **org-side first**: an "On the map" view inside
+  `/org/act/goods/*`, reusing the same Atlas component with the layer enabled.
+- The layer registry's consent tier (`public | org | withheld`) is enforced
+  **server-side** — strip fields in the RSC/API, never blur or hide client-side
+  (the Phase-6 flight-payload lesson).
+- Public activation is per-place, only when a consent flag flips in the data. The Atlas
+  with story mode is the right artifact to bring TO the consent conversation — the open
+  question from the ledger (would someone from Utopia or Hope Vale recognise
+  themselves?) is answered in person, with this on the screen.
+
+## What not to do
+
+- Do not fold the `/place/*` prose pages into the map. Depth and door are different jobs.
+- Do not put any Goods figure on a public surface before the flag exists.
+- Do not adopt a new viz stack. Leaflet + the existing boundary file carry all of this;
+  the 16MB boundary GeoJSON already loads on `/map` today.
+
+## Sequence (one session each)
+
+1. `/map` → full-viewport `/atlas` shell + typed layer registry (the two existing metrics
+   become the first two layers, caveats attached).
+2. Place rail + shareable URLs + CSV export.
+3. Story mode with the four-region findings.
+4. Goods overlay org-side, behind the login.
+5. Public Goods activation — blocked on the consent conversation, by design.
+
+## Open questions for Ben
+
+- Does `/atlas` replace `/map` (redirect) or sit beside it? Proposal: replace — two maps
+  is a fork nobody maintains.
+- Story mode voice: the place pages' register ("we cannot tell you X") projected in a
+  room reads differently than on a screen alone. Worth a read-aloud pass before a real
+  session with community.


### PR DESCRIPTION
The four follow-ups queued in the merged place ledger, plus the Atlas surface proposal. Follows #176 and #177.

## What changed

**All 721 Kimberley organisations are named.** The unplaced-list cap rises 300 to 1000 (PostgREST's per-request ceiling). The comment above the query already said "all of them, not a slice" while the code sliced; the code now agrees. The existing "showing X of Y" line reports any future region that exceeds the ceiling.

**Corrections accumulate instead of dying in a mailbox.** Every council page swaps its mailto for a form writing to `place_corrections`: RLS enabled with no public policies, service-role writes only through a rate-limited API route with a honeypot. The page's promise holds — it still goes to a person, nothing publishes automatically — and the mailto stays as the fallback path so a failed request loses nothing.

> **Not yet live:** the migration (`migrations/2026-08-08-place-corrections.sql`) is committed but **not applied** — the permission classifier blocked autonomous DDL, deliberately not routed around. Until it runs, the API returns 503 and the form falls back to email. Apply command is in the file header.

**The 73 coordless councils render.** 207 `postcode_geo` rows backfilled from same-postcode siblings (113 councils without coordinates down to 73, applied to the DB), and the map API no longer gates on latitude: the choropleth paints by boundary-name match, which needs no centroid. **526 councils in the payload, up from 416**, verified with zero duplicate features. Client guards fix a real trap: `Number(null)` is `0`, so a coordless council used to drag map bounds toward the equator.

**Crime counts are state-qualified.** Bayside exists in NSW and VIC; a name-only count on council pages claimed crime records we do not hold.

## Also in this PR

`thoughts/shared/plans/place-atlas-surface.md` — the full-screen Atlas proposal: layers with caveats attached to the number, a place rail that doors into the prose pages, story mode for a room, per-council data takeaway, and the Goods overlay org-side first with consent enforced server-side.

## What to eyeball on the preview

- `/place/kimberley`: the unplaced list runs to 721 names.
- Any `/place/council/*` page: the correction form renders; submitting shows the email fallback (503 until the migration is applied — expected).
- `/map`: 526 councils; Sunshine Coast, Townsville and Mount Isa now painted; the summary line reads "73 councils… appear only where a map boundary matches their name."

🤖 Generated with [Claude Code](https://claude.com/claude-code)