### PR TITLE
The place rail: search, take the data, and a link that IS the presentation

### DIFF
--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { money } from '@/lib/format';
 import {
@@ -11,6 +12,15 @@ import {
   type AtlasFeature,
   type AtlasLiveLayer,
 } from '@/lib/atlas/layers';
+import {
+  buildAtlasUrl,
+  councilCsv,
+  councilJson,
+  exportFilename,
+  parseAtlasUrl,
+  placeSlug,
+  resolvePlace,
+} from '@/lib/atlas/share';
 
 // Lazy-load the map to avoid SSR issues with Leaflet
 const AtlasMap = dynamic(() => import('./atlas-map'), { ssr: false });
@@ -20,7 +30,33 @@ const LAYERS = visibleAtlasLayers('public');
 
 const STATES = ['ALL', 'NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
 
-export default function AtlasClient() {
+/** A council that has a full /place/council/[slug] prose page. */
+export interface CouncilPageLink {
+  slug: string;
+  lgaName: string;
+  state: string | null;
+}
+
+interface RailEntity {
+  gs_id: string;
+  canonical_name: string;
+  entity_type: string;
+  power_score: number | null;
+  system_count: number | null;
+  is_community_controlled: boolean;
+}
+
+function downloadFile(name: string, mime: string, text: string) {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function AtlasClient({ councilPages }: { councilPages: CouncilPageLink[] }) {
   const [features, setFeatures] = useState<AtlasFeature[]>([]);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
@@ -30,6 +66,12 @@ export default function AtlasClient() {
   // painted (the map) is always the last live pick.
   const [activeKey, setActiveKey] = useState(DEFAULT_ATLAS_LAYER_KEY);
   const [mapKey, setMapKey] = useState(DEFAULT_ATLAS_LAYER_KEY);
+  const [query, setQuery] = useState('');
+  const [entities, setEntities] = useState<RailEntity[]>([]);
+  const [loadingEntities, setLoadingEntities] = useState(false);
+  const [copied, setCopied] = useState(false);
+  // URL state only starts writing after the inbound URL has been applied.
+  const urlReady = useRef(false);
 
   // One fetch: the API returns every council and both metrics in one payload.
   // The state filter slices client-side.
@@ -55,6 +97,68 @@ export default function AtlasClient() {
     if (layer && isLiveLayer(layer)) setMapKey(key);
   }
 
+  function selectPlace(f: AtlasFeature) {
+    setSelected(f);
+    setQuery('');
+    // A selection hidden by the state filter would be invisible — follow it.
+    if (stateFilter !== 'ALL' && f.state !== stateFilter) setStateFilter(f.state);
+  }
+
+  // Apply the inbound URL once the payload exists: a link IS the presentation.
+  useEffect(() => {
+    if (loading || urlReady.current) return;
+    const wanted = parseAtlasUrl(window.location.search);
+    if (wanted.layerKey && LAYERS.some(l => l.key === wanted.layerKey)) {
+      pickLayer(wanted.layerKey);
+    }
+    let nextFilter = stateFilter;
+    if (wanted.state && STATES.includes(wanted.state)) {
+      nextFilter = wanted.state;
+      setStateFilter(wanted.state);
+    }
+    if (wanted.place) {
+      const place = resolvePlace(features, wanted.place, wanted.pst, nextFilter);
+      if (place) {
+        setSelected(place);
+        if (nextFilter !== 'ALL' && place.state !== nextFilter) setStateFilter(place.state);
+      }
+    }
+    urlReady.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, features]);
+
+  // Reflect the current view into the URL without navigating.
+  useEffect(() => {
+    if (!urlReady.current) return;
+    const url = buildAtlasUrl({
+      layerKey: activeKey,
+      defaultLayerKey: DEFAULT_ATLAS_LAYER_KEY,
+      stateFilter,
+      selected,
+    });
+    window.history.replaceState(null, '', url);
+  }, [activeKey, stateFilter, selected]);
+
+  // Fetch the selected place's top entities — the same endpoint the boxed
+  // /map panel used.
+  useEffect(() => {
+    if (!selected) {
+      setEntities([]);
+      return;
+    }
+    setLoadingEntities(true);
+    fetch(`/api/data/entity/search?lga=${encodeURIComponent(selected.lga_name)}&limit=10`)
+      .then(r => r.json())
+      .then(data => {
+        setEntities(data.results || []);
+        setLoadingEntities(false);
+      })
+      .catch(() => {
+        setEntities([]);
+        setLoadingEntities(false);
+      });
+  }, [selected]);
+
   const filtered = useMemo(
     () => (stateFilter === 'ALL' ? features : features.filter(f => f.state === stateFilter)),
     [features, stateFilter]
@@ -66,6 +170,54 @@ export default function AtlasClient() {
     () => LAYERS.filter(isLiveLayer).filter(l => l.key !== mapLayer.key),
     [mapLayer.key]
   );
+
+  // Search over every council we hold, not just the filtered view.
+  const searchResults = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q.length < 2) return [];
+    const starts: AtlasFeature[] = [];
+    const contains: AtlasFeature[] = [];
+    for (const f of features) {
+      const name = f.lga_name.toLowerCase();
+      if (name.startsWith(q)) starts.push(f);
+      else if (name.includes(q)) contains.push(f);
+    }
+    return [...starts, ...contains].slice(0, 8);
+  }, [features, query]);
+
+  const topPlaces = useMemo(() => {
+    return [...filtered]
+      .map(f => ({ f, v: mapLayer.value(f) }))
+      .filter((x): x is { f: AtlasFeature; v: number } => x.v !== null)
+      .sort((a, b) => b.v - a.v)
+      .slice(0, 10);
+  }, [filtered, mapLayer]);
+
+  // The full prose page for the selected council, when one exists.
+  const selectedPage = useMemo(() => {
+    if (!selected) return null;
+    const slug = placeSlug(selected.lga_name);
+    const candidates = councilPages.filter(c => c.slug === slug);
+    if (candidates.length === 0) return null;
+    return (
+      candidates.find(c => (c.state ?? '').toUpperCase() === selected.state) ?? candidates[0]
+    );
+  }, [selected, councilPages]);
+
+  function copyLink() {
+    const url =
+      window.location.origin +
+      buildAtlasUrl({
+        layerKey: activeKey,
+        defaultLayerKey: DEFAULT_ATLAS_LAYER_KEY,
+        stateFilter,
+        selected,
+      });
+    navigator.clipboard?.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
 
   return (
     <div className="fixed inset-0 z-0 bg-bauhaus-canvas">
@@ -90,7 +242,7 @@ export default function AtlasClient() {
             features={filtered}
             layer={mapLayer}
             selected={selected}
-            onSelect={setSelected}
+            onSelect={selectPlace}
           />
         )}
       </div>
@@ -148,6 +300,14 @@ export default function AtlasClient() {
               </button>
             ))}
           </div>
+
+          {/* The URL always mirrors the view, so the link IS the presentation */}
+          <button
+            onClick={copyLink}
+            className="mt-4 w-full border-2 border-bauhaus-black px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+          >
+            {copied ? 'Link copied' : 'Copy link to this view'}
+          </button>
         </div>
 
         {/* The caveat, attached to the number — not a help page */}
@@ -200,79 +360,220 @@ export default function AtlasClient() {
         </div>
       )}
 
-      {/* Selected place — the numbers, with the caveat one glance away */}
-      {selected && (
-        <div className="absolute right-4 top-20 z-[900] w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-6.5rem)] overflow-y-auto">
-          <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
-            <div className="flex items-start justify-between gap-2">
-              <div>
-                <h3 className="font-black text-lg uppercase tracking-wider leading-tight">{selected.lga_name}</h3>
-                <p className="text-xs text-gray-400 mt-0.5">
-                  {selected.state}{selected.remoteness ? ` · ${selected.remoteness}` : ''}
+      {/* Right rail: the door to every place. Search when nothing is chosen,
+          the place's numbers when something is. On small screens the rail
+          appears only for a selection. */}
+      {!loading && !failed && (
+        <div className={`absolute right-4 top-20 z-[900] w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-6.5rem)] overflow-y-auto ${selected ? '' : 'hidden lg:block'}`}>
+          {selected ? (
+            <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <h3 className="font-black text-lg uppercase tracking-wider leading-tight">{selected.lga_name}</h3>
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    {selected.state}{selected.remoteness ? ` · ${selected.remoteness}` : ''}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setSelected(null)}
+                  aria-label="Close"
+                  className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors"
+                >
+                  ×
+                </button>
+              </div>
+
+              <div className="mt-4 flex justify-between items-baseline">
+                <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{mapLayer.name}</span>
+                <span className="text-3xl font-black">
+                  {(() => {
+                    const v = mapLayer.value(selected);
+                    return v === null ? '—' : mapLayer.format(v);
+                  })()}
+                </span>
+              </div>
+
+              <div className="mt-3 space-y-2">
+                {otherLiveLayers.map(layer => {
+                  const v = layer.value(selected);
+                  return (
+                    <div key={layer.key} className="flex justify-between items-baseline">
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{layer.name}</span>
+                      <span className="text-sm font-black">{v === null ? '—' : layer.format(v)}</span>
+                    </div>
+                  );
+                })}
+                <div className="flex justify-between items-baseline">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Recorded funding</span>
+                  <span className="text-sm font-black text-green-700">
+                    {selected.total_funding_all_sources === null ? '—' : money(Number(selected.total_funding_all_sources))}
+                  </span>
+                </div>
+                <div className="flex justify-between items-baseline">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">SEIFA decile</span>
+                  <span className="text-sm font-black">{selected.avg_irsd_decile ?? '—'}</span>
+                </div>
+                <div className="flex justify-between items-baseline">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Entities</span>
+                  <span className="text-sm font-black">{selected.indexed_entities ?? '—'}</span>
+                </div>
+                <div className="flex justify-between items-baseline">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Community controlled</span>
+                  <span className="text-sm font-black">{selected.community_controlled_entities ?? '—'}</span>
+                </div>
+                <div className="flex justify-between items-baseline">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Cannot place</span>
+                  <span className={`text-sm font-black ${Number(selected.unplaced_share) >= 50 ? 'text-bauhaus-red' : ''}`}>
+                    {selected.unplaced_count}
+                    {selected.unplaced_share !== null && (
+                      <span className="text-xs font-bold text-gray-400 ml-1">({Number(selected.unplaced_share).toFixed(0)}%)</span>
+                    )}
+                  </span>
+                </div>
+              </div>
+
+              {selectedPage && (
+                <Link
+                  href={`/place/council/${selectedPage.slug}`}
+                  className="mt-4 block border-2 border-bauhaus-black bg-bauhaus-black text-white px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-center hover:bg-white hover:text-bauhaus-black transition-colors"
+                >
+                  Read the full place page →
+                </Link>
+              )}
+
+              {/* Top entities — the same endpoint the boxed /map panel used */}
+              <div className="mt-4 pt-3 border-t border-gray-200">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">
+                  Top entities here
+                </p>
+                {loadingEntities ? (
+                  <div className="flex items-center gap-2 text-gray-400 text-xs">
+                    <span className="inline-block w-3 h-3 border-2 border-gray-300 border-t-bauhaus-red rounded-full animate-spin" />
+                    Loading…
+                  </div>
+                ) : entities.length > 0 ? (
+                  <div className="space-y-1">
+                    {entities.map(e => (
+                      <Link
+                        key={e.gs_id}
+                        href={`/entity/${encodeURIComponent(e.gs_id)}`}
+                        className="block text-xs hover:bg-gray-50 px-1 py-1 transition-colors group"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-medium truncate group-hover:text-bauhaus-red transition-colors">
+                            {e.canonical_name}
+                          </span>
+                          {e.power_score !== null && Number(e.power_score) > 0 && (
+                            <span className="font-mono font-bold text-gray-500 shrink-0">
+                              {Number(e.power_score).toFixed(0)}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1.5 mt-0.5">
+                          <span className="text-[9px] px-1.5 py-0.5 bg-gray-100 text-gray-500">{e.entity_type}</span>
+                          {e.is_community_controlled && (
+                            <span className="text-[9px] px-1.5 py-0.5 bg-bauhaus-red/10 text-bauhaus-red">CC</span>
+                          )}
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-gray-400">No indexed entities placed in this council.</p>
+                )}
+              </div>
+
+              {/* Take the data — the caveats travel inside the files */}
+              <div className="mt-4 pt-3 border-t border-gray-200">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">
+                  Take the data
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => downloadFile(`${exportFilename(selected)}.csv`, 'text/csv', councilCsv(selected))}
+                    className="flex-1 border-2 border-bauhaus-black px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+                  >
+                    CSV
+                  </button>
+                  <button
+                    onClick={() =>
+                      downloadFile(
+                        `${exportFilename(selected)}.json`,
+                        'application/json',
+                        JSON.stringify({ generated_at: new Date().toISOString(), ...councilJson(selected) }, null, 2)
+                      )
+                    }
+                    className="flex-1 border-2 border-bauhaus-black px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+                  >
+                    JSON
+                  </button>
+                </div>
+                <p className="text-[10px] text-gray-400 mt-2 leading-snug">
+                  Every layer's caveat ships inside the file. All councils at once:{' '}
+                  <a href="/api/data/map" target="_blank" rel="noopener noreferrer" className="underline hover:text-bauhaus-black">
+                    GET /api/data/map
+                  </a>
+                  .
                 </p>
               </div>
-              <button
-                onClick={() => setSelected(null)}
-                aria-label="Close"
-                className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors"
-              >
-                ×
-              </button>
-            </div>
 
-            <div className="mt-4 flex justify-between items-baseline">
-              <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{mapLayer.name}</span>
-              <span className="text-3xl font-black">
-                {(() => {
-                  const v = mapLayer.value(selected);
-                  return v === null ? '—' : mapLayer.format(v);
-                })()}
-              </span>
+              <p className="text-[11px] text-gray-400 mt-4 pt-3 border-t border-gray-200 leading-snug">
+                {mapLayer.honestAtNote}
+              </p>
             </div>
-
-            <div className="mt-3 space-y-2">
-              {otherLiveLayers.map(layer => {
-                const v = layer.value(selected);
-                return (
-                  <div key={layer.key} className="flex justify-between items-baseline">
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{layer.name}</span>
-                    <span className="text-sm font-black">{v === null ? '—' : layer.format(v)}</span>
-                  </div>
-                );
-              })}
-              <div className="flex justify-between items-baseline">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Recorded funding</span>
-                <span className="text-sm font-black text-green-700">
-                  {selected.total_funding_all_sources === null ? '—' : money(Number(selected.total_funding_all_sources))}
-                </span>
-              </div>
-              <div className="flex justify-between items-baseline">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">SEIFA decile</span>
-                <span className="text-sm font-black">{selected.avg_irsd_decile ?? '—'}</span>
-              </div>
-              <div className="flex justify-between items-baseline">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Entities</span>
-                <span className="text-sm font-black">{selected.indexed_entities ?? '—'}</span>
-              </div>
-              <div className="flex justify-between items-baseline">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Community controlled</span>
-                <span className="text-sm font-black">{selected.community_controlled_entities ?? '—'}</span>
-              </div>
-              <div className="flex justify-between items-baseline">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Cannot place</span>
-                <span className={`text-sm font-black ${Number(selected.unplaced_share) >= 50 ? 'text-bauhaus-red' : ''}`}>
-                  {selected.unplaced_count}
-                  {selected.unplaced_share !== null && (
-                    <span className="text-xs font-bold text-gray-400 ml-1">({Number(selected.unplaced_share).toFixed(0)}%)</span>
+          ) : (
+            <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">Find a place</p>
+              <input
+                type="text"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder="Council name…"
+                className="w-full border-2 border-bauhaus-black px-3 py-2 text-sm focus:outline-none focus:border-bauhaus-blue"
+              />
+              {query.trim().length >= 2 && (
+                <div className="mt-2 space-y-0.5">
+                  {searchResults.length > 0 ? (
+                    searchResults.map(f => (
+                      <button
+                        key={`${f.lga_name}|${f.state}`}
+                        onClick={() => selectPlace(f)}
+                        className="w-full flex items-center justify-between gap-2 text-xs px-1 py-1 hover:bg-gray-50 text-left transition-colors"
+                      >
+                        <span className="font-medium truncate">{f.lga_name}</span>
+                        <span className="text-gray-400 shrink-0">{f.state}</span>
+                      </button>
+                    ))
+                  ) : (
+                    <p className="text-xs text-gray-400 px-1 py-1">
+                      No council by that name in our records.
+                    </p>
                   )}
-                </span>
+                </div>
+              )}
+
+              <div className="mt-4 pt-3 border-t border-gray-200">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">
+                  Highest: {mapLayer.name}
+                </p>
+                <div className="space-y-1">
+                  {topPlaces.map(({ f, v }) => (
+                    <button
+                      key={`${f.lga_name}|${f.state}`}
+                      onClick={() => selectPlace(f)}
+                      className="w-full flex items-center justify-between gap-2 text-xs px-1 py-0.5 hover:bg-gray-50 text-left transition-colors"
+                    >
+                      <span className="font-medium truncate">{f.lga_name}</span>
+                      <span className="flex items-center gap-2 shrink-0">
+                        <span className="text-gray-400">{f.state}</span>
+                        <span className="font-mono font-bold text-bauhaus-red">{mapLayer.format(v)}</span>
+                      </span>
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
-
-            <p className="text-[11px] text-gray-400 mt-4 pt-3 border-t border-gray-200 leading-snug">
-              {mapLayer.honestAtNote}
-            </p>
-          </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/app/atlas/page.tsx
+++ b/apps/web/src/app/atlas/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import AtlasClient from './atlas-client';
+import { getRemoteCouncils } from '@/lib/services/council-place-report';
+import AtlasClient, { type CouncilPageLink } from './atlas-client';
 
 export const metadata: Metadata = {
   title: 'The Atlas — CivicGraph',
@@ -9,6 +10,22 @@ export const metadata: Metadata = {
     'and what we cannot yet say.',
 };
 
-export default function AtlasPage() {
-  return <AtlasClient />;
+// The council-page list moves slowly; rebuild it hourly rather than per view.
+export const revalidate = 3600;
+
+export default async function AtlasPage() {
+  // The remote councils that have a full /place/council/[slug] prose page —
+  // the Atlas is the door, those pages stay the depth. If the lookup fails
+  // the Atlas still renders; the rail just loses its deep links.
+  let councilPages: CouncilPageLink[] = [];
+  try {
+    councilPages = (await getRemoteCouncils()).map(c => ({
+      slug: c.slug,
+      lgaName: c.lgaName,
+      state: c.state,
+    }));
+  } catch {
+    // Map without deep links beats no map.
+  }
+  return <AtlasClient councilPages={councilPages} />;
 }

--- a/apps/web/src/lib/atlas/share.test.ts
+++ b/apps/web/src/lib/atlas/share.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import type { AtlasFeature } from './layers';
+import {
+  buildAtlasUrl,
+  councilCsv,
+  councilJson,
+  exportFilename,
+  parseAtlasUrl,
+  placeSlug,
+  resolvePlace,
+} from './share';
+
+function feature(overrides: Partial<AtlasFeature> = {}): AtlasFeature {
+  return {
+    lga_name: 'Ceduna',
+    state: 'SA',
+    remoteness: 'Very Remote Australia',
+    avg_irsd_decile: 2,
+    avg_irsd_score: 800,
+    indexed_entities: 23,
+    community_controlled_entities: 6,
+    total_funding_all_sources: 4200000,
+    desert_score: 180,
+    unplaced_count: 30,
+    placed_count: 70,
+    unplaced_share: 30,
+    lat: -32.1,
+    lng: 133.7,
+    lga_code: 'LGA40700',
+    ...overrides,
+  };
+}
+
+describe('placeSlug', () => {
+  it('matches the council page slugs', () => {
+    expect(placeSlug('Ceduna')).toBe('ceduna');
+    expect(placeSlug('Maralinga Tjarutja')).toBe('maralinga-tjarutja');
+    expect(placeSlug("Augusta-Margaret River")).toBe('augusta-margaret-river');
+    expect(placeSlug('  Derwent Valley  ')).toBe('derwent-valley');
+  });
+});
+
+describe('atlas URLs', () => {
+  it('a fresh Atlas is just /atlas', () => {
+    expect(
+      buildAtlasUrl({ layerKey: 'funding-deserts', defaultLayerKey: 'funding-deserts', stateFilter: 'ALL', selected: null })
+    ).toBe('/atlas');
+  });
+
+  it('carries layer, state filter and place, and pst always rides with place', () => {
+    const url = buildAtlasUrl({
+      layerKey: 'unplaced-orgs',
+      defaultLayerKey: 'funding-deserts',
+      stateFilter: 'SA',
+      selected: feature(),
+    });
+    expect(url).toBe('/atlas?layer=unplaced-orgs&state=SA&place=ceduna&pst=SA');
+  });
+
+  it('round-trips through parse', () => {
+    const url = buildAtlasUrl({
+      layerKey: 'unplaced-orgs',
+      defaultLayerKey: 'funding-deserts',
+      stateFilter: 'ALL',
+      selected: feature(),
+    });
+    const parsed = parseAtlasUrl(url.split('?')[1] ?? '');
+    expect(parsed.layerKey).toBe('unplaced-orgs');
+    expect(parsed.place).toBe('ceduna');
+    expect(parsed.pst).toBe('SA');
+    expect(parsed.state).toBeUndefined();
+  });
+
+  it('parse ignores junk and normalises case', () => {
+    const parsed = parseAtlasUrl('?layer=unplaced-orgs&state=sa&place=CEDUNA&pst=sa&utm_source=x');
+    expect(parsed.state).toBe('SA');
+    expect(parsed.place).toBe('ceduna');
+    expect(parsed.pst).toBe('SA');
+  });
+});
+
+describe('resolvePlace', () => {
+  const baysideNsw = feature({ lga_name: 'Bayside', state: 'NSW' });
+  const baysideVic = feature({ lga_name: 'Bayside', state: 'VIC' });
+  const all = [feature(), baysideNsw, baysideVic];
+
+  it('finds a unique slug', () => {
+    expect(resolvePlace(all, 'ceduna')?.state).toBe('SA');
+  });
+
+  it('disambiguates duplicate names by pst, then state filter, then first', () => {
+    expect(resolvePlace(all, 'bayside', 'VIC')).toBe(baysideVic);
+    expect(resolvePlace(all, 'bayside', undefined, 'VIC')).toBe(baysideVic);
+    expect(resolvePlace(all, 'bayside')).toBe(baysideNsw);
+  });
+
+  it('returns null for a place we do not hold', () => {
+    expect(resolvePlace(all, 'atlantis')).toBeNull();
+  });
+});
+
+describe('taking the data with its caveats', () => {
+  it('CSV carries a _contains column per live layer', () => {
+    const csv = councilCsv(feature());
+    const [headers, row] = csv.trimEnd().split('\n');
+    expect(headers).toContain('funding_deserts');
+    expect(headers).toContain('funding_deserts_contains');
+    expect(headers).toContain('unplaced_orgs_contains');
+    expect(row).toContain('Ceduna');
+    expect(row).toContain('where it was recorded');
+    expect(headers.split(',').length).toBeGreaterThanOrEqual(14);
+  });
+
+  it('CSV escapes commas and quotes properly', () => {
+    const csv = councilCsv(feature({ lga_name: 'Fake, "Weird" Council' }));
+    expect(csv).toContain('"Fake, ""Weird"" Council"');
+    // Caveats contain commas, so every _contains cell must be quoted
+    const row = csv.trimEnd().split('\n')[1];
+    expect(row.match(/"/g)?.length ?? 0).toBeGreaterThan(2);
+  });
+
+  it('null values export as empty cells, never zero', () => {
+    const csv = councilCsv(feature({ desert_score: null, total_funding_all_sources: null }));
+    const [headerLine, rowLine] = csv.trimEnd().split('\n');
+    const headers = headerLine.split(',');
+    // The fixture holds no commas before the first quoted caveat cell, so a
+    // naive split is exact for the leading value columns.
+    const cells = rowLine.split(',');
+    expect(cells[headers.indexOf('recorded_funding')]).toBe('');
+    expect(cells[headers.indexOf('funding_deserts')]).toBe('');
+  });
+
+  it('JSON attaches caveat and honesty to every layer value', () => {
+    const json = councilJson(feature());
+    expect(json.source).toBe('/api/data/map');
+    expect(json.place.council).toBe('Ceduna');
+    for (const layer of json.layers) {
+      expect(String(layer.contains).length).toBeGreaterThan(80);
+      expect(layer.honest_at).toBe('council');
+    }
+    const deserts = json.layers.find(l => l.key === 'funding-deserts');
+    expect(deserts?.formatted).toBe('180');
+  });
+
+  it('JSON keeps null values null', () => {
+    const json = councilJson(feature({ unplaced_share: null }));
+    const unplaced = json.layers.find(l => l.key === 'unplaced-orgs');
+    expect(unplaced?.value).toBeNull();
+    expect(unplaced?.formatted).toBeNull();
+  });
+
+  it('filenames are slugged and state-qualified', () => {
+    expect(exportFilename(feature())).toBe('ceduna-sa-atlas');
+  });
+});

--- a/apps/web/src/lib/atlas/share.ts
+++ b/apps/web/src/lib/atlas/share.ts
@@ -1,0 +1,164 @@
+// Taking the Atlas with you: shareable URLs and per-council data exports.
+//
+// A link IS the presentation — /atlas?layer=unplaced-orgs&place=ceduna&pst=SA
+// restores the layer, the state filter and the open place panel. And when a
+// council's numbers leave as CSV or JSON, every layer's caveat travels in the
+// same file: the number never ships without what it contains.
+
+import {
+  isLiveLayer,
+  visibleAtlasLayers,
+  type AtlasFeature,
+  type AtlasLiveLayer,
+  type AtlasSurface,
+} from './layers';
+
+/** URL-safe slug for a place name. Also the slug of /place/council/[slug] —
+ * council-place-report.ts imports this one so the two can never drift. */
+export function placeSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export interface AtlasUrlState {
+  layerKey?: string;
+  /** State filter chip; 'ALL' and undefined both mean no filter. */
+  state?: string;
+  /** Selected place slug. */
+  place?: string;
+  /** The selected place's state. Council names repeat across states
+   * (Bayside exists in NSW and VIC), so the slug alone is ambiguous. */
+  pst?: string;
+}
+
+/** Read Atlas state out of a query string. Unknown params are ignored;
+ * values are not validated here — resolve against real data before use. */
+export function parseAtlasUrl(search: string): AtlasUrlState {
+  const params = new URLSearchParams(search);
+  const read = (key: string): string | undefined => {
+    const value = params.get(key)?.trim();
+    return value ? value : undefined;
+  };
+  return {
+    layerKey: read('layer'),
+    state: read('state')?.toUpperCase(),
+    place: read('place')?.toLowerCase(),
+    pst: read('pst')?.toUpperCase(),
+  };
+}
+
+/** Build the shareable path. Defaults are omitted so a fresh Atlas is just
+ * /atlas; pst always accompanies place because slugs collide across states. */
+export function buildAtlasUrl(input: {
+  layerKey: string;
+  defaultLayerKey: string;
+  stateFilter: string;
+  selected: AtlasFeature | null;
+}): string {
+  const params = new URLSearchParams();
+  if (input.layerKey !== input.defaultLayerKey) params.set('layer', input.layerKey);
+  if (input.stateFilter && input.stateFilter !== 'ALL') params.set('state', input.stateFilter);
+  if (input.selected) {
+    params.set('place', placeSlug(input.selected.lga_name));
+    params.set('pst', input.selected.state);
+  }
+  const qs = params.toString();
+  return qs ? `/atlas?${qs}` : '/atlas';
+}
+
+/** Find the feature a place slug points at. When the slug is ambiguous the
+ * place-state wins, then the state filter, then the first match — a
+ * hand-typed /atlas?place=bayside still lands somewhere rather than nowhere. */
+export function resolvePlace(
+  features: readonly AtlasFeature[],
+  place: string,
+  pst?: string,
+  stateFilter?: string
+): AtlasFeature | null {
+  const matches = features.filter(f => placeSlug(f.lga_name) === place);
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0];
+  return (
+    (pst && matches.find(f => f.state === pst)) ||
+    (stateFilter && stateFilter !== 'ALL' && matches.find(f => f.state === stateFilter)) ||
+    matches[0]
+  );
+}
+
+function csvCell(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+/** The payload fields that describe the place itself, before any layer. */
+const PLACE_COLUMNS: Array<{ header: string; read(f: AtlasFeature): unknown }> = [
+  { header: 'council', read: f => f.lga_name },
+  { header: 'state', read: f => f.state },
+  { header: 'remoteness', read: f => f.remoteness },
+  { header: 'lga_code', read: f => f.lga_code },
+  { header: 'seifa_irsd_decile', read: f => f.avg_irsd_decile },
+  { header: 'entities', read: f => f.indexed_entities },
+  { header: 'community_controlled', read: f => f.community_controlled_entities },
+  { header: 'recorded_funding', read: f => f.total_funding_all_sources },
+  { header: 'unplaced_count', read: f => f.unplaced_count },
+  { header: 'placed_count', read: f => f.placed_count },
+];
+
+function liveLayers(surface: AtlasSurface): AtlasLiveLayer[] {
+  return visibleAtlasLayers(surface).filter(isLiveLayer);
+}
+
+/** One council as CSV: a header row and a data row. Each live layer
+ * contributes its value and a `<key>_contains` column carrying the caveat,
+ * so the file stays honest after it leaves. */
+export function councilCsv(feature: AtlasFeature, surface: AtlasSurface = 'public'): string {
+  const layers = liveLayers(surface);
+  const headers = [
+    ...PLACE_COLUMNS.map(c => c.header),
+    ...layers.flatMap(l => [l.key.replace(/-/g, '_'), `${l.key.replace(/-/g, '_')}_contains`]),
+  ];
+  const row = [
+    ...PLACE_COLUMNS.map(c => csvCell(c.read(feature))),
+    ...layers.flatMap(l => {
+      const v = l.value(feature);
+      return [csvCell(v), csvCell(`${l.caveat} Honest at ${l.honestAt} level: ${l.honestAtNote}`)];
+    }),
+  ];
+  return `${headers.join(',')}\n${row.join(',')}\n`;
+}
+
+/** One council as JSON: the place fields plus every live layer's value with
+ * its caveat and the geography it is honest at. */
+export function councilJson(feature: AtlasFeature, surface: AtlasSurface = 'public'): {
+  source: string;
+  note: string;
+  place: Record<string, unknown>;
+  layers: Array<Record<string, unknown>>;
+} {
+  return {
+    source: '/api/data/map',
+    note: 'The full payload (every council, every live layer) is one GET of the source endpoint.',
+    place: Object.fromEntries(PLACE_COLUMNS.map(c => [c.header, c.read(feature) ?? null])),
+    layers: liveLayers(surface).map(layer => {
+      const value = layer.value(feature);
+      return {
+        key: layer.key,
+        name: layer.name,
+        unit: layer.unit,
+        value,
+        formatted: value === null ? null : layer.format(value),
+        contains: layer.caveat,
+        honest_at: layer.honestAt,
+        honest_at_note: layer.honestAtNote,
+      };
+    }),
+  };
+}
+
+/** Filename stem for a council's export files. */
+export function exportFilename(feature: AtlasFeature): string {
+  return `${placeSlug(feature.lga_name)}-${feature.state.toLowerCase()}-atlas`;
+}

--- a/apps/web/src/lib/services/council-place-report.ts
+++ b/apps/web/src/lib/services/council-place-report.ts
@@ -1,5 +1,6 @@
 import { cache } from 'react';
 import { getServiceSupabase } from '@/lib/supabase';
+import { placeSlug } from '@/lib/atlas/share';
 
 /**
  * The part of a place report that needs no local knowledge.
@@ -72,12 +73,9 @@ export interface CouncilPlaceReport extends CouncilSummary {
   computedAt: string;
 }
 
-export function councilSlug(lgaName: string): string {
-  return lgaName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
+// The Atlas builds the same slug client-side (lib/atlas/share.ts); one
+// implementation means /atlas links and /place/council/[slug] cannot drift.
+export const councilSlug = placeSlug;
 
 function quoted(values: string[]): string {
   return values.map(value => `'${value.replace(/'/g, "''")}'`).join(',');


### PR DESCRIPTION
**Stacked on #179** (Atlas step 1) — base is `feat/atlas-shell` so this diff reads step-2-only; GitHub retargets to `main` when #179 merges. Step 2 of `thoughts/shared/plans/place-atlas-surface.md`.

## What this builds

- **The place rail.** Nothing selected: search over all councils plus the top-10 for the painted layer (registry-driven — it follows whichever layer the map shows). Selected: the place's numbers, its top entities (the same `/api/data/entity/search` endpoint the boxed `/map` panel used), and — for the 117 remote councils that have one — a link to the full `/place/council/[slug]` prose page. The prose pages stay the depth; the Atlas is the door.
- **Shareable URLs.** `/atlas?layer=unplaced-orgs&place=ceduna&pst=SA` restores layer, state filter, and open panel — a link IS the presentation. `pst` always accompanies `place` because council names repeat across states (Bayside exists in NSW and VIC). Written with `history.replaceState`, read once on load, resolved against real data before use.
- **Take the data.** Per-council CSV and JSON built from the registry: every live layer ships its value WITH its caveat (`<layer>_contains` column in the CSV; `contains` / `honest_at` fields in the JSON). The number never leaves without what it contains. The rail points at `GET /api/data/map` as the documented all-councils endpoint rather than growing a second one.
- **One slug.** `councilSlug` in `council-place-report.ts` now IS `placeSlug` from `lib/atlas/share.ts` — `/atlas` links and `/place/council/[slug]` cannot drift.
- **Server-side page list.** `/atlas` fetches the council-page list via `getRemoteCouncils()` (ISR, hourly); if the lookup fails the Atlas renders without deep links rather than not rendering.

## Deliberately left for later steps

- The remoteness breakdown from the boxed `/map` panel — it reads as story-mode material (step 3).
- A real mobile pass: on small screens the rail appears only when a place is selected.

## Gates

`tsc --noEmit` clean · vitest 617 passed (603 after step 1 + 14 new share-module tests) · no DB objects · no new endpoints · no Goods data on any surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)