### PR TITLE
Cache the nine expensive public report pages instead of re-querying per hit

### DIFF
--- a/apps/web/src/app/foundations/prf/page.tsx
+++ b/apps/web/src/app/foundations/prf/page.tsx
@@ -1,7 +1,10 @@
 import { getServiceSupabase } from '@/lib/supabase';
 import Link from 'next/link';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 const PRF_FOUNDATION_ID = '4ee5baca-c898-4318-ae2b-d79b95379cc7';
 const SNOW_FOUNDATION_ID = 'd242967e-0e68-4367-9785-06cf0ec7485e';

--- a/apps/web/src/app/insights/page.tsx
+++ b/apps/web/src/app/insights/page.tsx
@@ -1,7 +1,10 @@
 import { getServiceSupabase } from '@/lib/supabase';
 import Link from 'next/link';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 function formatMoney(amount: number | null): string {
   if (!amount) return '\u2014';

--- a/apps/web/src/app/reports/community-efficiency/page.tsx
+++ b/apps/web/src/app/reports/community-efficiency/page.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Community-Controlled Efficiency | CivicGraph Investigation',

--- a/apps/web/src/app/reports/data-health/page.tsx
+++ b/apps/web/src/app/reports/data-health/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Data Health | CivicGraph',

--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -3,7 +3,10 @@ import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 import { DESERT_COMMUNITY_ORGS_SQL, mapDesertCommunityOrgs } from '@/lib/funding-deserts';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Funding Deserts | CivicGraph Investigation',

--- a/apps/web/src/app/reports/political-money/page.tsx
+++ b/apps/web/src/app/reports/political-money/page.tsx
@@ -3,7 +3,10 @@ import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
 import { ReportCTA } from '../_components/report-cta';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Political Money | CivicGraph Investigation',

--- a/apps/web/src/app/reports/power-concentration/page.tsx
+++ b/apps/web/src/app/reports/power-concentration/page.tsx
@@ -3,7 +3,10 @@ import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
 import { ReportCTA } from '../_components/report-cta';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Cross-System Power Concentration | CivicGraph Investigation',

--- a/apps/web/src/app/reports/power-network/page.tsx
+++ b/apps/web/src/app/reports/power-network/page.tsx
@@ -3,7 +3,10 @@ import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
 import { ReportCTA } from '../_components/report-cta';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Power Network: Who Runs Australia\'s Civic Sector | CivicGraph',

--- a/apps/web/src/app/reports/reallocation-atlas/page.tsx
+++ b/apps/web/src/app/reports/reallocation-atlas/page.tsx
@@ -3,7 +3,10 @@ import Link from 'next/link';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReallocationAtlasClient } from './reallocation-atlas-client';
 
-export const dynamic = 'force-dynamic';
+// Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
+// anonymous traffic cannot drive one service-role query fan-out per hit
+// (the /foundations/backlog pool-saturation shape, 2026-08-15).
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Reallocation Atlas | CivicGraph',


### PR DESCRIPTION
Follow-up to #205. That PR gated `/foundations/backlog`; this audits the rest of the app for the same bug shape — public + \`force-dynamic\` + \`getServiceSupabase()\` + multi-RPC fan-out.

## What the audit found

Checked all 68 pages using \`getServiceSupabase()\`, including the six paths on the "Expensive public data routes" firewall rule (\`/entity/\`, \`/entities/\`, \`/grants\`, \`/foundations/compare\`, \`/person/\`, \`/places/\`).

**No second exposure bug.** Nothing else is a service-role review queue left public by mistake. Those six are intentionally public product surfaces and none fan out more than 1–3 queries per hit. Gating them would be wrong.

**The remaining risk is uncached fan-out, not exposure.** Nine public pages pair service-role access with a heavy per-hit query burst and take *no per-request input at all* — no \`searchParams\`, no \`cookies()\`, no \`headers()\`. \`force-dynamic\` bought nothing and cost a fresh burst on every anonymous hit.

| Page | queries/hit |
|---|---|
| \`/reports/data-health\` | 17 |
| \`/insights\` | 12 |
| \`/foundations/prf\` | 9 |
| \`/reports/reallocation-atlas\` | 8 |
| \`/reports/funding-deserts\` | 7 |
| \`/reports/power-network\` | 7 |
| \`/reports/power-concentration\` | 5 |
| \`/reports/community-efficiency\` | 4 |
| \`/reports/political-money\` | 4 |

## Change

Those nine move from \`force-dynamic\` to \`revalidate = 3600\`. They read nightly-refreshed matviews, so an hour is conservative against a 24h refresh cycle.

\`/foundations\` keeps \`force-dynamic\` — it genuinely reads filter \`searchParams\`.

## Verification

\`npx tsc --noEmit\` clean. (Two \`.next/types/validator.ts\` errors for deleted \`clarity/q/[slug]\` routes are stale build artifacts, present before this change.)

Not verified: cache behaviour in the deployed app. Worth eyeballing one report page's response headers after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)