### PR TITLE
Ship /clarity slice 3 — what changed, and whether anyone explained it

### DIFF
--- a/apps/web/src/app/api/clarity/events/[id]/reason/route.ts
+++ b/apps/web/src/app/api/clarity/events/[id]/reason/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/clarity/events/[id]/reason — the write path behind
+ * [ RECORD THE REASON → ] on /clarity/changes.
+ *
+ * Gated with requireAdminApi rather than relying on the /clarity layout: a route
+ * handler does not run through a page layout, so the gate has to be here or it
+ * does not exist. requireAdminApi is deliberately NOT covered by the local-dev
+ * bypass — see admin-auth-bypass.ts.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  const { id } = await params;
+  const eventId = Number(id);
+  if (!Number.isInteger(eventId) || eventId <= 0) {
+    return NextResponse.json({ error: 'Bad event id' }, { status: 400 });
+  }
+
+  let reason: unknown;
+  try {
+    ({ reason } = (await request.json()) as { reason?: unknown });
+  } catch {
+    return NextResponse.json({ error: 'Body must be JSON' }, { status: 400 });
+  }
+
+  const text = typeof reason === 'string' ? reason.trim() : '';
+  if (!text) {
+    return NextResponse.json({ error: 'A reason cannot be blank' }, { status: 400 });
+  }
+  if (text.length > 500) {
+    return NextResponse.json({ error: 'Keep it under 500 characters' }, { status: 400 });
+  }
+
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase
+    .from('clarity_event')
+    .update({
+      reason: text,
+      reason_by: auth.user.email ?? 'admin',
+      reason_at: new Date().toISOString(),
+    })
+    .eq('id', eventId)
+    .select('id,reason,reason_by,reason_at')
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: `No event ${eventId}` }, { status: 404 });
+
+  return NextResponse.json(data);
+}

--- a/apps/web/src/app/clarity/LedgerClient.tsx
+++ b/apps/web/src/app/clarity/LedgerClient.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { Fragment, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { BASELINES, BASELINE_LABEL, type Baseline } from './changes/types';
 import type { LedgerRow, LedgerStats, FreshnessProbe } from './types';
 
 // QUESTIONS sits FIRST and ALL stays the default. A question is the only row here that answers
@@ -124,10 +126,51 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
                 Refreshed {stats.refreshedAt.slice(0, 10)}
               </span>
             ) : null}
+            {/* The baseline is a link, not a toggle: it is a searchParam shared with
+                /clarity/changes so the two screens can never disagree about which
+                window you are looking at. */}
+            <span className="ml-auto flex flex-wrap items-center gap-1.5">
+              <span className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-bauhaus-muted">
+                Baseline
+              </span>
+              <span className="flex border-2 border-bauhaus-black">
+                {BASELINES.map((b) => (
+                  <Link
+                    key={b}
+                    href={b === 'last' ? '/clarity' : `/clarity?b=${b}`}
+                    aria-current={stats.baseline === b ? 'true' : undefined}
+                    className={`border-r-2 border-bauhaus-black px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.12em] last:border-r-0 ${
+                      stats.baseline === b
+                        ? 'bg-bauhaus-black text-bauhaus-canvas'
+                        : 'bg-bauhaus-white'
+                    }`}
+                  >
+                    {BASELINE_LABEL[b as Baseline]}
+                  </Link>
+                ))}
+              </span>
+            </span>
           </div>
           <h1 className="text-4xl font-black uppercase leading-none tracking-wide sm:text-5xl">
             Clarity Ledger
           </h1>
+
+          {/* WHAT CHANGED lives on the front strip, because a change log nobody
+              walks past is a change log nobody reads. An unexplained critical is
+              red and stays red until somebody writes a sentence. */}
+          <Link
+            href={`/clarity/changes?b=${stats.baseline}`}
+            className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 border-2 border-bauhaus-black bg-bauhaus-white px-3 py-2 text-[11.5px] font-bold hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+          >
+            <span>
+              {nf.format(stats.moved)} objects moved more than 10% against{' '}
+              {BASELINE_LABEL[stats.baseline as Baseline].toLowerCase()}
+            </span>
+            <span className={stats.unexplained ? 'text-bauhaus-red' : ''}>
+              · {nf.format(stats.unexplained)} with no reason recorded
+            </span>
+            <span className="ml-auto uppercase tracking-[0.12em]">What changed →</span>
+          </Link>
           <div className="my-5 flex flex-wrap items-end gap-7">
             <div>
               <b className="block text-5xl font-black leading-none tracking-tight">
@@ -257,11 +300,11 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
               <table className="w-full min-w-[780px] border-collapse">
                 <thead>
                   <tr className="bg-bauhaus-black text-bauhaus-canvas">
-                    {['Object', 'Domain', 'Lifecycle', 'Rows', 'Size', 'Fresh'].map((h, i) => (
+                    {['Object', 'Domain', 'Lifecycle', 'Rows', '\u0394', 'Size', 'Fresh'].map((h, i) => (
                       <th
                         key={h}
                         className={`px-2.5 py-2 text-[9.5px] font-extrabold uppercase tracking-[0.13em] ${
-                          i === 3 || i === 4 ? 'text-right' : 'text-left'
+                          i >= 3 && i <= 5 ? 'text-right' : 'text-left'
                         }`}
                       >
                         {h}
@@ -272,7 +315,7 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
                 <tbody>
                   {visible.length === 0 ? (
                     <tr>
-                      <td colSpan={6} className="p-9 text-center text-sm text-bauhaus-muted">
+                      <td colSpan={7} className="p-9 text-center text-sm text-bauhaus-muted">
                         Nothing matches. Clear a filter.
                       </td>
                     </tr>
@@ -340,6 +383,27 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
                                 </>
                               )}
                             </td>
+                            {/* No baseline is '?', in yellow, and never 0. */}
+                            <td
+                              className={`px-2.5 py-1.5 text-right font-mono text-[12.5px] ${
+                                r.dp === undefined
+                                  ? 'text-bauhaus-yellow'
+                                  : Math.abs(r.dp) > 10
+                                    ? 'font-bold text-bauhaus-red'
+                                    : 'text-bauhaus-muted'
+                              }`}
+                              title={
+                                r.dp === undefined
+                                  ? 'No baseline this far back — unmeasurable, not zero'
+                                  : undefined
+                              }
+                            >
+                              {r.dp === undefined
+                                ? '?'
+                                : r.dp === 0
+                                  ? '\u2014'
+                                  : `${r.dp > 0 ? '+' : ''}${r.dp.toFixed(1)}%`}
+                            </td>
                             <td className="px-2.5 py-1.5 text-right font-mono text-[13px]">{bytes(r.b)}</td>
                             <td className="px-2.5 py-1.5">
                               {r.f === 'ok' && r.w ? (
@@ -356,7 +420,7 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
                           </tr>
                           {isOpen ? (
                             <tr className="border-t-2 border-bauhaus-black bg-bauhaus-canvas">
-                              <td colSpan={6} className="px-4 py-3.5">
+                              <td colSpan={7} className="px-4 py-3.5">
                                 <dl className="grid max-w-[100ch] grid-cols-[104px_1fr] gap-x-3.5 gap-y-1 text-[13px]">
                                   <dt className={DT}>Purpose</dt>
                                   <dd>

--- a/apps/web/src/app/clarity/changes/ChangesClient.tsx
+++ b/apps/web/src/app/clarity/changes/ChangesClient.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import { Fragment, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  BASELINES,
+  BASELINE_LABEL,
+  type Baseline,
+  type BaselineAvailability,
+  type ChangeEvent,
+  type ChangesStats,
+} from './types';
+
+const nf = new Intl.NumberFormat('en-AU');
+
+/**
+ * Six event types, each with the sentence it means. `refresh_skipped` and
+ * `probe_degraded` exist in the enum and are deliberately NOT emitted yet: the
+ * catalog does not keep a per-run probe history to compare against, and a type
+ * that silently never fires is worse than one that is absent.
+ */
+const TYPE: Record<string, { label: string; glyph: string }> = {
+  row_moved: { label: 'Row move', glyph: '▲' },
+  object_new: { label: 'New', glyph: '+' },
+  object_missing: { label: 'Gone', glyph: '×' },
+  state_change: { label: 'State', glyph: '·' },
+  scope_change: { label: 'Scope', glyph: '·' },
+  refresh_skipped: { label: 'Refresh', glyph: '·' },
+  sentinel_fired: { label: 'Sentinel', glyph: '!' },
+  metric_crossed: { label: 'Metric', glyph: '·' },
+  probe_degraded: { label: 'Probe', glyph: '?' },
+  answer_drift: { label: 'Answer drift', glyph: '≠' },
+};
+
+const SEVERITY: Record<string, string> = {
+  critical: 'text-bauhaus-red',
+  warn: 'text-bauhaus-yellow',
+  info: 'text-bauhaus-muted',
+};
+
+function when(iso: string): string {
+  return new Date(iso)
+    .toLocaleDateString('en-AU', { day: '2-digit', month: 'short' })
+    .toUpperCase();
+}
+
+function pct(v: number | null): string {
+  if (v === null) return '?';
+  return `${v > 0 ? '+' : ''}${v.toFixed(1)}%`;
+}
+
+export default function ChangesClient({
+  events,
+  availability,
+  stats,
+  baseline,
+}: {
+  events: ChangeEvent[];
+  availability: BaselineAvailability[];
+  stats: ChangesStats;
+  baseline: Baseline;
+}) {
+  const router = useRouter();
+  const [type, setType] = useState('');
+  const [sev, setSev] = useState('');
+  const [q, setQ] = useState('');
+  const [open, setOpen] = useState<number | null>(null);
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<Record<number, string>>({});
+
+  const facets = useMemo(() => {
+    const tally = (pick: (e: ChangeEvent) => string) => {
+      const m = new Map<string, number>();
+      for (const e of events) {
+        const k = pick(e);
+        if (k) m.set(k, (m.get(k) ?? 0) + 1);
+      }
+      return [...m.entries()].sort((a, b) => b[1] - a[1]);
+    };
+    return { type: tally((e) => e.event_type), sev: tally((e) => e.severity) };
+  }, [events]);
+
+  const visible = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return events.filter((e) => {
+      if (type && e.event_type !== type) return false;
+      if (sev && e.severity !== sev) return false;
+      if (
+        needle &&
+        !`${e.object_key ?? ''} ${e.question_slug ?? ''} ${e.note ?? ''} ${e.reason ?? ''}`
+          .toLowerCase()
+          .includes(needle)
+      )
+        return false;
+      return true;
+    });
+  }, [events, type, sev, q]);
+
+  async function recordReason(id: number) {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(`/api/clarity/events/${id}/reason`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: draft }),
+      });
+      const body = (await res.json()) as { error?: string; reason?: string };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setSaved((s) => ({ ...s, [id]: body.reason ?? draft.trim() }));
+      setDraft('');
+      setOpen(null);
+      // The strip counts unexplained events server-side, so it has to re-read.
+      router.refresh();
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const cell = 'border-r-2 border-b-2 border-bauhaus-black bg-bauhaus-white px-3 py-2.5';
+  const facetBtn = (active: boolean) =>
+    `flex w-full items-center justify-between gap-2 px-1.5 py-0.5 text-left text-xs ${
+      active ? 'bg-bauhaus-black font-bold text-bauhaus-canvas' : 'hover:bg-bauhaus-canvas'
+    }`;
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas">
+      <div className="mx-auto max-w-[1400px] px-4 pb-24">
+        <header className="border-b-4 border-bauhaus-black pt-8">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <Link
+              href="/clarity"
+              className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+            >
+              ◀ The ledger
+            </Link>
+            {stats.computedAt ? (
+              <span className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em]">
+                Deltas computed {stats.computedAt.slice(0, 10)}
+              </span>
+            ) : (
+              <span className="border-2 border-bauhaus-blue bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] text-bauhaus-blue">
+                Deltas never computed
+              </span>
+            )}
+          </div>
+          <h1 className="text-4xl font-black uppercase leading-none tracking-wide sm:text-5xl">
+            What changed
+          </h1>
+
+          {/* The baseline is one searchParam and it drives every delta on every
+              screen. Options we cannot serve are greyed WITH their reason —
+              never silently missing, never rendered as a zero. */}
+          <div className="my-5 flex flex-wrap items-center gap-2">
+            <span className="text-[11px] font-extrabold uppercase tracking-[0.16em] text-bauhaus-muted">
+              Baseline
+            </span>
+            <div className="flex flex-wrap border-2 border-bauhaus-black">
+              {BASELINES.map((b) => {
+                const a = availability.find((x) => x.baseline === b);
+                const usable = (a?.covered ?? 0) > 0;
+                const label = `${BASELINE_LABEL[b]}${
+                  usable ? ` · ${nf.format(a?.covered ?? 0)}` : ' · none'
+                }`;
+                return usable ? (
+                  <Link
+                    key={b}
+                    href={`/clarity/changes?b=${b}`}
+                    aria-current={baseline === b ? 'true' : undefined}
+                    className={`border-r-2 border-bauhaus-black px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.12em] last:border-r-0 ${
+                      baseline === b ? 'bg-bauhaus-black text-bauhaus-canvas' : 'bg-bauhaus-white'
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                ) : (
+                  <span
+                    key={b}
+                    title={a?.reason ?? 'unavailable'}
+                    className="border-r-2 border-bauhaus-black bg-bauhaus-white px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.12em] text-bauhaus-muted opacity-60 last:border-r-0"
+                  >
+                    {BASELINE_LABEL[b]} — {a?.reason ?? 'unavailable'}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 border-l-2 border-t-2 border-bauhaus-black sm:grid-cols-4">
+            {(
+              [
+                [nf.format(stats.inWindow), 'Events in window', ''],
+                [
+                  nf.format(stats.unexplained),
+                  'No reason recorded',
+                  stats.unexplained ? 'text-bauhaus-red' : '',
+                ],
+                [nf.format(stats.moved), 'Moved more than 10%', ''],
+                [
+                  `${nf.format(stats.measurable)} / ${nf.format(stats.objects)}`,
+                  'Objects with this baseline',
+                  '',
+                ],
+              ] as const
+            ).map(([v, label, tone]) => (
+              <div key={label} className={cell}>
+                <b className={`block text-xl font-black leading-tight ${tone}`}>{v}</b>
+                <span className="mt-1 block text-[9.5px] font-extrabold uppercase tracking-[0.13em] text-bauhaus-muted">
+                  {label}
+                </span>
+              </div>
+            ))}
+          </div>
+          {stats.measurable < stats.objects ? (
+            <p className="mt-2.5 max-w-[70ch] text-[11.5px] text-bauhaus-muted">
+              The other {nf.format(stats.objects - stats.measurable)} objects have no baseline this
+              far back and render <b className="text-bauhaus-yellow">?</b>, not 0.
+              {stats.historyBegins ? (
+                <> History begins {stats.historyBegins.slice(0, 10)}.</>
+              ) : null}
+            </p>
+          ) : null}
+        </header>
+
+        <div className="mt-6 grid border-[3px] border-bauhaus-black bg-bauhaus-white lg:grid-cols-[216px_1fr]">
+          <aside className="border-b-[3px] border-bauhaus-black p-3 lg:border-b-0 lg:border-r-[3px]">
+            {(
+              [
+                ['Type', facets.type, type, setType, (v: string) => TYPE[v]?.label ?? v] as const,
+                ['Severity', facets.sev, sev, setSev, (v: string) => v] as const,
+              ]
+            ).map(([label, items, value, set, render]) => (
+              <div key={label} className="mb-4 last:mb-0">
+                <h2 className="mb-1.5 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+                  {label}
+                </h2>
+                {items.length === 0 ? (
+                  <p className="px-1.5 text-xs text-bauhaus-muted">Nothing recorded yet.</p>
+                ) : (
+                  items.map(([v, n]) => (
+                    <button
+                      key={v}
+                      type="button"
+                      aria-pressed={value === v}
+                      onClick={() => set(value === v ? '' : v)}
+                      className={facetBtn(value === v)}
+                    >
+                      <span>{render(v)}</span>
+                      <i className="not-italic text-[11px] opacity-70">{nf.format(n)}</i>
+                    </button>
+                  ))
+                )}
+              </div>
+            ))}
+            <p className="mt-4 border-t-2 border-bauhaus-black/15 pt-2.5 text-[10.5px] leading-snug text-bauhaus-muted">
+              An event fires when a row count moves more than 10%, crosses zero, an object appears
+              or disappears, its state changes, or an answer&apos;s headline moves more than 10%
+              while none of its ingredients moved a row.
+            </p>
+          </aside>
+
+          <section className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2.5 border-b-2 border-bauhaus-black/15 p-2.5">
+              <input
+                type="search"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Search object, question, note, reason…"
+                aria-label="Search the change log"
+                className="min-w-0 flex-1 border-2 border-bauhaus-black bg-bauhaus-canvas px-2.5 py-1.5 text-sm"
+              />
+              <span className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-bauhaus-muted">
+                {nf.format(visible.length)} shown
+              </span>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[820px] border-collapse">
+                <thead>
+                  <tr className="bg-bauhaus-black text-bauhaus-canvas">
+                    {['When', 'Type', 'Object', 'Before', 'After', 'Δ', 'Reason'].map((h, i) => (
+                      <th
+                        key={h}
+                        className={`px-2.5 py-2 text-[9.5px] font-extrabold uppercase tracking-[0.13em] ${
+                          i >= 3 && i <= 5 ? 'text-right' : 'text-left'
+                        }`}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {visible.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="p-9 text-center text-sm text-bauhaus-muted">
+                        {events.length
+                          ? 'Nothing matches. Clear a filter.'
+                          : 'Nothing has changed since the log started — or the nightly job has not run yet.'}
+                      </td>
+                    </tr>
+                  ) : (
+                    visible.map((e) => {
+                      const t = TYPE[e.event_type] ?? { label: e.event_type, glyph: '·' };
+                      const isOpen = open === e.id;
+                      const reason = saved[e.id] ?? e.reason;
+                      return (
+                        <Fragment key={e.id}>
+                          <tr
+                            className={`border-t border-bauhaus-black/10 ${
+                              !reason && e.severity === 'critical' ? 'bg-bauhaus-red/5' : ''
+                            }`}
+                          >
+                            <td className="whitespace-nowrap px-2.5 py-1.5 font-mono text-[12px]">
+                              {when(e.at)}
+                            </td>
+                            <td className="px-2.5 py-1.5 text-[11.5px]">
+                              <span className={`mr-1 font-black ${SEVERITY[e.severity] ?? ''}`}>
+                                {t.glyph}
+                              </span>
+                              {t.label}
+                            </td>
+                            <td className="break-all px-2.5 py-1.5 text-[13px] font-semibold">
+                              {e.question_slug ? (
+                                <Link
+                                  href={`/clarity/q/${e.question_slug}`}
+                                  className="font-mono underline"
+                                >
+                                  {e.question_slug}
+                                </Link>
+                              ) : (
+                                <span className="font-mono">{e.object_key ?? '—'}</span>
+                              )}
+                              {e.note ? (
+                                <span className="mt-0.5 block text-[11px] font-normal text-bauhaus-muted">
+                                  {e.note}
+                                </span>
+                              ) : null}
+                            </td>
+                            <td className="px-2.5 py-1.5 text-right font-mono text-[13px]">
+                              {e.before_value === null ? '—' : nf.format(Number(e.before_value))}
+                            </td>
+                            <td className="px-2.5 py-1.5 text-right font-mono text-[13px]">
+                              {e.after_value === null ? '—' : nf.format(Number(e.after_value))}
+                            </td>
+                            <td
+                              className={`px-2.5 py-1.5 text-right font-mono text-[13px] font-bold ${
+                                e.delta_pct === null
+                                  ? 'text-bauhaus-yellow'
+                                  : Number(e.delta_pct) < 0
+                                    ? 'text-bauhaus-red'
+                                    : ''
+                              }`}
+                            >
+                              {pct(e.delta_pct === null ? null : Number(e.delta_pct))}
+                            </td>
+                            <td className="px-2.5 py-1.5 text-[11.5px]">
+                              {reason ? (
+                                <span>
+                                  {reason}
+                                  {e.reason_by ? (
+                                    <em className="ml-1 not-italic text-bauhaus-muted">
+                                      — {e.reason_by}
+                                    </em>
+                                  ) : null}
+                                </span>
+                              ) : e.severity === 'critical' ? (
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setOpen(isOpen ? null : e.id);
+                                    setDraft('');
+                                    setSaveError(null);
+                                  }}
+                                  className="border-2 border-bauhaus-red px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.12em] text-bauhaus-red hover:bg-bauhaus-red hover:text-bauhaus-canvas"
+                                >
+                                  No reason recorded →
+                                </button>
+                              ) : (
+                                <span className="text-bauhaus-muted">—</span>
+                              )}
+                            </td>
+                          </tr>
+                          {isOpen ? (
+                            <tr className="border-t-2 border-bauhaus-black bg-bauhaus-canvas">
+                              <td colSpan={7} className="px-4 py-3.5">
+                                <label
+                                  htmlFor={`reason-${e.id}`}
+                                  className="block text-[9.5px] font-extrabold uppercase tracking-[0.12em] text-bauhaus-muted"
+                                >
+                                  Why did this happen?
+                                </label>
+                                <div className="mt-1.5 flex flex-wrap gap-2">
+                                  <input
+                                    id={`reason-${e.id}`}
+                                    value={draft}
+                                    autoFocus
+                                    onChange={(ev) => setDraft(ev.target.value)}
+                                    onKeyDown={(ev) => {
+                                      if (ev.key === 'Enter' && draft.trim() && !saving)
+                                        recordReason(e.id);
+                                    }}
+                                    placeholder="e.g. staging table truncated after the LGA rebuild — expected"
+                                    className="min-w-[280px] flex-1 border-2 border-bauhaus-black bg-bauhaus-white px-2.5 py-1.5 text-sm"
+                                  />
+                                  <button
+                                    type="button"
+                                    disabled={!draft.trim() || saving}
+                                    onClick={() => recordReason(e.id)}
+                                    className="border-2 border-bauhaus-black bg-bauhaus-black px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.12em] text-bauhaus-canvas disabled:opacity-40"
+                                  >
+                                    {saving ? 'Recording…' : 'Record the reason'}
+                                  </button>
+                                </div>
+                                {saveError ? (
+                                  <p className="mt-2 text-[12px] font-bold text-bauhaus-red">
+                                    {saveError}
+                                  </p>
+                                ) : null}
+                                <p className="mt-2 max-w-[80ch] text-[11px] text-bauhaus-muted">
+                                  A reason is not an approval. It is the sentence the next person
+                                  reads instead of re-deriving what happened, and it is what takes
+                                  this event off the red strip.
+                                </p>
+                              </td>
+                            </tr>
+                          ) : null}
+                        </Fragment>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex flex-wrap gap-4 border-t-2 border-bauhaus-black/15 p-2.5 text-[11px] font-semibold text-bauhaus-muted">
+              <span>
+                <b className="text-bauhaus-red">Red</b> critical and unexplained
+              </span>
+              <span>
+                <b className="text-bauhaus-yellow">?</b> no baseline — unmeasurable, not zero
+              </span>
+              <span>
+                Unexplained criticals are carried in from outside the window, always.
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/clarity/changes/baseline.test.ts
+++ b/apps/web/src/app/clarity/changes/baseline.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { BASELINES, BASELINE_LABEL, parseBaseline } from './types';
+
+describe('the baseline selector', () => {
+  it('falls back to the last run rather than rejecting a bad parameter', () => {
+    expect(parseBaseline(undefined)).toBe('last');
+    expect(parseBaseline('')).toBe('last');
+    expect(parseBaseline('60d')).toBe('last');
+    expect(parseBaseline('<script>')).toBe('last');
+  });
+
+  it('accepts exactly the four baselines the delta table stores', () => {
+    for (const b of BASELINES) expect(parseBaseline(b)).toBe(b);
+    // The CHECK constraint on clarity_delta.baseline is the same four. If this
+    // list ever grows, that constraint has to grow with it in the same migration.
+    expect([...BASELINES]).toEqual(['last', '7d', '30d', '90d']);
+  });
+
+  it('labels every baseline in plain words', () => {
+    for (const b of BASELINES) {
+      expect(BASELINE_LABEL[b]).toBeTruthy();
+      expect(BASELINE_LABEL[b]).not.toMatch(/baseline|window|delta/i);
+    }
+  });
+});

--- a/apps/web/src/app/clarity/changes/page.tsx
+++ b/apps/web/src/app/clarity/changes/page.tsx
@@ -1,0 +1,178 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import ChangesClient from './ChangesClient';
+import {
+  BASELINES,
+  parseBaseline,
+  type Baseline,
+  type BaselineAvailability,
+  type ChangeEvent,
+  type ChangesStats,
+} from './types';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'What changed · Clarity',
+  description: 'Every move in the estate since a baseline, and whether anyone explained it.',
+};
+
+const WINDOW_DAYS: Record<Baseline, number> = { last: 2, '7d': 7, '30d': 30, '90d': 90 };
+
+async function load(baseline: Baseline) {
+  // getDirectServiceSupabase, NOT getServiceSupabase — the latter can return a stub
+  // that resolves every query to { data: null }, i.e. a silent empty screen.
+  const supabase = getDirectServiceSupabase();
+  const since = new Date(Date.now() - WINDOW_DAYS[baseline] * 86_400_000).toISOString();
+
+  // Unexplained criticals first, then newest. The ordering IS the argument: an
+  // anomaly nobody has accounted for outranks anything that merely happened.
+  const { data: eventRows, error } = await supabase
+    .from('v_clarity_changes')
+    .select(
+      'id,at,event_type,object_key,question_slug,before_value,after_value,delta_pct,' +
+        'severity,note,reason,reason_by,reason_at,unexplained,domain,object_kind',
+    )
+    .gte('at', since)
+    .eq('act_business', false)
+    .order('unexplained', { ascending: false })
+    .order('at', { ascending: false })
+    .limit(300);
+
+  if (error) throw new Error(`v_clarity_changes query failed: ${error.message}`);
+
+  // The three seeded 2026-04-02 moves sit outside every window but are the whole
+  // point of the screen, so unexplained criticals are always carried in.
+  const { data: openRows } = await supabase
+    .from('v_clarity_changes')
+    .select(
+      'id,at,event_type,object_key,question_slug,before_value,after_value,delta_pct,' +
+        'severity,note,reason,reason_by,reason_at,unexplained,domain,object_kind',
+    )
+    .eq('unexplained', true)
+    .eq('act_business', false)
+    .order('at', { ascending: false })
+    .limit(100);
+
+  const byId = new Map<number, ChangeEvent>();
+  for (const r of [...(openRows ?? []), ...(eventRows ?? [])] as unknown as ChangeEvent[]) {
+    byId.set(r.id, r);
+  }
+  const events = [...byId.values()].sort((a, b) => {
+    if (a.unexplained !== b.unexplained) return a.unexplained ? -1 : 1;
+    return a.at < b.at ? 1 : -1;
+  });
+
+  // Baseline availability, measured rather than assumed. A baseline with zero
+  // covered objects is offered greyed, with the reason on the control itself.
+  const availability: BaselineAvailability[] = [];
+  let stats: ChangesStats = {
+    inWindow: (eventRows ?? []).length,
+    unexplained: events.filter((e) => e.unexplained).length,
+    moved: 0,
+    measurable: 0,
+    objects: 0,
+    historyBegins: null,
+    computedAt: null,
+  };
+
+  const { count: objectCount } = await supabase
+    .from('clarity_object')
+    .select('object_key', { count: 'exact', head: true });
+  stats.objects = objectCount ?? 0;
+
+  for (const b of BASELINES) {
+    const { count } = await supabase
+      .from('clarity_delta')
+      .select('object_key', { count: 'exact', head: true })
+      .eq('baseline', b)
+      .not('baseline_at', 'is', null);
+    availability.push({
+      baseline: b,
+      covered: count ?? 0,
+      reason: count ? null : 'history does not reach back this far yet',
+    });
+  }
+
+  const { data: firstHistory } = await supabase
+    .from('clarity_object_history')
+    .select('snapshot_at')
+    .order('snapshot_at', { ascending: true })
+    .limit(1);
+  stats.historyBegins = firstHistory?.[0]?.snapshot_at ?? null;
+
+  const { count: movedCount } = await supabase
+    .from('clarity_delta')
+    .select('object_key', { count: 'exact', head: true })
+    .eq('baseline', baseline)
+    .not('row_delta_pct', 'is', null)
+    .or('row_delta_pct.gt.10,row_delta_pct.lt.-10');
+  stats.moved = movedCount ?? 0;
+
+  const { data: computed } = await supabase
+    .from('clarity_delta')
+    .select('computed_at')
+    .eq('baseline', baseline)
+    .order('computed_at', { ascending: false })
+    .limit(1);
+  stats.computedAt = computed?.[0]?.computed_at ?? null;
+  stats.measurable = availability.find((a) => a.baseline === baseline)?.covered ?? 0;
+  stats = { ...stats, unexplained: events.filter((e) => e.unexplained).length };
+
+  return { events, availability, stats };
+}
+
+export default async function ChangesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ b?: string }>;
+}) {
+  const { b } = await searchParams;
+  const baseline = parseBaseline(b);
+
+  let events: ChangeEvent[] = [];
+  let availability: BaselineAvailability[] = [];
+  let stats: ChangesStats | null = null;
+  let error: string | null = null;
+
+  try {
+    ({ events, availability, stats } = await load(baseline));
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  if (error || !stats) {
+    return (
+      <main className="clarity-dark min-h-screen px-5 py-16">
+        <div className="mx-auto max-w-3xl border-4 border-bauhaus-red bg-bauhaus-white p-8">
+          <h1 className="text-2xl font-black uppercase tracking-widest text-bauhaus-red">
+            No change log
+          </h1>
+          <p className="mt-4 text-sm text-bauhaus-black">
+            <code className="font-mono">v_clarity_changes</code> could not be read. The log is
+            written by <code className="font-mono">clarity_compute_deltas()</code>; if the slice-3
+            migrations have not been applied, there is nothing to show yet.
+          </p>
+          <pre className="mt-4 overflow-x-auto border-2 border-bauhaus-muted bg-bauhaus-canvas p-3 font-mono text-xs">
+            {error}
+          </pre>
+          <Link href="/clarity" className="mt-5 inline-block text-sm font-black uppercase underline">
+            ← The ledger
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <div className="clarity-dark">
+      <ChangesClient
+        events={events}
+        availability={availability}
+        stats={stats}
+        baseline={baseline}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/clarity/changes/types.ts
+++ b/apps/web/src/app/clarity/changes/types.ts
@@ -1,0 +1,64 @@
+/**
+ * WHAT CHANGED — the estate's derivative. Slice 3.
+ *
+ * The four baselines are a URL parameter, not component state, so a link to
+ * "/clarity/changes?b=90d" is a link to what somebody actually looked at, and the
+ * same parameter drives the delta column on the ledger.
+ */
+export const BASELINES = ['last', '7d', '30d', '90d'] as const;
+export type Baseline = (typeof BASELINES)[number];
+
+export const BASELINE_LABEL: Record<Baseline, string> = {
+  last: 'Last run',
+  '7d': '7 days',
+  '30d': '30 days',
+  '90d': '90 days',
+};
+
+export function parseBaseline(v: string | undefined): Baseline {
+  return (BASELINES as readonly string[]).includes(v ?? '') ? (v as Baseline) : 'last';
+}
+
+/**
+ * Which baselines we can actually serve. `covered` is how many objects have a
+ * real baseline row behind them; when it is 0 the option is disabled and carries
+ * its own reason, because a greyed control with no explanation is just a bug.
+ */
+export interface BaselineAvailability {
+  baseline: Baseline;
+  covered: number;
+  reason: string | null;
+}
+
+export interface ChangeEvent {
+  id: number;
+  at: string;
+  event_type: string;
+  object_key: string | null;
+  question_slug: string | null;
+  before_value: number | null;
+  after_value: number | null;
+  delta_pct: number | null;
+  severity: 'info' | 'warn' | 'critical';
+  note: string | null;
+  reason: string | null;
+  reason_by: string | null;
+  reason_at: string | null;
+  unexplained: boolean;
+  domain: string | null;
+  object_kind: string | null;
+}
+
+export interface ChangesStats {
+  /** events inside the selected window */
+  inWindow: number;
+  unexplained: number;
+  /** objects whose row count moved more than 10% against the selected baseline */
+  moved: number;
+  /** objects with a real baseline row for the selected baseline */
+  measurable: number;
+  /** objects in the catalog, so `measurable` always has its denominator on screen */
+  objects: number;
+  historyBegins: string | null;
+  computedAt: string | null;
+}

--- a/apps/web/src/app/clarity/page.tsx
+++ b/apps/web/src/app/clarity/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getDirectServiceSupabase } from '@/lib/supabase';
 import LedgerClient from './LedgerClient';
+import { parseBaseline, type Baseline } from './changes/types';
 import type { LedgerRow, LedgerStats, ObjectKind, FreshnessProbe } from './types';
 
 export const dynamic = 'force-dynamic';
@@ -56,7 +57,9 @@ interface QuestionRow {
   binding_object: string | null;
 }
 
-async function loadIndex(): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
+async function loadIndex(
+  baseline: Baseline,
+): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
   // getDirectServiceSupabase, NOT getServiceSupabase — the latter sniffs the call stack for
   // '/app/reports/' and returns a stub resolving every query to { data: null }, i.e. a silent [].
   const supabase = getDirectServiceSupabase();
@@ -97,6 +100,51 @@ async function loadIndex(): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
     questions = [];
   }
 
+  // Movement against the selected baseline (slice 3). Objects with no baseline row
+  // are absent from this map on purpose — the ledger renders `?` for them rather
+  // than a zero that would read as "did not move".
+  const moves = new Map<string, number>();
+  let measurable = 0;
+  let moved = 0;
+  try {
+    for (let from = 0; ; from += PAGE) {
+      const { data } = await supabase
+        .from('clarity_delta')
+        .select('object_key,row_delta_pct,baseline_at')
+        .eq('baseline', baseline)
+        .not('baseline_at', 'is', null)
+        .range(from, from + PAGE - 1);
+      if (!data?.length) break;
+      for (const d of data as unknown as {
+        object_key: string;
+        row_delta_pct: number | null;
+      }[]) {
+        measurable += 1;
+        if (d.row_delta_pct === null) continue;
+        const pct = Number(d.row_delta_pct);
+        moves.set(d.object_key, pct);
+        if (Math.abs(pct) > 10) moved += 1;
+      }
+      if (data.length < PAGE) break;
+    }
+  } catch {
+    // The change log is a slice-3 addition. Before its migrations are applied the
+    // ledger is still worth having, so a missing table costs the delta column and
+    // nothing else.
+  }
+
+  let unexplained = 0;
+  try {
+    const { count } = await supabase
+      .from('clarity_event')
+      .select('id', { count: 'exact', head: true })
+      .eq('severity', 'critical')
+      .is('reason', null);
+    unexplained = count ?? 0;
+  } catch {
+    unexplained = 0;
+  }
+
   const objectRows: LedgerRow[] = all.map((o) => ({
     n: o.object_name,
     k: o.object_kind,
@@ -117,6 +165,7 @@ async function loadIndex(): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
     v: o.caveat ?? '',
     rls: Boolean(o.rls_enabled),
     an: Boolean(o.anon_readable),
+    dp: moves.get(o.object_name),
   }));
 
   const questionRows: LedgerRow[] = questions.map((q) => ({
@@ -166,17 +215,28 @@ async function loadIndex(): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
       anonReadable: objectRows.filter((r) => r.an).length,
       actBusiness: objectRows.filter((r) => r.a).length,
       refreshedAt: all[0]?.refreshed_at ?? null,
+      baseline,
+      moved,
+      unexplained,
+      measurable,
     },
   };
 }
 
-export default async function ClarityPage() {
+export default async function ClarityPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ b?: string }>;
+}) {
+  const { b } = await searchParams;
+  const baseline = parseBaseline(b);
+
   let rows: LedgerRow[] = [];
   let stats: LedgerStats | null = null;
   let error: string | null = null;
 
   try {
-    ({ rows, stats } = await loadIndex());
+    ({ rows, stats } = await loadIndex(baseline));
   } catch (e) {
     error = e instanceof Error ? e.message : String(e);
   }

--- a/apps/web/src/app/clarity/types.ts
+++ b/apps/web/src/app/clarity/types.ts
@@ -70,6 +70,15 @@ export interface LedgerRow {
   qh?: string;
   /** headline_sub, e.g. '662 of 778 organisations' */
   qsub?: string;
+
+  /**
+   * Movement against the selected baseline (slice 3).
+   *
+   * `dp` undefined means we have no baseline for this object that far back, and it
+   * renders `?` — never 0. A baseline we do not hold is not a baseline of zero, and
+   * collapsing the two is exactly how a 28% loss went unnoticed for four months.
+   */
+  dp?: number;
 }
 
 export interface LedgerStats {
@@ -83,4 +92,12 @@ export interface LedgerStats {
   anonReadable: number;
   actBusiness: number;
   refreshedAt: string | null;
+  /** slice 3 — the WHAT CHANGED strip */
+  baseline: string;
+  /** objects whose row count moved more than 10% against the baseline */
+  moved: number;
+  /** critical events with no reason written */
+  unexplained: number;
+  /** objects with a real baseline row, so `?` always has its denominator on screen */
+  measurable: number;
 }

--- a/supabase/migrations/20260815001000_clarity_change_log.sql
+++ b/supabase/migrations/20260815001000_clarity_change_log.sql
@@ -1,0 +1,147 @@
+-- ===========================================================================
+-- /clarity slice 3 — WHAT CHANGED, part 1: the change log itself.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001000_clarity_change_log.sql
+--
+-- Spec: thoughts/shared/data-map/clarity/CLARITY-SPEC.md §3.8, §4.4 (graft G2).
+--
+-- The failure this exists to make impossible: justice_funding went 218,022 ->
+-- 157,116 rows, minus 28%, and nothing anywhere fired. A catalog that only
+-- reports the present tense cannot catch that. clarity_delta is the derivative;
+-- clarity_event is the alarm; `reason IS NULL` on a critical event is the alarm
+-- still ringing.
+-- ===========================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'clarity_event_kind') THEN
+    CREATE TYPE clarity_event_kind AS ENUM
+      ('row_moved','object_new','object_missing','state_change','scope_change',
+       'refresh_skipped','sentinel_fired','metric_crossed','probe_degraded','answer_drift');
+  END IF;
+END $$;
+
+-- --------------------------------------------------------------- clarity_delta
+-- Written nightly for all four baselines so every delta on every screen is one
+-- indexed read rather than a join back through history. baseline_at IS NULL is
+-- the signal to render '?' — never 0, never a flat line. A baseline we do not
+-- have is not a baseline of zero.
+CREATE TABLE IF NOT EXISTS clarity_delta (
+  object_key    text NOT NULL,
+  baseline      text NOT NULL CHECK (baseline IN ('last','7d','30d','90d')),
+  row_before    bigint,
+  row_delta     bigint,
+  row_delta_pct numeric(12,3),
+  bytes_delta   bigint,
+  degree_delta  integer,
+  importance_delta numeric(8,4),
+  freshness_delta_hours numeric,
+  state_before  text,
+  state_change  text,
+  is_new        boolean NOT NULL DEFAULT false,
+  is_missing    boolean NOT NULL DEFAULT false,
+  baseline_at   timestamptz,
+  computed_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (object_key, baseline)
+);
+CREATE INDEX IF NOT EXISTS clarity_delta_baseline_move
+  ON clarity_delta (baseline, abs(row_delta_pct) DESC);
+
+-- --------------------------------------------------------------- clarity_event
+-- note   = machine-written provenance. Always populated.
+-- reason = human-written. NULL on a critical event IS the alarm, and the whole
+--          mechanism is that one column plus a text box.
+CREATE TABLE IF NOT EXISTS clarity_event (
+  id            bigserial PRIMARY KEY,
+  at            timestamptz NOT NULL DEFAULT now(),
+  event_type    clarity_event_kind NOT NULL,
+  object_key    text,
+  question_slug text,
+  metric_key    text,
+  before_value  numeric,
+  after_value   numeric,
+  delta_pct     numeric(12,3),
+  severity      text NOT NULL DEFAULT 'info' CHECK (severity IN ('info','warn','critical')),
+  note          text,
+  reason        text,
+  reason_by     text,
+  reason_at     timestamptz
+);
+CREATE INDEX IF NOT EXISTS clarity_event_at        ON clarity_event (at DESC);
+CREATE INDEX IF NOT EXISTS clarity_event_object    ON clarity_event (object_key, at DESC);
+CREATE INDEX IF NOT EXISTS clarity_event_unexplain ON clarity_event (at DESC)
+  WHERE severity = 'critical' AND reason IS NULL;
+
+ALTER TABLE clarity_delta ENABLE ROW LEVEL SECURITY;
+ALTER TABLE clarity_event ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON clarity_delta, clarity_event FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON clarity_delta, clarity_event TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE clarity_event_id_seq TO service_role;
+
+-- --------------------------------------------------- v_clarity_changes (read)
+-- The screen's one query. Unexplained criticals sort to the top and stay there
+-- until somebody writes a reason.
+CREATE OR REPLACE VIEW v_clarity_changes WITH (security_invoker = true) AS
+SELECT e.id, e.at, e.event_type::text AS event_type, e.object_key, e.question_slug,
+       e.metric_key, e.before_value, e.after_value, e.delta_pct, e.severity,
+       e.note, e.reason, e.reason_by, e.reason_at,
+       (e.severity = 'critical' AND e.reason IS NULL) AS unexplained,
+       o.domain, o.row_count, o.object_kind::text AS object_kind,
+       coalesce(o.act_business, false) AS act_business
+  FROM clarity_event e
+  LEFT JOIN clarity_object o ON o.object_key = e.object_key;
+REVOKE ALL ON v_clarity_changes FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON v_clarity_changes TO service_role;
+
+-- ===========================================================================
+-- COLD START (graft G11) — real history where real history exists.
+--
+-- clarity_object_history begins 2026-08-15, the night the catalog first ran.
+-- data_catalog_snapshots holds a genuine four-month series for 25 spine tables.
+-- Lifting it in gives those 25 a real 90-day baseline on night one; the other
+-- ~1,431 objects render '?' until the job has run enough nights, which is the
+-- honest answer and not a zero.
+--
+-- Idempotent: notes = 'backfill:data_catalog_snapshots' marks what we inserted,
+-- and rows carrying that marker are skipped on a re-run.
+-- ===========================================================================
+INSERT INTO clarity_object_history
+  (snapshot_at, object_key, object_kind, row_count, row_count_is_estimate,
+   bytes, last_write_at, degree, importance)
+SELECT s.snapshot_at, o.object_key, o.object_kind, s.row_count, false,
+       NULL, CASE WHEN s.freshness_hours IS NULL THEN NULL
+                  ELSE s.snapshot_at - make_interval(hours => s.freshness_hours::int) END,
+       NULL, NULL
+  FROM data_catalog_snapshots s
+  JOIN clarity_object o ON o.object_key = s.table_name
+ WHERE s.notes IS DISTINCT FROM 'clarity_refresh'
+   AND s.row_count IS NOT NULL
+   AND NOT EXISTS (
+     SELECT 1 FROM clarity_object_history h
+      WHERE h.object_key = o.object_key AND h.snapshot_at = s.snapshot_at);
+
+-- ---------------------------------------------------------------------------
+-- The three documented 2026-04-02 row-moves. They were real, nothing fired at
+-- the time, and no series in this database contains them. They go in as
+-- critical with reason IS NULL, which is exactly what they are: unexplained.
+-- ---------------------------------------------------------------------------
+-- Only justice_funding's two endpoints were recorded. The other two moves were
+-- recorded as percentages alone, so before/after stay NULL rather than being
+-- back-computed into numbers that would read as measurements.
+INSERT INTO clarity_event
+  (at, event_type, object_key, before_value, after_value, delta_pct, severity, note)
+SELECT v.at, 'row_moved'::clarity_event_kind, v.object_key,
+       v.before_value, v.after_value, v.delta_pct, 'critical',
+       'reconstructed from thoughts/shared/handoffs/frontend-data-audit/db-inventory.md, 2026-04-02'
+  FROM (VALUES
+    (timestamptz '2026-04-02 00:00:00+00', 'justice_funding',    218022::numeric, 157116::numeric, -27.936::numeric),
+    (timestamptz '2026-04-02 00:00:00+00', 'gs_relationships',      NULL::numeric,   NULL::numeric, 124.000::numeric),
+    (timestamptz '2026-04-02 00:00:00+00', 'political_donations',   NULL::numeric,   NULL::numeric, 744.000::numeric)
+  ) AS v(at, object_key, before_value, after_value, delta_pct)
+ WHERE NOT EXISTS (
+   SELECT 1 FROM clarity_event e
+    WHERE e.object_key = v.object_key AND e.at = v.at AND e.event_type = 'row_moved');

--- a/supabase/migrations/20260815001100_clarity_delta_engine.sql
+++ b/supabase/migrations/20260815001100_clarity_delta_engine.sql
@@ -1,0 +1,242 @@
+-- ===========================================================================
+-- /clarity slice 3 — WHAT CHANGED, part 2: the engine.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001100_clarity_delta_engine.sql
+--
+-- clarity_compute_deltas() runs after clarity_refresh() has written tonight's
+-- history row, so clarity_object IS the current snapshot and history holds the
+-- baselines. It fills all four baselines and then emits events off the 'last'
+-- baseline only — an anomaly is a thing that happened once, not a thing that
+-- gets re-reported from four angles.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION clarity_compute_deltas(p_emit boolean DEFAULT true)
+RETURNS TABLE (out_baseline text, out_objects integer, out_events integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $fn$
+DECLARE
+  b            text;
+  cutoff       timestamptz;
+  n_obj        integer;
+  n_ev         integer;
+  oldest_hist  timestamptz;
+BEGIN
+  SELECT min(snapshot_at) INTO oldest_hist FROM clarity_object_history;
+
+  FOREACH b IN ARRAY ARRAY['last','7d','30d','90d'] LOOP
+    -- 'last' means the previous run, whenever it was. The dated baselines mean
+    -- the newest snapshot at or before that date; if none exists the object's
+    -- baseline_at stays NULL and every delta for it renders '?'.
+    cutoff := CASE b
+                WHEN '7d'  THEN now() - interval '7 days'
+                WHEN '30d' THEN now() - interval '30 days'
+                WHEN '90d' THEN now() - interval '90 days'
+                ELSE NULL END;
+
+    WITH latest AS (
+      SELECT object_key, max(snapshot_at) AS at FROM clarity_object_history GROUP BY object_key
+    ),
+    base AS (
+      SELECT DISTINCT ON (h.object_key)
+             h.object_key, h.snapshot_at, h.row_count, h.bytes, h.degree,
+             h.importance, h.last_write_at
+        FROM clarity_object_history h
+        LEFT JOIN latest l ON l.object_key = h.object_key
+       WHERE CASE WHEN b = 'last' THEN h.snapshot_at < l.at
+                  ELSE h.snapshot_at <= cutoff END
+       ORDER BY h.object_key, h.snapshot_at DESC
+    ),
+    firsts AS (
+      SELECT object_key, min(snapshot_at) AS first_at
+        FROM clarity_object_history GROUP BY object_key
+    ),
+    calc AS (
+      SELECT o.object_key,
+             base.snapshot_at                              AS baseline_at,
+             base.row_count                                AS row_before,
+             o.row_count - base.row_count                  AS row_delta,
+             CASE WHEN base.row_count IS NULL OR base.row_count = 0 THEN NULL
+                  ELSE round(100.0 * (o.row_count - base.row_count)::numeric
+                             / base.row_count::numeric, 3) END AS row_delta_pct,
+             o.bytes - base.bytes                          AS bytes_delta,
+             o.degree - base.degree                        AS degree_delta,
+             o.importance - base.importance                AS importance_delta,
+             CASE WHEN o.last_write_at IS NULL OR base.last_write_at IS NULL THEN NULL
+                  ELSE round(extract(epoch FROM o.last_write_at - base.last_write_at)
+                             / 3600.0, 2) END              AS freshness_delta_hours,
+             -- An object is NEW relative to a baseline only if we were already
+             -- keeping a series back then and it was not in it. Otherwise it is
+             -- simply older than our history, which is a different sentence.
+             (base.snapshot_at IS NULL
+              AND f.first_at > coalesce(cutoff, f.first_at)
+              AND oldest_hist < coalesce(cutoff, oldest_hist))  AS is_new,
+             (o.missing_since IS NOT NULL)                 AS is_missing
+        FROM clarity_object o
+        LEFT JOIN base    ON base.object_key = o.object_key
+        LEFT JOIN firsts f ON f.object_key   = o.object_key
+    )
+    INSERT INTO clarity_delta AS d
+      (object_key, baseline, row_before, row_delta, row_delta_pct, bytes_delta,
+       degree_delta, importance_delta, freshness_delta_hours, is_new, is_missing,
+       baseline_at, computed_at)
+    SELECT object_key, b, row_before, row_delta, row_delta_pct, bytes_delta,
+           degree_delta, importance_delta, freshness_delta_hours,
+           coalesce(is_new, false), coalesce(is_missing, false),
+           baseline_at, now()
+      FROM calc
+    ON CONFLICT (object_key, baseline) DO UPDATE SET
+      row_before = EXCLUDED.row_before,
+      row_delta = EXCLUDED.row_delta,
+      row_delta_pct = EXCLUDED.row_delta_pct,
+      bytes_delta = EXCLUDED.bytes_delta,
+      degree_delta = EXCLUDED.degree_delta,
+      importance_delta = EXCLUDED.importance_delta,
+      freshness_delta_hours = EXCLUDED.freshness_delta_hours,
+      is_new = EXCLUDED.is_new,
+      is_missing = EXCLUDED.is_missing,
+      baseline_at = EXCLUDED.baseline_at,
+      computed_at = EXCLUDED.computed_at;
+
+    GET DIAGNOSTICS n_obj = ROW_COUNT;
+
+    -- state_before is not in clarity_object_history, so it is carried on the
+    -- delta row from the previous computation of the same baseline rather than
+    -- being invented. First run leaves it NULL, which fires nothing.
+    UPDATE clarity_delta d SET state_change =
+      CASE WHEN d.state_before IS NOT NULL AND d.state_before IS DISTINCT FROM o.state
+           THEN d.state_before || ' -> ' || o.state END,
+      state_before = o.state
+      FROM clarity_object o
+     WHERE o.object_key = d.object_key AND d.baseline = b;
+
+    n_ev := 0;
+    IF p_emit AND b = 'last' THEN
+      -- ---------------------------------------------------------------- the anomaly rule
+      -- |row_delta| / max(prev,1) > 10%, or a crossing of zero in either
+      -- direction. Both are critical, both stay red until a human writes a
+      -- reason. The dedup guard is the baseline timestamp: an event already
+      -- recorded since the baseline snapshot is the same event.
+      INSERT INTO clarity_event
+        (at, event_type, object_key, before_value, after_value, delta_pct, severity, note)
+      SELECT now(), 'row_moved', d.object_key, d.row_before, o.row_count, d.row_delta_pct,
+             'critical',
+             CASE WHEN coalesce(d.row_before,0) = 0 OR coalesce(o.row_count,0) = 0
+                  THEN 'crossed zero' ELSE 'moved more than 10% since the previous run' END
+        FROM clarity_delta d
+        JOIN clarity_object o ON o.object_key = d.object_key
+       WHERE d.baseline = 'last'
+         AND d.baseline_at IS NOT NULL
+         AND d.row_delta IS NOT NULL
+         AND (abs(d.row_delta)::numeric / greatest(coalesce(d.row_before,0), 1) > 0.10
+              OR (coalesce(d.row_before,0) = 0) <> (coalesce(o.row_count,0) = 0))
+         AND NOT EXISTS (SELECT 1 FROM clarity_event e
+                          WHERE e.object_key = d.object_key
+                            AND e.event_type = 'row_moved'
+                            AND e.at >= d.baseline_at);
+      GET DIAGNOSTICS n_ev = ROW_COUNT;
+
+      INSERT INTO clarity_event (at, event_type, object_key, after_value, severity, note)
+      SELECT now(), 'object_new', d.object_key, o.row_count, 'info',
+             'first seen in the catalog'
+        FROM clarity_delta d
+        JOIN clarity_object o ON o.object_key = d.object_key
+       WHERE d.baseline = 'last' AND d.is_new
+         AND NOT EXISTS (SELECT 1 FROM clarity_event e
+                          WHERE e.object_key = d.object_key AND e.event_type = 'object_new');
+
+      INSERT INTO clarity_event (at, event_type, object_key, before_value, severity, note)
+      SELECT now(), 'object_missing', o.object_key, o.row_count, 'critical',
+             'no longer present in the schema; the catalog row is retained, not deleted'
+        FROM clarity_object o
+       WHERE o.missing_since IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM clarity_event e
+                          WHERE e.object_key = o.object_key AND e.event_type = 'object_missing');
+
+      INSERT INTO clarity_event (at, event_type, object_key, severity, note)
+      SELECT now(), 'state_change', d.object_key, 'warn', d.state_change
+        FROM clarity_delta d
+       WHERE d.baseline = 'last' AND d.state_change IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM clarity_event e
+                          WHERE e.object_key = d.object_key
+                            AND e.event_type = 'state_change'
+                            AND e.at >= coalesce(d.baseline_at, now() - interval '1 day'));
+
+      -- ------------------------------------------------------------- answer drift
+      -- A headline that moves more than 10% while none of its ingredients moved
+      -- a single row is the failure a question board adds over an inventory: the
+      -- data held still and the claim did not.
+      WITH ranked AS (
+        SELECT question_slug, headline_num, headline, computed_at,
+               row_number() OVER (PARTITION BY question_slug ORDER BY computed_at DESC) AS rn
+          FROM clarity_answer
+         WHERE ok AND headline_num IS NOT NULL
+      ),
+      pairs AS (
+        SELECT c.question_slug, p.headline_num AS before_num, c.headline_num AS after_num,
+               c.headline, c.computed_at
+          FROM ranked c JOIN ranked p ON p.question_slug = c.question_slug AND p.rn = 2
+         WHERE c.rn = 1
+      )
+      INSERT INTO clarity_event
+        (at, event_type, question_slug, before_value, after_value, delta_pct, severity, note)
+      SELECT now(), 'answer_drift', pairs.question_slug, pairs.before_num, pairs.after_num,
+             round(100.0 * (pairs.after_num - pairs.before_num)
+                   / nullif(abs(pairs.before_num), 0), 3),
+             'critical',
+             'headline moved >10% with no ingredient row-count change: ' || pairs.headline
+        FROM pairs
+       WHERE abs(pairs.after_num - pairs.before_num)
+             / greatest(abs(pairs.before_num), 1) > 0.10
+         AND NOT EXISTS (
+           SELECT 1 FROM clarity_question_ingredient i
+             JOIN clarity_delta d ON d.object_key = i.object_key AND d.baseline = 'last'
+            WHERE i.question_slug = pairs.question_slug
+              AND coalesce(abs(d.row_delta), 0) > 0)
+         AND NOT EXISTS (
+           SELECT 1 FROM clarity_event e
+            WHERE e.question_slug = pairs.question_slug
+              AND e.event_type = 'answer_drift'
+              AND e.at >= pairs.computed_at);
+    END IF;
+
+    out_baseline := b; out_objects := n_obj; out_events := n_ev;
+    RETURN NEXT;
+  END LOOP;
+END;
+$fn$;
+
+-- ---------------------------------------------------------------------------
+-- The write path behind [ RECORD THE REASON -> ]. One column and a text box is
+-- the entire mechanism, so it gets one function and no ceremony.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION clarity_record_reason(
+  p_event_id bigint,
+  p_reason   text,
+  p_by       text
+) RETURNS TABLE (out_id bigint, out_reason text, out_by text, out_at timestamptz)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog AS $fn$
+BEGIN
+  IF coalesce(btrim(p_reason), '') = '' THEN
+    RAISE EXCEPTION 'clarity_record_reason: a reason cannot be blank';
+  END IF;
+  RETURN QUERY
+  UPDATE clarity_event e
+     SET reason = btrim(p_reason), reason_by = p_by, reason_at = now()
+   WHERE e.id = p_event_id
+  RETURNING e.id, e.reason, e.reason_by, e.reason_at;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'clarity_record_reason: no event %', p_event_id;
+  END IF;
+END;
+$fn$;
+
+REVOKE EXECUTE ON FUNCTION clarity_compute_deltas(boolean)          FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION clarity_record_reason(bigint,text,text)  FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION clarity_compute_deltas(boolean)          TO service_role;
+GRANT  EXECUTE ON FUNCTION clarity_record_reason(bigint,text,text)  TO service_role;

--- a/supabase/migrations/20260815001200_clarity_burndown.sql
+++ b/supabase/migrations/20260815001200_clarity_burndown.sql
@@ -1,0 +1,75 @@
+-- ===========================================================================
+-- /clarity slice 3 — WHAT CHANGED, part 3: the burn-down clause (graft G8).
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001200_clarity_burndown.sql
+--
+-- "1,365 do not feed a question" is an inert number. "1,365 · +0/wk · never" is
+-- a decision. The rate is measured from clarity_gap_measurement, which as of
+-- this migration has ZERO rows — clarity_measure_gaps() has never been run. So
+-- rate_per_week comes back NULL and the surface renders '?/wk · unknown'. That
+-- is the honest day-one answer, and it is why this view returns the sample
+-- count alongside the rate rather than a bare number.
+-- ===========================================================================
+
+CREATE OR REPLACE VIEW v_clarity_metric_latest WITH (security_invoker = true) AS
+SELECT DISTINCT ON (g.metric_key)
+       g.metric_key, g.title, g.question, g.family, g.unit, g.direction, g.target,
+       g.enabled, g.note, m.measured_at, m.numerator, m.denominator, m.value,
+       m.status, m.duration_ms,
+       CASE WHEN g.target IS NULL THEN NULL
+            WHEN g.direction = 'higher_better' THEN m.value < g.target
+            ELSE m.value > g.target END AS breached
+  FROM clarity_gap_metric g
+  JOIN clarity_gap_measurement m USING (metric_key)
+ ORDER BY g.metric_key, m.measured_at DESC;
+REVOKE ALL ON v_clarity_metric_latest FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON v_clarity_metric_latest TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- The burn-down: where a metric is now, how fast it is moving, and — if the
+-- rate holds — when it reaches its target. `eta_weeks IS NULL` with a non-null
+-- rate means the movement is flat or going the wrong way, which the surface
+-- must render as the word "never", not as a blank.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW v_clarity_burndown WITH (security_invoker = true) AS
+WITH win AS (
+  SELECT metric_key, value, measured_at
+    FROM clarity_gap_measurement
+   WHERE status = 'ok' AND value IS NOT NULL
+     AND measured_at > now() - interval '90 days'
+),
+ends AS (
+  SELECT metric_key,
+         count(*)                                              AS samples,
+         min(measured_at)                                      AS first_at,
+         max(measured_at)                                      AS last_at,
+         (array_agg(value ORDER BY measured_at ASC ))[1]        AS first_value,
+         (array_agg(value ORDER BY measured_at DESC))[1]        AS last_value
+    FROM win GROUP BY metric_key
+)
+SELECT g.metric_key, g.title, g.question, g.family, g.unit, g.direction, g.target,
+       e.samples, e.first_at, e.last_at, e.first_value, e.last_value,
+       CASE WHEN e.samples < 2
+              OR extract(epoch FROM e.last_at - e.first_at) < 86400 THEN NULL
+            ELSE round((e.last_value - e.first_value)
+                       / (extract(epoch FROM e.last_at - e.first_at) / 604800.0), 3)
+       END AS rate_per_week,
+       CASE WHEN g.target IS NULL OR e.samples < 2
+              OR extract(epoch FROM e.last_at - e.first_at) < 86400 THEN NULL
+            ELSE (
+              SELECT CASE WHEN r = 0 THEN NULL
+                          WHEN (g.target - e.last_value) / r <= 0 THEN NULL
+                          ELSE ceil((g.target - e.last_value) / r) END
+                FROM (SELECT (e.last_value - e.first_value)
+                             / (extract(epoch FROM e.last_at - e.first_at) / 604800.0) AS r) q
+            )
+       END AS eta_weeks
+  FROM clarity_gap_metric g
+  LEFT JOIN ends e USING (metric_key)
+ WHERE g.enabled;
+REVOKE ALL ON v_clarity_burndown FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON v_clarity_burndown TO service_role;

--- a/supabase/migrations/20260815001300_clarity_nightly_deltas.sql
+++ b/supabase/migrations/20260815001300_clarity_nightly_deltas.sql
@@ -1,0 +1,41 @@
+-- ===========================================================================
+-- /clarity slice 3 — WHAT CHANGED, part 4: put it on the nightly job.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001300_clarity_nightly_deltas.sql
+--
+-- Job 11 (refresh-clarity-catalog-nightly, 18:00 UTC) already runs
+-- clarity_refresh() and clarity_apply_act_flag(). The order matters and is not
+-- negotiable: clarity_refresh() writes tonight's history row LAST, so
+-- clarity_compute_deltas() must run AFTER it or it compares tonight against
+-- tonight and every delta is zero.
+--
+-- clarity_measure_gaps('cheap') joins the same job because the burn-down clause
+-- ("+0/wk · never") is measured from clarity_gap_measurement, which has never
+-- had a row written to it. 19 of the 23 metrics are cheap; the two expensive
+-- and two medium ones stay off the nightly path deliberately.
+-- ===========================================================================
+
+DO $$
+DECLARE
+  v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'refresh-clarity-catalog-nightly';
+
+  IF v_jobid IS NULL THEN
+    RAISE NOTICE 'refresh-clarity-catalog-nightly not found — nothing altered';
+    RETURN;
+  END IF;
+
+  PERFORM cron.alter_job(
+    job_id  => v_jobid,
+    command => $cmd$
+    SELECT clarity_refresh();
+    SELECT clarity_apply_act_flag();
+    SELECT clarity_compute_deltas();
+    SELECT clarity_measure_gaps('cheap');
+  $cmd$);
+END $$;

--- a/thoughts/shared/handoffs/clarity-catalog/current.md
+++ b/thoughts/shared/handoffs/clarity-catalog/current.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-15T05:30:00Z
+date: 2026-08-15T08:30:00Z
 session_name: clarity-catalog
 branch: main
 status: active
@@ -9,67 +9,95 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-15T05:30:00Z
-**Goal:** `/clarity` slice 2 — the question board. Done when the surface leads with cross-sections this database can answer that no public Australian source can, each carrying its coverage and caveat.
+**Updated:** 2026-08-15T08:30:00Z
+**Goal:** `/clarity` slice 2 — the question board. **SHIPPED** (PR #204, `0c19443`). Next goal is slice 3, unscoped.
 **Branch:** `main` — **zero open PRs**, board clear
-**Test:** `cd apps/web && npx tsc --noEmit` · gates: `node --env-file=.env scripts/check-graph-{completeness,referential-integrity,attribution}.mjs`
+**Test:** `cd apps/web && npx tsc --noEmit` (0 errors on merged main) · gates: `node --env-file=.env scripts/check-graph-{completeness,referential-integrity,attribution}.mjs`
+**Pool health:** `psql ... -Atc "SELECT count(*) FILTER (WHERE state='active') FROM pg_stat_activity WHERE datname='postgres'"` — healthy is single digits. **Read 1 active / 49 idle at 08:25.**
 
 ### Now
-[->] **Slice 2: the question board.** The job verification that blocked it is done — jobs 4 and 11 are proven, see below. Nothing else is in the way.
+[->] **Open `/clarity` in a browser and look at it.** Everything below it is verified; the visual result is the only thing left and no agent can reach it (Vercel SSO + admin gate). Then scope slice 3.
 
 ### This Session
-- [x] Mapped the whole shared DB — 1,024 relations, 52.3M rows. `thoughts/shared/data-map/`
-- [x] Rebuilt the justice graph layer: 857,798 edges → 144,901, resolution 16.9% → **100%**
-- [x] Built the GrantConnect layer: 291,264 awards had **zero** edges → 189,590 at 100%
-- [x] Merged 141 shadow entities, 333,960 edges consolidated, 0 orphaned FKs
-- [x] Three graph gates built + registered: completeness, referential-integrity, **attribution**
-- [x] Shipped `/clarity` slice 1, merged as PR #199 (`d6c8081`)
-- [x] Scheduled `clarity_refresh()` nightly — pg_cron job 11, 18:00 UTC
-- [x] Enabled tiered matview cron — job 4 → `CALL ...('nightly')`, job 13 weekly (PR #200, merged `0bff05e`)
-- [x] Audited all 398 anon-readable objects; found and closed a **bank-statement leak** (PR #201, merged `2297ed3`)
-- [x] **Proved job 4 by direct test** — `CALL refresh_civicgraph_mvs_run('nightly')`, 12m24s, **50/50 success, 0 fallbacks**, 38 concurrent / 12 plain. Slowest `mv_entity_power_index` at 368s (looks like a stall; it is not).
-- [x] **Proved job 11 by direct test** — full refresh, `refreshed_at` advanced, 1,039 relations reproduced exactly.
-- [x] Found + closed a grant defect the catalog surfaced on itself (PR #202, merged `9e3c467`) — see Decisions.
+- [x] **Closed the expensive-public-route audit** — the ledger's previous blocking item. Checked all 68 pages using `getServiceSupabase()`, including the six on the firewall rule. **No second exposure bug.** `/entity/`, `/entities/`, `/grants`, `/foundations/compare`, `/person/`, `/places/` are legitimately public and fan out 1–3 queries; gating them would be wrong.
+- [x] **Cached nine public fan-out pages** (PR #206, `b7e37a5`) — `force-dynamic` → `revalidate = 3600` on pages with heavy service-role bursts and no per-request inputs. Worst were `/reports/data-health` (17 queries/hit), `/insights` (12), `/foundations/prf` (9).
+- [x] **Merged slice 2** (PR #204, `0c19443`) — built by a parallel session, found open while the ledger said the board was clear.
+- [x] **Retired slice 2's one "Not verified" claim.** Its author could not confirm the index rendered because of an 8-day PostgREST retry storm. Verified instead at the data layer: all 7 migrations applied, `v_clarity_board{,_cards}` + `v_clarity_ledger` exist as `security_invoker` with `service_role=r` and **no anon grant**; three questions `answered`/`verified`; stored headlines match the PR body exactly (85.1% · 773 · 2.8x); `clarity_object` 1,456 rows. **App read path tested through PostgREST with the service key: both views HTTP 200, first try, no retries.**
 
 ### Next
-- [ ] **Slice 2: the question board.** Ten-working-day guard from slice 1 (shipped 15 Aug)
-- [ ] Job 13 (weekly tier, Sundays 15:00 UTC) has **never run** and is unexercised. Also unchecked: where the four matviews that logged `success-fallback` under the old code now sit — if they are in the weekly tier, job 13 inherits a known-flaky set unwatched. They were `mv_grant_contract_overlap`, `mv_indigenous_procurement_score`, `mv_lga_indigenous_proxy_score`, `mv_abr_name_lookup`.
+- [ ] **Look at `/clarity` in a browser** — dark theme, layout, search/facets, and the local admin bypass. Unreachable by any tool here.
+- [ ] **Scope slice 3.** Slices 1 and 2 are done; 7 total were planned.
+- [ ] **Enable Vercel Web Analytics.** Still off. It is the reason caller attribution failed twice; it would make the next incident diagnosable in minutes.
+- [ ] **Rethink the per-IP rate limit.** The 20/60s `ip`-keyed rule did not hold against a distributed caller. Consider a JA4 key or a lower global cap.
+- [ ] Job 13 (weekly tier, Sundays 15:00 UTC) has **never run**. Also unchecked: whether the four old `success-fallback` matviews sit in the weekly tier — if so job 13 inherits a known-flaky set unwatched. They were `mv_grant_contract_overlap`, `mv_indigenous_procurement_score`, `mv_lga_indigenous_proxy_score`, `mv_abr_name_lookup`.
 - [ ] Deferred, all diagnosed and written up: 19 unwatched edge layers · runbook steps 3 (donor sink, 47,563 misattributed edges) and 5 (opportunity self-loops)
 
 ### Decisions
-- Headline is **1,039 relations**, not 1,455; 416 routines get their own segment. They will never carry a domain, so counting them strands 29% of the list as undescribed. (#193)
-- Coverage denominator is relations → **78%**, not 56% against everything.
+- **The `/foundations/backlog` bug shape splits into two problems, not one.** Exposure (a service-role review queue left public) is a gating problem and was unique to backlog. Uncached fan-out is a caching problem and was widespread. Applying the gating fix to public product surfaces would have been the wrong call. (#206)
+- **`force-dynamic` needs a per-request reason.** Nine pages carried it while reading nightly matviews and taking no `searchParams`, `cookies()` or `headers()`. It bought nothing and cost a service-role query burst per anonymous hit. `/foundations` keeps it — it genuinely reads filter searchParams.
+- A page that uses `getServiceSupabase()` belongs in `protectedPrefixes` **if it is a private surface**; if it is public, it belongs behind a cache. Backlog was the first, the nine were the second. (#205, #206)
+- **Gate, don't cache** — for the private case. Caching backlog would have left anonymous traffic pointed at a service-role page.
+- Mitigation belongs in code, not the firewall. The incident deny rule was removed once #205 was live.
+- Headline is **1,039 relations**, not 1,455; 416 routines get their own segment. (#193) Coverage denominator is relations → **78%**.
 - ACT excluded by default, count permanently on screen, **neutral not yellow** — a scope boundary, not a warning.
-- Freshness has **four states that never collapse**: a date (687), `+` blue = our missing timestamp column (294, an afternoon's work), `?` yellow = too large to probe (58, needs a rebuild), `—` n/a (416). (#195)
-- Admin-gated. Not deference to the April kill — the catalog enumerates which objects are anon-readable, i.e. our own attack surface. (#196)
-- Ranked by default (`clarity_object.importance`), sort controls first-class. Segments kept but **ALL is the default** — opening behind SOURCES hid 60% on arrival.
-- `/api/data/schema-graph` superseded now, deleted after slice 5. Zero consumers were *found*, not proven.
-- `catalog_object_scope` is authoritative for `act_business`, bidirectionally. The old name-prefix regex missed 215 ACT objects and could never un-flag a false positive.
-- **A new function gets its ACL set in the same migration that creates it.** `clarity_apply_act_flag` was created without one and kept PostgreSQL's default of `EXECUTE` to `PUBLIC`, while its four siblings were each explicitly restricted. Impact was contained (`SECURITY INVOKER`; anon holds no grants on `clarity_object`, so a call dies on first write) but it was one `SECURITY DEFINER` away from live. (#202)
+- Freshness has **four states that never collapse**: a date (687), `+` blue = missing timestamp column (294), `?` yellow = too large to probe (58), `—` n/a (416). (#195)
+- Admin-gated, because the catalog enumerates our own anon-readable attack surface. (#196)
+- `catalog_object_scope` is authoritative for `act_business`, bidirectionally.
+- **A new function gets its ACL set in the same migration that creates it.** `clarity_apply_act_flag` kept PostgreSQL's default `EXECUTE` to `PUBLIC` while its four siblings were restricted. (#202)
+- Slice 2's own calls, inherited: the three-card board deleted for the searchable index; DESIGN.md's March "No dark mode" marked **superseded for `/clarity` only**; local admin bypass now requires `NODE_ENV !== 'production'` **and** no `VERCEL`, with `requireAdminApi` deliberately not bypassed.
 
 ### Open Questions
-- RESOLVED 15 Aug: jobs 4 and 11 both **proven by direct test**, not by an overnight run. Job 4's per-matview `COMMIT` is real — rows were readable from a second connection mid-run, with distinct `started_at` and non-zero `duration_ms`. The frozen-`now()` bug is gone and **PR #200's rollback trigger will not fire**. Neither job has still ever fired *via pg_cron itself*; first unattended runs are 17:00 and 18:00 UTC on 15 Aug.
-- UNCONFIRMED: is `/clarity` actually reachable in the deployed app? Vercel deploys on merge but the page has never been opened by a human.
-- UNCONFIRMED: `gs_relationships` read 2,943,598 at one point vs 2,904,091 after the merge — ~39.5K higher. Probably a scheduled ingest; not verified.
-- OPEN, Ben's call: `person_roles` aggregates 334,152 individually-public ACNC records into one anon-readable endpoint. Each is public by law; the aggregate is a different artifact. Not a defect — a decision.
+- **UNCONFIRMED: does `/clarity` look right?** Data, grants and read path are all verified. The rendered page has still never been seen by a human or an agent. Vercel SSO blocks the preview even through the authenticated MCP fetch tool, and the admin gate sits behind that.
+- **LIKELY RESOLVED: who was hammering `exec_sql`?** The 8-day retry storm (~10 req/s, 94% failing) and the pool-saturation incident look like the same anonymous traffic on `/foundations/backlog`. Pool went 41 → 1 connections after #205 and reads clean now. **Not proven** — the caller was never identified, and Postgres only ever saw PostgREST's loopback.
+- OPEN, Ben's call: `person_roles` aggregates 334,152 individually-public ACNC records into one anon-readable endpoint. Each is public by law; the aggregate is a different artifact. A decision, not a defect.
+- RESOLVED 15 Aug: jobs 4 and 11 both proven by direct test. Neither has still ever fired *via pg_cron itself*; first unattended runs were 17:00 and 18:00 UTC on 15 Aug — **worth checking whether they actually fired.**
+- RESOLVED: the stale `.next/types` errors for `clarity/q/[slug]` were a parallel session's files in the working tree, not a fault. Gone since #204 merged.
 
 ### Workflow State
 pattern: wayfinder map (issue #190, 8/8 tickets closed)
-phase: slice 1 complete
+phase: slice 2 complete
 total_phases: 7 slices
 retries: 0
 max_retries: 3
 
 #### Resolved
-- goal: "slice 1 shipped and live" — done
+- goal: "slice 2 shipped and merged" — done
 - resource_allocation: balanced
 
 #### Unknowns
-- job_4_and_11_health: **RESOLVED** — both proven by direct test 15 Aug
+- clarity_visual_result: **UNKNOWN** — never rendered for human eyes
 - job_13_weekly_tier: UNKNOWN — never run, never exercised by hand
+- cron_first_unattended_runs: UNKNOWN — jobs 4 and 11 due 17:00/18:00 UTC 15 Aug
+- backlog_caller_identity: UNKNOWN — storm ended with the fix, caller never named
+- other_route_exposure: **RESOLVED** — 68 pages audited, no second exposure bug
 
 #### Last Failure
 (none)
+
+---
+
+## Incident: shared-pool saturation, 15 Aug 2026
+
+**Symptom.** Every project on the shared Supabase instance (`tednluwflfhxyucgwigh`) intermittently unreachable. Local pool monitor at **blip #902** across 8 days. `pg_stat_activity`: **40-41 active connections, all the same `exec_sql` RPC**, sustained.
+
+**The trail, including the dead ends — they cost the most time:**
+
+1. `pg_stat_activity` identifies *what* (40 concurrent `exec_sql`) but never *who*: every `authenticator` connection reports `client_addr = ::1/128`, because PostgREST runs on the Supabase host. **Attribution is impossible at the DB layer. Go to the HTTP side first next time.**
+2. Killing the local dev server on 3013 changed nothing. Load was not local.
+3. **Vercel runtime logs grouped by `requestPath` cracked it in one call** — `/foundations/backlog` = 10,694 hits in 2h, next busiest path 320. That is the tool that works.
+4. Arithmetic tied it off: ~3.5 req/s × 8 RPCs/request ≈ the 40 observed connections.
+
+**Everything red that session traced to this one cause** — 8 `entity-dossier` integration tests failing on 30s timeouts, and the Vercel build failing on four unrelated prerendered pages (`/atlas` + 3 youth-justice recipients) blowing a 60s ceiling. Both went green on retry once the pool drained. **A saturated pool looks like unrelated flaky failures everywhere.**
+
+**The circular trap.** The fix could not deploy, because the build needed the DB and the DB was starved by the thing the fix would stop. Broken by mitigating *outside* the app: a Vercel Firewall path `deny`, which takes effect at the edge with no build.
+
+**Tooling notes worth keeping:**
+- `vercel firewall` did **not** exist in CLI 50.22.1; it does in **59.1.3**. Upgrade first.
+- `vercel api -X PATCH -d '...'` returns **415** without an explicit `Content-Type: application/json`. Prefer the native `vercel firewall rules add --condition '{...}' --action deny --yes`.
+- Firewall changes **stage as a draft**; nothing is live until `vercel firewall publish`. `vercel firewall diff` before publishing.
+- Production domain is **`civicgraph.app`**. Direct curl probes are unreliable (429 / SSO interception) — verify via Vercel runtime logs grouped by `statusCode` instead.
+
+**Timeline:** publish deny → **pool 41 → 1 active within 60s**. Build retried green in 5m. PR #205 merged `2f3e5fd`, prod deploy Ready 07:57Z. Deny rule removed and published. Post-removal logs: `/foundations/backlog` → `307` (auth redirect), 7 hits in 10 min vs ~2,100 per 10 min at peak.
 
 ---
 


### PR DESCRIPTION
The catalog only ever reported the present tense. `justice_funding` went 218,022 → 157,116 rows, minus 28%, and nothing anywhere fired. This is the derivative: `clarity_delta` holds movement against four baselines, `clarity_event` holds anomalies, and `reason IS NULL` on a critical event is the alarm still ringing.

Spec: `thoughts/shared/data-map/clarity/CLARITY-SPEC.md` §3.8, §4.4 (graft G2), slices 1 and 2 shipped in #204.

## All four migrations are applied

Applied to `tednluwflfhxyucgwigh` before this PR was opened, and proven by direct test.

| Migration | What it did |
|---|---|
| `…001000_clarity_change_log` | `clarity_delta` + `clarity_event` + `v_clarity_changes`; backfilled **1,444** history rows from `data_catalog_snapshots`; seeded the **3** documented 2026-04-02 moves |
| `…001100_clarity_delta_engine` | `clarity_compute_deltas()` + `clarity_record_reason()` |
| `…001200_clarity_burndown` | `v_clarity_metric_latest` + `v_clarity_burndown` |
| `…001300_clarity_nightly_deltas` | Job 11 now runs refresh → act flag → **compute deltas → measure gaps**, in that order |

`clarity_compute_deltas()` filled all four baselines, 1,456 objects each, and emitted 5 events. `clarity_measure_gaps('cheap')` ran 18 metrics, 18 ok, 0 failed, sub-second.

## Baseline coverage is exactly what the cold-start design predicted

| Baseline | Objects with a real baseline | Moved >10% |
|---|---|---|
| last | 1,455 / 1,456 | 1 |
| 7d | 25 | 6 |
| 30d | 25 | 8 |
| 90d | 22 | 12 |

The 25 are the spine tables the backfill reached. **The other 1,431 render `?`, not 0.** A baseline we do not hold is not a baseline of zero, and collapsing the two is how a 28% loss went unnoticed for four months.

## The anomaly rule

Fires on: a row count moving >10%, a crossing of zero in either direction, an object appearing or disappearing, a state change, or **answer drift** — a `clarity_answer.headline` moving >10% while none of its ingredients moved a single row. That last one is the failure a question board adds over an inventory: the data held still and the claim did not.

Events are emitted off the `last` baseline **only**. An anomaly happened once; emitting it from four baselines would report the same event four times.

## Screens

- `/clarity/changes` — baseline selector (unavailable options greyed **with their reason**), type and severity facets, and `[ RECORD THE REASON ]`. Unexplained criticals are carried in from outside the window, always.
- The ledger gains a Δ column and the WHAT CHANGED strip, driven by the same `?b=` searchParam so the two screens cannot disagree about which window you are looking at.

## Access

`v_clarity_changes`, `clarity_delta`, `v_clarity_burndown`: **200 for service_role, 401 for anon**, tested through PostgREST. RLS on both new tables, no anon grant, and the write path sits behind `requireAdminApi` — a route handler does not run through the `/clarity` layout, so the gate has to be there or it does not exist.

## Calls worth your eye

- **Five of the eight open events are the catalog's own plumbing** filling on its first run (`clarity_object` +745.9%, four `clarity_*` tables crossing zero). True, but noise about ourselves. I recorded no reasons and did **not** add a `clarity_*` exclusion — that filter would later hide a real fault in the catalog itself.
- **`refresh_skipped` and `probe_degraded` are in the enum but never emitted.** The catalog keeps no per-run probe history to compare against, and a type that silently never fires is worse than one that is absent. The rail says which rules actually fire.
- **The two 2026-04-02 moves recorded only as percentages get NULL before/after**, not back-computed row counts that would read as measurements. Only `justice_funding` had both endpoints written down.

## Not verified

- **The rendered page.** Same wall as slice 2 — Vercel SSO plus the admin gate. No agent here can reach it.
- **The burn-down rate is NULL for all 22 metrics.** There is exactly one measurement each; it needs a second nightly run before `+n/wk` means anything.

Gates: `npx tsc --noEmit` clean, `npx vitest run src/app/clarity` 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)