### PR TITLE
Goods Investment Portfolio: start from the community decision, not the grant

### DIFF
--- a/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
+++ b/apps/web/src/app/org/[slug]/_components/act-workspace-shell.tsx
@@ -312,7 +312,7 @@ function WorkspaceModeLink({ href, label, active, index, hint }: WorkspaceLink &
 // Rail-owned Goods navigation (Ben's call, 2026-08-05): the rail is the ONE
 // nav. These groups replace the pill rows that lived in the green page header.
 const GOODS_RAIL_SECTIONS: ReadonlyArray<{ label: string; items: ReadonlyArray<readonly [string, string]> }> = [
-  { label: 'Work', items: [['today', 'Today'], ['capital', 'Capital'], ['matters', 'Matters'], ['network', 'Network'], ['applications', 'Applications'], ['learning', 'Learning']] },
+  { label: 'Work', items: [['today', 'Today'], ['portfolio', 'Portfolio'], ['capital', 'Capital'], ['matters', 'Matters'], ['network', 'Network'], ['applications', 'Applications'], ['learning', 'Learning']] },
   { label: 'Money in', items: [['foundations', 'Foundations'], ['foundations/scan', 'Funder Scan'], ['grants', 'Grants'], ['money', 'Money']] },
   { label: 'Delivery', items: [['funnel', 'Delivery map'], ['map', 'On the map'], ['communities', 'Communities'], ['channels', 'Channels'], ['buyers', 'Buyers']] },
   { label: 'Trust', items: [['model', 'Story & model'], ['proof', 'Evidence'], ['governance', 'Governance']] },

--- a/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
+++ b/apps/web/src/app/org/[slug]/goods/_components/goods-sub-nav.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 // around warmth scores or weighted pipeline values.
 const OPERATING_TABS = [
   ['today', 'Today'],
+  ['portfolio', 'Portfolio'],
   ['capital', 'Capital'],
   ['matters', 'Matters'],
   ['network', 'Network'],

--- a/apps/web/src/app/org/[slug]/goods/portfolio/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/portfolio/page.tsx
@@ -1,0 +1,217 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/services/fast-local-org';
+import {
+  COMMUNITY_PATHWAYS,
+  INVESTMENT_USES,
+  PORTFOLIO_DATA_LIMITS,
+  STAGE_LABEL,
+  isPortfolioEligible,
+  type CommunityPathway,
+  type PortfolioDecision,
+} from '@/lib/services/goods-investment-portfolio';
+import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
+import {
+  GoodsWorkspaceHeader,
+  Metric,
+  SectionTitle,
+  StatusPill,
+} from '../_components/goods-capital-ui';
+
+export const revalidate = 300;
+
+export async function generateMetadata() {
+  return {
+    title: 'Goods — Investment Portfolio',
+    description: 'One row per community pathway: decision, authority, evidence, investment use, money route.',
+  };
+}
+
+const DECISION_TONE: Record<PortfolioDecision, 'neutral' | 'good' | 'warn' | 'bad' | 'info' | 'dark'> = {
+  listen: 'neutral',
+  scope: 'info',
+  'ready to pursue': 'warn',
+  submitted: 'dark',
+  'funded/delivering': 'good',
+  hold: 'bad',
+};
+
+function PathwayCard({ pathway }: { pathway: CommunityPathway }) {
+  const eligible = isPortfolioEligible(pathway);
+  const use = INVESTMENT_USES[pathway.investmentUse];
+  return (
+    <article className="border-4 border-bauhaus-black bg-white">
+      <header className="flex flex-wrap items-start justify-between gap-3 border-b-4 border-bauhaus-black bg-bauhaus-canvas px-4 py-3">
+        <div>
+          <h3 className="text-lg font-black uppercase tracking-widest text-bauhaus-black">{pathway.community}</h3>
+          <div className="mt-1 text-[11px] leading-5 text-bauhaus-muted">{pathway.authority}</div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusPill tone="neutral">Stage: {STAGE_LABEL[pathway.stage]}</StatusPill>
+          <StatusPill tone={DECISION_TONE[pathway.decision]}>{pathway.decision}</StatusPill>
+          <StatusPill tone={eligible ? 'good' : 'warn'}>
+            {eligible ? 'Investment work OK' : 'Relationship work only'}
+          </StatusPill>
+        </div>
+      </header>
+
+      <div className="grid gap-0 md:grid-cols-3">
+        <div className="border-b-2 border-bauhaus-black/15 px-4 py-3 md:border-b-0 md:border-r-2">
+          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Next community decision</div>
+          <p className="mt-1 text-xs leading-5 text-bauhaus-black">{pathway.nextDecision ?? 'None named — nothing to pursue yet.'}</p>
+          <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Relationship owner</div>
+          <p className="mt-1 text-xs leading-5 text-bauhaus-black">
+            {pathway.relationshipOwner ?? <span className="text-bauhaus-red font-bold">Not named</span>}
+          </p>
+          {pathway.nextActionDue ? (
+            <>
+              <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Due</div>
+              <p className="mt-1 text-xs leading-5 text-bauhaus-black">{pathway.nextActionDue}</p>
+            </>
+          ) : null}
+        </div>
+
+        <div className="border-b-2 border-bauhaus-black/15 px-4 py-3 md:border-b-0 md:border-r-2">
+          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Evidence already held</div>
+          <ul className="mt-1 space-y-1 text-xs leading-5 text-bauhaus-black">
+            {pathway.evidenceHeld.map((item) => (
+              <li key={item}>· {item}</li>
+            ))}
+          </ul>
+          <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Evidence this use requires</div>
+          <p className="mt-1 text-xs leading-5 text-bauhaus-muted">{use.evidenceRequired}</p>
+        </div>
+
+        <div className="px-4 py-3">
+          <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-blue">Investment use</div>
+          <p className="mt-1 text-xs font-bold leading-5 text-bauhaus-black">{use.label}</p>
+          <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Money route</div>
+          <p className="mt-1 text-xs leading-5 text-bauhaus-black">{pathway.moneyRoute}</p>
+          <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Suitable capital</div>
+          <p className="mt-1 text-xs leading-5 text-bauhaus-muted">{use.suitableCapital}</p>
+        </div>
+      </div>
+
+      <div className="border-t-4 border-bauhaus-black bg-bauhaus-yellow px-4 py-3">
+        <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-black">Do not do yet</div>
+        <p className="mt-1 text-xs leading-5 text-bauhaus-black">{pathway.doNotYet}</p>
+      </div>
+
+      {pathway.links.length > 0 ? (
+        <div className="flex flex-wrap gap-2 border-t-2 border-bauhaus-black/15 px-4 py-3">
+          {pathway.links.map((link) => (
+            <Link
+              key={link.href + link.label}
+              href={link.href}
+              className="inline-flex min-h-9 items-center border-2 border-bauhaus-black bg-white px-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-black hover:bg-bauhaus-canvas"
+            >
+              {link.system}: {link.label}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export default async function GoodsInvestmentPortfolioPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const profile = shouldUseFastLocalOrg() && isActSlug(slug)
+    ? ACT_FAST_PROFILE
+    : await getOrgProfileBySlug(slug);
+  if (!profile) notFound();
+
+  const pathways = [...COMMUNITY_PATHWAYS];
+  const eligible = pathways.filter(isPortfolioEligible);
+  const listening = pathways.filter((p) => !isPortfolioEligible(p));
+  const submitted = pathways.filter((p) => p.decision === 'submitted').length;
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas text-bauhaus-black">
+      <GoodsWorkspaceHeader
+        slug={slug}
+        orgName={profile.name}
+        active="portfolio"
+        eyebrow="Community decision → relationship → investment need → opportunity"
+        title="Investment portfolio"
+        description={(
+          <>
+            One row per community pathway, not one row per grant. Start with the community decision, check the
+            relationship, then decide whether investment is appropriate. Only after that does grant, buyer or lender
+            work belong on the table.
+          </>
+        )}
+        aside={(
+          <div className="border-4 border-white bg-white px-4 py-3 text-bauhaus-black">
+            <div className="text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Pathways carrying investment work</div>
+            <div className="mt-1 text-3xl font-black tabular-nums">{eligible.length} / {pathways.length}</div>
+            <div className="mt-1 text-[10px] font-bold text-bauhaus-muted">Needs a named decision and an owner</div>
+          </div>
+        )}
+      />
+
+      <div className="mx-auto max-w-[1760px] px-4 py-6">
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <Metric label="Community pathways" value={String(pathways.length)} detail="The whole portfolio; one row each" />
+          <Metric label="Investment-eligible" value={String(eligible.length)} detail="Named decision + relationship owner" tone="yellow" />
+          <Metric label="Listening only" value={String(listening.length)} detail="No application work yet" />
+          <Metric label="Submitted" value={String(submitted)} detail="Application in with a funder" tone="dark" />
+        </div>
+
+        <div className="mt-8">
+          <SectionTitle
+            eyebrow="Weekly read"
+            title="Community pathways"
+            description="A pathway becomes eligible for investment work only when it has both a named next community decision and a relationship owner. Nothing here is an ownership claim, and no CRM stage counts as approval."
+          />
+          <div className="space-y-4">
+            {pathways.map((pathway) => (
+              <PathwayCard key={pathway.id} pathway={pathway} />
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-10">
+          <SectionTitle
+            eyebrow="Six uses"
+            title="Investment lenses"
+            description="Every investment or opportunity must declare one primary use. This is the field that makes grants useful rather than noisy — if an opportunity cannot fund a named use for a named community or the shared network, it stays outside the portfolio."
+          />
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {Object.entries(INVESTMENT_USES).map(([key, use]) => {
+              const count = pathways.filter((p) => p.investmentUse === key).length;
+              return (
+                <div key={key} className="border-4 border-bauhaus-black bg-white p-4">
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="text-sm font-black uppercase tracking-widest text-bauhaus-black">{use.label}</h3>
+                    <StatusPill tone={count > 0 ? 'dark' : 'neutral'}>{count} pathway{count === 1 ? '' : 's'}</StatusPill>
+                  </div>
+                  <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Suitable capital</div>
+                  <p className="mt-1 text-xs leading-5 text-bauhaus-black">{use.suitableCapital}</p>
+                  <div className="mt-3 text-[10px] font-black uppercase tracking-widest text-bauhaus-muted">Evidence required before pursuit</div>
+                  <p className="mt-1 text-xs leading-5 text-bauhaus-muted">{use.evidenceRequired}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-10">
+          <SectionTitle eyebrow="Honesty" title="Known source conflicts" description="Shown here rather than quietly resolved in a number." />
+          <ul className="space-y-2">
+            {PORTFOLIO_DATA_LIMITS.map((limit) => (
+              <li key={limit} className="border-l-4 border-bauhaus-red bg-white px-4 py-3 text-xs leading-5 text-bauhaus-black">
+                {limit}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-4 text-[11px] leading-5 text-bauhaus-muted">
+            Readings sourced from <code className="font-mono">thoughts/shared/handoffs/goods-investment-portfolio-alignment-2026-08-10.md</code>,
+            which cites the Goods Asset Register decision log. Edit{' '}
+            <code className="font-mono">src/lib/services/goods-investment-portfolio.ts</code> to change what this screen says.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/services/goods-investment-portfolio.ts
+++ b/apps/web/src/lib/services/goods-investment-portfolio.ts
@@ -1,0 +1,204 @@
+/**
+ * Goods Investment Portfolio — one row per community pathway, not one row per grant.
+ *
+ * Source of truth for the readings below:
+ *   thoughts/shared/handoffs/goods-investment-portfolio-alignment-2026-08-10.md
+ * which in turn cites the Goods Asset Register STRATEGY.md / DECISIONS.md and
+ * scripts/funding-profiles/goods-on-country.json.
+ *
+ * This lives in code, not markdown, so the stage vocabulary and the "do not do
+ * yet" guards cannot drift away from the screen that renders them. A pathway is
+ * eligible for investment work ONLY when it has a named next community decision
+ * AND a relationship owner — `isPortfolioEligible()` enforces that, it is not a
+ * label someone can type.
+ */
+
+/** Goods decision-log stage vocabulary. Ordered listen -> deliver. */
+export type PathwayStage = 'yarn' | 'shape' | 'resource' | 'deliver';
+
+/** Decision status for the weekly portfolio read (handoff column 9). */
+export type PortfolioDecision =
+  | 'listen'
+  | 'scope'
+  | 'ready to pursue'
+  | 'submitted'
+  | 'funded/delivering'
+  | 'hold';
+
+/** The six investment uses. Every opportunity must declare exactly one. */
+export type InvestmentUse =
+  | 'relationship-and-scoping'
+  | 'community-wraparound'
+  | 'production-equipment'
+  | 'measured-production-run'
+  | 'buyer-delivery'
+  | 'shared-network';
+
+export const INVESTMENT_USES: Record<InvestmentUse, {
+  label: string;
+  suitableCapital: string;
+  evidenceRequired: string;
+}> = {
+  'relationship-and-scoping': {
+    label: 'Community relationship & scoping',
+    suitableCapital: 'Grant, philanthropy',
+    evidenceRequired: 'Named conversation, relationship owner, scope question, community-controlled next step',
+  },
+  'community-wraparound': {
+    label: 'Community wraparound',
+    suitableCapital: 'Grant, donation, philanthropic support',
+    evidenceRequired: 'Participant/support design, delivery partner, cost centre separated from product making',
+  },
+  'production-equipment': {
+    label: 'Product making / production equipment',
+    suitableCapital: 'Repayable capital, productive-asset finance, order-backed pre-purchase',
+    evidenceRequired: 'Asset owner, repayment source, buyer or order pathway, release gates',
+  },
+  'measured-production-run': {
+    label: 'Measured production run',
+    suitableCapital: 'Grant, catalytic funding',
+    evidenceRequired: '50-bed measurement plan, cost capture, learning/reporting plan',
+  },
+  'buyer-delivery': {
+    label: 'Buyer delivery / procurement',
+    suitableCapital: 'Purchase order, pre-purchase, contract',
+    evidenceRequired: 'Product bundle, price, freight, warranty/support, contracting party',
+  },
+  'shared-network': {
+    label: 'Shared Goods network',
+    suitableCapital: 'Grant, philanthropy, shared-service revenue',
+    evidenceRequired: 'Explicit network costs: design, quality, training, back office, field travel',
+  },
+};
+
+export type PathwayLink = { label: string; href: string; system: 'GrantScope' | 'Notion' | 'GHL' | 'Repo' };
+
+export type CommunityPathway = {
+  id: string;
+  /** Community name first, colonial or administrative name in brackets where used. */
+  community: string;
+  stage: PathwayStage;
+  decision: PortfolioDecision;
+  /** Relationship and authority state, in plain words. */
+  authority: string;
+  /** Null when nobody is named — this is what blocks portfolio eligibility. */
+  relationshipOwner: string | null;
+  /** Null when there is no current named community decision. */
+  nextDecision: string | null;
+  nextActionDue: string | null;
+  /** Evidence already held: asset/service history, request, invoice/order, partner artefact. */
+  evidenceHeld: string[];
+  investmentUse: InvestmentUse;
+  moneyRoute: string;
+  /** Hard eligibility blocks and things not to claim yet. */
+  doNotYet: string;
+  links: PathwayLink[];
+};
+
+/**
+ * Stage and authority readings come from the Goods decision log via the
+ * 2026-08-10 alignment handoff. No community site is currently eligible for an
+ * ownership claim, and CRM stage is never treated as approval.
+ */
+export const COMMUNITY_PATHWAYS: readonly CommunityPathway[] = [
+  {
+    id: 'oonchiumpa',
+    community: 'Oonchiumpa / Mparntwe (Alice Springs)',
+    stage: 'resource',
+    decision: 'submitted',
+    authority: 'Oonchiumpa leads the REAL consortium; production pathway is active',
+    relationshipOwner: 'Nicholas Marchesi',
+    nextDecision: 'Keep the submitted facility pathway, governance and seller-of-record logic current',
+    nextActionDue: null,
+    evidenceHeld: [
+      'REAL Innovation Fund application submitted',
+      'Consortium governance and seller-of-record work in progress',
+    ],
+    investmentUse: 'production-equipment',
+    moneyRoute: 'REAL Innovation Fund is submitted; other grants or capital only after entity/eligibility checks',
+    doNotYet: 'Do not present site pricing as a community-agreed commitment, or treat CRM status as approval.',
+    links: [{ label: 'Alice Springs pathway notes', href: '/org/act/goods/communities', system: 'GrantScope' }],
+  },
+  {
+    id: 'utopia',
+    community: 'Utopia / Urapuntja',
+    stage: 'shape',
+    decision: 'scope',
+    authority: 'Community pathway is present; intended module is a shredder, not a full facility',
+    relationshipOwner: 'Nicholas Marchesi',
+    nextDecision: 'Agree the module, operator, place and maintenance arrangement',
+    nextActionDue: null,
+    evidenceHeld: ['Community pathway conversation recorded in the Goods decision log'],
+    investmentUse: 'relationship-and-scoping',
+    moneyRoute: 'Small scoping/capability money; later partner-led enterprise route',
+    doNotYet: 'Do not force this into a whole-site capital case, or count delivered assets as a current request.',
+    links: [{ label: 'Communities hub', href: '/org/act/goods/communities', system: 'GrantScope' }],
+  },
+  {
+    id: 'tennant-creek',
+    community: 'Tennant Creek / Wumpurrarni',
+    stage: 'yarn',
+    decision: 'listen',
+    authority: 'Existing relationships, but reconnection is still unresolved',
+    relationshipOwner: null,
+    nextDecision: 'Send and receive a response to the reconnection conversation; establish what the shed and partners want',
+    nextActionDue: null,
+    evidenceHeld: ['Prior relationships on record'],
+    investmentUse: 'relationship-and-scoping',
+    moneyRoute: 'Centrecorp/buyer route only after a real purchase or partner proposition exists',
+    doNotYet: 'Do not write a production or capital application before the community direction is current.',
+    links: [{ label: 'Network', href: '/org/act/goods/network', system: 'GrantScope' }],
+  },
+  {
+    id: 'palm-island',
+    community: 'Palm Island / Bwgcolman',
+    stage: 'yarn',
+    decision: 'listen',
+    authority: 'Council and PICC relationship records exist; no current authorised request is established',
+    relationshipOwner: null,
+    nextDecision: 'Ask where this sits and what governance work is wanted',
+    nextActionDue: null,
+    evidenceHeld: ['PICC receivable on the sole trader ($113.3K)', 'Prior delivery and paid non-product work'],
+    investmentUse: 'relationship-and-scoping',
+    moneyRoute: 'Place-based partner or foundation conversation, after a request exists',
+    doNotYet: 'Do not turn prior delivery or paid non-product work into a demand claim.',
+    links: [{ label: 'Network', href: '/org/act/goods/network', system: 'GrantScope' }],
+  },
+  {
+    id: 'maningrida',
+    community: 'Maningrida',
+    stage: 'deliver',
+    decision: 'funded/delivering',
+    authority: 'Delivery evidence, not a community production site: Homeland School partnership',
+    relationshipOwner: 'Nicholas Marchesi',
+    nextDecision: 'Capture production-rate cost and operational learning from the measured 40-bed farm-pressed run',
+    nextActionDue: null,
+    evidenceHeld: ['40-bed farm-pressed run', 'Homeland School partnership'],
+    investmentUse: 'measured-production-run',
+    moneyRoute: 'Evidence/support funding; buyer proof',
+    doNotYet: 'Do not claim a community-owned site, or use this run as measured unit economics.',
+    links: [{ label: 'Evidence', href: '/org/act/goods/proof', system: 'GrantScope' }],
+  },
+];
+
+/**
+ * A pathway earns investment work only with BOTH a named next community
+ * decision and a relationship owner. Everything else is relationship work.
+ */
+export function isPortfolioEligible(p: CommunityPathway): boolean {
+  return Boolean(p.relationshipOwner) && Boolean(p.nextDecision);
+}
+
+/** Known source conflicts — shown on the screen rather than silently resolved. */
+export const PORTFOLIO_DATA_LIMITS: readonly string[] = [
+  'The asset CSV holds 389 individual records while Goods canon says 540 deployed beds and 22 washers in community. Operational evidence, not the portfolio aggregate.',
+  'The REAL pathway is ~$2m over three years in the Goods decision log, but an older GrantScope operating-system row says $1.2m over four years. Use the newer Goods ruling until reconciled.',
+  'Partner records and CRM stages support internal coordination only. They do not prove a community request or approval.',
+];
+
+export const STAGE_LABEL: Record<PathwayStage, string> = {
+  yarn: 'Yarn',
+  shape: 'Shape',
+  resource: 'Resource',
+  deliver: 'Deliver',
+};

--- a/thoughts/shared/handoffs/goods-investment-portfolio-alignment-2026-08-10.md
+++ b/thoughts/shared/handoffs/goods-investment-portfolio-alignment-2026-08-10.md
@@ -1,0 +1,102 @@
+# Goods investment portfolio alignment
+
+**Purpose:** make Goods funding decisions start with a community and its pathway, then connect the right partner, investment need and opportunity. This is not a grant tracker.
+
+## The decision model
+
+```
+Community decision
+  -> relationship and authority
+  -> pathway module / next proof
+  -> investment need and money door
+  -> named partner and opportunity
+  -> application, agreement or order
+  -> delivered asset and learning
+```
+
+The asset register is the evidence at the right-hand end of this chain. It proves delivery and gives each place a service history. It must not be treated as a demand list, authority record, or investment portfolio on its own.
+
+GrantScope should be the decision layer across the chain. Notion should hold the working brief and application-writing materials. GoHighLevel should hold the people, organisations, commitments and next conversations.
+
+## What each system owns
+
+| System | Owns | Must not decide |
+|---|---|---|
+| Goods Asset Register | Deployed assets, service/check-in history, product evidence | Current community request, authority, investment readiness |
+| GrantScope | Canonical community crosswalk, evidence status, investment case, opportunity eligibility and portfolio coverage | Community consent or relationship truth by inference |
+| Notion | Writing brief, budget version, documents, reviewer notes and application tasks | Canonical opportunity identity or CRM follow-up |
+| GoHighLevel | Partner/contact relationship, owner, next touch, commitment and application movement | Community approval, financial truth, or grant eligibility |
+
+## The portfolio view to use every week
+
+One row per community pathway, not one row per grant. A row is eligible for investment work only when it has a named next community decision and a relationship owner.
+
+| Community pathway | Current stage | Relationship / authority state | Next decision or proof | Right investment use | Current money route | Do not do yet |
+|---|---|---|---|---|---|---|
+| Oonchiumpa / Alice Springs | Resource | Oonchiumpa leads the REAL consortium; production pathway is active | Keep the submitted facility pathway, governance and seller-of-record logic current | Production infrastructure, measured production and wraparound | REAL Innovation Fund is submitted; suitable grants or capital only after entity/eligibility checks | Present site pricing as a community-agreed commitment or treat CRM status as approval |
+| Utopia / Urapuntja | Shape | Community pathway is present; the intended module is a shredder, not a full facility | Agree the module, operator, place and maintenance arrangement | Scoping, module selection, servicing and learning | Small scoping/capability money; later partner-led enterprise route | Force it into a whole-site capital case or count delivered assets as a current request |
+| Tennant Creek / Wumpurrarni | Yarn | Existing relationships, but reconnection is still unresolved | Send and receive a response to the reconnection conversation; establish what the shed/partners want | Relationship work, scoping and buyer proof | Centrecorp/buyer route after a real purchase or partner proposition exists | Write a production or capital application before the community direction is current |
+| Palm Island / Bwgcolman | Yarn | Council and PICC relationship records exist; no current authorised request is established | Ask where this sits and what governance work is wanted | Governance, relationship, service/asset learning | Place-based partner or foundation conversation after a request | Turn prior delivery or paid non-product work into a demand claim |
+| Maningrida | Delivery evidence, not a community production site | Homeland School partnership and the 40-bed farm-pressed run provide proof | Capture production-rate cost and operational learning from the measured run | Evidence, quality, service and production learning | Evidence/support funding; buyer proof | Claim a community-owned site or use the run as measured unit economics |
+
+These stage readings come from the Goods decision log: Tennant Creek and Palm Island are at Yarn, Utopia at Shape and Oonchiumpa at Resource. No community site is currently eligible for an ownership claim.
+
+## Investment lenses
+
+Every investment or opportunity must declare one primary use. This is the field that makes grants useful rather than noisy.
+
+| Investment use | Suitable capital | Evidence required before pursuit |
+|---|---|---|
+| Community relationship and scoping | Grant, philanthropy | Named conversation, relationship owner, scope question and community-controlled next step |
+| Community wraparound | Grant, donation, philanthropic support | Participant/support design, delivery partner, cost centre separated from product making |
+| Product making / production equipment | Repayable capital, productive-asset finance, order-backed pre-purchase | Asset owner, repayment source, buyer or order pathway, release gates |
+| Measured production run | Grant, catalytic funding | 50-bed measurement plan, cost capture and learning/reporting plan |
+| Buyer delivery / procurement | Purchase order, pre-purchase, contract | Product bundle, price, freight, warranty/support and contracting party |
+| Shared Goods network | Grant, philanthropy, shared-service revenue | Explicit network costs: design, quality, training, back office and field travel |
+
+## The one practical dashboard
+
+Build a **Goods Investment Portfolio** view in GrantScope, then link out to the existing Notion brief and GHL opportunity. It needs only these columns:
+
+1. Community pathway
+2. Relationship owner and authority status
+3. Current stage and next community decision
+4. Evidence already held: asset/service history, request, invoice/order, partner artefact
+5. Investment use and required money door
+6. Named partner/funder/buyer
+7. Opportunity fit and hard eligibility blocks
+8. Application or relationship next action, owner and due date
+9. Decision status: `listen`, `scope`, `ready to pursue`, `submitted`, `funded/delivering`, `hold`
+
+This gives a simple weekly meeting order: start with the community decision; check the relationship; decide whether investment is appropriate; only then look at the grant, buyer or lender work.
+
+## Immediate portfolio decisions
+
+1. Treat Oonchiumpa as the only active production-investment case, while keeping the submitted REAL route separate from generic grant discovery.
+2. Treat Utopia, Tennant Creek and Palm Island as relationship/scoping portfolios, each with a different first investment need. They should not compete on a generic grant score.
+3. Use Maningrida and the wider asset register as proof and learning evidence, not as a fifth capital case.
+4. Route every open grant through one of the six investment uses above. If it cannot fund a named use for a named community or the shared network, leave it outside the active portfolio.
+5. Keep the three cost centres separate: product making, Goods network and community wraparound. No opportunity should cover all three by implication.
+
+## Known data limits
+
+- The asset CSV contains 389 individual records, while Goods canon says 540 deployed beds and 22 washers in community. It is operational evidence, but not the portfolio aggregate source of truth.
+- The REAL pathway is recorded as approximately $2m over three years in the Goods decision log, while an older GrantScope operating-system row says $1.2m over four years. Treat that as a source conflict and use the newer Goods ruling until reconciled.
+- Current partner records and CRM stages support internal coordination only. They do not prove a community request or approval.
+
+## Implementation sequence
+
+1. Create four community-pathway records above in GrantScope with clear crosswalk IDs.
+2. Add the portfolio columns to the existing Goods operating surface, without changing the asset register or broad grant sync.
+3. Link each row to one Notion application brief and its relevant GHL relationship/opportunity.
+4. Backfill only the named Oonchiumpa, Utopia, Tennant Creek and Palm Island rows, then review the decision read with the Goods team.
+5. Only after that, attach open opportunities that satisfy a named investment use and eligibility check.
+
+## Source basis
+
+- `/Users/benknight/Code/Goods Asset Register/STRATEGY.md`
+- `/Users/benknight/Code/Goods Asset Register/DECISIONS.md`
+- `/Users/benknight/Code/Goods Asset Register/GRANTSCOPE.md`
+- `/Users/benknight/Code/Goods Asset Register/data/expanded_assets_final.csv`
+- `/Users/benknight/Code/grantscope/scripts/funding-profiles/goods-on-country.json`
+- `/Users/benknight/Code/grantscope/docs/strategy/repeatable-project-funding-discovery.md`


### PR DESCRIPTION
## What

A new Goods tab at `/org/[slug]/goods/portfolio`. Every other Goods surface is grant-, money- or asset-shaped; this one is **one row per community pathway** — Oonchiumpa/Mparntwe, Utopia/Urapuntja, Tennant Creek/Wumpurrarni, Palm Island/Bwgcolman, Maningrida.

Each row carries: stage, authority state, next community decision, evidence already held, investment use, money route, and an explicit "do not do yet" guard.

## Why it is built this way

- **Eligibility is a guard, not a label.** `isPortfolioEligible()` requires both a named next community decision and a relationship owner. Tennant Creek and Palm Island therefore render as "relationship work only" — nobody can type their way past it.
- **Readings live in a typed module**, not a markdown doc, so the stage vocabulary and the guards cannot drift from the screen that renders them.
- **Known source conflicts are shown, not resolved into a number**: 389 CSV asset records vs 540 canon beds; REAL at ~$2m/3yr in the Goods decision log vs the stale $1.2m/4yr GrantScope row.

## Scope

Seeded from `thoughts/shared/handoffs/goods-investment-portfolio-alignment-2026-08-10.md`, committed alongside as the audit trail. DB-backed pathway records with crosswalk IDs (handoff step 1) are a separate call and not in this PR. No Notion/GHL deep links yet — the mirror tables have no matching rows.

## Verification

- `npx tsc --noEmit` clean (also via pre-commit hook)
- Renders 200 on localhost:3013; 5 pathways, 3 investment-eligible, the two listening-only rows flagged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)