### PR TITLE
Lock the one clarity function whose grant the catalog caught wide open

### DIFF
--- a/migrations/2026-08-15-lock-clarity-act-flag-grant.sql
+++ b/migrations/2026-08-15-lock-clarity-act-flag-grant.sql
@@ -1,0 +1,43 @@
+-- Lock EXECUTE on clarity_apply_act_flag to match its four sibling functions.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-15-lock-clarity-act-flag-grant.sql
+--
+-- Rollback (restores the PostgreSQL default, i.e. EXECUTE to PUBLIC):
+--   ALTER FUNCTION public.clarity_apply_act_flag() OWNER TO postgres;
+--   REVOKE EXECUTE ON FUNCTION public.clarity_apply_act_flag() FROM service_role;
+--   GRANT EXECUTE ON FUNCTION public.clarity_apply_act_flag() TO PUBLIC;
+--
+-- Why this exists
+--
+-- 2026-08-15-act-flag-from-scope-table.sql created clarity_apply_act_flag() but never
+-- set its ACL, so it kept PostgreSQL's default of EXECUTE to PUBLIC -- which includes
+-- anon. Its four siblings (clarity_refresh, clarity_score, clarity_measure_gaps,
+-- clarity_set_probe) were all explicitly restricted to postgres + service_role in their
+-- own migrations. This is drift, not a deliberate exception.
+--
+-- Impact today is contained, and that was verified rather than assumed: the function is
+-- SECURITY INVOKER, and anon/authenticated hold zero grants on clarity_object and
+-- catalog_object_scope, so an anonymous call fails on its first write. The reason to
+-- close it anyway is that it is one "SECURITY DEFINER" away from being live, and an
+-- unexplained asymmetry reads as intentional to whoever finds it next.
+--
+-- Found by the catalog itself: clarity_object surfaced the function as a newly-seen
+-- routine with anon_execute = true on the first refresh after the migration that
+-- created it.
+
+BEGIN;
+
+REVOKE EXECUTE ON FUNCTION public.clarity_apply_act_flag() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.clarity_apply_act_flag() TO service_role;
+
+COMMIT;
+
+-- Verify: expects "postgres=X/postgres | service_role=X/postgres", matching the siblings.
+--
+--   SELECT p.proname, array_to_string(p.proacl, ' | ') AS acl
+--   FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--   WHERE n.nspname = 'public' AND p.proname LIKE 'clarity%'
+--   ORDER BY p.proname;


### PR DESCRIPTION
## What

`clarity_apply_act_flag()` was created by `2026-08-15-act-flag-from-scope-table.sql` without an ACL, so it kept PostgreSQL's default of `EXECUTE` to `PUBLIC` — which includes `anon`. Its four siblings (`clarity_refresh`, `clarity_score`, `clarity_measure_gaps`, `clarity_set_probe`) were each explicitly restricted to `postgres` + `service_role`. Four of five locked identically is drift, not a convention.

## Impact — contained, and checked rather than assumed

- The function is `SECURITY INVOKER`, so a caller runs with their own rights.
- `anon` and `authenticated` hold **zero** grants on `clarity_object` and `catalog_object_scope`.
- An anonymous call therefore fails on its first write. This was not a second leak.

Closed anyway for two reasons: it is one `SECURITY DEFINER` away from being live, and an unexplained asymmetry reads as intentional to whoever finds it in six months.

## Already applied to prod

This PR records a change that is already live. All five `clarity_*` functions now report `postgres=X/postgres | service_role=X/postgres`.

Job 11 calls this function nightly, so after the revoke I re-ran it as `postgres` — returned `(299,7,29)`, identical to the pre-revoke run. Unaffected.

Rollback is in the migration header.

## How it surfaced

`clarity_object` flagged it as a newly-seen routine with `anon_execute = true` on the first refresh after the migration that created it. The catalog caught a defect in the migration that extended the catalog.