### PR TITLE
Gate /foundations/backlog behind auth

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -51,7 +51,18 @@ export async function middleware(request: NextRequest) {
     return supabaseResponse;
   }
 
-  const protectedPrefixes = ['/home', '/tracker', '/foundations/tracker', '/ops', '/profile', '/org'];
+  // /foundations/backlog renders a service-role review queue and fans out 8
+  // concurrent exec_sql calls per hit with no cache. Left ungated it let
+  // anonymous traffic drive service-role queries and starve the shared pool.
+  const protectedPrefixes = [
+    '/home',
+    '/tracker',
+    '/foundations/tracker',
+    '/foundations/backlog',
+    '/ops',
+    '/profile',
+    '/org',
+  ];
   const isProtectedRoute = protectedPrefixes.some(p => pathname.startsWith(p));
   const isLoginRoute = pathname === '/login';
 


### PR DESCRIPTION
## What

Adds `/foundations/backlog` to `protectedPrefixes` in `apps/web/src/middleware.ts`. One prefix, plus a comment recording why.

## Why

`/foundations/backlog` renders a service-role review queue (`getServiceSupabase()`), is `force-dynamic`, and fans out **8 concurrent `exec_sql` RPCs per request** (`page.tsx:639-688`). It was missing from `protectedPrefixes` while its sibling `/foundations/tracker` was gated — so anonymous traffic drove service-role queries with no cache in front.

The exposure was wrong independently of the outage below. The outage is just what made us look.

## How it was found

Tracing saturation on the shared Supabase instance (`tednluwflfhxyucgwigh`):

- `pg_stat_activity`: **40-41 active connections, all the same `exec_sql` RPC**, sustained. PostgREST unreachable; the local pool monitor was on **blip #902** in 8 days.
- Killing the local dev server on 3013 changed nothing — the load was not local.
- Attribution is impossible at the DB layer: every `authenticator` connection reports `client_addr = ::1/128`, because PostgREST runs on the Supabase host.
- Vercel runtime logs, 2h, grouped by path: **`/foundations/backlog` = 10,694** requests. Next busiest path: `/grants` at **320**. Sustained ~3.5 req/s, most returning status `0` (never completed).

~3.5 req/s x 8 concurrent RPCs lands on the ~40 concurrent `exec_sql` measured. The numbers match.

## What this does not do

- **The caller is unidentified.** Web Analytics is not enabled on the project and the runtime logs carry no user-agent or client IP. Gating stops it regardless of origin, but if this is a bot sweeping the site it will find the next ungated expensive route. An audit of other ungated `getServiceSupabase()` pages is worth doing separately.
- **It does not stop the bleed until deployed.** Production is still taking the traffic.

## Verification

- `npx tsc --noEmit` — clean, exit 0.
- `npx vitest run` — 654 passed, 1 skipped, **8 failed**.

The 8 failures are all in `tests/integration/entities/entity-dossier.test.ts` and all are **30,000ms timeouts**. They are live-DB integration tests and the pool was at 42 active / 40 `exec_sql` when they ran, so I read them as collateral from the incident, not from this change — a middleware prefix cannot make a DB query time out. **This is inferred, not proven.** Re-run that file once the pool recovers to confirm before merging.

Note: the pre-commit hook printed two `TS2307` errors against `.next/types/validator.ts` referencing `/clarity/q/[slug]` pages, then passed. Those pages exist on `clarity-slice-2-question-board`, not on `main` — stale build artifact, not a defect here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)