### PR TITLE
The caveat card reads why: six reason codes live, per council and per layer

### DIFF
--- a/apps/web/src/app/api/data/map/route.ts
+++ b/apps/web/src/app/api/data/map/route.ts
@@ -52,8 +52,14 @@ export async function GET(request: Request) {
     // Councils without point coordinates stay in the payload with a null
     // lat/lng: the choropleth paints them by boundary-name match, which needs
     // no centroid. Coordinates only drive bounds-fitting and fallback markers.
-    const { data, error } = await supabase.rpc('exec_sql', {
-      query: `WITH lga_centroids AS (
+    //
+    // The second query is the live "why" tally: every null-lga row carries
+    // exactly one lga_source reason code (the 2026-08 placement migrations
+    // stamped them), grouped per state so the caveat card can scope to the
+    // state filter. State is null for records that hold no state at all.
+    const [councilResult, reasonResult] = await Promise.all([
+      supabase.rpc('exec_sql', {
+        query: `WITH lga_centroids AS (
         SELECT lga_name, MAX(lga_code) AS lga_code, UPPER(state) as state,
                AVG(latitude::float) as lat,
                AVG(longitude::float) as lng
@@ -85,10 +91,10 @@ export async function GET(request: Request) {
                  dd.desert_score DESC
       ),
       unplaced_pc AS MATERIALIZED (
-        SELECT postcode, COUNT(*) AS n
+        SELECT postcode, COALESCE(lga_source, 'unstamped') AS reason, COUNT(*) AS n
         FROM gs_entities
         WHERE lga_name IS NULL AND postcode IS NOT NULL
-        GROUP BY postcode
+        GROUP BY 1, 2
       ),
       council_pc AS MATERIALIZED (
         SELECT DISTINCT lga_name, UPPER(state) AS state, postcode
@@ -96,9 +102,14 @@ export async function GET(request: Request) {
         WHERE lga_name IS NOT NULL
       ),
       unplaced AS MATERIALIZED (
-        SELECT cp.lga_name, cp.state, SUM(u.n)::int AS unplaced
-        FROM council_pc cp
-        JOIN unplaced_pc u USING (postcode)
+        SELECT lga_name, state, SUM(n)::int AS unplaced,
+               jsonb_object_agg(reason, n) AS unplaced_reasons
+        FROM (
+          SELECT cp.lga_name, cp.state, u.reason, SUM(u.n)::int AS n
+          FROM council_pc cp
+          JOIN unplaced_pc u USING (postcode)
+          GROUP BY 1, 2, 3
+        ) by_reason
         GROUP BY 1, 2
       ),
       placed AS MATERIALIZED (
@@ -122,6 +133,7 @@ export async function GET(request: Request) {
              dd.total_funding_all_sources, dd.desert_score,
              jt.justice_total AS justice_funding_total,
              COALESCE(un.unplaced, 0) AS unplaced_count,
+             un.unplaced_reasons,
              COALESCE(pl.placed, 0) AS placed_count,
              CASE WHEN COALESCE(un.unplaced, 0) + COALESCE(pl.placed, 0) > 0
                   THEN ROUND(100.0 * COALESCE(un.unplaced, 0)
@@ -135,17 +147,34 @@ export async function GET(request: Request) {
       LEFT JOIN justice jt ON jt.lga_name = lc.lga_name AND jt.state = lc.state
       WHERE dd.desert_score IS NOT NULL OR COALESCE(un.unplaced, 0) > 0
       ORDER BY dd.desert_score DESC NULLS LAST`,
-    });
+      }),
+      supabase.rpc('exec_sql', {
+        query: `SELECT UPPER(state) AS state,
+               COALESCE(lga_source, 'unstamped') AS reason,
+               COUNT(*)::int AS n
+        FROM gs_entities
+        WHERE lga_name IS NULL
+        GROUP BY 1, 2`,
+      }),
+    ]);
 
-    if (error) throw error;
+    if (councilResult.error) throw councilResult.error;
+    if (reasonResult.error) throw reasonResult.error;
 
-    const features = (data || []) as Array<{
+    const features = (councilResult.data || []) as Array<{
       lga_name: string; state: string; remoteness: string | null;
       avg_irsd_decile: number | null; desert_score: number | null;
       indexed_entities: number | null; community_controlled_entities: number | null;
       total_funding_all_sources: number | null; lat: number | null; lng: number | null;
       unplaced_count: number; placed_count: number; unplaced_share: number | null;
       justice_funding_total: number | null;
+      unplaced_reasons: Record<string, number> | null;
+    }>;
+
+    // The live why-tally rides the summary: (state, reason, n) rows the
+    // client scopes to its state filter. ~40 rows, six reason codes.
+    const unplacedReasons = (reasonResult.data || []) as Array<{
+      state: string | null; reason: string; n: number;
     }>;
 
     // Councils with data but no point coordinates render only where a map
@@ -172,6 +201,7 @@ export async function GET(request: Request) {
         f => Number(f.unplaced_share) >= 50 && Number(f.unplaced_count) >= 50
       ).length,
       undrawn_lgas: undrawnLgas,
+      unplaced_reasons: unplacedReasons,
     };
 
     const response = NextResponse.json({ features, summary, metric });

--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -28,6 +28,13 @@ import {
   resolvePlace,
 } from '@/lib/atlas/share';
 import {
+  beyondCouncilRows,
+  reasonRows,
+  scopeReasonRows,
+  totalOf,
+  type StateReasonCount,
+} from '@/lib/atlas/reasons';
+import {
   ATLAS_STORY,
   ATLAS_STORY_MEASURED_AT,
   getStoryStep,
@@ -97,6 +104,9 @@ export default function AtlasClient({
   const LAYERS = useMemo(() => visibleAtlasLayers(surface), [surface]);
 
   const [features, setFeatures] = useState<AtlasFeature[]>([]);
+  // The live why-tally behind every "cannot place" number: (state, reason,
+  // count) rows, scoped client-side to the state filter or a selection.
+  const [reasonTally, setReasonTally] = useState<StateReasonCount[]>([]);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [stateFilter, setStateFilter] = useState('ALL');
@@ -129,6 +139,7 @@ export default function AtlasClient({
       .then(r => r.json())
       .then(data => {
         setFeatures(data.features || []);
+        setReasonTally(data.summary?.unplaced_reasons || []);
         setLoading(false);
       })
       .catch(() => {
@@ -278,8 +289,13 @@ export default function AtlasClient({
 
   const undrawn = useMemo(() => filtered.filter(f => f.lat === null).length, [filtered]);
 
+  // Unplaced-orgs is excluded from the generic metric rows: its story is the
+  // How-sure breakdown on the place panel, not one more percentage.
   const otherLiveLayers = useMemo(
-    () => LAYERS.filter(isChoroplethLayer).filter(l => l.key !== mapLayer.key),
+    () =>
+      LAYERS.filter(isChoroplethLayer).filter(
+        l => l.key !== mapLayer.key && l.key !== 'unplaced-orgs'
+      ),
     [LAYERS, mapLayer.key]
   );
 
@@ -554,6 +570,40 @@ export default function AtlasClient({
             </p>
             <p className="text-xs text-gray-500 mt-1">{activeLayer.honestAtNote}</p>
           </div>
+
+          {/* The live why behind every number here: not one red percentage
+              but the six reason codes, read from the database and scoped to
+              the state filter. Uncertainty qualifies every layer, so this
+              block travels with all of them. */}
+          {(() => {
+            const scoped = scopeReasonRows(reasonTally, stateFilter);
+            if (scoped.length === 0) return null;
+            return (
+              <div className="mt-3 pt-3 border-t border-gray-200">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                  Cannot be placed{stateFilter !== 'ALL' ? ` · ${stateFilter}` : ''}
+                </p>
+                <p className="text-xs text-gray-600 mt-1 leading-snug">
+                  {totalOf(scoped).toLocaleString()} organisations
+                  {stateFilter !== 'ALL' ? ` recorded in ${stateFilter}` : ''} sit on no
+                  council&apos;s count. Why, counted live:
+                </p>
+                <div className="mt-2 space-y-1">
+                  {scoped.map(r => (
+                    <div key={r.code} className="flex justify-between items-baseline gap-2 text-[11px]">
+                      <span className="text-gray-600">{r.label}</span>
+                      <span className="font-black tabular-nums">{r.n.toLocaleString()}</span>
+                    </div>
+                  ))}
+                </div>
+                <p className="text-[10px] text-gray-400 mt-1.5 leading-snug">
+                  An organisation with no postcode, or one we do not recognise, can appear
+                  under no council at all. The rest count toward every council sharing
+                  their postcode — never sum them.
+                </p>
+              </div>
+            );
+          })()}
           </div>
         </div>
       </aside>
@@ -600,14 +650,6 @@ export default function AtlasClient({
                 </span>
               </div>
 
-              {/* Uncertainty travels with every number, on every layer */}
-              {Number(selected.unplaced_share) >= 50 && (
-                <p className="mt-2 text-[11px] text-bauhaus-red leading-snug">
-                  Half or more of what might be here cannot be placed — read every
-                  number on this panel gently.
-                </p>
-              )}
-
               <div className="mt-3 space-y-2">
                 {otherLiveLayers.map(layer => {
                   const v = layer.value(selected);
@@ -636,16 +678,73 @@ export default function AtlasClient({
                   <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Community controlled</span>
                   <span className="text-sm font-black">{selected.community_controlled_entities ?? '—'}</span>
                 </div>
-                <div className="flex justify-between items-baseline">
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Cannot place</span>
-                  <span className={`text-sm font-black ${Number(selected.unplaced_share) >= 50 ? 'text-bauhaus-red' : ''}`}>
-                    {selected.unplaced_count}
-                    {selected.unplaced_share !== null && (
-                      <span className="text-xs font-bold text-gray-400 ml-1">({Number(selected.unplaced_share).toFixed(0)}%)</span>
-                    )}
-                  </span>
-                </div>
               </div>
+
+              {/* How sure are we, for this council: the live reasons, not one
+                  red percentage. Counts include every organisation whose
+                  postcode touches this council, so the same organisation
+                  counts toward every council sharing it — never summed. */}
+              {(() => {
+                const rows = reasonRows(selected.unplaced_reasons);
+                const total = Number(selected.unplaced_count) || 0;
+                const share =
+                  selected.unplaced_share === null ? null : Number(selected.unplaced_share);
+                const severe = share !== null && share >= 50;
+                const beyond = beyondCouncilRows(reasonTally, selected.state);
+                const beyondParts = beyond.map(r =>
+                  r.code === 'no_postcode'
+                    ? `${r.n.toLocaleString()} hold no postcode`
+                    : r.code === 'unknown_postcode'
+                      ? `${r.n.toLocaleString()} hold a postcode we do not recognise`
+                      : `${r.n.toLocaleString()} ${r.label}`
+                );
+                return (
+                  <div className="mt-4 pt-3 border-t border-gray-200">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                      How sure are we
+                    </p>
+                    {total > 0 ? (
+                      <>
+                        <p
+                          className={`text-xs mt-1 leading-snug ${severe ? 'text-bauhaus-red' : 'text-gray-600'}`}
+                        >
+                          {total.toLocaleString()} organisations that might be here cannot be
+                          tied to one council
+                          {share !== null
+                            ? ` — ${share.toFixed(0)}% of everything this council might hold`
+                            : ''}
+                          .{severe ? ' Read every number on this panel gently.' : ''}
+                        </p>
+                        {rows.length > 0 && (
+                          <div className="mt-2 space-y-1">
+                            {rows.map(r => (
+                              <div
+                                key={r.code}
+                                className="flex justify-between items-baseline gap-2 text-[11px]"
+                              >
+                                <span className="text-gray-600">{r.label}</span>
+                                <span className="font-black tabular-nums">
+                                  {r.n.toLocaleString()}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <p className="text-xs mt-1 text-gray-600 leading-snug">
+                        Every organisation recorded in this council&apos;s postcodes is placed.
+                      </p>
+                    )}
+                    {beyondParts.length > 0 && (
+                      <p className="text-[10px] text-gray-400 mt-2 leading-snug">
+                        In {selected.state} records, {beyondParts.join(' and ')} — none of
+                        them can appear under any council.
+                      </p>
+                    )}
+                  </div>
+                );
+              })()}
 
               {selectedPage && (
                 <Link

--- a/apps/web/src/lib/atlas/layers.ts
+++ b/apps/web/src/lib/atlas/layers.ts
@@ -40,6 +40,10 @@ export interface AtlasFeature {
   unplaced_count: number;
   placed_count: number;
   unplaced_share: number | null;
+  /** Why the unplaced cannot be placed: lga_source reason code -> count for
+   * this council's postcodes. Optional because a cached payload from before
+   * the field existed may still hydrate a newer client. */
+  unplaced_reasons?: Record<string, number> | null;
   justice_funding_total: number | null;
   /** Null when the council has no point coordinates; it still renders where a
    * boundary matches its name. Coordinates only drive bounds-fitting. */

--- a/apps/web/src/lib/atlas/reasons.test.ts
+++ b/apps/web/src/lib/atlas/reasons.test.ts
@@ -1,0 +1,107 @@
+// The reason registry is a contract with the database: the six codes here
+// are exactly the lga_source stamps the 2026-08 placement migrations wrote.
+// A code drifting out of sync fails loudly here, not silently on the map.
+
+import { describe, expect, it } from 'vitest';
+import {
+  beyondCouncilRows,
+  COUNCIL_REASON_COLUMNS,
+  reasonLabel,
+  reasonRows,
+  scopeReasonRows,
+  totalOf,
+  UNPLACED_REASONS,
+  type StateReasonCount,
+} from './reasons';
+
+describe('the reason registry', () => {
+  it('pins the six lga_source codes the migrations stamp', () => {
+    expect(UNPLACED_REASONS.map(r => r.code).sort()).toEqual([
+      'no_postcode',
+      'no_state',
+      'postcode_unmapped_in_abs',
+      'state_conflict',
+      'unknown_postcode',
+      'unresolved_multi_lga_postcode',
+    ]);
+  });
+
+  it('every label is plain words, no codes leaking through', () => {
+    for (const r of UNPLACED_REASONS) {
+      expect(r.label.length).toBeGreaterThan(5);
+      expect(r.label).not.toMatch(/_/);
+      expect(r.label).toBe(r.label.toLowerCase());
+    }
+  });
+
+  it('only postcode-less and unrecognised-postcode records are impossible per council', () => {
+    const impossible = UNPLACED_REASONS.filter(r => !r.councilPossible)
+      .map(r => r.code)
+      .sort();
+    expect(impossible).toEqual(['no_postcode', 'unknown_postcode']);
+  });
+
+  it('labels a code it has not met honestly instead of dropping it', () => {
+    expect(reasonLabel('future_code')).toBe('future code');
+  });
+});
+
+describe('per-council rows', () => {
+  it('sorts biggest first and drops empty or broken counts', () => {
+    const rows = reasonRows({
+      unresolved_multi_lga_postcode: 312,
+      state_conflict: 40,
+      postcode_unmapped_in_abs: 0,
+      no_state: Number.NaN,
+    });
+    expect(rows.map(r => r.code)).toEqual(['unresolved_multi_lga_postcode', 'state_conflict']);
+    expect(rows[0].label).toBe('postcode spans several councils');
+  });
+
+  it('tolerates payloads from before the reason codes existed', () => {
+    expect(reasonRows(null)).toEqual([]);
+    expect(reasonRows(undefined)).toEqual([]);
+  });
+});
+
+describe('scoping the live tally', () => {
+  const tally: StateReasonCount[] = [
+    { state: 'SA', reason: 'unresolved_multi_lga_postcode', n: 5592 },
+    { state: 'SA', reason: 'no_postcode', n: 1065 },
+    { state: 'QLD', reason: 'no_postcode', n: 5360 },
+    { state: null, reason: 'no_postcode', n: 262506 },
+    { state: null, reason: 'no_state', n: 7 },
+  ];
+
+  it('ALL sums every state including records with no state at all', () => {
+    const rows = scopeReasonRows(tally, 'ALL');
+    expect(rows.find(r => r.code === 'no_postcode')?.n).toBe(1065 + 5360 + 262506);
+    expect(rows.find(r => r.code === 'no_state')?.n).toBe(7);
+  });
+
+  it('a state filter shows that state alone', () => {
+    const rows = scopeReasonRows(tally, 'SA');
+    expect(rows.map(r => r.code)).toEqual(['unresolved_multi_lga_postcode', 'no_postcode']);
+    expect(totalOf(rows)).toBe(5592 + 1065);
+  });
+
+  it('beyond-council rows name only what no council can ever count', () => {
+    expect(beyondCouncilRows(tally, 'SA').map(r => r.code)).toEqual(['no_postcode']);
+  });
+
+  it('a missing tally yields no rows, never a crash', () => {
+    expect(scopeReasonRows(undefined, 'ALL')).toEqual([]);
+    expect(beyondCouncilRows(null, 'SA')).toEqual([]);
+  });
+});
+
+describe('export columns', () => {
+  it('one column per council-possible reason, raw code in the header', () => {
+    expect(COUNCIL_REASON_COLUMNS.map(c => c.header)).toEqual([
+      'unplaced_unresolved_multi_lga_postcode',
+      'unplaced_postcode_unmapped_in_abs',
+      'unplaced_state_conflict',
+      'unplaced_no_state',
+    ]);
+  });
+});

--- a/apps/web/src/lib/atlas/reasons.ts
+++ b/apps/web/src/lib/atlas/reasons.ts
@@ -1,0 +1,111 @@
+// Why an organisation sits on no council's count — the reason codes.
+//
+// Every gs_entities row without a council carries exactly one lga_source
+// reason code (stamped by the 2026-08 placement migrations; zero unstamped
+// rows, verified live). The Atlas reads them live so "cannot place" is never
+// one opaque percentage: the caveat card and the place panel both say WHY,
+// with counts.
+//
+// Two kinds of reason:
+//  - councilPossible: the organisation's postcode ties it to candidate
+//    councils, so it appears in per-council breakdowns — counting toward
+//    every council that shares the postcode, which is why these can never
+//    be summed across councils.
+//  - not councilPossible: nothing ties it to any council. These exist only
+//    in state and national tallies, and by construction can never appear
+//    under any council on the map.
+
+export interface UnplacedReason {
+  /** The lga_source code exactly as stamped in the database. */
+  code: string;
+  /** Plain words for a row label — what a person in a room would say. */
+  label: string;
+  /** Whether entities with this code can appear in a council's breakdown. */
+  councilPossible: boolean;
+}
+
+/** Canonical order: national magnitude, largest first (checked 2026-08-09). */
+export const UNPLACED_REASONS: readonly UnplacedReason[] = [
+  { code: 'no_postcode', label: 'no postcode on the record', councilPossible: false },
+  { code: 'unresolved_multi_lga_postcode', label: 'postcode spans several councils', councilPossible: true },
+  { code: 'postcode_unmapped_in_abs', label: 'postcode unmappable to one council', councilPossible: true },
+  { code: 'unknown_postcode', label: 'postcode we do not recognise', councilPossible: false },
+  { code: 'state_conflict', label: 'recorded state disagrees with the postcode', councilPossible: true },
+  { code: 'no_state', label: 'no state on the record', councilPossible: true },
+];
+
+/** Label for a code, including codes this registry has not met — a new stamp
+ * in the database still renders honestly instead of vanishing. */
+export function reasonLabel(code: string): string {
+  const known = UNPLACED_REASONS.find(r => r.code === code);
+  return known ? known.label : code.replace(/_/g, ' ');
+}
+
+export interface ReasonRow {
+  code: string;
+  label: string;
+  n: number;
+}
+
+/** Rows for a per-council breakdown, biggest first. Zero, negative and
+ * non-numeric counts are dropped; null/missing payloads yield no rows. */
+export function reasonRows(counts: Record<string, number> | null | undefined): ReasonRow[] {
+  if (!counts) return [];
+  return Object.entries(counts)
+    .map(([code, raw]) => ({ code, label: reasonLabel(code), n: Number(raw) }))
+    .filter(r => Number.isFinite(r.n) && r.n > 0)
+    .sort((a, b) => b.n - a.n);
+}
+
+/** One (state, reason, n) row of the live tally in the map summary. State is
+ * null for records that hold no state at all. */
+export interface StateReasonCount {
+  state: string | null;
+  reason: string;
+  n: number;
+}
+
+/** Scope the live tally to the current state filter. 'ALL' sums every state
+ * INCLUDING records with no state — the national number must not quietly
+ * drop the stateless. A state filter shows that state's records only. */
+export function scopeReasonRows(
+  rows: readonly StateReasonCount[] | null | undefined,
+  stateFilter: string
+): ReasonRow[] {
+  if (!rows) return [];
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    if (stateFilter !== 'ALL' && (row.state ?? '') !== stateFilter) continue;
+    const n = Number(row.n);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    totals.set(row.reason, (totals.get(row.reason) ?? 0) + n);
+  }
+  return [...totals.entries()]
+    .map(([code, n]) => ({ code, label: reasonLabel(code), n }))
+    .sort((a, b) => b.n - a.n);
+}
+
+/** The reasons that can never appear under any council, scoped to a state.
+ * The place panel names these so a council's "cannot place" count is never
+ * mistaken for the whole uncertainty. */
+export function beyondCouncilRows(
+  rows: readonly StateReasonCount[] | null | undefined,
+  state: string
+): ReasonRow[] {
+  const impossible = new Set(
+    UNPLACED_REASONS.filter(r => !r.councilPossible).map(r => r.code)
+  );
+  return scopeReasonRows(rows, state).filter(r => impossible.has(r.code));
+}
+
+export function totalOf(rows: readonly ReasonRow[]): number {
+  return rows.reduce((sum, r) => sum + r.n, 0);
+}
+
+/** Export columns for the council-possible reasons: the raw code is the
+ * header suffix on purpose — a data user can grep the database for it. */
+export const COUNCIL_REASON_COLUMNS: ReadonlyArray<{ code: string; header: string }> =
+  UNPLACED_REASONS.filter(r => r.councilPossible).map(r => ({
+    code: r.code,
+    header: `unplaced_${r.code}`,
+  }));

--- a/apps/web/src/lib/atlas/share.test.ts
+++ b/apps/web/src/lib/atlas/share.test.ts
@@ -139,6 +139,22 @@ describe('taking the data with its caveats', () => {
     expect(row.match(/"/g)?.length ?? 0).toBeGreaterThan(2);
   });
 
+  it('CSV carries the why behind unplaced, empty when the payload predates it', () => {
+    const csv = councilCsv(
+      feature({ unplaced_reasons: { unresolved_multi_lga_postcode: 25, state_conflict: 5 } })
+    );
+    const [headerLine, rowLine] = csv.trimEnd().split('\n');
+    const headers = headerLine.split(',');
+    const cells = rowLine.split(',');
+    expect(cells[headers.indexOf('unplaced_unresolved_multi_lga_postcode')]).toBe('25');
+    expect(cells[headers.indexOf('unplaced_state_conflict')]).toBe('5');
+    // Held reasons make an absent code a real zero…
+    expect(cells[headers.indexOf('unplaced_no_state')]).toBe('0');
+    // …but a payload from before the reason codes exports empty, never zero.
+    const oldCells = councilCsv(feature()).trimEnd().split('\n')[1].split(',');
+    expect(oldCells[headers.indexOf('unplaced_no_state')]).toBe('');
+  });
+
   it('null values export as empty cells, never zero', () => {
     const csv = councilCsv(feature({ desert_score: null, total_funding_all_sources: null }));
     const [headerLine, rowLine] = csv.trimEnd().split('\n');

--- a/apps/web/src/lib/atlas/share.ts
+++ b/apps/web/src/lib/atlas/share.ts
@@ -12,6 +12,7 @@ import {
   type AtlasLiveLayer,
   type AtlasSurface,
 } from './layers';
+import { COUNCIL_REASON_COLUMNS } from './reasons';
 
 /** URL-safe slug for a place name. Also the slug of /place/council/[slug] —
  * council-place-report.ts imports this one so the two can never drift. */
@@ -112,6 +113,12 @@ const PLACE_COLUMNS: Array<{ header: string; read(f: AtlasFeature): unknown }> =
   { header: 'recorded_funding', read: f => f.total_funding_all_sources },
   { header: 'unplaced_count', read: f => f.unplaced_count },
   { header: 'placed_count', read: f => f.placed_count },
+  // Why the unplaced cannot be placed, one column per reason that can touch
+  // a council. Null (not zero) when the payload predates the reason codes.
+  ...COUNCIL_REASON_COLUMNS.map(({ code, header }) => ({
+    header,
+    read: (f: AtlasFeature) => (f.unplaced_reasons ? (f.unplaced_reasons[code] ?? 0) : null),
+  })),
 ];
 
 // Only choropleth layers read council features; a point layer's data never


### PR DESCRIPTION
## What

The /atlas "how sure are we" story stops being one red percentage. Both rails now read the six `lga_source` reason codes live from the database:

- **Caveat card (left rail, every layer):** a "Cannot be placed" section scoped to the state filter — e.g. SA shows 6,739 organisations on no council's count, decomposed: 5,592 postcode spans several councils · 1,065 no postcode · 71 unmappable · 7 state disagrees · 4 unrecognised postcode. ALL shows the national 355,051 including the 262K stateless. The never-sum warning travels with the rows.
- **Place panel (right rail, per council):** the lone "Cannot place: N (X%)" row and separate red line become one How-sure block — the count+share sentence (red with the read-gently register at ≥50%), per-reason rows from the council's own postcode join, and a state-level line naming what no council can ever count ("In SA records, 1,065 hold no postcode…").
- **Contract:** `lib/atlas/reasons.ts` pins the six codes, plain-word labels, and which codes can ever touch a council (no_postcode and unknown_postcode cannot, by construction). A code the registry hasn't met still renders honestly.
- **API:** `/api/data/map` features carry a per-council `unplaced_reasons` jsonb (same postcode→council join, grouped by reason); the summary carries the (state, reason, n) tally. Two queries run in parallel; payload change is additive and the client tolerates cached pre-change payloads.
- **Exports:** council CSV/JSON gain one column per council-possible reason — null, never zero, when the payload predates the codes.

## Verification

- End-to-end on the dev server: Ceduna `unplaced_count` 126 = 126 unresolved_multi_lga_postcode; tally grand total 355,051 ties the six-code national sum exactly; SA rows match the direct DB query.
- `tsc --noEmit` clean; 642 unit tests passing (+12 new: reason-registry contract, scoping helpers, CSV columns).
- Both rails eyeballed on localhost at Ceduna/SA — Bauhaus register maintained (uppercase micro-labels, tabular-nums, red only for the severe line).

## Seen, not touched (for /polish, not this PR)

The place panel has pre-existing duplicate rows — "Recorded money" (layer row) vs "Recorded funding" (hardcoded), and "SEIFA disadvantage: decile 2" vs raw "SEIFA decile 2.411764705882353". Left alone here to keep the PR one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)