### PR TITLE
Story mode: five map states, five paragraphs, read aloud in a room

### DIFF
--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -21,6 +21,13 @@ import {
   placeSlug,
   resolvePlace,
 } from '@/lib/atlas/share';
+import {
+  ATLAS_STORY,
+  ATLAS_STORY_MEASURED_AT,
+  getStoryStep,
+  storyStepIndex,
+  type AtlasStoryStep,
+} from '@/lib/atlas/story';
 
 // Lazy-load the map to avoid SSR issues with Leaflet
 const AtlasMap = dynamic(() => import('./atlas-map'), { ssr: false });
@@ -70,6 +77,8 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
   const [entities, setEntities] = useState<RailEntity[]>([]);
   const [loadingEntities, setLoadingEntities] = useState(false);
   const [copied, setCopied] = useState(false);
+  // Story mode: index into ATLAS_STORY, or null when browsing freely.
+  const [storyIdx, setStoryIdx] = useState<number | null>(null);
   // URL state only starts writing after the inbound URL has been applied.
   const urlReady = useRef(false);
 
@@ -90,6 +99,7 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
 
   const activeLayer = getAtlasLayer(activeKey) ?? LAYERS[0];
   const mapLayer = (getAtlasLayer(mapKey) ?? LAYERS[0]) as AtlasLiveLayer;
+  const story = storyIdx !== null ? ATLAS_STORY[storyIdx] : null;
 
   function pickLayer(key: string) {
     setActiveKey(key);
@@ -104,10 +114,51 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
     if (stateFilter !== 'ALL' && f.state !== stateFilter) setStateFilter(f.state);
   }
 
+  // A story step is a saved view plus a paragraph: apply the view.
+  function applyStoryStep(step: AtlasStoryStep, all: AtlasFeature[]) {
+    pickLayer(step.view.layerKey);
+    setStateFilter(step.view.state ?? 'ALL');
+    setQuery('');
+    if (step.view.place) {
+      setSelected(resolvePlace(all, step.view.place, step.view.pst, step.view.state));
+    } else {
+      setSelected(null);
+    }
+  }
+
+  function enterStory(idx: number) {
+    const step = ATLAS_STORY[idx];
+    if (!step) return;
+    setStoryIdx(idx);
+    applyStoryStep(step, features);
+  }
+
+  function moveStory(delta: number) {
+    if (storyIdx === null) return;
+    const next = storyIdx + delta;
+    if (next < 0 || next >= ATLAS_STORY.length) return;
+    enterStory(next);
+  }
+
+  function exitStory() {
+    setStoryIdx(null);
+  }
+
   // Apply the inbound URL once the payload exists: a link IS the presentation.
   useEffect(() => {
     if (loading || urlReady.current) return;
     const wanted = parseAtlasUrl(window.location.search);
+    // A story link defines the whole view; the other params stay unread.
+    if (wanted.story) {
+      const idx = storyStepIndex(wanted.story);
+      const step = getStoryStep(wanted.story);
+      if (step && idx >= 0) {
+        setStoryIdx(idx);
+        applyStoryStep(step, features);
+        urlReady.current = true;
+        return;
+      }
+    }
     if (wanted.layerKey && LAYERS.some(l => l.key === wanted.layerKey)) {
       pickLayer(wanted.layerKey);
     }
@@ -135,9 +186,29 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
       defaultLayerKey: DEFAULT_ATLAS_LAYER_KEY,
       stateFilter,
       selected,
+      story: storyIdx !== null ? ATLAS_STORY[storyIdx].id : null,
     });
     window.history.replaceState(null, '', url);
-  }, [activeKey, stateFilter, selected]);
+  }, [activeKey, stateFilter, selected, storyIdx]);
+
+  // In a room the presenter holds arrow keys, not a mouse.
+  useEffect(() => {
+    if (storyIdx === null) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === 'PageDown' || e.key === ' ') {
+        e.preventDefault();
+        moveStory(1);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp') {
+        e.preventDefault();
+        moveStory(-1);
+      } else if (e.key === 'Escape') {
+        exitStory();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storyIdx]);
 
   // Fetch the selected place's top entities — the same endpoint the boxed
   // /map panel used.
@@ -212,6 +283,7 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
         defaultLayerKey: DEFAULT_ATLAS_LAYER_KEY,
         stateFilter,
         selected,
+        story: storyIdx !== null ? ATLAS_STORY[storyIdx].id : null,
       });
     navigator.clipboard?.writeText(url).then(() => {
       setCopied(true);
@@ -247,7 +319,9 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
         )}
       </div>
 
-      {/* Left rail: what you are looking at, and what it contains */}
+      {/* Left rail: what you are looking at, and what it contains.
+          Story mode clears the stage: the paragraph does this job there. */}
+      {!story && (
       <div className="absolute left-4 top-20 z-[900] w-[min(22rem,calc(100vw-2rem))] max-h-[calc(100dvh-6.5rem)] overflow-y-auto space-y-4 pr-1">
         {/* Brand + layer picker */}
         <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
@@ -308,6 +382,14 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
           >
             {copied ? 'Link copied' : 'Copy link to this view'}
           </button>
+
+          {/* The fixed sequence for a room */}
+          <button
+            onClick={() => enterStory(0)}
+            className="mt-2 w-full border-2 border-bauhaus-blue text-bauhaus-blue px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-blue hover:text-white transition-colors"
+          >
+            Story mode · tell it in a room
+          </button>
         </div>
 
         {/* The caveat, attached to the number — not a help page */}
@@ -337,10 +419,12 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
           </div>
         </div>
       </div>
+      )}
 
-      {/* Legend for the painted layer */}
+      {/* Legend for the painted layer. It stays up in story mode — the room
+          needs to know what the colours mean — but yields on small screens. */}
       {!loading && !failed && (
-        <div className="absolute left-4 bottom-4 z-[900] bg-white border-2 border-bauhaus-black p-3 w-[min(15rem,calc(100vw-2rem))]">
+        <div className={`absolute left-4 bottom-4 z-[900] bg-white border-2 border-bauhaus-black p-3 w-[min(15rem,calc(100vw-2rem))] ${story ? 'hidden lg:block' : ''}`}>
           <p className="text-[10px] font-bold uppercase tracking-widest mb-2">{mapLayer.name}</p>
           <div className="space-y-1">
             {mapLayer.scale.map(stop => (
@@ -362,8 +446,8 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
 
       {/* Right rail: the door to every place. Search when nothing is chosen,
           the place's numbers when something is. On small screens the rail
-          appears only for a selection. */}
-      {!loading && !failed && (
+          appears only for a selection. Story mode clears it. */}
+      {!loading && !failed && !story && (
         <div className={`absolute right-4 top-20 z-[900] w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-6.5rem)] overflow-y-auto ${selected ? '' : 'hidden lg:block'}`}>
           {selected ? (
             <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
@@ -574,6 +658,73 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Story mode: one map state, one paragraph, read aloud. */}
+      {story && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[950] w-[min(46rem,calc(100vw-2rem))]">
+          <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-5 md:p-6">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-red">
+                Story · {storyIdx! + 1} / {ATLAS_STORY.length}
+              </p>
+              <div className="flex items-center gap-3">
+                <p className="text-[10px] text-gray-400 uppercase tracking-widest hidden sm:block">
+                  Measured {ATLAS_STORY_MEASURED_AT} · public registers
+                </p>
+                <button
+                  onClick={exitStory}
+                  aria-label="Exit story mode"
+                  className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+
+            <h2 className="text-xl md:text-2xl font-black uppercase tracking-wider leading-tight mt-2">
+              {story.title}
+            </h2>
+            <p className="text-base md:text-lg leading-relaxed mt-3">{story.paragraph}</p>
+
+            {story.cannotSay && (
+              <div className="mt-4 border-l-4 border-bauhaus-red pl-3">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-red">
+                  What we cannot say
+                </p>
+                <p className="text-sm text-gray-600 mt-1">{story.cannotSay}</p>
+              </div>
+            )}
+
+            <div className="mt-5 flex items-center justify-between gap-3">
+              <button
+                onClick={() => moveStory(-1)}
+                disabled={storyIdx === 0}
+                className="border-2 border-bauhaus-black px-4 py-2 text-[10px] font-bold uppercase tracking-widest disabled:opacity-30 disabled:cursor-default hover:enabled:bg-bauhaus-black hover:enabled:text-white transition-colors"
+              >
+                ← Back
+              </button>
+              <p className="text-[10px] text-gray-400 uppercase tracking-widest hidden md:block">
+                Arrow keys move · Esc leaves
+              </p>
+              {storyIdx === ATLAS_STORY.length - 1 ? (
+                <button
+                  onClick={exitStory}
+                  className="border-2 border-bauhaus-black bg-bauhaus-black text-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest hover:bg-white hover:text-bauhaus-black transition-colors"
+                >
+                  Open the Atlas →
+                </button>
+              ) : (
+                <button
+                  onClick={() => moveStory(1)}
+                  className="border-2 border-bauhaus-black bg-bauhaus-black text-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest hover:bg-white hover:text-bauhaus-black transition-colors"
+                >
+                  Next →
+                </button>
+              )}
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/lib/atlas/share.test.ts
+++ b/apps/web/src/lib/atlas/share.test.ts
@@ -77,6 +77,18 @@ describe('atlas URLs', () => {
     expect(parsed.place).toBe('ceduna');
     expect(parsed.pst).toBe('SA');
   });
+
+  it('a story step travels alone: it defines the whole view', () => {
+    const url = buildAtlasUrl({
+      layerKey: 'unplaced-orgs',
+      defaultLayerKey: 'funding-deserts',
+      stateFilter: 'SA',
+      selected: feature(),
+      story: 'utopia-alice-springs',
+    });
+    expect(url).toBe('/atlas?story=utopia-alice-springs');
+    expect(parseAtlasUrl(url.split('?')[1]).story).toBe('utopia-alice-springs');
+  });
 });
 
 describe('resolvePlace', () => {

--- a/apps/web/src/lib/atlas/share.ts
+++ b/apps/web/src/lib/atlas/share.ts
@@ -31,6 +31,9 @@ export interface AtlasUrlState {
   /** The selected place's state. Council names repeat across states
    * (Bayside exists in NSW and VIC), so the slug alone is ambiguous. */
   pst?: string;
+  /** Story-mode step id. When present it defines the whole view, so the
+   * other params are neither written nor read. */
+  story?: string;
 }
 
 /** Read Atlas state out of a query string. Unknown params are ignored;
@@ -46,17 +49,21 @@ export function parseAtlasUrl(search: string): AtlasUrlState {
     state: read('state')?.toUpperCase(),
     place: read('place')?.toLowerCase(),
     pst: read('pst')?.toUpperCase(),
+    story: read('story')?.toLowerCase(),
   };
 }
 
 /** Build the shareable path. Defaults are omitted so a fresh Atlas is just
- * /atlas; pst always accompanies place because slugs collide across states. */
+ * /atlas; pst always accompanies place because slugs collide across states.
+ * A story step id defines the whole view, so it travels alone. */
 export function buildAtlasUrl(input: {
   layerKey: string;
   defaultLayerKey: string;
   stateFilter: string;
   selected: AtlasFeature | null;
+  story?: string | null;
 }): string {
+  if (input.story) return `/atlas?story=${encodeURIComponent(input.story)}`;
   const params = new URLSearchParams();
   if (input.layerKey !== input.defaultLayerKey) params.set('layer', input.layerKey);
   if (input.stateFilter && input.stateFilter !== 'ALL') params.set('state', input.stateFilter);

--- a/apps/web/src/lib/atlas/story.test.ts
+++ b/apps/web/src/lib/atlas/story.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { getAtlasLayer } from './layers';
+import {
+  ATLAS_STORY,
+  ATLAS_STORY_MEASURED_AT,
+  getStoryStep,
+  storyLayersVisibleAt,
+  storyStepIndex,
+} from './story';
+
+describe('the story sequence', () => {
+  it('holds five steps with stable unique ids', () => {
+    expect(ATLAS_STORY.length).toBe(5);
+    const ids = ATLAS_STORY.map(s => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('every step points at a registered, publicly visible layer', () => {
+    expect(storyLayersVisibleAt('public')).toBe(true);
+    for (const step of ATLAS_STORY) {
+      expect(getAtlasLayer(step.view.layerKey), step.id).not.toBeNull();
+    }
+  });
+
+  it('a step that opens a place always says which state it means', () => {
+    for (const step of ATLAS_STORY) {
+      if (step.view.place) {
+        expect(step.view.pst, `${step.id} pst`).toBeTruthy();
+        expect(step.view.place).toMatch(/^[a-z0-9-]+$/);
+      }
+    }
+  });
+
+  it('paragraphs are read-aloud length, titles are spoken length', () => {
+    for (const step of ATLAS_STORY) {
+      expect(step.paragraph.length, `${step.id} paragraph`).toBeGreaterThan(200);
+      expect(step.paragraph.length, `${step.id} paragraph`).toBeLessThan(700);
+      expect(step.title.length, `${step.id} title`).toBeLessThan(70);
+      // The room register bans em-dashes; sentences carry the pauses.
+      expect(step.paragraph, `${step.id} em-dash`).not.toContain('—');
+    }
+  });
+
+  it('pins the figures that were verified against the registers', () => {
+    // Verified 2026-08-08 against grantconnect_awards via exec_sql:
+    //   Central Australia scope (place-intelligence PLACE_REGIONS):
+    //     active $1,829.1M, ending within 24 months $1,170.6M (64%).
+    //   The five Utopia orgs named in hubAdministration, all lga Alice
+    //     Springs: $93.2M lifetime.
+    // If these assertions fail because the copy changed, re-run those
+    // queries before updating: the paragraphs are spoken as fact in a room.
+    const utopia = getStoryStep('utopia-alice-springs');
+    expect(utopia?.paragraph).toContain('93 million');
+    expect(utopia?.paragraph).toContain('250 kilometres');
+    const cliff = getStoryStep('renewal-cliff');
+    expect(cliff?.paragraph).toContain('58 and 64 per cent');
+    expect(cliff?.paragraph).toContain('1.17 billion of 1.83 billion');
+    expect(ATLAS_STORY_MEASURED_AT).toBe('August 2026');
+  });
+
+  it('steps resolve by id and report their position', () => {
+    expect(getStoryStep('recorded-not-landed')?.title).toBe('Recorded is not landed');
+    expect(getStoryStep('nope')).toBeNull();
+    expect(storyStepIndex('recorded-not-landed')).toBe(0);
+    expect(storyStepIndex('correct-us')).toBe(4);
+    expect(storyStepIndex('nope')).toBe(-1);
+  });
+
+  it('never references Goods on the public story surface', () => {
+    for (const step of ATLAS_STORY) {
+      const text = `${step.title} ${step.paragraph} ${step.cannotSay ?? ''}`.toLowerCase();
+      expect(text.includes('goods'), `${step.id} mentions Goods`).toBe(false);
+      expect(text.includes('beds'), `${step.id} mentions beds`).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/atlas/story.ts
+++ b/apps/web/src/lib/atlas/story.ts
@@ -1,0 +1,126 @@
+// Story mode: the fixed sequence the Atlas walks through in a room.
+//
+// Five steps. Each one is a map state plus one paragraph, written to be read
+// aloud. This is the community-conversation artifact: the thing on the screen
+// when the consent question gets asked in person. The register is the same
+// one the place pages hold — say what the number contains, and where we
+// cannot say, say that instead of guessing.
+//
+// Every figure in these paragraphs was verified against the database on the
+// date below, using the same queries the region pages run. The paragraphs
+// use rounded words ("more than 93 million dollars") so a small movement in
+// the registers does not make the room copy wrong; the live region pages
+// carry the exact current numbers.
+
+import { getAtlasLayer, type AtlasConsentTier } from './layers';
+
+export interface AtlasStoryView {
+  /** Layer to select. May be a declared layer: the point of that step is
+   * saying out loud that the Atlas cannot draw it yet. */
+  layerKey: string;
+  /** State filter chip; omitted means the whole country. */
+  state?: string;
+  /** Place to open in the rail, as a placeSlug. */
+  place?: string;
+  /** The place's state. Required whenever place is set: slugs collide. */
+  pst?: string;
+}
+
+export interface AtlasStoryStep {
+  /** Stable id — it is the URL (?story=<id>), so renumbering never breaks a link. */
+  id: string;
+  title: string;
+  /** The read-aloud paragraph. One breath long, plain words. */
+  paragraph: string;
+  /** The "what we cannot say" line, when the step carries one. */
+  cannotSay?: string;
+  view: AtlasStoryView;
+}
+
+/** When the figures in the paragraphs were verified against the registers. */
+export const ATLAS_STORY_MEASURED_AT = 'August 2026';
+
+export const ATLAS_STORY: readonly AtlasStoryStep[] = [
+  {
+    id: 'recorded-not-landed',
+    title: 'Recorded is not landed',
+    paragraph:
+      'This map colours every council by how much public money our records can see ' +
+      'reaching it, set against how much disadvantage sits there. Before reading it, ' +
+      'know one thing: money is counted where it was recorded, not where it landed. ' +
+      'A grant run from a regional office is credited to the office’s town, not to ' +
+      'the communities the work reaches.',
+    view: { layerKey: 'funding-deserts' },
+  },
+  {
+    id: 'utopia-alice-springs',
+    title: 'Utopia’s money sits in Alice Springs',
+    paragraph:
+      'The Utopia homelands are roughly 250 kilometres north-east of Mparntwe, Alice ' +
+      'Springs. Their organisations, including Urapuntja Health Service and Urapuntja ' +
+      'Aboriginal Corporation, are registered to town addresses because that is where ' +
+      'the post goes. More than 93 million dollars of their funding is counted as money ' +
+      'reaching Alice Springs. Utopia has no council area of its own. On this map, ' +
+      'Utopia is invisible, and Alice Springs looks better funded than it is.',
+    cannotSay:
+      'The national gazetteer holds no entry for Urapuntja or the homelands around it. ' +
+      'We cannot place what the reference data cannot name.',
+    view: { layerKey: 'funding-deserts', state: 'NT', place: 'alice-springs', pst: 'NT' },
+  },
+  {
+    id: 'what-we-cannot-place',
+    title: 'What we cannot place',
+    paragraph:
+      'This layer is the map grading its own homework. It shows the share of ' +
+      'organisations registered in each council’s postcodes that our records cannot ' +
+      'tie to any single council. One postcode, 0872, spans eight councils and a third ' +
+      'of the continent. The darker the red, the less certain every other number on ' +
+      'this map is. The places where the records are weakest are the same places the ' +
+      'money is hardest to see.',
+    view: { layerKey: 'unplaced-orgs' },
+  },
+  {
+    id: 'renewal-cliff',
+    title: 'The renewal cliff',
+    paragraph:
+      'Now add time. Across the four regions we have measured, between 58 and 64 per ' +
+      'cent of committed federal grant money ends within the next 24 months. In Central ' +
+      'Australia that is 1.17 billion of 1.83 billion dollars. An agreement ending is ' +
+      'not the same as funding stopping, but it is the moment a decision gets made ' +
+      'somewhere else. The Atlas cannot draw this layer per council yet, and the layer ' +
+      'picker says so rather than hiding it.',
+    cannotSay:
+      'Renewals that happen without a new public record look like cliffs that never ' +
+      'fall. The records show endings, not decisions.',
+    view: { layerKey: 'renewal-cliff' },
+  },
+  {
+    id: 'correct-us',
+    title: 'The people who can correct this map are the people it is about',
+    paragraph:
+      'Everything here comes from public registers, and registers record addresses, ' +
+      'councils and financial years. They do not record homelands, or money held by a ' +
+      'regional body for communities, or work delivered 250 kilometres from where it ' +
+      'is filed. So this map will be wrong in ways only local people can see. Every ' +
+      'place page carries a correction form that goes to a person, not a pipeline. If ' +
+      'this map says something wrong about your place, we want to be corrected.',
+    view: { layerKey: 'funding-deserts' },
+  },
+];
+
+export function getStoryStep(id: string): AtlasStoryStep | null {
+  return ATLAS_STORY.find(step => step.id === id) ?? null;
+}
+
+export function storyStepIndex(id: string): number {
+  return ATLAS_STORY.findIndex(step => step.id === id);
+}
+
+/** Story mode is a public-surface artifact: every layer a step points at must
+ * be visible at the given tier. Used by tests and by the client as a guard. */
+export function storyLayersVisibleAt(tier: AtlasConsentTier): boolean {
+  return ATLAS_STORY.every(step => {
+    const layer = getAtlasLayer(step.view.layerKey);
+    return layer !== null && (tier !== 'public' || layer.consent === 'public');
+  });
+}


### PR DESCRIPTION
Step 3 of `thoughts/shared/plans/place-atlas-surface.md` — the community-conversation artifact: the thing on the screen when the consent question gets asked in person.

## The sequence

1. **Recorded is not landed** — the thesis, national deserts view
2. **Utopia's money sits in Alice Springs** — NT view, Alice Springs panel open
3. **What we cannot place** — the unplaced layer grading the map's own homework
4. **The renewal cliff** — lands on the *declared* layer on purpose: the picker saying "not yet held" in front of a room is the register doing its job
5. **The people who can correct this map are the people it is about** — closes on the correction promise

Each step is a saved view (layer, filter, place) plus one read-aloud paragraph, with an optional "what we cannot say" line. Step ids are the URL — `/atlas?story=utopia-alice-springs` — so a link drops a room straight into a step and renumbering can never break one. Arrow keys advance, Esc leaves, rails clear, the legend stays (a room needs the colours explained), type steps up a size.

## Figures re-verified against the DB today

Not taken from the handoff — re-queried with the same scopes the region pages use:

- The five Utopia organisations named in `hubAdministration` sum to **$93.2M lifetime, all recorded in Alice Springs** (the handoff's $93.6M was per-org rounding). Copy says "more than 93 million dollars" so small register movements cannot make spoken words wrong.
- Central Australia: **$1,829.1M committed, $1,170.6M ending within 24 months (64%)** — matches the region scope query exactly.
- The 58–64% four-region range is the documented August 2026 measurement; the story card carries a "Measured August 2026 · public registers" stamp.

A test pins these figures with the verification queries in its comment — editing the copy forces a trip back to the DB. Another test asserts no story step mentions Goods or beds: the public surface stays clean.

## Before this meets a real community session

- **The read-aloud pass is Ben's** — the paragraphs are written for a voice; only saying them aloud tells you if they hold.
- The ledger's standing question outranks the feature: whether someone from Utopia would recognise themselves in step 2. This artifact exists to be brought TO that conversation.

## Gates

`tsc --noEmit` clean · vitest 625 passed (+8) · no DB objects · no new endpoints · no Goods data on any surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)