### PR TITLE
Security: close a bank-statement leak that table-level RLS auditing cannot see

### DIFF
--- a/migrations/2026-08-15-close-bank-statement-view-leak.sql
+++ b/migrations/2026-08-15-close-bank-statement-view-leak.sql
@@ -1,0 +1,76 @@
+-- =============================================================================
+-- 2026-08-15-close-bank-statement-view-leak.sql
+--
+-- APPLIED 2026-08-15. Recorded here after the fact.
+--
+-- THE LEAK. `v_finance_bank_line_evidence` returned **1,618 ACT bank transactions**
+-- (2025-10-01 to 2026-03-31 — date, type, payee, particulars) to anyone holding the
+-- public publishable key. Confirmed by fetching it over the live REST endpoint, not
+-- inferred from grants.
+--
+-- WHY THE EARLIER SWEEP MISSED IT. The 14 Aug revoke closed 48 policies on *tables*.
+-- This is a VIEW, and views do not have RLS. It leaked through a different mechanism
+-- entirely: the view had no `security_invoker` option, so it ran with its OWNER's
+-- rights, and `bank_statement_lines` being locked down was irrelevant — the view
+-- never consulted the caller's permissions at all. anon simply had SELECT on the view.
+--
+-- Table-level RLS auditing cannot find this class of defect. A definer view is a
+-- legitimate, invisible bypass of every protection on its base table.
+--
+-- THE FIX — both halves, deliberately:
+--   1. REVOKE anon's SELECT. Closes it now.
+--   2. SET security_invoker = true. Closes it PERMANENTLY: if anyone re-grants
+--      SELECT later, the view will evaluate the caller's rights on
+--      bank_statement_lines rather than the owner's, and return nothing.
+-- Doing only (1) would leave a re-grant one command away from reopening it.
+--
+-- VERIFIED AFTER APPLY, with the live publishable key:
+--   {"code":"42501","message":"permission denied for view v_finance_bank_line_evidence"}
+--
+-- THE FULL AUDIT THIS CAME FROM. All 398 anon-readable objects were reviewed:
+--   206  unclassified (overwhelmingly views)
+--    22  justice/youth detention · 16 philanthropy · 16 place · 16 social services
+--    14  political influence · 13 grants · 10 corporate registry · 10 gov spend
+--   Everything with rows was checked by domain. Legitimately public:
+--     - NDIS market data (~419K rows), DSS payment demographics, community directory
+--     - person_roles (339,698) — 334,152 are ACNC responsible persons, published by
+--       law on the public ACNC register, plus parliamentary records. Names and roles
+--       only; no contact details, addresses or dates of birth.
+--     - civic_intelligence_chunks (7,022) — sourced ONLY from Hansard, ministerial
+--       statements, RTI disclosures, oversight recommendations and media articles.
+--     - media_items (219) — ZERO rows carry storyteller_ids, so this is not the
+--       consent-governed storyteller corpus despite sitting in that domain.
+--     - org_governance, v_harvest_public_social_posts, jr_site_front_door — all
+--       fetched over the public endpoint and confirmed to return public register
+--       data, posts explicitly named public, and organisation websites/logos.
+--
+--   ONE genuine leak in 398. This file closes it.
+--
+-- A JUDGEMENT CALL LEFT FOR BEN, not a defect: person_roles aggregates 334,152
+-- individually-public ACNC records into one queryable endpoint. Each record is
+-- public by law; the aggregate is a different artifact from the sum of its parts.
+-- Worth a conscious decision rather than an inherited default.
+--
+-- APPLY WITH (already applied):
+--   psql ... -f migrations/2026-08-15-close-bank-statement-view-leak.sql
+--
+-- RE-AUDIT QUERY — run this after adding any view, it is the check that found this:
+--   WITH v AS (
+--     SELECT c.oid, c.relname AS view_name FROM pg_class c
+--       JOIN pg_namespace n ON n.oid = c.relnamespace
+--      WHERE n.nspname = 'public' AND c.relkind = 'v'
+--        AND has_table_privilege('anon', c.oid, 'SELECT')
+--        AND coalesce((SELECT option_value FROM pg_options_to_table(c.reloptions)
+--                       WHERE option_name = 'security_invoker'), 'false') <> 'true')
+--   SELECT DISTINCT v.view_name, b.relname AS base_table
+--     FROM v JOIN pg_depend d ON d.refobjid = v.oid
+--     JOIN pg_rewrite r ON r.oid = d.objid
+--     JOIN pg_depend d2 ON d2.objid = r.oid AND d2.classid = 'pg_rewrite'::regclass
+--     JOIN pg_class b ON b.oid = d2.refobjid AND b.relkind = 'r'
+--    WHERE b.relname <> v.view_name
+--      AND NOT has_table_privilege('anon', ('public.'||b.relname)::regclass, 'SELECT');
+--   -- Any row is a definer view exposing a base table anon cannot otherwise read.
+-- =============================================================================
+
+REVOKE SELECT ON public.v_finance_bank_line_evidence FROM anon;
+ALTER VIEW public.v_finance_bank_line_evidence SET (security_invoker = true);

--- a/thoughts/shared/handoffs/clarity-catalog/current.md
+++ b/thoughts/shared/handoffs/clarity-catalog/current.md
@@ -1,0 +1,97 @@
+---
+date: 2026-08-15T05:10:00Z
+session_name: clarity-catalog
+branch: close-bank-view-leak
+status: active
+---
+
+# Work Stream: clarity-catalog
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-08-15T05:10:00Z
+**Goal:** `/clarity` slice 2 — the question board. Done when the surface leads with cross-sections this database can answer that no public Australian source can, each carrying its coverage and caveat.
+**Branch:** `close-bank-view-leak` (slice 1 already merged to main via #199)
+**Test:** `cd apps/web && npx tsc --noEmit` · gates: `node --env-file=.env scripts/check-graph-{completeness,referential-integrity,attribution}.mjs`
+
+### Now
+[->] **Before any new work: verify the two scheduled jobs survived their first night.** They have never run unattended.
+
+### This Session
+- [x] Mapped the whole shared DB — 1,024 relations, 52.3M rows. `thoughts/shared/data-map/`
+- [x] Rebuilt the justice graph layer: 857,798 edges → 144,901, resolution 16.9% → **100%**
+- [x] Built the GrantConnect layer: 291,264 awards had **zero** edges → 189,590 at 100%
+- [x] Merged 141 shadow entities, 333,960 edges consolidated, 0 orphaned FKs
+- [x] Three graph gates built + registered: completeness, referential-integrity, **attribution**
+- [x] Shipped `/clarity` slice 1, merged as PR #199 (`d6c8081`)
+- [x] Scheduled `clarity_refresh()` nightly — pg_cron job 11, 18:00 UTC
+- [x] Enabled tiered matview cron — job 4 → `CALL ...('nightly')`, job 13 weekly (PR #200, open)
+- [x] Audited all 398 anon-readable objects; found and closed a **bank-statement leak** (PR #201, open)
+
+### Next
+- [ ] Verify job 4 (17:00) and job 11 (18:00) ran clean — **do this first**
+- [ ] Merge PR #200 (matview cron) once the 17:00 run proves out
+- [ ] Merge PR #201 (bank leak) — already applied to prod, just recording it
+- [ ] **Slice 2: the question board.** Ten-working-day guard from slice 1 (shipped 15 Aug)
+- [ ] Deferred, all diagnosed and written up: 19 unwatched edge layers · runbook steps 3 (donor sink, 47,563 misattributed edges) and 5 (opportunity self-loops)
+
+### Decisions
+- Headline is **1,039 relations**, not 1,455; 416 routines get their own segment. They will never carry a domain, so counting them strands 29% of the list as undescribed. (#193)
+- Coverage denominator is relations → **78%**, not 56% against everything.
+- ACT excluded by default, count permanently on screen, **neutral not yellow** — a scope boundary, not a warning.
+- Freshness has **four states that never collapse**: a date (687), `+` blue = our missing timestamp column (294, an afternoon's work), `?` yellow = too large to probe (58, needs a rebuild), `—` n/a (416). (#195)
+- Admin-gated. Not deference to the April kill — the catalog enumerates which objects are anon-readable, i.e. our own attack surface. (#196)
+- Ranked by default (`clarity_object.importance`), sort controls first-class. Segments kept but **ALL is the default** — opening behind SOURCES hid 60% on arrival.
+- `/api/data/schema-graph` superseded now, deleted after slice 5. Zero consumers were *found*, not proven.
+- `catalog_object_scope` is authoritative for `act_business`, bidirectionally. The old name-prefix regex missed 215 ACT objects and could never un-flag a false positive.
+
+### Open Questions
+- UNCONFIRMED: **did jobs 4 and 11 run correctly overnight?** Check `mv_refresh_log` for `triggered_by='pg_cron:nightly'` — **durations must be non-zero and `started_at` must differ per row**. Every pg_cron row before 15 Aug had `duration_ms = 0` because `now()` is frozen per transaction. If zeros return, the per-matview COMMIT is not happening → roll back PR #200 (rollback is in the migration header).
+- UNCONFIRMED: is `/clarity` actually reachable in the deployed app? Vercel deploys on merge but the page has never been opened by a human.
+- UNCONFIRMED: `gs_relationships` read 2,943,598 at one point vs 2,904,091 after the merge — ~39.5K higher. Probably a scheduled ingest; not verified.
+- OPEN, Ben's call: `person_roles` aggregates 334,152 individually-public ACNC records into one anon-readable endpoint. Each is public by law; the aggregate is a different artifact. Not a defect — a decision.
+
+### Workflow State
+pattern: wayfinder map (issue #190, 8/8 tickets closed)
+phase: slice 1 complete
+total_phases: 7 slices
+retries: 0
+max_retries: 3
+
+#### Resolved
+- goal: "slice 1 shipped and live" — done
+- resource_allocation: balanced
+
+#### Unknowns
+- overnight_job_health: UNKNOWN until the 17:00/18:00 runs are checked
+
+#### Last Failure
+(none)
+
+---
+
+## Context
+
+### Where things live
+- **The map**: `thoughts/shared/data-map/README.md` → then `VERIFICATION.md` (68 claims checked, 3 blockers found). Never act on `CANONICAL-DATA-MAP.md` without it.
+- **Slice 2 source material**: `thoughts/shared/data-map/clarity/OPPORTUNITY-MAP.md` — 16 cross-sections, **9 already run for real** with numbers. Plus `BAR-CHECK.md` and `BAR-CHECK-CLOSURE.md`.
+- **The spec**: `thoughts/shared/data-map/clarity/CLARITY-SPEC.md` (1,816 lines). Its scope corrections are in the closure doc.
+- **The code**: `apps/web/src/app/clarity/` — 4 files, one client island.
+
+### Hard-won facts that will save a session
+- **The pooler drops long connections.** One operation per psql invocation; TCP keepalives (`?keepalives=1&keepalives_idle=20&...`) on anything over ~5 min. A chained psql call reports the **echo's** exit code, so a failure looks like success. There is no direct non-pooler host.
+- **`pg_stat_user_tables.n_live_tup` is broken here** — reports 0 for a 2.5M-row table.
+- **`LIMIT n` without `ORDER BY` is not a sample.** Two 20,000-row "samples" of the same dataset gave 0% and 34.2%; the exact answer was 16.9%.
+- **Use `getDirectServiceSupabase()`**, never `getServiceSupabase()` — the latter sniffs the call stack for `/app/reports/` and returns a stub resolving every query to null.
+- **PostgREST caps a page at 1,000 rows.** The catalog is 1,455. Without explicit pagination a ledger renders complete and is missing a third.
+- **Read the producer before diagnosing the product.** Six confident readings were wrong this session; every one died within two minutes of opening the code that generated the number. Two would have caused damage.
+- **Empty ≠ unused.** No drop verdict without grepping both `src` trees AND `pg_proc.prosrc`.
+- **A merge rule keyed on identifier presence must also consider entity KIND.** The shadow merge nearly merged 1,209 people into companies and would have broken two derivations that resolve entities by name.
+- **Table-level RLS auditing cannot see definer views.** That is how 1,618 bank transactions stayed public through a sweep that closed 48 policies. The re-audit query is in `migrations/2026-08-15-close-bank-statement-view-leak.sql` — run it after adding any view.
+
+### The bar slice 2 has to clear
+`BAR-CHECK.md`'s verdict on slice 1, and it still stands:
+
+> Nothing on any screen answers a question about the world today; every screen audits our estate. There is no reason to open this on a Tuesday when nothing is broken.
+
+Slice 2 is the fix. It is the half that makes `/clarity` Ben's rather than a competent data catalog anyone could buy.


### PR DESCRIPTION
**Already applied to production.** This PR records the fix and, more importantly, the query that finds this class of defect.

## What was exposed

`v_finance_bank_line_evidence` returned **1,618 ACT bank transactions** — 2025-10-01 to 2026-03-31, with date, direction, payee and statement particulars — to anyone holding the public publishable key.

Confirmed by fetching them over the live REST endpoint, not inferred from grants.

No account numbers or balances. But enough to see who ACT pays, when, and for what. Duration of exposure is **unknown and unknowable** — there is no access log that would tell us.

## Why the 14 Aug sweep could not have found it

That sweep closed 48 permissive policies on **tables**. Views do not have RLS, so it was never in scope.

This leaked by a different mechanism entirely. The view carried no `security_invoker` option, so it executed with its **owner's** rights and never consulted the caller at all — `bank_statement_lines` being locked down was simply irrelevant to it.

> A definer view is a legitimate, invisible bypass of every protection on its base table. Table-level RLS auditing is structurally blind to it.

## The fix, both halves deliberately

1. `REVOKE SELECT ... FROM anon` — closes it now.
2. `SET (security_invoker = true)` — closes it **permanently**. If anyone re-grants SELECT later, the view evaluates the caller's rights on `bank_statement_lines` and returns nothing.

Doing only (1) would leave a re-grant one command away from reopening it.

Verified after apply with the live publishable key:
```
{"code":"42501","message":"permission denied for view v_finance_bank_line_evidence"}
```

## Context — this came from auditing all 398 anon-readable objects

Everything else checked out as genuinely public:

- NDIS market data (~419K rows), DSS payment demographics, community directory
- `person_roles` (339,698) — 334,152 are ACNC responsible persons, **published by law** on the public register. Names and roles only; no contact details, addresses or DOB.
- `civic_intelligence_chunks` (7,022) — sourced **only** from Hansard, ministerial statements, RTI disclosures and oversight recommendations
- `media_items` (219) sits in the `storytelling_consent` domain but carries **zero** `storyteller_ids`, so it is not the consent-governed corpus
- `org_governance`, `v_harvest_public_social_posts`, `jr_site_front_door` — each fetched over the public endpoint and confirmed to return public-register data, posts explicitly named public, and organisation websites

**One genuine leak in 398.**

## The most useful thing in this PR

The re-audit query in the file header. **Run it after adding any view.** It is what found this, and this defect class will recur — it is invisible to every other check we have.

## Left for Ben, a judgement call rather than a defect

`person_roles` aggregates 334,152 individually-public ACNC records into one queryable endpoint. Each record is public by law; the aggregate is a different artifact from the sum of its parts. Worth a conscious decision rather than an inherited default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)