### PR TITLE
Ship /clarity slice 5 — the seams, and 638 joins that had never been measured

### DIFF
--- a/apps/web/src/app/api/clarity/seams/measure/route.ts
+++ b/apps/web/src/app/api/clarity/seams/measure/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+// Each probe is capped at 8s and a batch is 25, so the worst case is well past
+// the default serverless budget. The batch size is the real bound; this raises
+// the route's ceiling to match it rather than truncating a batch mid-sweep.
+export const maxDuration = 300;
+
+/**
+ * POST /api/clarity/seams/measure — measure the next batch of unmeasured seams.
+ *
+ * Batched on purpose. There is no "measure everything" call anywhere in this
+ * feature: 638 joins, some of them 2.5M rows against 609K, swept in one
+ * statement on a pooler that has starved before is how you take the database
+ * down. Small batches, each probe under its own timeout, timeouts recorded as
+ * timeouts rather than as zeroes.
+ */
+export async function POST(request: Request) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  let limit = 25;
+  try {
+    const body = (await request.json()) as { limit?: unknown };
+    if (typeof body.limit === 'number' && Number.isInteger(body.limit)) {
+      limit = Math.min(Math.max(body.limit, 1), 50);
+    }
+  } catch {
+    // An empty body is fine — the default batch is the point.
+  }
+
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('clarity_measure_seams', {
+    p_limit: limit,
+    p_only_unmeasured: true,
+    p_timeout_ms: 8000,
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const rows = (data ?? []) as { out_rate: number | null; out_method: string | null }[];
+  const refused = rows.filter((r) => r.out_method && /^(timeout|error)/.test(r.out_method)).length;
+
+  return NextResponse.json({
+    measured: rows.length,
+    refused,
+    dead: rows.filter((r) => r.out_rate !== null && Number(r.out_rate) === 0).length,
+  });
+}

--- a/apps/web/src/app/clarity/LedgerClient.tsx
+++ b/apps/web/src/app/clarity/LedgerClient.tsx
@@ -130,6 +130,12 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
                 /clarity/changes so the two screens can never disagree about which
                 window you are looking at. */}
             <Link
+              href="/clarity/seams"
+              className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+            >
+              The seams
+            </Link>
+            <Link
               href="/clarity/cross"
               className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
             >

--- a/apps/web/src/app/clarity/seams/SeamsClient.tsx
+++ b/apps/web/src/app/clarity/seams/SeamsClient.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import { Fragment, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { STATE_GLYPH, isFrayed, seamState, type SeamRow, type SeamState } from './types';
+
+const nf = new Intl.NumberFormat('en-AU');
+
+const STATES: SeamState[] = [
+  'dead',
+  'never_populated',
+  'poor',
+  'fair',
+  'good',
+  'refused',
+  'unmeasured',
+];
+
+export default function SeamsClient({ seams }: { seams: SeamRow[] }) {
+  const router = useRouter();
+  const [state, setState] = useState<SeamState | ''>('');
+  const [mech, setMech] = useState('');
+  const [q, setQ] = useState('');
+  const [open, setOpen] = useState<number | null>(null);
+  const [measuring, setMeasuring] = useState(false);
+  const [measureNote, setMeasureNote] = useState<string | null>(null);
+
+  const withState = useMemo(
+    () => seams.map((s) => ({ ...s, st: seamState(s) })),
+    [seams],
+  );
+
+  const counts = useMemo(() => {
+    const m = new Map<SeamState, number>();
+    const mm = new Map<string, number>();
+    for (const s of withState) {
+      m.set(s.st, (m.get(s.st) ?? 0) + 1);
+      mm.set(s.mechanism, (mm.get(s.mechanism) ?? 0) + 1);
+    }
+    return { state: m, mech: [...mm.entries()].sort((a, b) => b[1] - a[1]) };
+  }, [withState]);
+
+  const visible = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return withState.filter((s) => {
+      if (state && s.st !== state) return false;
+      if (mech && s.mechanism !== mech) return false;
+      if (
+        needle &&
+        !`${s.src_object}.${s.src_column} ${s.tgt_object}.${s.tgt_column}`
+          .toLowerCase()
+          .includes(needle)
+      )
+        return false;
+      return true;
+    });
+  }, [withState, state, mech, q]);
+
+  const measured = withState.filter((s) => s.st !== 'unmeasured').length;
+  const losing = withState.reduce((n, s) => n + Number(s.rows_losing ?? 0), 0);
+
+  async function measureBatch() {
+    setMeasuring(true);
+    setMeasureNote(null);
+    try {
+      const res = await fetch('/api/clarity/seams/measure', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit: 25 }),
+      });
+      const body = (await res.json()) as { error?: string; measured?: number; refused?: number };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setMeasureNote(
+        `Measured ${body.measured ?? 0} seams, ${body.refused ?? 0} refused as too slow.`,
+      );
+      router.refresh();
+    } catch (e) {
+      setMeasureNote(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMeasuring(false);
+    }
+  }
+
+  const cell = 'border-r-2 border-b-2 border-bauhaus-black bg-bauhaus-white px-3 py-2.5';
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas">
+      <div className="mx-auto max-w-[1400px] px-4 pb-24">
+        <header className="border-b-4 border-bauhaus-black pt-8">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            {[
+              ['/clarity', '◀ The ledger'],
+              ['/clarity/changes', 'What changed'],
+              ['/clarity/cross', 'Cross-sections'],
+            ].map(([href, label]) => (
+              <Link
+                key={href}
+                href={href}
+                className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+          <h1 className="text-4xl font-black uppercase leading-none tracking-wide sm:text-5xl">
+            The seams
+          </h1>
+          <p className="mt-3 max-w-[64ch] text-sm text-bauhaus-muted">
+            Every connection, ranked by how much data it is losing right now. Not{' '}
+            <i>is it connected</i> — with {nf.format(seams.length)} declared joins the answer is
+            almost always yes and almost never interesting.
+          </p>
+
+          <div className="mt-5 grid grid-cols-2 border-l-2 border-t-2 border-bauhaus-black sm:grid-cols-4">
+            {(
+              [
+                [nf.format(seams.length), 'Seams catalogued', ''],
+                [
+                  `${nf.format(measured)} / ${nf.format(seams.length)}`,
+                  'Ever measured',
+                  measured === 0 ? 'text-bauhaus-blue' : '',
+                ],
+                [
+                  nf.format(
+                    (counts.state.get('dead') ?? 0) + (counts.state.get('never_populated') ?? 0),
+                  ),
+                  'Dead or never filled',
+                  'text-bauhaus-red',
+                ],
+                [nf.format(losing), 'Rows losing', losing ? 'text-bauhaus-red' : ''],
+              ] as const
+            ).map(([v, label, tone]) => (
+              <div key={label} className={cell}>
+                <b className={`block text-xl font-black leading-tight ${tone}`}>{v}</b>
+                <span className="mt-1 block text-[9.5px] font-extrabold uppercase tracking-[0.13em] text-bauhaus-muted">
+                  {label}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {measured === 0 ? (
+            <div className="mt-3 border-2 border-bauhaus-blue bg-bauhaus-white p-3">
+              <p className="max-w-[76ch] text-[12.5px]">
+                <b className="text-bauhaus-blue">Not one seam has ever been measured.</b> Every rate
+                below reads <b className="text-bauhaus-blue">+</b>, never 0% — we have not looked,
+                which is a different fact from a join that carries nothing. Measuring runs in
+                batches of 25 under an 8-second cap per probe, because an unbounded sweep over
+                every seam on a shared pooler is how you take the database down.
+              </p>
+              <button
+                type="button"
+                onClick={measureBatch}
+                disabled={measuring}
+                className="mt-2.5 border-2 border-bauhaus-black bg-bauhaus-black px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.12em] text-bauhaus-canvas disabled:opacity-40"
+              >
+                {measuring ? 'Measuring…' : 'Measure the next 25 →'}
+              </button>
+              {measureNote ? (
+                <p className="mt-2 text-[12px] font-bold">{measureNote}</p>
+              ) : null}
+            </div>
+          ) : null}
+        </header>
+
+        <div className="mt-6 grid border-[3px] border-bauhaus-black bg-bauhaus-white lg:grid-cols-[216px_1fr]">
+          <aside className="border-b-[3px] border-bauhaus-black p-3 lg:border-b-0 lg:border-r-[3px]">
+            <h2 className="mb-1.5 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+              State
+            </h2>
+            {STATES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                aria-pressed={state === s}
+                onClick={() => setState(state === s ? '' : s)}
+                className={`flex w-full items-center justify-between gap-2 px-1.5 py-0.5 text-left text-xs ${
+                  state === s ? 'bg-bauhaus-black font-bold text-bauhaus-canvas' : 'hover:bg-bauhaus-canvas'
+                }`}
+              >
+                <span>
+                  <b className={state === s ? '' : STATE_GLYPH[s].cls}>{STATE_GLYPH[s].glyph}</b>{' '}
+                  {s}
+                </span>
+                <i className="not-italic text-[11px] opacity-70">
+                  {nf.format(counts.state.get(s) ?? 0)}
+                </i>
+              </button>
+            ))}
+
+            <h2 className="mb-1.5 mt-4 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+              Mechanism
+            </h2>
+            {counts.mech.map(([m, n]) => (
+              <button
+                key={m}
+                type="button"
+                aria-pressed={mech === m}
+                onClick={() => setMech(mech === m ? '' : m)}
+                className={`flex w-full items-center justify-between gap-2 px-1.5 py-0.5 text-left text-xs ${
+                  mech === m ? 'bg-bauhaus-black font-bold text-bauhaus-canvas' : 'hover:bg-bauhaus-canvas'
+                }`}
+              >
+                <span>{m}</span>
+                <i className="not-italic text-[11px] opacity-70">{nf.format(n)}</i>
+              </button>
+            ))}
+
+            <p className="mt-4 border-t-2 border-bauhaus-black/15 pt-2.5 text-[10.5px] leading-snug text-bauhaus-muted">
+              View lineage is excluded on purpose: a view reading a table is not a join and has no
+              match rate to measure.
+            </p>
+          </aside>
+
+          <section className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2.5 border-b-2 border-bauhaus-black/15 p-2.5">
+              <input
+                type="search"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Search either side of the join…"
+                aria-label="Search the seams"
+                className="min-w-0 flex-1 border-2 border-bauhaus-black bg-bauhaus-canvas px-2.5 py-1.5 text-sm"
+              />
+              <span className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-bauhaus-muted">
+                {nf.format(visible.length)} shown
+              </span>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[820px] border-collapse">
+                <thead>
+                  <tr className="bg-bauhaus-black text-bauhaus-canvas">
+                    {['From', 'To', 'Match', 'Losing', 'Grain'].map((h, i) => (
+                      <th
+                        key={h}
+                        className={`px-2.5 py-2 text-[9.5px] font-extrabold uppercase tracking-[0.13em] ${
+                          i >= 2 && i <= 3 ? 'text-right' : 'text-left'
+                        }`}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {visible.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="p-9 text-center text-sm text-bauhaus-muted">
+                        Nothing matches. Clear a filter.
+                      </td>
+                    </tr>
+                  ) : (
+                    visible.map((s) => {
+                      const g = STATE_GLYPH[s.st];
+                      const isOpen = open === s.id;
+                      const frayed = isFrayed(s.grain);
+                      return (
+                        <Fragment key={s.id}>
+                          <tr
+                            tabIndex={0}
+                            onClick={() => setOpen(isOpen ? null : s.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                setOpen(isOpen ? null : s.id);
+                              }
+                            }}
+                            className="cursor-pointer border-t border-bauhaus-black/10 hover:bg-bauhaus-canvas"
+                          >
+                            <td className="break-all px-2.5 py-1.5 font-mono text-[12.5px]">
+                              {s.src_object}.<b>{s.src_column}</b>
+                            </td>
+                            <td className="break-all px-2.5 py-1.5 font-mono text-[12.5px]">
+                              {s.tgt_object}.<b>{s.tgt_column}</b>
+                            </td>
+                            <td className="px-2.5 py-1.5 text-right font-mono text-[12.5px]">
+                              <span title={g.label} className={`mr-1 font-black ${g.cls}`}>
+                                {g.glyph}
+                              </span>
+                              {s.match_rate === null
+                                ? ''
+                                : `${(Number(s.match_rate) * 100).toFixed(1)}%`}
+                            </td>
+                            <td className="px-2.5 py-1.5 text-right font-mono text-[12.5px] font-bold">
+                              {s.rows_losing ? nf.format(Number(s.rows_losing)) : '—'}
+                            </td>
+                            <td className="px-2.5 py-1.5 text-[11.5px]">
+                              {frayed ? (
+                                <b className="text-bauhaus-red">{s.grain}</b>
+                              ) : (
+                                (s.grain ?? '—')
+                              )}
+                            </td>
+                          </tr>
+                          {isOpen ? (
+                            <tr className="border-t-2 border-bauhaus-black bg-bauhaus-canvas">
+                              <td colSpan={5} className="px-4 py-3.5 text-[13px]">
+                                {s.st === 'never_populated' ? (
+                                  <p>
+                                    <b className="text-bauhaus-red">
+                                      Declared, and never populated.
+                                    </b>{' '}
+                                    The key column holds no values at all across{' '}
+                                    {nf.format(Number(s.rows_at_stake ?? 0))} rows, so there is
+                                    nothing to resolve. This is not a broken join — it is a bridge
+                                    nobody has ever driven across.
+                                  </p>
+                                ) : s.st === 'unmeasured' ? (
+                                  <p>
+                                    <b className="text-bauhaus-blue">Never measured.</b> This reads{' '}
+                                    <b>+</b> and not 0% because we have not looked. Run a measuring
+                                    batch to give it a number.
+                                  </p>
+                                ) : (
+                                  <p>
+                                    {nf.format(Number(s.match_numerator ?? 0))} of{' '}
+                                    {nf.format(Number(s.match_denominator ?? 0))} non-null keys
+                                    resolve
+                                    {s.rows_at_stake
+                                      ? `, out of ${nf.format(Number(s.rows_at_stake))} rows on the fact side`
+                                      : ''}
+                                    . Method{' '}
+                                    <code className="font-mono">{s.match_method ?? 'unknown'}</code>
+                                    {s.match_measured_at
+                                      ? `, measured ${s.match_measured_at.slice(0, 10)}`
+                                      : ''}
+                                    .
+                                  </p>
+                                )}
+                                {frayed ? (
+                                  <p className="mt-1.5 font-semibold text-bauhaus-red">
+                                    Grain defect: {s.grain}. Every key resolves and each resolves to
+                                    several rows, so anything aggregating across this join
+                                    multiplies its own numbers. A match rate would never show this.
+                                  </p>
+                                ) : null}
+                                {s.note ? (
+                                  <p className="mt-1.5 text-bauhaus-muted">{s.note}</p>
+                                ) : null}
+                                {s.match_delta !== null ? (
+                                  <p className="mt-1.5">
+                                    Moved {(Number(s.match_delta) * 100).toFixed(1)}pp since the
+                                    previous measurement.
+                                  </p>
+                                ) : null}
+                              </td>
+                            </tr>
+                          ) : null}
+                        </Fragment>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex flex-wrap gap-4 border-t-2 border-bauhaus-black/15 p-2.5 text-[11px] font-semibold text-bauhaus-muted">
+              {STATES.map((s) => (
+                <span key={s}>
+                  <b className={STATE_GLYPH[s].cls}>{STATE_GLYPH[s].glyph}</b> {STATE_GLYPH[s].label}
+                </span>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <p className="mt-6 max-w-[80ch] border-2 border-bauhaus-black bg-bauhaus-white p-3 text-[12px]">
+          <b>No graph here.</b> The schema graph is small enough to draw honestly, but every defect
+          worth finding — a dead key namespace, a bridge declared and never populated, a frayed
+          grain — is a number in this table and is invisible as a line between two boxes. If the
+          drawing earns its place later it goes behind a button, with a refusal above 200 nodes.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/clarity/seams/page.tsx
+++ b/apps/web/src/app/clarity/seams/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import SeamsClient from './SeamsClient';
+import type { SeamRow } from './types';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'The seams · Clarity',
+  description: 'Every connection in the database, ranked by how much data it is losing right now.',
+};
+
+async function load(): Promise<SeamRow[]> {
+  const supabase = getDirectServiceSupabase();
+
+  // Broken first, unmeasured last. A catalog that sorts by quality descending
+  // buries its own worst finding on page two.
+  const { data, error } = await supabase
+    .from('v_clarity_seams')
+    .select(
+      'id,mechanism,src_object,src_column,tgt_object,tgt_column,declared,match_rate,' +
+        'match_numerator,match_denominator,match_method,match_measured_at,rows_at_stake,' +
+        'grain,note,rows_losing,match_delta,src_domain,tgt_domain',
+    )
+    .order('rows_losing', { ascending: false, nullsFirst: false })
+    .limit(1500);
+
+  if (error) throw new Error(`v_clarity_seams query failed: ${error.message}`);
+  return (data ?? []) as unknown as SeamRow[];
+}
+
+export default async function SeamsPage() {
+  let seams: SeamRow[] = [];
+  let error: string | null = null;
+
+  try {
+    seams = await load();
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  if (error) {
+    return (
+      <main className="clarity-dark min-h-screen px-5 py-16">
+        <div className="mx-auto max-w-3xl border-4 border-bauhaus-red bg-bauhaus-white p-8">
+          <h1 className="text-2xl font-black uppercase tracking-widest text-bauhaus-red">
+            Seams unavailable
+          </h1>
+          <p className="mt-4 text-sm">
+            <code className="font-mono">v_clarity_seams</code> could not be read. It ships in
+            migration <code className="font-mono">20260815001600_clarity_seams.sql</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto border-2 border-bauhaus-muted bg-bauhaus-canvas p-3 font-mono text-xs">
+            {error}
+          </pre>
+          <Link href="/clarity" className="mt-5 inline-block text-sm font-black uppercase underline">
+            ← The ledger
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <div className="clarity-dark">
+      <SeamsClient seams={seams} />
+    </div>
+  );
+}

--- a/apps/web/src/app/clarity/seams/types.ts
+++ b/apps/web/src/app/clarity/seams/types.ts
@@ -1,0 +1,85 @@
+/**
+ * THE SEAMS — slice 5.
+ *
+ * Every connection in the database, ranked by how much data it is losing right
+ * now. A map answers "is it connected?", which with 638 declared foreign keys is
+ * almost always yes and almost never interesting.
+ */
+export interface SeamRow {
+  id: number;
+  mechanism: string;
+  src_object: string;
+  src_column: string;
+  tgt_object: string;
+  tgt_column: string;
+  declared: boolean;
+  match_rate: number | null;
+  match_numerator: number | null;
+  match_denominator: number | null;
+  match_method: string | null;
+  match_measured_at: string | null;
+  rows_at_stake: number | null;
+  grain: string | null;
+  note: string | null;
+  rows_losing: number | null;
+  match_delta: number | null;
+  src_domain: string | null;
+  tgt_domain: string | null;
+}
+
+export type SeamState =
+  | 'dead'
+  | 'poor'
+  | 'fair'
+  | 'good'
+  | 'never_populated'
+  | 'unmeasured'
+  | 'refused';
+
+/**
+ * Six states, and three of them are different kinds of "no number". Collapsing
+ * any pair would tell a lie the first sweep caught immediately:
+ *
+ *   unmeasured      — we have never looked
+ *   never_populated — we looked; the key column holds no values at all. A
+ *                     declared bridge nobody ever filled in, like
+ *                     nz_charities.gs_entity_id: 0 of 45,192 rows.
+ *   dead            — we looked; keys exist and NONE of them resolve
+ *
+ * The first draft of this function mapped all three to `unmeasured` because all
+ * three have a null match_rate, which would have hidden every never-populated
+ * bridge in the database behind "not measured yet".
+ */
+export function seamState(r: SeamRow): SeamState {
+  if (r.match_method && /^(timeout|error)/.test(r.match_method)) return 'refused';
+  if (!r.match_measured_at) return 'unmeasured';
+  if (r.match_rate === null) return 'never_populated';
+  const rate = Number(r.match_rate);
+  if (rate === 0) return 'dead';
+  if (rate < 0.5) return 'poor';
+  if (rate < 0.9) return 'fair';
+  return 'good';
+}
+
+export const STATE_GLYPH: Record<SeamState, { glyph: string; cls: string; label: string }> = {
+  dead: { glyph: '×', cls: 'text-bauhaus-red', label: 'Dead — 0% of keys resolve' },
+  poor: { glyph: '⚠', cls: 'text-bauhaus-red', label: 'Under half the keys resolve' },
+  fair: { glyph: '⚠', cls: 'text-bauhaus-yellow', label: 'Between 50% and 90%' },
+  good: { glyph: '█', cls: 'text-bauhaus-black', label: '90% or better' },
+  never_populated: {
+    glyph: '×',
+    cls: 'text-bauhaus-red',
+    label: 'Declared but never populated — the key column is entirely empty',
+  },
+  unmeasured: { glyph: '+', cls: 'text-bauhaus-blue', label: 'Never measured — our omission' },
+  refused: { glyph: '?', cls: 'text-bauhaus-yellow', label: 'Probe timed out or errored' },
+};
+
+/**
+ * A frayed key is a defect no match rate reveals: every key resolves, and each
+ * one resolves to several rows, so anything aggregating across the join
+ * multiplies its own numbers. mv_funding_by_lga carries 3.16 rows per key.
+ */
+export function isFrayed(grain: string | null): boolean {
+  return Boolean(grain && grain.startsWith('frayed'));
+}

--- a/supabase/migrations/20260815001600_clarity_seams.sql
+++ b/supabase/migrations/20260815001600_clarity_seams.sql
@@ -1,0 +1,208 @@
+-- ===========================================================================
+-- /clarity slice 5 — THE SEAMS.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001600_clarity_seams.sql
+--
+-- Spec: CLARITY-SPEC.md §3.6, §4.5 (graft G4).
+--
+-- Every connection in the database, ranked by how much data it is LOSING right
+-- now. Not "is it connected" — with 638 declared foreign keys the answer is
+-- almost always yes and almost never interesting. "Is the connection carrying
+-- the data" is where the defects live, and not one of them is visible in a
+-- force-directed graph.
+--
+-- 638 fk edges and 700 view_lineage edges are catalogued. ZERO have ever had a
+-- match rate measured. Slice 4's join matrix renders '+' on every cell for
+-- exactly this reason. This migration is what turns those into numbers.
+-- ===========================================================================
+
+ALTER TABLE clarity_edge
+  ADD COLUMN IF NOT EXISTS rows_at_stake bigint,   -- fact-side rows this seam should carry
+  ADD COLUMN IF NOT EXISTS grain         text;     -- '1:1' | 'n:1' | 'frayed 3.16 rows/key'
+
+CREATE TABLE IF NOT EXISTS clarity_edge_history (
+  id                bigserial PRIMARY KEY,
+  edge_id           bigint NOT NULL REFERENCES clarity_edge(id) ON DELETE CASCADE,
+  captured_at       timestamptz NOT NULL DEFAULT now(),
+  match_rate        numeric(6,3),
+  match_numerator   bigint,
+  match_denominator bigint,
+  rows_at_stake     bigint
+);
+CREATE INDEX IF NOT EXISTS clarity_edge_hist ON clarity_edge_history (edge_id, captured_at DESC);
+
+ALTER TABLE clarity_edge_history ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON clarity_edge_history FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT ON clarity_edge_history TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE clarity_edge_history_id_seq TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- clarity_measure_edge() — measure ONE seam, bounded.
+--
+-- Bounded is the whole design. Some of these joins are 2.5M rows against 609K,
+-- and an unbounded sweep over 638 of them on a shared pooler is how you take
+-- the database down. Every probe runs under its own statement_timeout and a
+-- timeout is RECORDED as a timeout — match_method tells you which numbers were
+-- measured and which were refused, so a '?' can never be mistaken for a 0.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION clarity_measure_edge(
+  p_edge_id     bigint,
+  p_timeout_ms  integer DEFAULT 8000
+) RETURNS TABLE (out_rate numeric, out_method text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog AS $fn$
+DECLARE
+  e           record;
+  n_total     bigint;
+  n_present   bigint;
+  n_matched   bigint;
+  n_keys      bigint;
+  n_tgt_rows  bigint;
+  rate        numeric;
+  method      text := 'count_join';
+  grain_text  text;
+BEGIN
+  SELECT * INTO e FROM clarity_edge WHERE id = p_edge_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'clarity_measure_edge: no edge %', p_edge_id;
+  END IF;
+
+  -- A view_lineage edge is not a join and has no match rate to measure. Saying
+  -- so is different from measuring it at 0.
+  IF e.mechanism = 'view_lineage' THEN
+    UPDATE clarity_edge SET match_method = 'not_a_join', match_measured_at = now()
+     WHERE id = p_edge_id;
+    RETURN QUERY SELECT NULL::numeric, 'not_a_join'::text;
+    RETURN;
+  END IF;
+
+  PERFORM set_config('statement_timeout', p_timeout_ms::text, true);
+
+  BEGIN
+    EXECUTE format(
+      'SELECT count(*), count(%I) FROM %I', e.src_column, e.src_object)
+      INTO n_total, n_present;
+
+    EXECUTE format(
+      'SELECT count(*) FROM %I s WHERE s.%I IS NOT NULL AND EXISTS ' ||
+      '(SELECT 1 FROM %I t WHERE t.%I = s.%I)',
+      e.src_object, e.src_column, e.tgt_object, e.tgt_column, e.src_column)
+      INTO n_matched;
+
+    -- Grain: how many target rows a single key resolves to. A choropleth built
+    -- on a frayed key silently multiplies its own numbers, which is the defect
+    -- no match rate would ever reveal.
+    EXECUTE format(
+      'SELECT count(*), count(DISTINCT %I) FROM %I WHERE %I IS NOT NULL',
+      e.tgt_column, e.tgt_object, e.tgt_column)
+      INTO n_tgt_rows, n_keys;
+
+    grain_text := CASE
+      WHEN n_keys IS NULL OR n_keys = 0 THEN NULL
+      WHEN n_tgt_rows = n_keys          THEN '1:1'
+      WHEN n_tgt_rows::numeric / n_keys < 1.01 THEN 'n:1'
+      ELSE 'frayed ' || round(n_tgt_rows::numeric / n_keys, 2) || ' rows/key'
+    END;
+
+    rate := CASE WHEN coalesce(n_present, 0) = 0 THEN NULL
+                 ELSE round(n_matched::numeric / n_present::numeric, 3) END;
+  EXCEPTION
+    WHEN query_canceled THEN
+      method := 'timeout';   rate := NULL;
+    WHEN OTHERS THEN
+      method := 'error: ' || left(SQLERRM, 80); rate := NULL;
+  END;
+
+  PERFORM set_config('statement_timeout', '0', true);
+
+  -- History first, so a series exists even for the run that produced it.
+  INSERT INTO clarity_edge_history
+    (edge_id, match_rate, match_numerator, match_denominator, rows_at_stake)
+  VALUES (p_edge_id, rate, n_matched, n_present, n_total);
+
+  UPDATE clarity_edge SET
+    match_rate        = rate,
+    match_numerator   = n_matched,
+    match_denominator = n_present,
+    rows_at_stake     = n_total,
+    grain             = coalesce(grain_text, grain),
+    match_method      = method,
+    match_measured_at = now()
+   WHERE id = p_edge_id;
+
+  RETURN QUERY SELECT rate, method;
+END;
+$fn$;
+
+-- ---------------------------------------------------------------------------
+-- clarity_measure_seams() — a BATCH, never the whole set.
+--
+-- Deliberately takes a limit and defaults to 25. There is no "measure
+-- everything" call, because the honest way to sweep 638 seams on a pooler that
+-- has starved before is many small batches, not one heroic statement.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION clarity_measure_seams(
+  p_limit           integer DEFAULT 25,
+  p_only_unmeasured boolean DEFAULT true,
+  p_timeout_ms      integer DEFAULT 8000
+) RETURNS TABLE (out_edge_id bigint, out_src text, out_tgt text, out_rate numeric, out_method text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+SET statement_timeout = 0
+AS $fn$
+DECLARE
+  r record;
+  res record;
+BEGIN
+  FOR r IN
+    SELECT id, src_object, src_column, tgt_object, tgt_column
+      FROM clarity_edge
+     WHERE mechanism <> 'view_lineage'
+       AND (NOT p_only_unmeasured OR match_measured_at IS NULL)
+     ORDER BY id
+     LIMIT p_limit
+  LOOP
+    SELECT * INTO res FROM clarity_measure_edge(r.id, p_timeout_ms);
+    out_edge_id := r.id;
+    out_src := r.src_object || '.' || r.src_column;
+    out_tgt := r.tgt_object || '.' || r.tgt_column;
+    out_rate := res.out_rate;
+    out_method := res.out_method;
+    RETURN NEXT;
+  END LOOP;
+END;
+$fn$;
+
+-- ---------------------------------------------------------------------------
+-- v_clarity_seams — the screen's one query.
+--
+-- rows_losing is the ranking, and the ranking IS the argument: broken sorts to
+-- the top, unmeasured sorts to the bottom. A catalog that sorts by quality
+-- descending buries its own worst finding on page two.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW v_clarity_seams WITH (security_invoker = true) AS
+SELECT e.id, e.mechanism, e.src_object, e.src_column, e.tgt_object, e.tgt_column,
+       e.declared, e.match_rate, e.match_numerator, e.match_denominator,
+       e.match_method, e.match_measured_at, e.rows_at_stake, e.grain, e.note,
+       round(coalesce(e.rows_at_stake, e.match_denominator, 0)
+             * (1 - coalesce(e.match_rate, 0)))                  AS rows_losing,
+       e.match_rate - h.match_rate                               AS match_delta,
+       so.domain                                                 AS src_domain,
+       tobj.domain                                               AS tgt_domain
+  FROM clarity_edge e
+  LEFT JOIN LATERAL (
+        SELECT x.match_rate FROM clarity_edge_history x
+         WHERE x.edge_id = e.id AND x.captured_at < e.match_measured_at
+         ORDER BY x.captured_at DESC LIMIT 1) h ON true
+  LEFT JOIN clarity_object so   ON so.object_key   = e.src_object
+  LEFT JOIN clarity_object tobj ON tobj.object_key = e.tgt_object
+ WHERE e.mechanism <> 'view_lineage';
+REVOKE ALL ON v_clarity_seams FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON v_clarity_seams TO service_role;
+
+REVOKE EXECUTE ON FUNCTION clarity_measure_edge(bigint,integer)                FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION clarity_measure_seams(integer,boolean,integer)      FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION clarity_measure_edge(bigint,integer)                TO service_role;
+GRANT  EXECUTE ON FUNCTION clarity_measure_seams(integer,boolean,integer)      TO service_role;


### PR DESCRIPTION
Every connection in the database, ranked by how much data it is losing right now. Not *is it connected* — with 638 declared foreign keys the answer is almost always yes and almost never interesting.

Spec: `CLARITY-SPEC.md` §3.6, §4.5 (graft G4). Slices 1–4 in #204, #207, #208.

## Applied, and the whole set is measured

`20260815001600_clarity_seams.sql` is live. **All 638 seams measured, zero refused**, swept in batches of 100 at ~3s each. Nothing timed out; the pooler stayed quiet.

| State | Count |
|---|---|
| Good (90%+) | 398 |
| **Declared but never populated** | **234** |
| Poor (<50%) | 3 |
| Dead (0% resolve) | 0 |
| Refused / unmeasured | 0 |

Slice 4's join matrix rendered `+` on every cell because nothing had ever been measured. This is what pays that off.

## The sweep caught a lie in my own first draft

`seamState()` mapped every null `match_rate` to "not measured yet". When the numbers came back, **234 rows lit up that way — and they are not unmeasured.** They are declared bridges nobody has ever populated, `nz_charities.gs_entity_id` at 0 of 45,192 rows among them. That is 37% of every foreign key in the database, and it would have shipped hidden behind the same blue `+` as "we have not looked yet".

Three kinds of "no number" now have three distinct states, and the comment in `types.ts` records the trap:

- `unmeasured` — we have never looked
- `never_populated` — we looked; the key column is entirely empty
- `dead` — we looked; keys exist and none resolve

## Bounded by design

There is deliberately **no "measure everything" call**. `clarity_measure_edge()` does one seam under its own `statement_timeout`; `clarity_measure_seams()` does a batch, default 25. 638 joins — some 2.5M rows against 609K — swept in one statement on a pooler that has starved before is how you take the database down.

A timeout is **recorded as a timeout**. `match_method` says which numbers were measured and which were refused, so a `?` can never be read as a `0`.

`v_clarity_seams` ranks by `rows_losing`, broken first and unmeasured last. A catalog that sorts by quality descending buries its worst finding on page two.

## Two scope calls, stated rather than hidden

- **No graph.** The spec put a force-directed schema graph behind `[ RENDER ]` with a 200-node refusal. Not built. Every defect worth finding is a number in this table and invisible as a line between two boxes, and the page says so on screen rather than implying the button is coming.
- **The spec's headline seams are not here.** The 25.1% donation attribution, the 0% justice drill-through, the NDIS LGA bridge — those are *undeclared* joins (`abn`, `uuid_stamp`, `postcode`), and `clarity_edge` holds only `fk` and `view_lineage`. Nothing catalogued them, so nothing measured them. Cataloguing the curated seams is real work and is not in this slice.

The 3 poor seams are all `*.user_id → users.id` at 21–75%, which smells like `auth.users` versus `public.users` rather than data loss.

## Not verified

- **The rendered page**, for the fourth slice running — Vercel SSO plus the admin gate.
- **The measure button's HTTP path.** The RPC underneath it swept all 638 seams from `psql`; the route wrapping it has not been exercised.

Gates: `npx tsc --noEmit` clean, `npx vitest run src/app/clarity` 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)