### PR TITLE
The inverse layer, org-side: Goods in community, consent enforced by the server

### DIFF
--- a/apps/web/src/app/api/data/map/route.ts
+++ b/apps/web/src/app/api/data/map/route.ts
@@ -106,12 +106,21 @@ export async function GET(request: Request) {
         FROM gs_entities
         WHERE lga_name IS NOT NULL
         GROUP BY 1, 2
+      ),
+      justice AS MATERIALIZED (
+        SELECT e.lga_name, UPPER(e.state) AS state,
+               SUM(jf.amount_dollars)::numeric AS justice_total
+        FROM justice_funding jf
+        JOIN gs_entities e ON e.id = jf.gs_entity_id
+        WHERE e.lga_name IS NOT NULL
+        GROUP BY 1, 2
       )
       SELECT lc.lga_name, lc.state, lc.lat, lc.lng, lc.lga_code,
              COALESCE(dd.remoteness, mr.remoteness) AS remoteness,
              dd.avg_irsd_decile, dd.avg_irsd_score,
              dd.indexed_entities, dd.community_controlled_entities,
              dd.total_funding_all_sources, dd.desert_score,
+             jt.justice_total AS justice_funding_total,
              COALESCE(un.unplaced, 0) AS unplaced_count,
              COALESCE(pl.placed, 0) AS placed_count,
              CASE WHEN COALESCE(un.unplaced, 0) + COALESCE(pl.placed, 0) > 0
@@ -123,6 +132,7 @@ export async function GET(request: Request) {
       LEFT JOIN modal_remoteness mr ON mr.lga_name = lc.lga_name AND mr.state = lc.state
       LEFT JOIN unplaced un ON un.lga_name = lc.lga_name AND un.state = lc.state
       LEFT JOIN placed pl ON pl.lga_name = lc.lga_name AND pl.state = lc.state
+      LEFT JOIN justice jt ON jt.lga_name = lc.lga_name AND jt.state = lc.state
       WHERE dd.desert_score IS NOT NULL OR COALESCE(un.unplaced, 0) > 0
       ORDER BY dd.desert_score DESC NULLS LAST`,
     });
@@ -135,6 +145,7 @@ export async function GET(request: Request) {
       indexed_entities: number | null; community_controlled_entities: number | null;
       total_funding_all_sources: number | null; lat: number | null; lng: number | null;
       unplaced_count: number; placed_count: number; unplaced_share: number | null;
+      justice_funding_total: number | null;
     }>;
 
     // Councils with data but no point coordinates render only where a map

--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -377,7 +377,7 @@ export default function AtlasClient({
       {/* Left rail: what you are looking at, and what it contains.
           Story mode clears the stage: the paragraph does this job there. */}
       {!story && (
-      <div className="absolute left-4 top-20 z-[900] w-[min(22rem,calc(100vw-2rem))] max-h-[calc(100dvh-6.5rem)] overflow-y-auto space-y-4 pr-1">
+      <div className="absolute left-4 top-20 z-[900] w-[min(22rem,calc(100vw-2rem))] max-h-[calc(100dvh-11.5rem)] overflow-y-auto space-y-4 pr-1">
         {/* Brand + layer picker */}
         <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
           <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-red">CivicGraph</p>
@@ -386,7 +386,10 @@ export default function AtlasClient({
             Every layer carries what its number contains.
           </p>
 
-          <div className="mt-4 space-y-1.5">
+          <p className="mt-4 mb-1.5 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+            Layers · pick one to switch the map
+          </p>
+          <div className="space-y-1.5">
             {LAYERS.map(layer => {
               const active = layer.key === activeKey;
               const declared = !isLiveLayer(layer);
@@ -394,7 +397,7 @@ export default function AtlasClient({
                 <button
                   key={layer.key}
                   onClick={() => pickLayer(layer.key)}
-                  className={`w-full flex items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-bold uppercase tracking-wider transition-colors border-2 ${
+                  className={`w-full flex items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-bold uppercase tracking-wider transition-colors border-2 cursor-pointer ${
                     active
                       ? 'bg-bauhaus-red border-bauhaus-red text-white'
                       : declared
@@ -414,12 +417,15 @@ export default function AtlasClient({
           </div>
 
           {/* State filter */}
-          <div className="mt-4 flex flex-wrap gap-1">
+          <p className="mt-4 mb-1.5 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+            State
+          </p>
+          <div className="flex flex-wrap gap-1">
             {STATES.map(s => (
               <button
                 key={s}
                 onClick={() => { setStateFilter(s); setSelected(null); }}
-                className={`text-[10px] px-2 py-1 font-bold uppercase tracking-wider transition-colors ${
+                className={`text-[10px] px-2 py-1 font-bold uppercase tracking-wider transition-colors cursor-pointer ${
                   stateFilter === s
                     ? 'bg-bauhaus-black text-white'
                     : 'bg-white text-gray-500 border border-gray-200 hover:border-bauhaus-black'
@@ -433,7 +439,7 @@ export default function AtlasClient({
           {/* The URL always mirrors the view, so the link IS the presentation */}
           <button
             onClick={copyLink}
-            className="mt-4 w-full border-2 border-bauhaus-black px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+            className="mt-4 w-full border-2 border-bauhaus-black px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors cursor-pointer"
           >
             {copied ? 'Link copied' : 'Copy link to this view'}
           </button>
@@ -441,7 +447,7 @@ export default function AtlasClient({
           {/* The fixed sequence for a room */}
           <button
             onClick={() => enterStory(0)}
-            className="mt-2 w-full border-2 border-bauhaus-blue text-bauhaus-blue px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-blue hover:text-white transition-colors"
+            className="mt-2 w-full border-2 border-bauhaus-blue text-bauhaus-blue px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-blue hover:text-white transition-colors cursor-pointer"
           >
             Story mode · tell it in a room
           </button>
@@ -473,6 +479,45 @@ export default function AtlasClient({
             </p>
           )}
 
+          {/* The colour scale lives WITH the caveat: what the number contains
+              and what the colours mean are one explanation. */}
+          {(() => {
+            const legendLayer = isLiveLayer(activeLayer) ? activeLayer : mapLayer;
+            return (
+              <div className="mt-3 pt-3 border-t border-gray-200">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-1.5">
+                  Colours{legendLayer.key !== activeLayer.key ? ` · still showing ${legendLayer.name.toLowerCase()}` : ''}
+                </p>
+                <div className="space-y-1">
+                  {legendLayer.scale.map(stop => (
+                    <div key={stop.min} className="flex items-center gap-2 text-[11px] text-gray-600">
+                      <span
+                        className="inline-block w-3.5 h-3.5 border border-bauhaus-black/30 shrink-0"
+                        style={{ backgroundColor: stop.color, opacity: 0.85 }}
+                      />
+                      <span>{stop.label}</span>
+                    </div>
+                  ))}
+                  <div className="flex items-center gap-2 text-[11px] text-gray-400">
+                    <span className="inline-block w-3.5 h-3.5 border border-gray-300 shrink-0" style={{ backgroundColor: '#e5e7eb' }} />
+                    <span>{legendLayer.noDataLabel}</span>
+                  </div>
+                </div>
+                {legendLayer.scaleNote && (
+                  <p className="text-[10px] text-gray-400 mt-1.5 leading-snug">{legendLayer.scaleNote}</p>
+                )}
+                {isPointLayer(legendLayer) && (
+                  <p className="text-[10px] text-gray-400 mt-1.5 leading-snug">
+                    Drawn as circles over the {mapLayer.name.toLowerCase()} choropleth.
+                  </p>
+                )}
+                <p className="text-[10px] text-gray-400 mt-1.5 leading-snug">
+                  {filtered.length} councils{undrawn > 0 ? `; ${undrawn} hold no coordinates and render only where a boundary name matches` : ''}.
+                </p>
+              </div>
+            );
+          })()}
+
           <div className="mt-3 pt-3 border-t border-gray-200">
             <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
               Honest at: <span className="text-bauhaus-black">{activeLayer.honestAt}</span> level
@@ -483,44 +528,11 @@ export default function AtlasClient({
       </div>
       )}
 
-      {/* Legend for the painted layer. It stays up in story mode — the room
-          needs to know what the colours mean — but yields on small screens. */}
-      {!loading && !failed && (
-        <div className={`absolute left-4 bottom-4 z-[900] bg-white border-2 border-bauhaus-black p-3 w-[min(15rem,calc(100vw-2rem))] ${story ? 'hidden lg:block' : ''}`}>
-          <p className="text-[10px] font-bold uppercase tracking-widest mb-2">
-            {activePointLayer ? activePointLayer.name : mapLayer.name}
-          </p>
-          <div className="space-y-1">
-            {(activePointLayer ?? mapLayer).scale.map(stop => (
-              <div key={stop.min} className="flex items-center gap-2 text-[11px] text-gray-600">
-                <span
-                  className={`inline-block w-3.5 h-3.5 border shrink-0 ${activePointLayer ? 'border-bauhaus-black' : 'border-bauhaus-black/30'}`}
-                  style={{ backgroundColor: stop.color, opacity: 0.85 }}
-                />
-                <span>{stop.label}</span>
-              </div>
-            ))}
-            <div className="flex items-center gap-2 text-[11px] text-gray-400">
-              <span className="inline-block w-3.5 h-3.5 border border-gray-300 shrink-0" style={{ backgroundColor: '#e5e7eb' }} />
-              <span>{(activePointLayer ?? mapLayer).noDataLabel}</span>
-            </div>
-          </div>
-          {activePointLayer && (
-            <p className="text-[10px] text-gray-400 mt-2 leading-snug">
-              Circles sit over the {mapLayer.name.toLowerCase()} choropleth.
-            </p>
-          )}
-          <p className="text-[10px] text-gray-400 mt-2 leading-snug">
-            {filtered.length} councils{undrawn > 0 ? `; ${undrawn} hold no coordinates and render only where a boundary name matches` : ''}.
-          </p>
-        </div>
-      )}
-
       {/* Right rail: the door to every place. Search when nothing is chosen,
           the place's numbers when something is. On small screens the rail
           appears only for a selection. Story mode clears it. */}
       {!loading && !failed && !story && (
-        <div className={`absolute right-4 top-20 z-[900] w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-6.5rem)] overflow-y-auto ${selected ? '' : 'hidden lg:block'}`}>
+        <div className={`absolute right-4 top-20 z-[900] w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-10.5rem)] overflow-y-auto ${selected ? '' : 'hidden lg:block'}`}>
           {selected ? (
             <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
               <div className="flex items-start justify-between gap-2">
@@ -533,7 +545,7 @@ export default function AtlasClient({
                 <button
                   onClick={() => setSelected(null)}
                   aria-label="Close"
-                  className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors"
+                  className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors cursor-pointer"
                 >
                   ×
                 </button>
@@ -647,7 +659,7 @@ export default function AtlasClient({
                 <div className="flex gap-2">
                   <button
                     onClick={() => downloadFile(`${exportFilename(selected)}.csv`, 'text/csv', councilCsv(selected))}
-                    className="flex-1 border-2 border-bauhaus-black px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+                    className="flex-1 border-2 border-bauhaus-black px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors cursor-pointer"
                   >
                     CSV
                   </button>
@@ -659,7 +671,7 @@ export default function AtlasClient({
                         JSON.stringify({ generated_at: new Date().toISOString(), ...councilJson(selected) }, null, 2)
                       )
                     }
-                    className="flex-1 border-2 border-bauhaus-black px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+                    className="flex-1 border-2 border-bauhaus-black px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors cursor-pointer"
                   >
                     JSON
                   </button>
@@ -694,7 +706,7 @@ export default function AtlasClient({
                       <button
                         key={`${f.lga_name}|${f.state}`}
                         onClick={() => selectPlace(f)}
-                        className="w-full flex items-center justify-between gap-2 text-xs px-1 py-1 hover:bg-gray-50 text-left transition-colors"
+                        className="w-full flex items-center justify-between gap-2 text-xs px-1 py-1 hover:bg-gray-50 text-left transition-colors cursor-pointer"
                       >
                         <span className="font-medium truncate">{f.lga_name}</span>
                         <span className="text-gray-400 shrink-0">{f.state}</span>
@@ -717,7 +729,7 @@ export default function AtlasClient({
                     <button
                       key={`${f.lga_name}|${f.state}`}
                       onClick={() => selectPlace(f)}
-                      className="w-full flex items-center justify-between gap-2 text-xs px-1 py-0.5 hover:bg-gray-50 text-left transition-colors"
+                      className="w-full flex items-center justify-between gap-2 text-xs px-1 py-0.5 hover:bg-gray-50 text-left transition-colors cursor-pointer"
                     >
                       <span className="font-medium truncate">{f.lga_name}</span>
                       <span className="flex items-center gap-2 shrink-0">
@@ -748,7 +760,7 @@ export default function AtlasClient({
                 <button
                   onClick={exitStory}
                   aria-label="Exit story mode"
-                  className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors"
+                  className="shrink-0 w-7 h-7 border-2 border-bauhaus-black font-black hover:bg-bauhaus-black hover:text-white transition-colors cursor-pointer"
                 >
                   ×
                 </button>
@@ -759,6 +771,16 @@ export default function AtlasClient({
               {story.title}
             </h2>
             <p className="text-base md:text-lg leading-relaxed mt-3">{story.paragraph}</p>
+
+            {/* What the colours behind this sentence mean */}
+            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+              {mapLayer.scale.map(stop => (
+                <span key={stop.min} className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                  <span className="inline-block w-3 h-3 border border-bauhaus-black/30" style={{ backgroundColor: stop.color, opacity: 0.85 }} />
+                  {stop.label}
+                </span>
+              ))}
+            </div>
 
             {story.cannotSay && (
               <div className="mt-4 border-l-4 border-bauhaus-red pl-3">
@@ -773,7 +795,7 @@ export default function AtlasClient({
               <button
                 onClick={() => moveStory(-1)}
                 disabled={storyIdx === 0}
-                className="border-2 border-bauhaus-black px-4 py-2 text-[10px] font-bold uppercase tracking-widest disabled:opacity-30 disabled:cursor-default hover:enabled:bg-bauhaus-black hover:enabled:text-white transition-colors"
+                className="border-2 border-bauhaus-black px-4 py-2 text-[10px] font-bold uppercase tracking-widest cursor-pointer disabled:opacity-30 disabled:cursor-default hover:enabled:bg-bauhaus-black hover:enabled:text-white transition-colors"
               >
                 ← Back
               </button>
@@ -783,14 +805,14 @@ export default function AtlasClient({
               {storyIdx === ATLAS_STORY.length - 1 ? (
                 <button
                   onClick={exitStory}
-                  className="border-2 border-bauhaus-black bg-bauhaus-black text-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest hover:bg-white hover:text-bauhaus-black transition-colors"
+                  className="border-2 border-bauhaus-black bg-bauhaus-black text-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest hover:bg-white hover:text-bauhaus-black transition-colors cursor-pointer"
                 >
                   Open the Atlas →
                 </button>
               ) : (
                 <button
                   onClick={() => moveStory(1)}
-                  className="border-2 border-bauhaus-black bg-bauhaus-black text-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest hover:bg-white hover:text-bauhaus-black transition-colors"
+                  className="border-2 border-bauhaus-black bg-bauhaus-black text-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest hover:bg-white hover:text-bauhaus-black transition-colors cursor-pointer"
                 >
                   Next →
                 </button>

--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { money } from '@/lib/format';
 import {
+  ATLAS_GROUP_LABELS,
+  ATLAS_GROUP_ORDER,
   DEFAULT_ATLAS_LAYER_KEY,
   getAtlasLayer,
   isChoroplethLayer,
@@ -112,6 +114,9 @@ export default function AtlasClient({
   const [entities, setEntities] = useState<RailEntity[]>([]);
   const [loadingEntities, setLoadingEntities] = useState(false);
   const [copied, setCopied] = useState(false);
+  // The right rail docks open and can be hidden; selecting a place reopens
+  // it, because a selection with nowhere to land is a dead click.
+  const [railOpen, setRailOpen] = useState(true);
   // Story mode: index into ATLAS_STORY, or null when browsing freely.
   const [storyIdx, setStoryIdx] = useState<number | null>(null);
   // URL state only starts writing after the inbound URL has been applied.
@@ -145,6 +150,7 @@ export default function AtlasClient({
   function selectPlace(f: AtlasFeature) {
     setSelected(f);
     setQuery('');
+    setRailOpen(true);
     // A selection hidden by the state filter would be invisible — follow it.
     if (stateFilter !== 'ALL' && f.state !== stateFilter) setStateFilter(f.state);
   }
@@ -335,8 +341,10 @@ export default function AtlasClient({
   }
 
   return (
-    <div className="fixed inset-0 z-0 bg-bauhaus-canvas">
-      {/* The map is the page. Everything else overlays it. */}
+    <div className="fixed inset-0 z-0 bg-bauhaus-canvas flex">
+      {/* CENTER — the map between the rails. isolate traps Leaflet's
+          internal z-indexes so the docked rails paint above its edges. */}
+      <div className="relative flex-1 min-w-0 order-2 isolate">
       <div className="absolute inset-0">
         {loading ? (
           <div className="flex items-center justify-center h-full">
@@ -374,12 +382,23 @@ export default function AtlasClient({
         </Link>
       )}
 
-      {/* Left rail: what you are looking at, and what it contains.
+      {/* Reopen tab when the right rail is hidden */}
+      {!story && !railOpen && !loading && !failed && (
+        <button
+          onClick={() => setRailOpen(true)}
+          className="absolute right-0 top-24 z-[900] bg-bauhaus-black text-white px-1.5 py-4 text-[10px] font-bold uppercase tracking-widest [writing-mode:vertical-rl] hover:bg-bauhaus-red transition-colors cursor-pointer"
+        >
+          Place rail ◂
+        </button>
+      )}
+      </div>
+
+      {/* LEFT — the locked rail: what you are looking at, what it contains.
           Story mode clears the stage: the paragraph does this job there. */}
       {!story && (
-      <div className="absolute left-4 top-20 z-[900] w-[min(22rem,calc(100vw-2rem))] max-h-[calc(100dvh-11.5rem)] overflow-y-auto space-y-4 pr-1">
+      <aside className="order-1 relative z-10 hidden md:block w-[21rem] shrink-0 bg-white border-r-4 border-bauhaus-black overflow-y-auto pt-20 px-4 pb-6">
         {/* Brand + layer picker */}
-        <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
+        <div>
           <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-red">CivicGraph</p>
           <h1 className="text-2xl font-black uppercase tracking-wider leading-none mt-1">The Atlas</h1>
           <p className="text-xs text-gray-500 mt-2">
@@ -389,32 +408,43 @@ export default function AtlasClient({
           <p className="mt-4 mb-1.5 text-[10px] font-bold uppercase tracking-widest text-gray-400">
             Layers · pick one to switch the map
           </p>
-          <div className="space-y-1.5">
-            {LAYERS.map(layer => {
-              const active = layer.key === activeKey;
-              const declared = !isLiveLayer(layer);
-              return (
-                <button
-                  key={layer.key}
-                  onClick={() => pickLayer(layer.key)}
-                  className={`w-full flex items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-bold uppercase tracking-wider transition-colors border-2 cursor-pointer ${
-                    active
-                      ? 'bg-bauhaus-red border-bauhaus-red text-white'
-                      : declared
-                        ? 'bg-white border-dashed border-gray-300 text-gray-400 hover:border-bauhaus-yellow'
-                        : 'bg-white border-bauhaus-black text-bauhaus-black hover:bg-bauhaus-black hover:text-white'
-                  }`}
-                >
-                  <span>{layer.name}</span>
-                  {declared && (
-                    <span className={`shrink-0 text-[9px] px-1.5 py-0.5 border ${active ? 'border-white/60 text-white' : 'border-bauhaus-yellow bg-bauhaus-yellow/20 text-bauhaus-black'}`}>
-                      Not yet held
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
+          {ATLAS_GROUP_ORDER.map(groupKey => {
+            const groupLayers = LAYERS.filter(l => l.group === groupKey);
+            if (groupLayers.length === 0) return null;
+            return (
+              <div key={groupKey} className="mb-2.5">
+                <p className="mb-1 text-[9px] font-bold uppercase tracking-widest text-gray-300">
+                  {ATLAS_GROUP_LABELS[groupKey]}
+                </p>
+                <div className="space-y-1.5">
+                  {groupLayers.map(layer => {
+                    const active = layer.key === activeKey;
+                    const declared = !isLiveLayer(layer);
+                    return (
+                      <button
+                        key={layer.key}
+                        onClick={() => pickLayer(layer.key)}
+                        className={`w-full flex items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-bold uppercase tracking-wider transition-colors border-2 cursor-pointer ${
+                          active
+                            ? 'bg-bauhaus-red border-bauhaus-red text-white'
+                            : declared
+                              ? 'bg-white border-dashed border-gray-300 text-gray-400 hover:border-bauhaus-yellow'
+                              : 'bg-white border-bauhaus-black text-bauhaus-black hover:bg-bauhaus-black hover:text-white'
+                        }`}
+                      >
+                        <span>{layer.name}</span>
+                        {declared && (
+                          <span className={`shrink-0 text-[9px] px-1.5 py-0.5 border ${active ? 'border-white/60 text-white' : 'border-bauhaus-yellow bg-bauhaus-yellow/20 text-bauhaus-black'}`}>
+                            Not yet held
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
 
           {/* State filter */}
           <p className="mt-4 mb-1.5 text-[10px] font-bold uppercase tracking-widest text-gray-400">
@@ -451,10 +481,10 @@ export default function AtlasClient({
           >
             Story mode · tell it in a room
           </button>
-        </div>
 
-        {/* The caveat, attached to the number — not a help page */}
-        <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
+          {/* The caveat, attached to the number — same card, one explanation
+              (Ben 2026-08-09: separate floating boxes read as clutter) */}
+          <div className="mt-4 pt-4 border-t-2 border-bauhaus-black">
           <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-red">
             What this number contains
           </p>
@@ -524,17 +554,26 @@ export default function AtlasClient({
             </p>
             <p className="text-xs text-gray-500 mt-1">{activeLayer.honestAtNote}</p>
           </div>
+          </div>
         </div>
-      </div>
+      </aside>
       )}
 
       {/* Right rail: the door to every place. Search when nothing is chosen,
           the place's numbers when something is. On small screens the rail
           appears only for a selection. Story mode clears it. */}
-      {!loading && !failed && !story && (
-        <div className={`absolute right-4 top-20 z-[900] w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100dvh-10.5rem)] overflow-y-auto ${selected ? '' : 'hidden lg:block'}`}>
+      {!loading && !failed && !story && railOpen && (
+        <aside className="order-3 relative z-10 hidden sm:block w-[min(20rem,85vw)] shrink-0 bg-white border-l-4 border-bauhaus-black overflow-y-auto pt-20 px-4 pb-6">
+          <div className="flex justify-end mb-2">
+            <button
+              onClick={() => setRailOpen(false)}
+              className="text-[10px] font-bold uppercase tracking-widest text-gray-400 hover:text-bauhaus-black transition-colors cursor-pointer"
+            >
+              Hide ▸
+            </button>
+          </div>
           {selected ? (
-            <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
+            <div>
               <div className="flex items-start justify-between gap-2">
                 <div>
                   <h3 className="font-black text-lg uppercase tracking-wider leading-tight">{selected.lga_name}</h3>
@@ -560,6 +599,14 @@ export default function AtlasClient({
                   })()}
                 </span>
               </div>
+
+              {/* Uncertainty travels with every number, on every layer */}
+              {Number(selected.unplaced_share) >= 50 && (
+                <p className="mt-2 text-[11px] text-bauhaus-red leading-snug">
+                  Half or more of what might be here cannot be placed — read every
+                  number on this panel gently.
+                </p>
+              )}
 
               <div className="mt-3 space-y-2">
                 {otherLiveLayers.map(layer => {
@@ -690,7 +737,7 @@ export default function AtlasClient({
               </p>
             </div>
           ) : (
-            <div className="bg-white border-4 border-bauhaus-black shadow-[8px_8px_0_0_#121212] p-4">
+            <div>
               <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">Find a place</p>
               <input
                 type="text"
@@ -742,7 +789,7 @@ export default function AtlasClient({
               </div>
             </div>
           )}
-        </div>
+        </aside>
       )}
 
       {/* Story mode: one map state, one paragraph, read aloud. */}

--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -7,10 +7,14 @@ import { money } from '@/lib/format';
 import {
   DEFAULT_ATLAS_LAYER_KEY,
   getAtlasLayer,
+  isChoroplethLayer,
   isLiveLayer,
+  isPointLayer,
   visibleAtlasLayers,
   type AtlasFeature,
   type AtlasLiveLayer,
+  type AtlasPoint,
+  type AtlasSurface,
 } from '@/lib/atlas/layers';
 import {
   buildAtlasUrl,
@@ -32,9 +36,6 @@ import {
 // Lazy-load the map to avoid SSR issues with Leaflet
 const AtlasMap = dynamic(() => import('./atlas-map'), { ssr: false });
 
-// This is the public surface: org and withheld layers never reach it.
-const LAYERS = visibleAtlasLayers('public');
-
 const STATES = ['ALL', 'NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
 
 /** A council that has a full /place/council/[slug] prose page. */
@@ -42,6 +43,24 @@ export interface CouncilPageLink {
   slug: string;
   lgaName: string;
   state: string | null;
+}
+
+interface AtlasClientProps {
+  councilPages: CouncilPageLink[];
+  /** Which consent tiers render here. 'public' (default) shows public layers
+   * only; 'org' adds org-tier layers. Withheld renders nowhere. */
+  surface?: AtlasSurface;
+  /** Point-layer data, keyed by layer key. Only a server component that sits
+   * behind the right gate may pass this — it is how org data stays org-side. */
+  pointsByLayer?: Partial<Record<string, AtlasPoint[]>>;
+  /** Server-fed lines shown under a layer's caveat (e.g. canon figures that
+   * must not ship in the public registry bundle). */
+  layerNotes?: Partial<Record<string, string>>;
+  /** Layer to open on. Falls back to the default when it is not visible here. */
+  initialLayerKey?: string;
+  /** Escape hatch for chromeless surfaces (the org workspace has no global
+   * nav above the Atlas). */
+  backLink?: { href: string; label: string };
 }
 
 interface RailEntity {
@@ -63,15 +82,31 @@ function downloadFile(name: string, mime: string, text: string) {
   URL.revokeObjectURL(url);
 }
 
-export default function AtlasClient({ councilPages }: { councilPages: CouncilPageLink[] }) {
+export default function AtlasClient({
+  councilPages,
+  surface = 'public',
+  pointsByLayer,
+  layerNotes,
+  initialLayerKey,
+  backLink,
+}: AtlasClientProps) {
+  // The one sanctioned filter: org and withheld layers never reach a public
+  // instance of this component.
+  const LAYERS = useMemo(() => visibleAtlasLayers(surface), [surface]);
+
   const [features, setFeatures] = useState<AtlasFeature[]>([]);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [stateFilter, setStateFilter] = useState('ALL');
   const [selected, setSelected] = useState<AtlasFeature | null>(null);
-  // The layer being read (caveat card) can be declared; the layer being
-  // painted (the map) is always the last live pick.
-  const [activeKey, setActiveKey] = useState(DEFAULT_ATLAS_LAYER_KEY);
+  // The layer being read (caveat card) can be declared or point-grain; the
+  // layer painting the choropleth is always the last choropleth pick.
+  const [activeKey, setActiveKey] = useState(() => {
+    const initial = initialLayerKey ? getAtlasLayer(initialLayerKey) : null;
+    return initial && visibleAtlasLayers(surface).some(l => l.key === initial.key)
+      ? initial.key
+      : DEFAULT_ATLAS_LAYER_KEY;
+  });
   const [mapKey, setMapKey] = useState(DEFAULT_ATLAS_LAYER_KEY);
   const [query, setQuery] = useState('');
   const [entities, setEntities] = useState<RailEntity[]>([]);
@@ -104,7 +139,7 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
   function pickLayer(key: string) {
     setActiveKey(key);
     const layer = getAtlasLayer(key);
-    if (layer && isLiveLayer(layer)) setMapKey(key);
+    if (layer && isChoroplethLayer(layer)) setMapKey(key);
   }
 
   function selectPlace(f: AtlasFeature) {
@@ -238,8 +273,16 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
   const undrawn = useMemo(() => filtered.filter(f => f.lat === null).length, [filtered]);
 
   const otherLiveLayers = useMemo(
-    () => LAYERS.filter(isLiveLayer).filter(l => l.key !== mapLayer.key),
-    [mapLayer.key]
+    () => LAYERS.filter(isChoroplethLayer).filter(l => l.key !== mapLayer.key),
+    [LAYERS, mapLayer.key]
+  );
+
+  // The active layer's points, when it is point-grain and this surface holds
+  // data for it. A public instance passes no points, so nothing renders.
+  const activePointLayer = isPointLayer(activeLayer) ? activeLayer : null;
+  const activePoints = useMemo(
+    () => (activePointLayer ? pointsByLayer?.[activePointLayer.key] ?? [] : []),
+    [activePointLayer, pointsByLayer]
   );
 
   // Search over every council we hold, not just the filtered view.
@@ -315,9 +358,21 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
             layer={mapLayer}
             selected={selected}
             onSelect={selectPlace}
+            pointLayer={activePointLayer}
+            points={activePoints}
           />
         )}
       </div>
+
+      {/* Escape hatch for chromeless surfaces (org workspace) */}
+      {backLink && (
+        <Link
+          href={backLink.href}
+          className="absolute right-4 top-4 z-[950] bg-white border-2 border-bauhaus-black px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest hover:bg-bauhaus-black hover:text-white transition-colors"
+        >
+          ← {backLink.label}
+        </Link>
+      )}
 
       {/* Left rail: what you are looking at, and what it contains.
           Story mode clears the stage: the paragraph does this job there. */}
@@ -411,6 +466,13 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
             </div>
           )}
 
+          {/* Server-fed note: figures that belong to this surface only */}
+          {layerNotes?.[activeLayer.key] && (
+            <p className="mt-3 border-l-4 border-bauhaus-blue pl-3 text-xs text-gray-600">
+              {layerNotes[activeLayer.key]}
+            </p>
+          )}
+
           <div className="mt-3 pt-3 border-t border-gray-200">
             <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
               Honest at: <span className="text-bauhaus-black">{activeLayer.honestAt}</span> level
@@ -425,19 +487,29 @@ export default function AtlasClient({ councilPages }: { councilPages: CouncilPag
           needs to know what the colours mean — but yields on small screens. */}
       {!loading && !failed && (
         <div className={`absolute left-4 bottom-4 z-[900] bg-white border-2 border-bauhaus-black p-3 w-[min(15rem,calc(100vw-2rem))] ${story ? 'hidden lg:block' : ''}`}>
-          <p className="text-[10px] font-bold uppercase tracking-widest mb-2">{mapLayer.name}</p>
+          <p className="text-[10px] font-bold uppercase tracking-widest mb-2">
+            {activePointLayer ? activePointLayer.name : mapLayer.name}
+          </p>
           <div className="space-y-1">
-            {mapLayer.scale.map(stop => (
+            {(activePointLayer ?? mapLayer).scale.map(stop => (
               <div key={stop.min} className="flex items-center gap-2 text-[11px] text-gray-600">
-                <span className="inline-block w-3.5 h-3.5 border border-bauhaus-black/30 shrink-0" style={{ backgroundColor: stop.color, opacity: 0.85 }} />
+                <span
+                  className={`inline-block w-3.5 h-3.5 border shrink-0 ${activePointLayer ? 'border-bauhaus-black' : 'border-bauhaus-black/30'}`}
+                  style={{ backgroundColor: stop.color, opacity: 0.85 }}
+                />
                 <span>{stop.label}</span>
               </div>
             ))}
             <div className="flex items-center gap-2 text-[11px] text-gray-400">
               <span className="inline-block w-3.5 h-3.5 border border-gray-300 shrink-0" style={{ backgroundColor: '#e5e7eb' }} />
-              <span>{mapLayer.noDataLabel}</span>
+              <span>{(activePointLayer ?? mapLayer).noDataLabel}</span>
             </div>
           </div>
+          {activePointLayer && (
+            <p className="text-[10px] text-gray-400 mt-2 leading-snug">
+              Circles sit over the {mapLayer.name.toLowerCase()} choropleth.
+            </p>
+          )}
           <p className="text-[10px] text-gray-400 mt-2 leading-snug">
             {filtered.length} councils{undrawn > 0 ? `; ${undrawn} hold no coordinates and render only where a boundary name matches` : ''}.
           </p>

--- a/apps/web/src/app/atlas/atlas-map.tsx
+++ b/apps/web/src/app/atlas/atlas-map.tsx
@@ -37,14 +37,29 @@ const STATE_ABBREV: Record<string, string> = {
   'Other Territories': 'OT',
 };
 
+// External territories (Christmas Island, Cocos, Norfolk) are real councils
+// and still render, but letting them drive the frame drags the view halfway
+// to Indonesia. The camera fits the mainland box; the data keeps everything.
+function frameCoords(features: AtlasFeature[]): { lats: number[]; lngs: number[] } {
+  const located = features.filter(f => f.lat != null && f.lng != null);
+  const inFrame = located.filter(f => {
+    const lat = Number(f.lat);
+    const lng = Number(f.lng);
+    return lat >= -44.5 && lat <= -9 && lng >= 112 && lng <= 154.5;
+  });
+  const use = inFrame.length > 0 ? inFrame : located;
+  return {
+    lats: use.map(f => Number(f.lat)).filter(v => !isNaN(v)),
+    lngs: use.map(f => Number(f.lng)).filter(v => !isNaN(v)),
+  };
+}
+
 // Fit bounds when the visible set changes
 function FitBounds({ features }: { features: AtlasFeature[] }) {
   const map = useMap();
   useEffect(() => {
     if (features.length === 0) return;
-    const located = features.filter(f => f.lat != null && f.lng != null);
-    const lats = located.map(f => Number(f.lat)).filter(v => !isNaN(v));
-    const lngs = located.map(f => Number(f.lng)).filter(v => !isNaN(v));
+    const { lats, lngs } = frameCoords(features);
     if (lats.length === 0) return;
     const bounds = L.latLngBounds(
       [Math.min(...lats), Math.min(...lngs)],
@@ -156,9 +171,7 @@ export default function AtlasMap({ features, layer, selected, onSelect, pointLay
   // Compute center from features
   const center = useMemo<[number, number]>(() => {
     if (features.length === 0) return [-25.5, 134.0];
-    const located = features.filter(f => f.lat != null && f.lng != null);
-    const lats = located.map(f => Number(f.lat)).filter(v => !isNaN(v));
-    const lngs = located.map(f => Number(f.lng)).filter(v => !isNaN(v));
+    const { lats, lngs } = frameCoords(features);
     if (lats.length === 0) return [-25.5, 134.0];
     return [
       (Math.min(...lats) + Math.max(...lats)) / 2,
@@ -180,8 +193,9 @@ export default function AtlasMap({ features, layer, selected, onSelect, pointLay
       scrollWheelZoom={true}
       zoomControl={false}
     >
-      {/* Default zoom control sits top-left, which the Atlas overlays occupy */}
-      <ZoomControl position="bottomright" />
+      {/* Top-left holds the Atlas overlays; bottom-right holds the chat
+          bubble and attribution. Bottom-left is the quiet corner. */}
+      <ZoomControl position="bottomleft" />
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>'
         url="https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png"

--- a/apps/web/src/app/atlas/atlas-map.tsx
+++ b/apps/web/src/app/atlas/atlas-map.tsx
@@ -10,6 +10,8 @@ import {
   ATLAS_NO_DATA_STYLE,
   type AtlasFeature,
   type AtlasLiveLayer,
+  type AtlasPoint,
+  type AtlasPointLayer,
 } from '@/lib/atlas/layers';
 
 interface AtlasMapProps {
@@ -17,6 +19,10 @@ interface AtlasMapProps {
   layer: AtlasLiveLayer;
   selected: AtlasFeature | null;
   onSelect: (f: AtlasFeature) => void;
+  /** A point-grain layer drawn over the choropleth. Its data arrives from
+   * the surface that is allowed to hold it; this component just draws. */
+  pointLayer?: AtlasPointLayer | null;
+  points?: AtlasPoint[];
 }
 
 const STATE_ABBREV: Record<string, string> = {
@@ -49,7 +55,7 @@ function FitBounds({ features }: { features: AtlasFeature[] }) {
   return null;
 }
 
-export default function AtlasMap({ features, layer, selected, onSelect }: AtlasMapProps) {
+export default function AtlasMap({ features, layer, selected, onSelect, pointLayer, points }: AtlasMapProps) {
   const [geoData, setGeoData] = useState<FeatureCollection | null>(null);
   const [geoLoading, setGeoLoading] = useState(true);
 
@@ -223,6 +229,40 @@ export default function AtlasMap({ features, layer, selected, onSelect }: AtlasM
               <div className="text-xs">
                 <strong>{f.lga_name}</strong> ({f.state})<br />
                 {layer.name}: <strong>{layer.format(value)}</strong>
+              </div>
+            </Tooltip>
+          </CircleMarker>
+        );
+      })}
+
+      {/* Point-grain layer over the choropleth (e.g. Goods in community,
+          org-side). Radius follows the square root so a big place does not
+          drown a small one. */}
+      {pointLayer && points?.map(p => {
+        const paint = atlasStyleFor(pointLayer, p.value);
+        return (
+          <CircleMarker
+            key={`point-${p.name}`}
+            center={[p.lat, p.lng]}
+            radius={Math.max(6, Math.min(6 + Math.sqrt(p.value) * 1.6, 26))}
+            pathOptions={{
+              fillColor: paint.color,
+              fillOpacity: paint.fillOpacity,
+              color: '#121212',
+              weight: 2,
+            }}
+          >
+            <Tooltip>
+              <div className="text-xs">
+                <strong>{p.name}</strong>
+                <br />
+                {pointLayer.name}: <strong>{pointLayer.format(p.value)}</strong>
+                {p.detail?.map(d => (
+                  <span key={d.label}>
+                    <br />
+                    {d.label}: {d.value}
+                  </span>
+                ))}
               </div>
             </Tooltip>
           </CircleMarker>

--- a/apps/web/src/app/atlas/atlas-map.tsx
+++ b/apps/web/src/app/atlas/atlas-map.tsx
@@ -54,6 +54,18 @@ function frameCoords(features: AtlasFeature[]): { lats: number[]; lngs: number[]
   };
 }
 
+// Docked rails resize the map's container when they open and close; Leaflet
+// has to be told, or it leaves a grey band where the rail used to be.
+function InvalidateOnResize() {
+  const map = useMap();
+  useEffect(() => {
+    const observer = new ResizeObserver(() => map.invalidateSize());
+    observer.observe(map.getContainer());
+    return () => observer.disconnect();
+  }, [map]);
+  return null;
+}
+
 // Fit bounds when the visible set changes
 function FitBounds({ features }: { features: AtlasFeature[] }) {
   const map = useMap();
@@ -284,6 +296,7 @@ export default function AtlasMap({ features, layer, selected, onSelect, pointLay
       })}
 
       <FitBounds features={features} />
+      <InvalidateOnResize />
     </MapContainer>
   );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -228,7 +228,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           </>
         )}
         <ShortlistBar />
-        <DeferredChatDrawer delayMs={isFastPublicPath ? 2500 : 1000} />
+        {/* The Atlas is a full-viewport map; the chat bubble sat on its
+            bottom corner controls (Ben, 2026-08-09: no AI button there). */}
+        {!pathname.startsWith('/atlas') && (
+          <DeferredChatDrawer delayMs={isFastPublicPath ? 2500 : 1000} />
+        )}
         </ShortlistProvider>
       </body>
     </html>

--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -314,7 +314,7 @@ function WorkspaceModeLink({ href, label, active, index, hint }: WorkspaceLink &
 const GOODS_RAIL_SECTIONS: ReadonlyArray<{ label: string; items: ReadonlyArray<readonly [string, string]> }> = [
   { label: 'Work', items: [['today', 'Today'], ['capital', 'Capital'], ['matters', 'Matters'], ['network', 'Network'], ['applications', 'Applications'], ['learning', 'Learning']] },
   { label: 'Money in', items: [['foundations', 'Foundations'], ['foundations/scan', 'Funder Scan'], ['grants', 'Grants'], ['money', 'Money']] },
-  { label: 'Delivery', items: [['funnel', 'Delivery map'], ['communities', 'Communities'], ['channels', 'Channels'], ['buyers', 'Buyers']] },
+  { label: 'Delivery', items: [['funnel', 'Delivery map'], ['map', 'On the map'], ['communities', 'Communities'], ['channels', 'Channels'], ['buyers', 'Buyers']] },
   { label: 'Trust', items: [['model', 'Story & model'], ['proof', 'Evidence'], ['governance', 'Governance']] },
 ];
 

--- a/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
@@ -15,6 +15,7 @@ const OPERATING_TABS = [
 
 const DELIVERY_TABS = [
   ['funnel', 'Delivery map'],
+  ['map', 'On the map'],
   ['we-owe', 'We owe'],
   ['communities', 'Demand & communities'],
   ['channels', 'Channels'],

--- a/apps/web/src/app/org/[slug]/goods/map/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/map/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from 'next/navigation';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import { getGoodsDeliveredPoints } from '@/lib/services/goods-atlas-points';
+import { getRemoteCouncils } from '@/lib/services/council-place-report';
+import { getCanonical } from '@/lib/services/goods-canonical-numbers';
+import AtlasClient, { type CouncilPageLink } from '@/app/atlas/atlas-client';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Goods on the map — CivicGraph',
+  description:
+    'The org-side Atlas with the Goods-in-community layer enabled: what the asset ' +
+    'register can place, over the same public layers everyone sees.',
+};
+
+/**
+ * The Atlas, org-side, with the Goods layer enabled.
+ *
+ * This page is the 'org' consent tier in practice: it sits behind the /org
+ * middleware login gate, and the Goods points exist only in this server
+ * render — the public /atlas fetches nothing Goods-shaped and its bundle
+ * carries no Goods figure. Public activation stays per-place and waits on
+ * the consent conversation (step 5 of the Atlas plan), by design.
+ */
+export default async function GoodsAtlasPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const org = await getOrgProfileBySlug(slug);
+  if (!org) notFound();
+
+  let points = [] as Awaited<ReturnType<typeof getGoodsDeliveredPoints>>;
+  let councilPages: CouncilPageLink[] = [];
+  try {
+    [points, councilPages] = await Promise.all([
+      getGoodsDeliveredPoints(),
+      getRemoteCouncils().then(councils =>
+        councils.map(c => ({ slug: c.slug, lgaName: c.lgaName, state: c.state }))
+      ),
+    ]);
+  } catch {
+    // The map without points still stands; the layer note says what is missing.
+  }
+
+  // Canon figures travel server-side only — never in the registry, which
+  // ships to public bundles. Claim labels per goods-canonical-numbers.
+  const canonBeds = getCanonical('deployed_bed_units');
+  const itemised = points.reduce((sum, p) => sum + p.value, 0);
+  const layerNote =
+    points.length === 0
+      ? 'The register feed did not load; no points are drawn.'
+      : `The canonical count is ${String(canonBeds?.value ?? '540')} deployed beds (verified ${canonBeds?.asOf ?? '2026-07-25'}); ` +
+        `the register itemises ${itemised} units by place across these ${points.length} communities. ` +
+        'The gap is mostly Stretch Beds, which the canon counts but the register does not itemise per place.';
+
+  return (
+    <AtlasClient
+      surface="org"
+      councilPages={councilPages}
+      pointsByLayer={{ 'goods-delivered': points }}
+      layerNotes={{ 'goods-delivered': layerNote }}
+      initialLayerKey="goods-delivered"
+      backLink={{ href: `/org/${slug}/goods`, label: 'Back to Goods' }}
+    />
+  );
+}

--- a/apps/web/src/app/reports/reallocation-atlas/reallocation-atlas-client.tsx
+++ b/apps/web/src/app/reports/reallocation-atlas/reallocation-atlas-client.tsx
@@ -25,6 +25,7 @@ type LgaFeature = {
   unplaced_count: number;
   placed_count: number;
   unplaced_share: number | null;
+  justice_funding_total: number | null;
   lat: number;
   lng: number;
   lga_code: string;

--- a/apps/web/src/lib/atlas/layers.test.ts
+++ b/apps/web/src/lib/atlas/layers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ATLAS_GROUP_ORDER,
   ATLAS_LAYERS,
   ATLAS_NO_DATA_STYLE,
   DEFAULT_ATLAS_LAYER_KEY,
@@ -27,6 +28,7 @@ function feature(overrides: Partial<AtlasFeature> = {}): AtlasFeature {
     unplaced_count: 40,
     placed_count: 60,
     unplaced_share: 40,
+    justice_funding_total: 2000000,
     lat: -32.1,
     lng: 133.7,
     lga_code: 'LGA00000',
@@ -86,6 +88,7 @@ describe('consent tiers gate surfaces', () => {
   const orgLayer: AtlasLayer = {
     key: 'test-org-layer',
     status: 'declared',
+    group: 'delivery',
     name: 'Org-only test layer',
     unit: 'things',
     caveat: 'A layer that must never appear on the public surface, used to prove the filter holds.',
@@ -121,10 +124,22 @@ describe('consent tiers gate surfaces', () => {
     // data. If this list grows, check the new layer's data path first.
     expect(visibleAtlasLayers('public').map(l => l.key)).toEqual([
       'funding-deserts',
-      'unplaced-orgs',
+      'money-recorded',
+      'justice-funding',
       'renewal-cliff',
+      'seifa-disadvantage',
+      'unplaced-orgs',
     ]);
     expect(visibleAtlasLayers('org').map(l => l.key)).toContain('goods-delivered');
+  });
+
+  it('substantive groups lead; uncertainty qualifies from the back', () => {
+    for (const layer of ATLAS_LAYERS) {
+      expect(ATLAS_GROUP_ORDER).toContain(layer.group);
+    }
+    expect(getAtlasLayer('unplaced-orgs')!.group).toBe('data-quality');
+    // data-quality is the LAST group the picker renders.
+    expect(ATLAS_GROUP_ORDER[ATLAS_GROUP_ORDER.length - 1]).toBe('data-quality');
   });
 });
 
@@ -153,6 +168,31 @@ describe('style resolution', () => {
 
   it('a value below every stop clamps to the lowest stop', () => {
     expect(atlasStyleFor(deserts, -1).color).toBe('#1040C0');
+  });
+});
+
+describe('the substantive layers', () => {
+  const seifa = getAtlasLayer('seifa-disadvantage') as AtlasLiveLayer;
+  const recorded = getAtlasLayer('money-recorded') as AtlasLiveLayer;
+  const justice = getAtlasLayer('justice-funding') as AtlasLiveLayer;
+
+  it('SEIFA runs backwards on purpose: decile 1 is red, decile 10 is blue', () => {
+    expect(atlasStyleFor(seifa, 1).color).toBe('#D02020');
+    expect(atlasStyleFor(seifa, 2).color).toBe('#D02020');
+    expect(atlasStyleFor(seifa, 5).color).toBe('#F0C020');
+    expect(atlasStyleFor(seifa, 10).color).toBe('#1040C0');
+    expect(seifa.value(feature({ avg_irsd_decile: 1 }))).toBe(1);
+  });
+
+  it('money layers use order-of-magnitude bands and read their own fields', () => {
+    expect(atlasStyleFor(recorded, 2_000_000_000).color).toBe('#D02020');
+    expect(atlasStyleFor(recorded, 500_000).color).toBe('#1040C0');
+    expect(recorded.value(feature({ total_funding_all_sources: 4200000 }))).toBe(4200000);
+    expect(atlasStyleFor(justice, 60_000_000).color).toBe('#D02020');
+    expect(justice.value(feature({ justice_funding_total: null }))).toBeNull();
+    expect(justice.value(feature())).toBe(2000000);
+    // Dollar formatting comes from the shared money() helper.
+    expect(recorded.format(4200000)).toMatch(/\$/);
   });
 });
 

--- a/apps/web/src/lib/atlas/layers.test.ts
+++ b/apps/web/src/lib/atlas/layers.test.ts
@@ -6,6 +6,7 @@ import {
   atlasStyleFor,
   getAtlasLayer,
   isLiveLayer,
+  isPointLayer,
   visibleAtlasLayers,
   type AtlasFeature,
   type AtlasLayer,
@@ -61,6 +62,18 @@ describe('the registry contract', () => {
     }
   });
 
+  it('the goods layer is org-tier, point-grain, and carries no figures', () => {
+    const goods = getAtlasLayer('goods-delivered');
+    expect(goods).not.toBeNull();
+    expect(goods!.consent).toBe('org');
+    expect(goods!.honestAt).toBe('community');
+    expect(isPointLayer(goods!)).toBe(true);
+    // The registry entry may ship in a public bundle; the numbers may not.
+    // Any digit in the caveat or notes is a Goods figure leaking public.
+    const text = `${goods!.name} ${goods!.unit} ${goods!.caveat} ${goods!.honestAtNote}`;
+    expect(text).not.toMatch(/\d/);
+  });
+
   it('the default layer is live and public', () => {
     const layer = getAtlasLayer(DEFAULT_ATLAS_LAYER_KEY);
     expect(layer).not.toBeNull();
@@ -102,10 +115,16 @@ describe('consent tiers gate surfaces', () => {
     }
   });
 
-  it('the seeded registry is entirely public today', () => {
-    // When this fails, someone added an org or withheld layer: make sure its
-    // data is stripped server-side before its surface renders, then update.
-    expect(visibleAtlasLayers('public').length).toBe(ATLAS_LAYERS.length);
+  it('the public surface sees exactly the public seed layers', () => {
+    // goods-delivered is org-tier: its points arrive only via the org page's
+    // server fetch, so the public surface never lists it and never holds its
+    // data. If this list grows, check the new layer's data path first.
+    expect(visibleAtlasLayers('public').map(l => l.key)).toEqual([
+      'funding-deserts',
+      'unplaced-orgs',
+      'renewal-cliff',
+    ]);
+    expect(visibleAtlasLayers('org').map(l => l.key)).toContain('goods-delivered');
   });
 });
 

--- a/apps/web/src/lib/atlas/layers.test.ts
+++ b/apps/web/src/lib/atlas/layers.test.ts
@@ -133,12 +133,14 @@ describe('style resolution', () => {
   const unplaced = getAtlasLayer('unplaced-orgs') as AtlasLiveLayer;
 
   it('picks the first stop the value clears, boundaries inclusive', () => {
-    expect(atlasStyleFor(deserts, 250).color).toBe('#D02020');
-    expect(atlasStyleFor(deserts, 200).color).toBe('#D02020');
-    expect(atlasStyleFor(deserts, 150).color).toBe('#E06C18');
-    expect(atlasStyleFor(deserts, 60).color).toBe('#F0C020');
-    expect(atlasStyleFor(deserts, 30).color).toBe('#4CB876');
-    expect(atlasStyleFor(deserts, 5).color).toBe('#1040C0');
+    // Desert stops are quantile breaks (2026-08-09 distribution: median 110,
+    // p90 152, max 205) — re-derive before moving them.
+    expect(atlasStyleFor(deserts, 205).color).toBe('#D02020');
+    expect(atlasStyleFor(deserts, 150).color).toBe('#D02020');
+    expect(atlasStyleFor(deserts, 140).color).toBe('#E06C18');
+    expect(atlasStyleFor(deserts, 120).color).toBe('#F0C020');
+    expect(atlasStyleFor(deserts, 90).color).toBe('#4CB876');
+    expect(atlasStyleFor(deserts, 20).color).toBe('#1040C0');
     expect(atlasStyleFor(unplaced, 80).color).toBe('#D02020');
     expect(atlasStyleFor(unplaced, 12).color).toBe('#4CB876');
     expect(atlasStyleFor(unplaced, 0).color).toBe('#1040C0');

--- a/apps/web/src/lib/atlas/layers.ts
+++ b/apps/web/src/lib/atlas/layers.ts
@@ -79,6 +79,8 @@ interface AtlasLayerCommon {
 
 export interface AtlasLiveLayer extends AtlasLayerCommon {
   status: 'live';
+  /** Paints the council choropleth by reading a value off each map feature. */
+  kind: 'choropleth';
   scale: AtlasScaleStop[];
   /** Legend entry for places where this layer holds nothing. */
   noDataLabel: string;
@@ -88,25 +90,61 @@ export interface AtlasLiveLayer extends AtlasLayerCommon {
   format(value: number): string;
 }
 
+/** A layer whose grain is points, not council areas — communities, mostly.
+ * Its data never lives in the registry or the public map payload: a surface
+ * that may render it receives the points server-side (the org RSC fetches
+ * them behind auth), so a public bundle carries the contract and nothing
+ * else. */
+export interface AtlasPointLayer extends AtlasLayerCommon {
+  status: 'live';
+  kind: 'points';
+  scale: AtlasScaleStop[];
+  /** Legend entry meaning "a point with none of the unit yet". */
+  noDataLabel: string;
+  format(value: number): string;
+}
+
+/** One point of an AtlasPointLayer, produced server-side by the surface that
+ * is allowed to see it. */
+export interface AtlasPoint {
+  name: string;
+  lat: number;
+  lng: number;
+  value: number;
+  /** Extra lines for the tooltip, already formatted. */
+  detail?: Array<{ label: string; value: string }>;
+}
+
 export interface AtlasDeclaredLayer extends AtlasLayerCommon {
   status: 'declared';
   /** What has to exist before this layer can turn on. User-facing. */
   waitingOn: string;
 }
 
-export type AtlasLayer = AtlasLiveLayer | AtlasDeclaredLayer;
+export type AtlasLayer = AtlasLiveLayer | AtlasPointLayer | AtlasDeclaredLayer;
 
-export function isLiveLayer(layer: AtlasLayer): layer is AtlasLiveLayer {
+export function isLiveLayer(layer: AtlasLayer): layer is AtlasLiveLayer | AtlasPointLayer {
   return layer.status === 'live';
+}
+
+/** The layers that paint the council choropleth and read map features.
+ * Point layers are live but carry their own data; feature-reading call
+ * sites (the map style, CSV export, panel rows) must use this guard. */
+export function isChoroplethLayer(layer: AtlasLayer): layer is AtlasLiveLayer {
+  return layer.status === 'live' && layer.kind === 'choropleth';
+}
+
+export function isPointLayer(layer: AtlasLayer): layer is AtlasPointLayer {
+  return layer.status === 'live' && layer.kind === 'points';
 }
 
 /** Style painted for places a live layer holds nothing about. */
 export const ATLAS_NO_DATA_STYLE = { color: '#e5e7eb', fillOpacity: 0.15 } as const;
 
-/** Resolve a live layer's paint for a value. Null → the no-data style; a
+/** Resolve a scaled layer's paint for a value. Null → the no-data style; a
  * value below every stop clamps to the lowest stop. */
 export function atlasStyleFor(
-  layer: AtlasLiveLayer,
+  layer: { scale: AtlasScaleStop[] },
   value: number | null
 ): { color: string; fillOpacity: number } {
   if (value === null) return ATLAS_NO_DATA_STYLE;
@@ -128,6 +166,7 @@ function num(raw: unknown): number | null {
 const fundingDeserts: AtlasLiveLayer = {
   key: 'funding-deserts',
   status: 'live',
+  kind: 'choropleth',
   name: 'Funding deserts',
   unit: 'desert score',
   caveat:
@@ -156,6 +195,7 @@ const fundingDeserts: AtlasLiveLayer = {
 const unplacedOrgs: AtlasLiveLayer = {
   key: 'unplaced-orgs',
   status: 'live',
+  kind: 'choropleth',
   name: 'Unplaced organisations',
   unit: '% of organisations we cannot place',
   caveat:
@@ -203,7 +243,47 @@ const renewalCliff: AtlasDeclaredLayer = {
     'Atlas needs it for every council before the layer can turn on.',
 };
 
-export const ATLAS_LAYERS: readonly AtlasLayer[] = [fundingDeserts, unplacedOrgs, renewalCliff];
+// The inverse layer: CivicGraph shows money recorded, Goods shows things in
+// community. Consent tier 'org' — it renders only inside the logged-in
+// workspace, its points arrive only from the org page's server fetch, and
+// this registry entry deliberately carries NO figures: the contract may ship
+// in a public bundle, the numbers may not. Public activation is per-place
+// and waits on the consent conversation (step 5), by design.
+const goodsDelivered: AtlasPointLayer = {
+  key: 'goods-delivered',
+  status: 'live',
+  kind: 'points',
+  name: 'Goods in community',
+  unit: 'units the asset register places here',
+  caveat:
+    'Beds and washing machines with an active row in the Goods asset register, ' +
+    'counted at the community the register names. The register itemises fewer ' +
+    'units by place than the canonical deployed total, so places that received ' +
+    'Stretch Beds read low here — the Utopia homelands most of all. And a unit ' +
+    'recorded at a town may have been staged through it: the register does not ' +
+    'distinguish delivered-to from staged-at.',
+  honestAt: 'community',
+  honestAtNote:
+    'Community points, not council areas. A place with no point holds no register ' +
+    'rows, which is not the same as nothing delivered.',
+  consent: 'org',
+  scale: [
+    { min: 100, color: '#D02020', fillOpacity: 0.85, label: '100+ units' },
+    { min: 50, color: '#E06C18', fillOpacity: 0.85, label: '50–100' },
+    { min: 20, color: '#F0C020', fillOpacity: 0.85, label: '20–50' },
+    { min: 1, color: '#4CB876', fillOpacity: 0.85, label: '1–20' },
+    { min: 0, color: '#1040C0', fillOpacity: 0.85, label: 'Demand recorded, none yet' },
+  ],
+  noDataLabel: 'No register rows',
+  format: v => `${v.toFixed(0)} units`,
+};
+
+export const ATLAS_LAYERS: readonly AtlasLayer[] = [
+  fundingDeserts,
+  unplacedOrgs,
+  renewalCliff,
+  goodsDelivered,
+];
 
 export const DEFAULT_ATLAS_LAYER_KEY = fundingDeserts.key;
 

--- a/apps/web/src/lib/atlas/layers.ts
+++ b/apps/web/src/lib/atlas/layers.ts
@@ -24,6 +24,8 @@
 // DATA must also be stripped server-side (RSC/API) — never sent and hidden
 // client-side. The registry itself holds no figures, only the contract.
 
+import { money } from '@/lib/format';
+
 /** One row of the /api/data/map payload. */
 export interface AtlasFeature {
   lga_name: string;
@@ -38,6 +40,7 @@ export interface AtlasFeature {
   unplaced_count: number;
   placed_count: number;
   unplaced_share: number | null;
+  justice_funding_total: number | null;
   /** Null when the council has no point coordinates; it still renders where a
    * boundary matches its name. Coordinates only drive bounds-fitting. */
   lat: number | null;
@@ -52,6 +55,20 @@ export type AtlasConsentTier = 'public' | 'org' | 'withheld';
  * its own caveat. */
 export type AtlasGeography = 'national' | 'state' | 'council' | 'postcode' | 'community';
 
+/** Picker groups. Substantive layers lead; the map's own error bars sit
+ * last under "How sure are we" — uncertainty qualifies the other layers,
+ * it does not compete with them (Ben, 2026-08-09). */
+export type AtlasLayerGroup = 'money' | 'need' | 'delivery' | 'data-quality';
+
+export const ATLAS_GROUP_ORDER: readonly AtlasLayerGroup[] = ['money', 'need', 'delivery', 'data-quality'];
+
+export const ATLAS_GROUP_LABELS: Record<AtlasLayerGroup, string> = {
+  money: 'Money',
+  need: 'Need',
+  delivery: 'Delivery',
+  'data-quality': 'How sure are we',
+};
+
 /** A step of a layer's color scale. Stops are ordered from highest `min` to
  * lowest; the first stop whose `min` is <= the value wins. */
 export interface AtlasScaleStop {
@@ -64,6 +81,7 @@ export interface AtlasScaleStop {
 
 interface AtlasLayerCommon {
   key: string;
+  group: AtlasLayerGroup;
   /** Plain words. What a person in a room would call it. */
   name: string;
   /** What one unit of the number means, e.g. "% of organisations". */
@@ -169,6 +187,7 @@ const fundingDeserts: AtlasLiveLayer = {
   key: 'funding-deserts',
   status: 'live',
   kind: 'choropleth',
+  group: 'money',
   name: 'Funding deserts',
   unit: 'desert score',
   caveat:
@@ -200,10 +219,107 @@ const fundingDeserts: AtlasLiveLayer = {
   format: v => v.toFixed(0),
 };
 
+// Order-of-magnitude bands, not quantiles: the distribution is extreme-tail
+// (checked 2026-08-09: median council $0, p90 $30M, max $281B).
+const moneyRecorded: AtlasLiveLayer = {
+  key: 'money-recorded',
+  status: 'live',
+  kind: 'choropleth',
+  group: 'money',
+  name: 'Recorded money',
+  unit: '$ recorded reaching the council',
+  caveat:
+    'Every dollar our records can see reaching organisations based in this council — ' +
+    'justice funding, contracts and grants together. Counted where it was recorded, ' +
+    "not where it landed, so a regional hub administering its neighbours' programs " +
+    'reads rich while the places the work reaches read poor. The biggest numbers on ' +
+    'this layer are capital cities and hubs: that is the recording, not the need.',
+  honestAt: 'council',
+  honestAtNote:
+    "Council of the recipient's registered address. Where the work is delivered is " +
+    'mostly unrecorded.',
+  consent: 'public',
+  scale: [
+    { min: 1_000_000_000, color: '#D02020', fillOpacity: 0.7, label: '$1B or more' },
+    { min: 100_000_000, color: '#E06C18', fillOpacity: 0.6, label: '$100M–1B' },
+    { min: 10_000_000, color: '#F0C020', fillOpacity: 0.5, label: '$10M–100M' },
+    { min: 1_000_000, color: '#4CB876', fillOpacity: 0.4, label: '$1M–10M' },
+    { min: 0, color: '#1040C0', fillOpacity: 0.3, label: 'Under $1M' },
+  ],
+  scaleNote: 'Order-of-magnitude bands: half of all councils hold under $1M recorded.',
+  noDataLabel: 'No funding records held',
+  value: f => num(f.total_funding_all_sources),
+  format: v => money(v),
+};
+
+// Same recording caveat as all money here; blank means no records tied to a
+// placed organisation, never "no justice spending".
+const justiceFunding: AtlasLiveLayer = {
+  key: 'justice-funding',
+  status: 'live',
+  kind: 'choropleth',
+  group: 'money',
+  name: 'Justice money',
+  unit: '$ of justice program funding recorded',
+  caveat:
+    'State and federal justice program funding recorded to organisations based in ' +
+    'this council — youth justice, legal services, diversion and adjacent programs. ' +
+    "Recorded at the recipient's registered address like everything else here, so " +
+    'hub crediting applies. Blank does not mean no justice spending: it means no ' +
+    'records our pipeline could tie to a placed organisation.',
+  honestAt: 'council',
+  honestAtNote:
+    "Council of the recipient's registered address; the program itself may run " +
+    'somewhere else entirely.',
+  consent: 'public',
+  // Checked 2026-08-09: 540 councils hold justice records; median $1.2M,
+  // p75 $11M, p90 $55M, max $29B (a capital-city hub).
+  scale: [
+    { min: 50_000_000, color: '#D02020', fillOpacity: 0.7, label: '$50M or more' },
+    { min: 10_000_000, color: '#E06C18', fillOpacity: 0.6, label: '$10M–50M' },
+    { min: 1_000_000, color: '#F0C020', fillOpacity: 0.5, label: '$1M–10M' },
+    { min: 50_000, color: '#4CB876', fillOpacity: 0.4, label: '$50K–1M' },
+    { min: 0, color: '#1040C0', fillOpacity: 0.3, label: 'Under $50K' },
+  ],
+  noDataLabel: 'No justice records held',
+  value: f => num(f.justice_funding_total),
+  format: v => money(v),
+};
+
+// The scale runs backwards on purpose: decile 1 is the most disadvantaged
+// tenth of Australia, so red sits at the LOW end.
+const seifaDisadvantage: AtlasLiveLayer = {
+  key: 'seifa-disadvantage',
+  status: 'live',
+  kind: 'choropleth',
+  group: 'need',
+  name: 'SEIFA disadvantage',
+  unit: 'IRSD decile · 1 is the most disadvantaged tenth',
+  caveat:
+    'The ABS index of relative socio-economic disadvantage, averaged across the ' +
+    "council's postcodes. Decile 1 means the most disadvantaged tenth of Australia; " +
+    'decile 10 the least. Averaging flattens pockets: a comfortable council can ' +
+    'contain a street in decile 1, and this layer will not show it.',
+  honestAt: 'council',
+  honestAtNote: 'Postcode SEIFA averaged to council. Suburb-sized pockets vanish in the average.',
+  consent: 'public',
+  scale: [
+    { min: 9, color: '#1040C0', fillOpacity: 0.3, label: 'Deciles 9–10 · least disadvantaged' },
+    { min: 7, color: '#4CB876', fillOpacity: 0.4, label: 'Deciles 7–8' },
+    { min: 5, color: '#F0C020', fillOpacity: 0.5, label: 'Deciles 5–6' },
+    { min: 3, color: '#E06C18', fillOpacity: 0.6, label: 'Deciles 3–4' },
+    { min: 0, color: '#D02020', fillOpacity: 0.7, label: 'Deciles 1–2 · most disadvantaged' },
+  ],
+  noDataLabel: 'No SEIFA held',
+  value: f => num(f.avg_irsd_decile),
+  format: v => `decile ${v.toFixed(0)}`,
+};
+
 const unplacedOrgs: AtlasLiveLayer = {
   key: 'unplaced-orgs',
   status: 'live',
   kind: 'choropleth',
+  group: 'data-quality',
   name: 'Unplaced organisations',
   unit: '% of organisations we cannot place',
   caveat:
@@ -234,6 +350,7 @@ const unplacedOrgs: AtlasLiveLayer = {
 const renewalCliff: AtlasDeclaredLayer = {
   key: 'renewal-cliff',
   status: 'declared',
+  group: 'money',
   name: 'Funding renewal cliff',
   unit: '% of visible funding ending within 24 months',
   caveat:
@@ -261,6 +378,7 @@ const goodsDelivered: AtlasPointLayer = {
   key: 'goods-delivered',
   status: 'live',
   kind: 'points',
+  group: 'delivery',
   name: 'Goods in community',
   unit: 'units the asset register places here',
   caveat:
@@ -288,9 +406,12 @@ const goodsDelivered: AtlasPointLayer = {
 
 export const ATLAS_LAYERS: readonly AtlasLayer[] = [
   fundingDeserts,
-  unplacedOrgs,
+  moneyRecorded,
+  justiceFunding,
   renewalCliff,
+  seifaDisadvantage,
   goodsDelivered,
+  unplacedOrgs,
 ];
 
 export const DEFAULT_ATLAS_LAYER_KEY = fundingDeserts.key;

--- a/apps/web/src/lib/atlas/layers.ts
+++ b/apps/web/src/lib/atlas/layers.ts
@@ -75,6 +75,8 @@ interface AtlasLayerCommon {
   /** One or two sentences on where the honesty ends. */
   honestAtNote: string;
   consent: AtlasConsentTier;
+  /** How the colour bands were chosen, when that needs saying. */
+  scaleNote?: string;
 }
 
 export interface AtlasLiveLayer extends AtlasLayerCommon {
@@ -180,13 +182,19 @@ const fundingDeserts: AtlasLiveLayer = {
     'Council level only. Within a council it cannot say which town the money reached, and ' +
     'in remote areas regional-office recording can move money to the wrong council entirely.',
   consent: 'public',
+  // Quantile breaks of the actual score distribution (checked 2026-08-09:
+  // min 20, median 110, p75 135, p90 152, max 205). The old 20/50/100/200
+  // stops painted three-quarters of the country one orange and made Severe
+  // nearly unreachable.
   scale: [
-    { min: 200, color: '#D02020', fillOpacity: 0.7, label: 'Severe' },
-    { min: 100, color: '#E06C18', fillOpacity: 0.6, label: 'High' },
-    { min: 50, color: '#F0C020', fillOpacity: 0.5, label: 'Elevated' },
-    { min: 20, color: '#4CB876', fillOpacity: 0.4, label: 'Mild' },
+    { min: 150, color: '#D02020', fillOpacity: 0.7, label: 'Severe' },
+    { min: 135, color: '#E06C18', fillOpacity: 0.6, label: 'High' },
+    { min: 110, color: '#F0C020', fillOpacity: 0.5, label: 'Elevated' },
+    { min: 80, color: '#4CB876', fillOpacity: 0.4, label: 'Mild' },
     { min: 0, color: '#1040C0', fillOpacity: 0.3, label: 'Low' },
   ],
+  scaleNote:
+    'Bands are quantile breaks of the current scores: the top tenth of councils reads Severe.',
   noDataLabel: 'No score held',
   value: f => num(f.desert_score),
   format: v => v.toFixed(0),

--- a/apps/web/src/lib/atlas/share.test.ts
+++ b/apps/web/src/lib/atlas/share.test.ts
@@ -24,6 +24,7 @@ function feature(overrides: Partial<AtlasFeature> = {}): AtlasFeature {
     unplaced_count: 30,
     placed_count: 70,
     unplaced_share: 30,
+    justice_funding_total: 1500000,
     lat: -32.1,
     lng: 133.7,
     lga_code: 'LGA40700',
@@ -121,6 +122,13 @@ describe('taking the data with its caveats', () => {
     expect(row).toContain('Ceduna');
     expect(row).toContain('where it was recorded');
     expect(headers.split(',').length).toBeGreaterThanOrEqual(14);
+  });
+
+  it('CSV headers never collide, even as the registry grows layers', () => {
+    const headers = councilCsv(feature()).split('\n')[0].split(',');
+    expect(new Set(headers).size).toBe(headers.length);
+    expect(headers).toContain('justice_funding');
+    expect(headers).toContain('seifa_disadvantage_contains');
   });
 
   it('CSV escapes commas and quotes properly', () => {

--- a/apps/web/src/lib/atlas/share.ts
+++ b/apps/web/src/lib/atlas/share.ts
@@ -6,7 +6,7 @@
 // same file: the number never ships without what it contains.
 
 import {
-  isLiveLayer,
+  isChoroplethLayer,
   visibleAtlasLayers,
   type AtlasFeature,
   type AtlasLiveLayer,
@@ -114,8 +114,10 @@ const PLACE_COLUMNS: Array<{ header: string; read(f: AtlasFeature): unknown }> =
   { header: 'placed_count', read: f => f.placed_count },
 ];
 
+// Only choropleth layers read council features; a point layer's data never
+// rides a council export.
 function liveLayers(surface: AtlasSurface): AtlasLiveLayer[] {
-  return visibleAtlasLayers(surface).filter(isLiveLayer);
+  return visibleAtlasLayers(surface).filter(isChoroplethLayer);
 }
 
 /** One council as CSV: a header row and a data row. Each live layer

--- a/apps/web/src/lib/services/goods-atlas-points.ts
+++ b/apps/web/src/lib/services/goods-atlas-points.ts
@@ -1,0 +1,72 @@
+import { getServiceSupabase } from '@/lib/supabase';
+import type { AtlasPoint } from '@/lib/atlas/layers';
+
+/**
+ * The Goods-in-community points for the org-side Atlas.
+ *
+ * Server-side only, behind the /org middleware gate: this feed is how the
+ * 'org' consent tier is actually enforced. The public Atlas never calls it,
+ * so the public payload never contains a Goods figure — the registry entry
+ * it renders from carries the contract and no numbers.
+ *
+ * Source is goods_communities.assets_deployed — the same per-community
+ * register the Communities hub tab shows, so the org surface agrees with
+ * itself. Its known limits are stated on the layer's caveat: the register
+ * itemises fewer units by place than the 540-bed canon
+ * (goods-canonical-numbers.ts), and staged-through vs delivered-to is not
+ * distinguished.
+ */
+
+function titleCase(name: string): string {
+  return name
+    .toLowerCase()
+    .split(/\s+/)
+    .map(word => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(' ');
+}
+
+function num(raw: unknown): number {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export async function getGoodsDeliveredPoints(): Promise<AtlasPoint[]> {
+  const db = getServiceSupabase();
+  const { data, error } = await db.rpc('exec_sql', {
+    query: `SELECT gc.community_name, gc.state,
+                   COALESCE(gc.latitude, pg.lat) AS lat,
+                   COALESCE(gc.longitude, pg.lng) AS lng,
+                   gc.assets_deployed, gc.demand_beds, gc.demand_washers
+              FROM goods_communities gc
+              LEFT JOIN (
+                SELECT postcode, AVG(latitude::float) AS lat, AVG(longitude::float) AS lng
+                  FROM postcode_geo
+                 GROUP BY postcode
+              ) pg ON pg.postcode = gc.postcode
+             WHERE gc.assets_deployed > 0
+             ORDER BY gc.assets_deployed DESC`,
+  });
+  if (error || !Array.isArray(data)) return [];
+
+  const points: AtlasPoint[] = [];
+  for (const entry of data as Array<Record<string, unknown>>) {
+    const lat = entry.lat === null ? null : Number(entry.lat);
+    const lng = entry.lng === null ? null : Number(entry.lng);
+    // A community the register cannot locate cannot be a point; it stays in
+    // the Communities tab rather than being pinned somewhere wrong.
+    if (lat === null || lng === null || !Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+    const demandBeds = num(entry.demand_beds);
+    const demandWashers = num(entry.demand_washers);
+    points.push({
+      name: `${titleCase(String(entry.community_name ?? ''))} (${String(entry.state ?? '')})`,
+      lat,
+      lng,
+      value: num(entry.assets_deployed),
+      detail: [
+        ...(demandBeds > 0 ? [{ label: 'Stated bed demand', value: String(demandBeds) }] : []),
+        ...(demandWashers > 0 ? [{ label: 'Stated washer demand', value: String(demandWashers) }] : []),
+      ],
+    });
+  }
+  return points;
+}

--- a/supabase/migrations/20260809070000_place_single_council_postcodes.sql
+++ b/supabase/migrations/20260809070000_place_single_council_postcodes.sql
@@ -1,0 +1,145 @@
+-- Place the unplaced entities whose postcode now names exactly one council.
+--
+-- APPLY (Ben, day-shift):
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U postgres.tednluwflfhxyucgwigh -d postgres -f supabase/migrations/20260809070000_place_single_council_postcodes.sql
+-- AFTERWARDS: mv_funding_deserts and friends go stale until the nightly
+--   refresh (pg_cron 17:00 UTC); to see it on /atlas sooner:
+--   node --env-file=.env scripts/refresh-views-v2.mjs
+--
+-- WHY. The 2026-08-08 resolve-or-null pass (20260808130000) nulled entities in
+-- multi-council postcodes, and the same day's postcode_geo rebuild and geocode
+-- backfill improved the geography underneath it. The verdicts went stale:
+-- 98,660 entities now sit unplaced, and for 15,251 of them (dry-run,
+-- 2026-08-09) today's ABS locality->LGA table names exactly one council for
+-- their postcode and state. This pass places those and only those.
+--
+-- WHAT IT DELIBERATELY DOES NOT DO. The naive "postcode_geo says one council"
+-- test matches ~41K entities, but most fail honesty checks: their state is
+-- NULL or contradicts the postcode's, or the postcode only looks single-
+-- council because its other localities are unmapped. Authority here is the
+-- same chain the original pass used - abs_locality_lga joined through
+-- postcode_geo - tightened with state qualification (the original matched
+-- locality names across states; RICHMOND exists in three).
+--
+-- RUN SHAPE. Same as the proven 20260808130000: autocommit, UNLOGGED indexed
+-- staging (inline joins plan as nested-loop-over-Materialize and never
+-- finish), batched UPDATE committing every 5,000 rows so pooler locks stay
+-- short. Idempotent and resumable: a placed row no longer matches
+-- lga_name IS NULL. Reversible: prior values of every touched row are in
+-- gs_entities_lga_backup_20260809.
+
+SET statement_timeout = '15min';
+
+-- Phase 0. Backup the rows this migration may touch, committed on its own.
+CREATE TABLE IF NOT EXISTS gs_entities_lga_backup_20260809 AS
+SELECT id, abn, postcode, state, lga_name, lga_code, lga_source
+  FROM gs_entities
+ WHERE lga_name IS NULL
+   AND postcode IS NOT NULL;
+
+-- Phase 1. Staging: postcodes whose localities map to exactly one council in
+-- ABS ASGS, state-qualified end to end.
+DROP TABLE IF EXISTS stg_pc_single;
+CREATE UNLOGGED TABLE stg_pc_single AS
+WITH state_codes(state_name, code) AS (
+  VALUES ('Australian Capital Territory','ACT'),
+         ('New South Wales','NSW'),
+         ('Northern Territory','NT'),
+         ('Queensland','QLD'),
+         ('South Australia','SA'),
+         ('Tasmania','TAS'),
+         ('Victoria','VIC'),
+         ('Western Australia','WA')
+)
+SELECT p.postcode,
+       p.state,
+       min(a.lga_name) AS lga_name,
+       min(a.lga_code) AS lga_code
+  FROM postcode_geo p
+  JOIN state_codes s ON s.code = p.state
+  JOIN abs_locality_lga a
+    ON upper(a.locality) = upper(p.locality)
+   AND a.state_name = s.state_name
+ GROUP BY p.postcode, p.state
+HAVING count(DISTINCT a.lga_name) = 1;
+CREATE INDEX ON stg_pc_single (postcode, state);
+ANALYZE stg_pc_single;
+
+-- Phase 2. Place, in committed batches. Only rows that are unplaced today;
+-- entities with no state or a state contradicting the postcode never match.
+DO $$
+DECLARE
+  batch int;
+  total int := 0;
+BEGIN
+  LOOP
+    UPDATE gs_entities e
+       SET lga_name = s.lga_name,
+           lga_code = s.lga_code,
+           lga_source = 'single_lga_postcode'
+      FROM stg_pc_single s
+     WHERE e.id IN (
+       SELECT e2.id
+         FROM gs_entities e2
+         JOIN stg_pc_single s2 ON s2.postcode = e2.postcode AND s2.state = e2.state
+        WHERE e2.lga_name IS NULL
+          AND e2.postcode IS NOT NULL
+        LIMIT 5000
+     )
+       AND s.postcode = e.postcode
+       AND s.state = e.state;
+    GET DIAGNOSTICS batch = ROW_COUNT;
+    EXIT WHEN batch = 0;
+    total := total + batch;
+    COMMIT;
+    RAISE NOTICE 'placed % this batch, % so far', batch, total;
+  END LOOP;
+  RAISE NOTICE 'placement complete: % rows', total;
+END $$;
+
+-- Phase 3. Refresh the open gap ledger. Postcodes that still hold unplaced
+-- multi-council entities get fresh counts; postcodes this pass emptied are
+-- closed rather than deleted, so the history of the gap survives.
+UPDATE geo_resolution_gaps g
+   SET affected_entities = c.n,
+       affected_community_controlled = c.cc,
+       detected_at = now()
+  FROM (
+    SELECT postcode,
+           count(*) AS n,
+           count(*) FILTER (WHERE is_community_controlled) AS cc
+      FROM gs_entities
+     WHERE lga_name IS NULL
+       AND lga_source = 'unresolved_multi_lga_postcode'
+     GROUP BY postcode
+  ) c
+ WHERE c.postcode = g.postcode
+   AND g.issue = 'Postcode spans multiple council areas and the entity record carries no locality'
+   AND g.resolved_at IS NULL;
+
+UPDATE geo_resolution_gaps g
+   SET resolved_at = now()
+ WHERE g.issue = 'Postcode spans multiple council areas and the entity record carries no locality'
+   AND g.resolved_at IS NULL
+   AND NOT EXISTS (
+     SELECT 1
+       FROM gs_entities e
+      WHERE e.postcode = g.postcode
+        AND e.lga_name IS NULL
+        AND e.lga_source = 'unresolved_multi_lga_postcode'
+   );
+
+-- Phase 4. Say what happened.
+DO $$
+DECLARE placed_n int; still_null int; gaps_open int; gaps_closed int;
+BEGIN
+  SELECT count(*) INTO placed_n   FROM gs_entities WHERE lga_source = 'single_lga_postcode';
+  SELECT count(*) INTO still_null FROM gs_entities WHERE lga_name IS NULL AND postcode IS NOT NULL;
+  SELECT count(*) INTO gaps_open   FROM geo_resolution_gaps WHERE resolved_at IS NULL;
+  SELECT count(*) INTO gaps_closed FROM geo_resolution_gaps WHERE resolved_at IS NOT NULL;
+  RAISE NOTICE 'placed via single-council postcode: % (dry-run predicted 15,251)', placed_n;
+  RAISE NOTICE 'still unplaced with a postcode:     %', still_null;
+  RAISE NOTICE 'geo_resolution_gaps open: %, closed: %', gaps_open, gaps_closed;
+END $$;
+
+DROP TABLE IF EXISTS stg_pc_single;

--- a/supabase/migrations/20260809100000_own_name_city_repair.sql
+++ b/supabase/migrations/20260809100000_own_name_city_repair.sql
@@ -1,0 +1,168 @@
+-- Own-name city repair: give 14 councils back their namesake towns.
+--
+-- APPLY (Ben, day-shift):
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U postgres.tednluwflfhxyucgwigh -d postgres -f supabase/migrations/20260809100000_own_name_city_repair.sql
+-- AFTERWARDS: node --env-file=.env scripts/refresh-views-v2.mjs (or wait for the
+--   nightly pg_cron 17:00 UTC refresh).
+--
+-- WHY. The 20260808120000 postcode_geo rebuild only aligned localities where
+-- ABS is unambiguous (lga_count = 1) and left straddlers "untouched rather
+-- than guessed at". Untouched meant: still carrying the legacy first-seen
+-- council. So WARRNAMBOOL locality sits recorded as Moyne, SUBIACO as
+-- Cambridge, HOPE VALE as Douglas, LOCKHART RIVER as Napranum - fourteen
+-- councils whose namesake town is credited to a neighbour, most of them the
+-- remote-community councils this map exists for. On /atlas they render 100%
+-- unplaced off postcodes recorded as someone else's, which reads as honest
+-- ambiguity and is actually an artifact.
+--
+-- THE RULE. A locality that carries a council's own name belongs to that
+-- council, even where the ABS suburb boundary spills a sliver into a
+-- neighbour. This is the inverse of the Ceduna failure: the resolve-or-null
+-- pass was built because postcode-derived guesses land on the SMALLEST
+-- community in a postcode (Maralinga Tjarutja swallowing Ceduna); own-name
+-- lands on the namesake - the largest. Guarded three ways:
+--   * only localities where exactly one council carries the name in that
+--     state (COUNT(DISTINCT lga_code) = 1);
+--   * entity placement additionally requires the namesake council to be a
+--     candidate council of the entity's own postcode (an org whose town says
+--     MELBOURNE but whose postcode is pure Port Phillip does not move);
+--   * every placement stamped lga_source = 'own_name_town+abs_asgs', so the
+--     whole class is auditable and reversible.
+--
+-- RESIDUAL RISK, stated. Inside a straddling postcode the sliver remains:
+-- a St Kilda Road org writing town MELBOURNE from the Port Phillip side will
+-- be placed into Melbourne. Bounded by the candidate-set guard, carried by
+-- the source stamp.
+--
+-- DRY-RUN (2026-08-09, live):
+--   postcode_geo rows corrected: 28 (26 postcodes, 14 councils)
+--   entities placed: 2,550 -> unplaced 83,409 -> ~80,859
+--   per council: Melbourne 2,014 · Warrnambool 108 · Nedlands 102 ·
+--   Subiaco 93 · Orange 92 · Broken Hill 58 · Port Lincoln 45 ·
+--   Coober Pedy 11 · Tumby Bay 8 · Hope Vale 6 · Lockhart 5 ·
+--   Lockhart River 4 · West Arnhem 2 · East Arnhem 2
+--
+-- Does NOT close geo_resolution_gaps rows: own-name resolves entities and
+-- locality rows, not whole postcodes (3280 still spans two councils; that is
+-- true and stays true).
+--
+-- Run shape: autocommit, no wrapping transaction (2026-08-08 lesson). Small
+-- statements; staging tables so nothing plans as a nested loop. Idempotent:
+-- every UPDATE excludes rows already carrying its target value.
+-- Reversible: postcode_geo_lga_backup_20260809b, gs_entities_lga_backup_20260809b.
+
+SET statement_timeout = '15min';
+
+-- Phase 0. Backups, committed on their own.
+CREATE TABLE IF NOT EXISTS postcode_geo_lga_backup_20260809b AS
+SELECT postcode, locality, state, lga_name, lga_code
+FROM postcode_geo;
+
+CREATE TABLE IF NOT EXISTS gs_entities_lga_backup_20260809b AS
+SELECT id, abn, postcode, state, lga_name, lga_code, lga_source
+FROM gs_entities
+WHERE lga_name IS NULL;
+
+-- Phase 1. Staging.
+DROP TABLE IF EXISTS stg_own_name;
+CREATE UNLOGGED TABLE stg_own_name AS
+WITH sc(state_name, code) AS (
+  VALUES ('Australian Capital Territory','ACT'),
+         ('New South Wales','NSW'),
+         ('Northern Territory','NT'),
+         ('Queensland','QLD'),
+         ('South Australia','SA'),
+         ('Tasmania','TAS'),
+         ('Victoria','VIC'),
+         ('Western Australia','WA')
+)
+SELECT upper(a.locality) AS loc,
+       s.code            AS state,
+       min(a.lga_name)   AS lga_name,
+       min(a.lga_code)   AS lga_code
+  FROM abs_locality_lga a
+  JOIN sc s ON s.state_name = a.state_name
+ WHERE upper(a.lga_name) = upper(a.locality)
+   AND a.lga_count >= 2
+ GROUP BY 1, 2
+HAVING count(DISTINCT a.lga_code) = 1;
+CREATE INDEX ON stg_own_name (loc, state);
+ANALYZE stg_own_name;
+
+-- Candidate councils per postcode, from the postcode's own localities.
+DROP TABLE IF EXISTS stg_pc_candidates;
+CREATE UNLOGGED TABLE stg_pc_candidates AS
+WITH sc(state_name, code) AS (
+  VALUES ('Australian Capital Territory','ACT'),
+         ('New South Wales','NSW'),
+         ('Northern Territory','NT'),
+         ('Queensland','QLD'),
+         ('South Australia','SA'),
+         ('Tasmania','TAS'),
+         ('Victoria','VIC'),
+         ('Western Australia','WA')
+)
+SELECT DISTINCT pg.postcode, pg.state, a.lga_code
+  FROM postcode_geo pg
+  JOIN sc s ON s.code = pg.state
+  JOIN abs_locality_lga a
+    ON a.locality = upper(pg.locality) AND a.state_name = s.state_name;
+CREATE INDEX ON stg_pc_candidates (postcode, state, lga_code);
+ANALYZE stg_pc_candidates;
+
+-- Phase 2. Repair postcode_geo: namesake localities get their council back.
+-- Dry-run measured 28 rows.
+UPDATE postcode_geo p
+   SET lga_name = o.lga_name,
+       lga_code = o.lga_code
+  FROM stg_own_name o
+ WHERE o.loc = upper(p.locality)
+   AND o.state = p.state
+   AND p.lga_name IS DISTINCT FROM o.lga_name;
+
+-- Phase 3. Place unplaced entities whose ACNC town names the council.
+-- ACNC abn is unique among rows carrying a town_city (established 20260808130000).
+-- Dry-run measured 2,550 rows.
+DROP TABLE IF EXISTS stg_own_name_resolved;
+CREATE UNLOGGED TABLE stg_own_name_resolved AS
+SELECT e.id, o.lga_name, o.lga_code
+  FROM gs_entities e
+  JOIN acnc_charities c ON c.abn = e.abn AND c.town_city IS NOT NULL
+  JOIN stg_own_name o ON o.loc = upper(c.town_city) AND o.state = e.state
+ WHERE e.lga_name IS NULL
+   AND (e.postcode IS NULL OR EXISTS (
+         SELECT 1 FROM stg_pc_candidates pc
+          WHERE pc.postcode = e.postcode
+            AND pc.state = e.state
+            AND pc.lga_code = o.lga_code));
+CREATE INDEX ON stg_own_name_resolved (id);
+ANALYZE stg_own_name_resolved;
+
+UPDATE gs_entities e
+   SET lga_name = r.lga_name,
+       lga_code = r.lga_code,
+       lga_source = 'own_name_town+abs_asgs'
+  FROM stg_own_name_resolved r
+ WHERE r.id = e.id
+   AND e.lga_name IS NULL;
+
+-- Phase 4. Verify, then clean up staging.
+SELECT 'postcode_geo namesake rows now correct' AS check,
+       count(*) AS rows
+  FROM postcode_geo p
+  JOIN stg_own_name o ON o.loc = upper(p.locality) AND o.state = p.state
+ WHERE p.lga_name = o.lga_name;
+
+SELECT 'entities placed by own_name_town' AS check,
+       count(*) AS rows
+  FROM gs_entities
+ WHERE lga_source = 'own_name_town+abs_asgs';
+
+SELECT 'unplaced remaining' AS check,
+       count(*) AS rows
+  FROM gs_entities
+ WHERE lga_name IS NULL AND postcode IS NOT NULL;
+
+DROP TABLE IF EXISTS stg_own_name_resolved;
+DROP TABLE IF EXISTS stg_pc_candidates;
+DROP TABLE IF EXISTS stg_own_name;

--- a/thoughts/shared/plans/place-data-truth.md
+++ b/thoughts/shared/plans/place-data-truth.md
@@ -1,0 +1,99 @@
+# Place data truth: one spine from geography repair to the surface
+
+**Written:** 2026-08-09, after the single-council placement pass (15,251 placed, 83,409
+remaining) and the Warrnambool-hole diagnosis. **Status: proposal.** Ben's standing call:
+get the data right before more screens. Data-session record:
+PR #183 comment (2026-08-09) · ladder in `thoughts/shared/handoffs/place-atlas/current.md`.
+
+## The principle
+
+Place is the join key for everything CivicGraph holds — money, entities, boards,
+interventions, Goods deliveries. Placement confidence is what decides whether any join is
+true: the hub-credit distortion (Ceduna credited with Oak Valley's money) is what a
+confident-but-wrong join looks like. The atlas already says "how sure are we" out loud,
+so data work and UX work are one spine viewed from two sides: every ladder rung climbed
+makes an existing surface more true; every new connection is a registry layer, not a
+screen.
+
+## Current state (verified live 2026-08-09)
+
+- **83,409 entities** hold a postcode and no council (`lga_name IS NULL AND postcode IS
+  NOT NULL`). 98,660 before the single-council pass; 15,251 placed by it
+  (`lga_source='single_lga_postcode'`, backup `gs_entities_lga_backup_20260809`).
+- **The remainder is not all honest ambiguity.** `postcode_geo` carries 3280/3281
+  (Warrnambool's own postcodes) only as Moyne — 434 orgs, 430 unplaced, 4 credited to
+  the neighbour, 0 to the city. Metro councils rendering 100% unplaced (Subiaco,
+  Queenscliffe, Darwin Waterfront, possibly Napranum) are suspect for the same hole.
+- The atlas currently presents these artifacts as ambiguity. That is the lie to remove
+  first.
+
+## The spine
+
+**Phase 0 — land what's built.** PR #183 carries the desk, the org-side Goods map, and
+the applied migration. Refresh the stale body, one preview look, Ben's merge verb.
+Everything below builds on its registry and desk layout.
+
+**Phase 1 — make the join key trustworthy** (ladder rungs 1–2, one data session).
+
+1. Quantify the hole class: councils whose own-name locality does not map to them in
+   `abs_locality_lga` / `postcode_geo`. Number first, then repair.
+2. Repair the city-locality rows; re-run the `20260809070000` placement logic
+   (idempotent, resumable, backup pattern established); re-run the ACNC town-city pass
+   (pass 1 of `20260808130000`) against the repaired tables.
+3. **Reason codes.** Every still-unplaced entity gets one: `multi_council_postcode` ·
+   `no_postcode` · `state_conflict` · `hub_postcode` · `unknown_postcode`. This taxonomy
+   is what turns rung 5 (the honest core) from an apology into a feature — the caveat
+   card can then say *why* per slice, not just *how many*.
+
+*Exit (Ben's check): no metro council renders 100% unplaced from a geography hole;
+open /atlas and Warrnambool looks sane; every unplaced entity carries a reason.*
+
+**Phase 2 — join what we already hold onto place.** No new screens. Wire the existing
+substrate into the place rail and layer registry, each entry carrying consent tier +
+honest-at + caveat, exactly as `lib/atlas/layers.ts` demands:
+
+- **Money reaching here** — justice funding, grants, contracts per council (CTEs on the
+  map API already started this).
+- **What is proven to work here** — Australian Living Map of Alternatives interventions
+  by place.
+- **Who is here** — entities by type; boards via `mv_person_entity_network`.
+- **What we deliver here** — Goods, org-side, consent enforced server-side (already in
+  PR #183).
+
+*Exit (Ben's check): one council he has stood in — Ceduna's or Warrnambool as the test —
+answers who / what money / what works / what we deliver from live joins, each line
+carrying its confidence. It reads true to someone who knows the place.*
+
+**Phase 3 — the surface pass.** Only now does polish pay: run the /polish loop
+(Clarity / Value-shown / Meaning / Aesthetic / Friction) on atlas + place rail + org
+map. Story-mode read-aloud pass with Ben remains the gate before any real community
+session. If there is a specific first user, phase 3 is shaped around her actual first
+session, not a generic one.
+
+**Between phases, day-shift data sessions** (ladder rungs 3–4, yield-ordered, nothing
+waits on them):
+
+- **ORIC registered addresses** — `scripts/fetch-oric-addresses.mjs` exists, dry-run
+  only. Auto-apply proven unsafe (resolves Oak Valley to CEDUNA — the hub-credit
+  distortion again). Per-org human judgement.
+- **ABR/ASIC street addresses** — the long pole; bulk extract carries state+postcode
+  only. A street address per entity is the required source.
+
+## What not to do
+
+- Do not polish surfaces over wrong data — it dresses noise as signal (standing rule:
+  data quality before scoring).
+- Do not sum unplaced counts across councils into a national total — an entity counts
+  toward every council sharing its postcode by design.
+- Do not auto-apply registered-address placements for remote corporations. Ever.
+- Do not treat null LGA as missing data — check `lga_source`; the null is often the
+  honest verdict.
+- DDL stays human-gated: migration file committed with the apply command in the header;
+  Ben applies day-shift.
+
+## How this gets worked
+
+Small PRs off origin/main, gates once at the end, Ben's verb for push/PR/merge. Data
+sessions produce: a migration file (committed, not applied), a dry-run count in the PR
+comment, and a re-verified before/after in the handoff ledger. The unplaced count is
+the scoreboard; the reason-code distribution is the honest version of it.


### PR DESCRIPTION
Step 4 of `thoughts/shared/plans/place-atlas-surface.md` — plus everything Ben's live localhost review added on top. This PR now carries five things:

1. **The Goods org layer** (`d19091f`): point-grain layer kind in the registry, first member `goods-delivered` (consent tier `org`). Public `/atlas` cannot list it and never fetches a point — the consent filter runs server-side, `/org/[slug]/goods/map` sits behind the /org middleware and fetches points in the RSC. A test rejects any digit of Goods data in the public registry copy.
2. **Preview-feedback fixes** (`87b90b1`): quantile colours that differentiate, one merged caveat card, labelled layer/state switchers, mainland framing.
3. **The desk layout + layer re-scope** (`787121a`): locked left rail, closable right rail, no AI bubble on /atlas; picker grouped Money · Need · Delivery · How-sure-are-we; new live layers money-recorded, justice-funding, seifa-disadvantage; justice CTE in /api/data/map; ≥50%-unplaced red confidence line on every panel.
4. **Placement migration: single-council postcodes** (`818da02`) — **applied**: 15,251 entities placed, unplaced 98,660 → 83,409.
5. **Placement migration: own-name city repair + plan spine** (`0c6b360`) — **applied**: 14 councils get their namesake towns back (Warrnambool, Subiaco, Hope Vale, Lockhart River…), 28 postcode_geo rows + 2,550 entities, unplaced → 80,859. Plan: `thoughts/shared/plans/place-data-truth.md`.

Both migrations are live in prod (day-shift, verified against dry-run exactly); merging closes the code↔DB gap. Data-session record in comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)