### PR TITLE
Ledger: jobs 4 and 11 proven, board clear, slice 2 unblocked

### DIFF
--- a/thoughts/shared/handoffs/clarity-catalog/current.md
+++ b/thoughts/shared/handoffs/clarity-catalog/current.md
@@ -1,7 +1,7 @@
 ---
-date: 2026-08-15T05:10:00Z
+date: 2026-08-15T05:30:00Z
 session_name: clarity-catalog
-branch: close-bank-view-leak
+branch: main
 status: active
 ---
 
@@ -9,13 +9,13 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-15T05:10:00Z
+**Updated:** 2026-08-15T05:30:00Z
 **Goal:** `/clarity` slice 2 — the question board. Done when the surface leads with cross-sections this database can answer that no public Australian source can, each carrying its coverage and caveat.
-**Branch:** `close-bank-view-leak` (slice 1 already merged to main via #199)
+**Branch:** `main` — **zero open PRs**, board clear
 **Test:** `cd apps/web && npx tsc --noEmit` · gates: `node --env-file=.env scripts/check-graph-{completeness,referential-integrity,attribution}.mjs`
 
 ### Now
-[->] **Before any new work: verify the two scheduled jobs survived their first night.** They have never run unattended.
+[->] **Slice 2: the question board.** The job verification that blocked it is done — jobs 4 and 11 are proven, see below. Nothing else is in the way.
 
 ### This Session
 - [x] Mapped the whole shared DB — 1,024 relations, 52.3M rows. `thoughts/shared/data-map/`
@@ -25,14 +25,15 @@ status: active
 - [x] Three graph gates built + registered: completeness, referential-integrity, **attribution**
 - [x] Shipped `/clarity` slice 1, merged as PR #199 (`d6c8081`)
 - [x] Scheduled `clarity_refresh()` nightly — pg_cron job 11, 18:00 UTC
-- [x] Enabled tiered matview cron — job 4 → `CALL ...('nightly')`, job 13 weekly (PR #200, open)
-- [x] Audited all 398 anon-readable objects; found and closed a **bank-statement leak** (PR #201, open)
+- [x] Enabled tiered matview cron — job 4 → `CALL ...('nightly')`, job 13 weekly (PR #200, merged `0bff05e`)
+- [x] Audited all 398 anon-readable objects; found and closed a **bank-statement leak** (PR #201, merged `2297ed3`)
+- [x] **Proved job 4 by direct test** — `CALL refresh_civicgraph_mvs_run('nightly')`, 12m24s, **50/50 success, 0 fallbacks**, 38 concurrent / 12 plain. Slowest `mv_entity_power_index` at 368s (looks like a stall; it is not).
+- [x] **Proved job 11 by direct test** — full refresh, `refreshed_at` advanced, 1,039 relations reproduced exactly.
+- [x] Found + closed a grant defect the catalog surfaced on itself (PR #202, merged `9e3c467`) — see Decisions.
 
 ### Next
-- [ ] Verify job 4 (17:00) and job 11 (18:00) ran clean — **do this first**
-- [ ] Merge PR #200 (matview cron) once the 17:00 run proves out
-- [ ] Merge PR #201 (bank leak) — already applied to prod, just recording it
 - [ ] **Slice 2: the question board.** Ten-working-day guard from slice 1 (shipped 15 Aug)
+- [ ] Job 13 (weekly tier, Sundays 15:00 UTC) has **never run** and is unexercised. Also unchecked: where the four matviews that logged `success-fallback` under the old code now sit — if they are in the weekly tier, job 13 inherits a known-flaky set unwatched. They were `mv_grant_contract_overlap`, `mv_indigenous_procurement_score`, `mv_lga_indigenous_proxy_score`, `mv_abr_name_lookup`.
 - [ ] Deferred, all diagnosed and written up: 19 unwatched edge layers · runbook steps 3 (donor sink, 47,563 misattributed edges) and 5 (opportunity self-loops)
 
 ### Decisions
@@ -44,9 +45,10 @@ status: active
 - Ranked by default (`clarity_object.importance`), sort controls first-class. Segments kept but **ALL is the default** — opening behind SOURCES hid 60% on arrival.
 - `/api/data/schema-graph` superseded now, deleted after slice 5. Zero consumers were *found*, not proven.
 - `catalog_object_scope` is authoritative for `act_business`, bidirectionally. The old name-prefix regex missed 215 ACT objects and could never un-flag a false positive.
+- **A new function gets its ACL set in the same migration that creates it.** `clarity_apply_act_flag` was created without one and kept PostgreSQL's default of `EXECUTE` to `PUBLIC`, while its four siblings were each explicitly restricted. Impact was contained (`SECURITY INVOKER`; anon holds no grants on `clarity_object`, so a call dies on first write) but it was one `SECURITY DEFINER` away from live. (#202)
 
 ### Open Questions
-- UNCONFIRMED: **did jobs 4 and 11 run correctly overnight?** Check `mv_refresh_log` for `triggered_by='pg_cron:nightly'` — **durations must be non-zero and `started_at` must differ per row**. Every pg_cron row before 15 Aug had `duration_ms = 0` because `now()` is frozen per transaction. If zeros return, the per-matview COMMIT is not happening → roll back PR #200 (rollback is in the migration header).
+- RESOLVED 15 Aug: jobs 4 and 11 both **proven by direct test**, not by an overnight run. Job 4's per-matview `COMMIT` is real — rows were readable from a second connection mid-run, with distinct `started_at` and non-zero `duration_ms`. The frozen-`now()` bug is gone and **PR #200's rollback trigger will not fire**. Neither job has still ever fired *via pg_cron itself*; first unattended runs are 17:00 and 18:00 UTC on 15 Aug.
 - UNCONFIRMED: is `/clarity` actually reachable in the deployed app? Vercel deploys on merge but the page has never been opened by a human.
 - UNCONFIRMED: `gs_relationships` read 2,943,598 at one point vs 2,904,091 after the merge — ~39.5K higher. Probably a scheduled ingest; not verified.
 - OPEN, Ben's call: `person_roles` aggregates 334,152 individually-public ACNC records into one anon-readable endpoint. Each is public by law; the aggregate is a different artifact. Not a defect — a decision.
@@ -63,7 +65,8 @@ max_retries: 3
 - resource_allocation: balanced
 
 #### Unknowns
-- overnight_job_health: UNKNOWN until the 17:00/18:00 runs are checked
+- job_4_and_11_health: **RESOLVED** — both proven by direct test 15 Aug
+- job_13_weekly_tier: UNKNOWN — never run, never exercised by hand
 
 #### Last Failure
 (none)


### PR DESCRIPTION
Handoff-doc update only — no code, no migration.

Replaces the ledger's UNCONFIRMED overnight-job question with what was actually tested this session. Both jobs were proven by direct `CALL` rather than by waiting for pg_cron:

- **Job 4** — `CALL refresh_civicgraph_mvs_run('nightly')`, 12m24s, **50/50 success, 0 fallbacks**, 38 concurrent / 12 plain. The per-matview `COMMIT` was confirmed by reading committed rows from a *second connection* while the proc was still running, with distinct `started_at` and non-zero `duration_ms`. The frozen-`now()` bug is gone and **#200's rollback trigger will not fire**.
- **Job 11** — full refresh, `refreshed_at` advanced, 1,039 relations reproduced exactly.

Kept honest: neither job has yet fired *via pg_cron itself*. First unattended runs are 17:00 and 18:00 UTC tonight.

Also records:

- The grant defect the catalog found on itself (#202) as a **decision** — a new function gets its ACL in the migration that creates it.
- **Job 13** (weekly tier) as the one job still unexercised, naming the four matviews that logged `success-fallback` under the old code, so the next session doesn't rediscover them.

Left alone deliberately: `/clarity`-never-opened-by-a-human, the `gs_relationships` count discrepancy, and the `person_roles` aggregate question that is Ben's call.