### PR TITLE
Ship /clarity slice 6 — the want list, and 22 questions about ourselves

### DIFF
--- a/apps/web/src/app/clarity/LedgerClient.tsx
+++ b/apps/web/src/app/clarity/LedgerClient.tsx
@@ -141,6 +141,12 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
             >
               Cross-sections
             </Link>
+            <Link
+              href="/clarity/wants"
+              className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+            >
+              The want list
+            </Link>
             <span className="ml-auto flex flex-wrap items-center gap-1.5">
               <span className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-bauhaus-muted">
                 Baseline

--- a/apps/web/src/app/clarity/changes/ChangesClient.tsx
+++ b/apps/web/src/app/clarity/changes/ChangesClient.tsx
@@ -139,6 +139,12 @@ export default function ChangesClient({
             >
               ◀ The ledger
             </Link>
+            <Link
+              href="/clarity/wants"
+              className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+            >
+              The want list
+            </Link>
             {stats.computedAt ? (
               <span className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em]">
                 Deltas computed {stats.computedAt.slice(0, 10)}

--- a/apps/web/src/app/clarity/cross/CrossClient.tsx
+++ b/apps/web/src/app/clarity/cross/CrossClient.tsx
@@ -167,6 +167,12 @@ export default function CrossClient({
             >
               What changed
             </Link>
+            <Link
+              href="/clarity/wants"
+              className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+            >
+              The want list
+            </Link>
           </div>
           <h1 className="text-4xl font-black uppercase leading-none tracking-wide sm:text-5xl">
             Cross-sections

--- a/apps/web/src/app/clarity/q/[slug]/page.tsx
+++ b/apps/web/src/app/clarity/q/[slug]/page.tsx
@@ -4,6 +4,13 @@ import { notFound } from 'next/navigation';
 import { getDirectServiceSupabase } from '@/lib/supabase';
 import { blockingSentinels, coverageText, type BoardCard, type Ingredient } from '../../board-types';
 import CopyClaim from './CopyClaim';
+import {
+  effortLabel,
+  formatMetric,
+  movementLabel,
+  targetLabel,
+  type WantRow,
+} from '../../wants/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,7 +28,9 @@ export async function generateMetadata({
  * sequential PostgREST calls meant the second could lose its connection under pool pressure and
  * 500 the whole page — which is exactly what happened on 15 Aug.
  */
-async function load(slug: string): Promise<{ card: BoardCard; ingredients: Ingredient[] } | null> {
+async function load(
+  slug: string,
+): Promise<{ card: BoardCard; ingredients: Ingredient[]; want: WantRow | null } | null> {
   const supabase = getDirectServiceSupabase();
 
   const { data: cards, error } = await supabase
@@ -33,7 +42,19 @@ async function load(slug: string): Promise<{ card: BoardCard; ingredients: Ingre
   if (!cards?.length) return null;
 
   const card = cards[0] as unknown as BoardCard;
-  return { card, ingredients: card.ingredients ?? [] };
+
+  // Contextual want rendering (G15): a want appears on every question it blocks, not only on the
+  // want list. This is a second round trip, so it degrades to null rather than taking the page
+  // down with it — the answer above is what the reader came for.
+  let want: WantRow | null = null;
+  try {
+    const { data } = await supabase.from('v_clarity_wants').select('*').eq('slug', slug).limit(1);
+    want = (data?.[0] as unknown as WantRow) ?? null;
+  } catch {
+    want = null;
+  }
+
+  return { card, ingredients: card.ingredients ?? [], want };
 }
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }) {
@@ -52,7 +73,7 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
   const loaded = await load(slug);
   if (!loaded) notFound();
 
-  const { card, ingredients } = loaded;
+  const { card, ingredients, want } = loaded;
   const blocked = blockingSentinels(card);
   const coverage = coverageText(card);
   const flags = Object.entries(card.sentinel_flags ?? {});
@@ -135,10 +156,58 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
               )}
             </Panel>
 
+            {want ? (
+              <Panel title="What would make this answerable">
+                <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                  <b className="font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-red">
+                    {effortLabel(want)}
+                  </b>
+                  {want.metric_now !== null ? (
+                    <span className="font-mono text-xs text-bauhaus-black">
+                      now {formatMetric(want.metric_now, want.metric_unit)} · {targetLabel(want)}
+                    </span>
+                  ) : null}
+                  <span className="font-mono text-[11px] text-bauhaus-muted">
+                    {movementLabel(want)}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-relaxed text-bauhaus-black">
+                  {want.unlock_note ??
+                    'Nobody has written down what closing this would take. Until somebody does, it ranks last on the want list and says so.'}
+                </p>
+                {want.blocker_objects.length > 0 && (
+                  <p className="mt-2 font-mono text-[11px] text-bauhaus-muted">
+                    blocked by {want.blocker_objects.map((b) => b.object_name).join(', ')}
+                  </p>
+                )}
+                {want.also_blocks > 0 && (
+                  <p className="mt-2 font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-black">
+                    Also stalls {want.also_blocks} other question
+                    {want.also_blocks === 1 ? '' : 's'}
+                  </p>
+                )}
+                <Link
+                  href="/clarity/wants"
+                  className="mt-4 inline-block border-2 border-bauhaus-black bg-bauhaus-white px-3 py-1.5 font-mono text-[11px] font-black uppercase tracking-widest hover:bg-bauhaus-yellow"
+                >
+                  The want list →
+                </Link>
+              </Panel>
+            ) : null}
+
             <Panel title="Say it this way">
-              <p className="border-l-4 border-bauhaus-blue pl-3 text-sm text-bauhaus-black">
-                {card.claim_phrasing}
-              </p>
+              {card.claim_phrasing?.trim() ? (
+                <p className="border-l-4 border-bauhaus-blue pl-3 text-sm text-bauhaus-black">
+                  {card.claim_phrasing}
+                </p>
+              ) : (
+                /* Internal questions — the HOUSE subject — carry no publishable phrasing on
+                   purpose. Rendering an empty quote block would read as a missing value. */
+                <p className="border-l-4 border-bauhaus-muted pl-3 text-sm text-bauhaus-muted">
+                  Nothing to quote. This is a question about ourselves, measured against this
+                  database, and it is not a claim about the world.
+                </p>
+              )}
               {card.forbidden_phrasing?.length > 0 && (
                 <ul className="mt-4 space-y-1">
                   {card.forbidden_phrasing.map((f) => (

--- a/apps/web/src/app/clarity/seams/SeamsClient.tsx
+++ b/apps/web/src/app/clarity/seams/SeamsClient.tsx
@@ -93,6 +93,7 @@ export default function SeamsClient({ seams }: { seams: SeamRow[] }) {
               ['/clarity', '◀ The ledger'],
               ['/clarity/changes', 'What changed'],
               ['/clarity/cross', 'Cross-sections'],
+              ['/clarity/wants', 'The want list'],
             ].map(([href, label]) => (
               <Link
                 key={href}

--- a/apps/web/src/app/clarity/wants/WantsClient.tsx
+++ b/apps/web/src/app/clarity/wants/WantsClient.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  effortLabel,
+  formatMetric,
+  isImproving,
+  movement,
+  movementLabel,
+  rankWants,
+  targetLabel,
+  type WantRow,
+} from './types';
+
+const nf = new Intl.NumberFormat('en-AU');
+
+const EFFORTS = ['S', 'M', 'L', 'unpriced'] as const;
+type EffortFilter = (typeof EFFORTS)[number];
+
+function matchesEffort(w: WantRow, f: EffortFilter): boolean {
+  return f === 'unpriced' ? !w.effort_known : w.unlock_effort === f;
+}
+
+export default function WantsClient({ wants }: { wants: WantRow[] }) {
+  const [effort, setEffort] = useState<EffortFilter | ''>('');
+  const [subject, setSubject] = useState('');
+
+  const ranked = useMemo(() => rankWants(wants), [wants]);
+
+  const subjects = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const w of ranked) m.set(w.subject, (m.get(w.subject) ?? 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  }, [ranked]);
+
+  const visible = useMemo(
+    () =>
+      ranked.filter(
+        (w) => (!effort || matchesEffort(w, effort)) && (!subject || w.subject === subject),
+      ),
+    [ranked, effort, subject],
+  );
+
+  const cheap = ranked.filter((w) => w.unlock_effort === 'S').length;
+  const unpriced = ranked.filter((w) => !w.effort_known).length;
+  const stalled = ranked.filter((w) => movement(w) === 'stalled').length;
+  const unwatched = ranked.filter((w) => movement(w) === 'unmeasured').length;
+
+  const cell = 'border-r-2 border-b-2 border-bauhaus-black bg-bauhaus-white px-3 py-2.5';
+
+  return (
+    <main className="min-h-screen bg-bauhaus-canvas">
+      <div className="mx-auto max-w-[1400px] px-4 pb-24">
+        <header className="border-b-4 border-bauhaus-black pt-8">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            {[
+              ['/clarity', '◀ The ledger'],
+              ['/clarity/changes', 'What changed'],
+              ['/clarity/cross', 'Cross-sections'],
+              ['/clarity/seams', 'The seams'],
+            ].map(([href, label]) => (
+              <Link
+                key={href}
+                href={href}
+                className="border-2 border-bauhaus-black bg-bauhaus-white px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.15em] hover:bg-bauhaus-black hover:text-bauhaus-canvas"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+          <h1 className="text-4xl font-black uppercase leading-none tracking-wide sm:text-5xl">
+            The want list
+          </h1>
+          <p className="mt-3 max-w-[68ch] text-sm text-bauhaus-muted">
+            Every gap with a price and a payoff — the coverage bar, inverted. Ranked by questions
+            unlocked × dollars made legible ÷ effort. Every row is derived from a question that
+            cannot be answered; nothing here is typed by hand that the registry did not already
+            have to hold.
+          </p>
+
+          <div className="mt-5 grid grid-cols-2 border-l-2 border-t-2 border-bauhaus-black sm:grid-cols-4">
+            {(
+              [
+                [nf.format(ranked.length), 'Questions we cannot answer', ''],
+                [nf.format(cheap), 'Fixes of effort S', cheap ? 'text-bauhaus-blue' : ''],
+                [
+                  nf.format(stalled),
+                  'Measured twice, not moved',
+                  stalled ? 'text-bauhaus-red' : '',
+                ],
+                [nf.format(unpriced), 'Nobody has priced', unpriced ? 'text-bauhaus-red' : ''],
+              ] as const
+            ).map(([v, label, tone]) => (
+              <div key={label} className={cell}>
+                <b className={`block text-xl font-black leading-tight ${tone}`}>{v}</b>
+                <span className="mt-1 block text-[9.5px] font-extrabold uppercase tracking-[0.13em] text-bauhaus-muted">
+                  {label}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {unwatched === ranked.length && ranked.length > 0 ? (
+            <p className="mt-3 max-w-[80ch] border-2 border-bauhaus-blue bg-bauhaus-white p-3 text-[12.5px]">
+              <b className="text-bauhaus-blue">No want has been watched twice yet.</b> Every row
+              reads <i>no trend yet</i> rather than <i>+0/wk</i>. A gap that has not moved is a
+              finding; a gap nobody has measured twice is not, and printing 0 for both would accuse
+              the work of being stuck when the truth is that nobody has looked. The second
+              measurement lands on the nightly job.
+            </p>
+          ) : null}
+        </header>
+
+        <div className="mt-6 grid border-[3px] border-bauhaus-black bg-bauhaus-white lg:grid-cols-[216px_1fr]">
+          <aside className="border-b-[3px] border-bauhaus-black p-3 lg:border-b-0 lg:border-r-[3px]">
+            <h2 className="mb-1.5 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+              Effort
+            </h2>
+            {EFFORTS.map((e) => (
+              <button
+                key={e}
+                type="button"
+                aria-pressed={effort === e}
+                onClick={() => setEffort(effort === e ? '' : e)}
+                className={`flex w-full items-center justify-between gap-2 px-1.5 py-0.5 text-left text-xs ${
+                  effort === e
+                    ? 'bg-bauhaus-black font-bold text-bauhaus-canvas'
+                    : 'hover:bg-bauhaus-canvas'
+                }`}
+              >
+                <span>{e === 'unpriced' ? 'not priced' : `effort ${e}`}</span>
+                <i className="not-italic text-[11px] opacity-70">
+                  {nf.format(ranked.filter((w) => matchesEffort(w, e)).length)}
+                </i>
+              </button>
+            ))}
+
+            <h2 className="mb-1.5 mt-4 text-[11px] font-black uppercase tracking-[0.18em] text-bauhaus-muted">
+              Subject
+            </h2>
+            {subjects.map(([s, n]) => (
+              <button
+                key={s}
+                type="button"
+                aria-pressed={subject === s}
+                onClick={() => setSubject(subject === s ? '' : s)}
+                className={`flex w-full items-center justify-between gap-2 px-1.5 py-0.5 text-left text-xs ${
+                  subject === s
+                    ? 'bg-bauhaus-black font-bold text-bauhaus-canvas'
+                    : 'hover:bg-bauhaus-canvas'
+                }`}
+              >
+                <span>{s}</span>
+                <i className="not-italic text-[11px] opacity-70">{nf.format(n)}</i>
+              </button>
+            ))}
+
+            <p className="mt-4 border-t-2 border-bauhaus-black/15 pt-2.5 text-[10.5px] leading-snug text-bauhaus-muted">
+              <b>Not priced</b> is not a synonym for large. It means nobody has scoped the fix, so
+              the row ranks at the bottom band and says so, rather than carrying a guess into the
+              ranking.
+            </p>
+          </aside>
+
+          <section className="min-w-0">
+            <div className="border-b-2 border-bauhaus-black/15 p-2.5 text-[11px] font-extrabold uppercase tracking-[0.1em] text-bauhaus-muted">
+              {nf.format(visible.length)} shown
+            </div>
+
+            {visible.length === 0 ? (
+              <p className="p-9 text-center text-sm text-bauhaus-muted">
+                Nothing matches. Clear a filter.
+              </p>
+            ) : (
+              <ol>
+                {visible.map((w, i) => {
+                  const improving = isImproving(w);
+                  return (
+                    <li
+                      key={w.slug}
+                      className="grid gap-x-4 gap-y-2 border-b-2 border-bauhaus-black/10 p-3.5 sm:grid-cols-[2.2rem_1fr_7rem]"
+                    >
+                      <b className="font-mono text-lg font-black leading-none">{i + 1}</b>
+
+                      <div className="min-w-0">
+                        <Link
+                          href={`/clarity/q/${w.slug}`}
+                          className="text-sm font-black uppercase tracking-wide hover:underline"
+                        >
+                          {w.stub}
+                        </Link>
+                        <p className="mt-0.5 text-[13px] text-bauhaus-muted">{w.question}</p>
+
+                        {w.unlock_note ? (
+                          <p className="mt-2 max-w-[86ch] text-[13px]">{w.unlock_note}</p>
+                        ) : (
+                          <p className="mt-2 text-[13px] font-semibold text-bauhaus-red">
+                            Nobody has written down what closing this would take.
+                          </p>
+                        )}
+
+                        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11.5px]">
+                          <span className="font-extrabold uppercase tracking-[0.1em]">
+                            {w.also_blocks > 0
+                              ? `Unlocks ${nf.format(w.also_blocks + 1)} questions`
+                              : 'Unlocks this question'}
+                          </span>
+                          {w.blocker_objects.length > 0 ? (
+                            <span className="font-mono text-bauhaus-muted">
+                              blocked by{' '}
+                              {w.blocker_objects.map((b) => b.object_name).join(', ')}
+                            </span>
+                          ) : null}
+                          {w.licence_note ? (
+                            <span className="text-bauhaus-muted">{w.licence_note}</span>
+                          ) : null}
+                        </div>
+                      </div>
+
+                      <div className="sm:text-right">
+                        <b
+                          className={`block text-[10px] font-extrabold uppercase tracking-[0.12em] ${
+                            w.effort_known ? '' : 'text-bauhaus-red'
+                          }`}
+                        >
+                          {effortLabel(w)}
+                        </b>
+
+                        {w.metric_now !== null ? (
+                          <>
+                            <b className="mt-1 block font-mono text-xl font-black leading-tight">
+                              {formatMetric(w.metric_now, w.metric_unit)}
+                            </b>
+                            <span className="block text-[10.5px] text-bauhaus-muted">
+                              {targetLabel(w)}
+                            </span>
+                            {w.metric_numerator !== null && w.metric_denominator !== null ? (
+                              <span className="block font-mono text-[10.5px] text-bauhaus-muted">
+                                {nf.format(Number(w.metric_numerator))} /{' '}
+                                {nf.format(Number(w.metric_denominator))}
+                              </span>
+                            ) : null}
+                          </>
+                        ) : (
+                          <b className="mt-1 block font-mono text-lg font-black leading-tight text-bauhaus-blue">
+                            +
+                          </b>
+                        )}
+
+                        <span
+                          className={`mt-1 block text-[11px] font-bold ${
+                            movement(w) === 'stalled'
+                              ? 'text-bauhaus-red'
+                              : improving === false
+                                ? 'text-bauhaus-red'
+                                : improving === true
+                                  ? 'text-bauhaus-blue'
+                                  : 'text-bauhaus-muted'
+                          }`}
+                        >
+                          {movementLabel(w)}
+                        </span>
+                        {w.eta_weeks !== null ? (
+                          <span className="block text-[10.5px] text-bauhaus-muted">
+                            {nf.format(Number(w.eta_weeks))} wk to target at this rate
+                          </span>
+                        ) : null}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+          </section>
+        </div>
+
+        <p className="mt-6 max-w-[80ch] border-2 border-bauhaus-black bg-bauhaus-white p-3 text-[12px]">
+          <b>Every row here also renders where it blocks.</b> A separate gaps page is a page nobody
+          opens. These same wants appear on the question they stall, so the cost of the gap is read
+          by whoever hits it rather than by whoever goes looking for it.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/clarity/wants/page.tsx
+++ b/apps/web/src/app/clarity/wants/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import WantsClient from './WantsClient';
+import type { WantRow } from './types';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'The want list · Clarity',
+  description: 'Every gap with a price and a payoff. The coverage bar, inverted.',
+};
+
+async function load(): Promise<WantRow[]> {
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.from('v_clarity_wants').select('*').limit(500);
+  if (error) throw new Error(`v_clarity_wants query failed: ${error.message}`);
+  return (data ?? []) as unknown as WantRow[];
+}
+
+export default async function WantsPage() {
+  let wants: WantRow[] = [];
+  let error: string | null = null;
+
+  try {
+    wants = await load();
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  if (error) {
+    return (
+      <main className="clarity-dark min-h-screen px-5 py-16">
+        <div className="mx-auto max-w-3xl border-4 border-bauhaus-red bg-bauhaus-white p-8">
+          <h1 className="text-2xl font-black uppercase tracking-widest text-bauhaus-red">
+            The want list is unavailable
+          </h1>
+          <p className="mt-4 text-sm">
+            <code className="font-mono">v_clarity_wants</code> could not be read. It ships in
+            migration{' '}
+            <code className="font-mono">20260815001700_clarity_house_and_wants.sql</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto border-2 border-bauhaus-muted bg-bauhaus-canvas p-3 font-mono text-xs">
+            {error}
+          </pre>
+          <Link href="/clarity" className="mt-5 inline-block text-sm font-black uppercase underline">
+            ← The ledger
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <div className="clarity-dark">
+      <WantsClient wants={wants} />
+    </div>
+  );
+}

--- a/apps/web/src/app/clarity/wants/rank.test.ts
+++ b/apps/web/src/app/clarity/wants/rank.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isImproving,
+  movement,
+  movementLabel,
+  rankWants,
+  targetLabel,
+  type WantRow,
+} from './types';
+
+function want(over: Partial<WantRow> = {}): WantRow {
+  return {
+    slug: 'house-x',
+    stub: 'X',
+    question: 'q?',
+    subject: 'HOUSE',
+    state: 'contested',
+    blocked_by: ['metric:x'],
+    blocked_by_metric: 'x',
+    unlock_effort: 'M',
+    unlock_note: null,
+    unlock_dollars: null,
+    licence_note: null,
+    blocker_objects: [],
+    also_blocks: 0,
+    unlocks_named: 0,
+    metric_now: 50,
+    metric_target: 95,
+    metric_unit: 'pct',
+    metric_direction: 'higher_better',
+    metric_numerator: null,
+    metric_denominator: null,
+    metric_measured_at: null,
+    metric_gap: 45,
+    rate_per_week: null,
+    eta_weeks: null,
+    metric_samples: 1,
+    effort_known: true,
+    rank_score: 0.33,
+    ...over,
+  };
+}
+
+describe('movement', () => {
+  it('calls a single measurement unmeasured, not stalled', () => {
+    expect(movement(want({ metric_samples: 1, rate_per_week: null }))).toBe('unmeasured');
+    expect(movementLabel(want({ metric_samples: 1, rate_per_week: null }))).toBe('no trend yet');
+  });
+
+  it('only says +0/wk once we have watched it twice', () => {
+    const w = want({ metric_samples: 4, rate_per_week: 0 });
+    expect(movement(w)).toBe('stalled');
+    expect(movementLabel(w)).toBe('+0pp/wk');
+  });
+
+  it('reads direction against the metric, not the sign', () => {
+    expect(isImproving(want({ metric_samples: 3, rate_per_week: 2 }))).toBe(true);
+    expect(
+      isImproving(want({ metric_samples: 3, rate_per_week: 2, metric_direction: 'lower_better' })),
+    ).toBe(false);
+    expect(isImproving(want({ metric_samples: 1, rate_per_week: null }))).toBeNull();
+  });
+});
+
+describe('rankWants', () => {
+  it('ranks by score, then by how far short, then stably by slug', () => {
+    const rows = [
+      want({ slug: 'b', rank_score: 0.33, metric_gap: 10 }),
+      want({ slug: 'a', rank_score: 1, metric_gap: 1 }),
+      want({ slug: 'c', rank_score: 0.33, metric_gap: 90 }),
+      want({ slug: 'd', rank_score: 0.33, metric_gap: 90 }),
+    ];
+    expect(rankWants(rows).map((r) => r.slug)).toEqual(['a', 'c', 'd', 'b']);
+  });
+
+  it('does not treat a missing gap as a gap of zero when ordering', () => {
+    const rows = [
+      want({ slug: 'nogap', rank_score: 1, metric_gap: null }),
+      want({ slug: 'zero', rank_score: 1, metric_gap: 0 }),
+    ];
+    expect(rankWants(rows).map((r) => r.slug)).toEqual(['zero', 'nogap']);
+  });
+});
+
+describe('targetLabel', () => {
+  it('flips the comparator with the metric direction', () => {
+    expect(targetLabel(want())).toBe('target ≥ 95.0%');
+    expect(targetLabel(want({ metric_direction: 'lower_better', metric_unit: 'count' }))).toBe(
+      'target ≤ 95',
+    );
+    expect(targetLabel(want({ metric_target: null }))).toBe('no target set');
+  });
+});

--- a/apps/web/src/app/clarity/wants/types.ts
+++ b/apps/web/src/app/clarity/wants/types.ts
@@ -1,0 +1,108 @@
+export interface BlockerObject {
+  object_key: string;
+  object_name: string;
+  rows: number | null;
+  state: string | null;
+}
+
+export interface WantRow {
+  slug: string;
+  stub: string;
+  question: string;
+  subject: string;
+  state: 'unanswerable' | 'refused' | 'contested';
+  blocked_by: string[];
+  blocked_by_metric: string | null;
+  unlock_effort: 'S' | 'M' | 'L' | null;
+  unlock_note: string | null;
+  unlock_dollars: number | null;
+  licence_note: string | null;
+  blocker_objects: BlockerObject[];
+  also_blocks: number;
+  unlocks_named: number | null;
+  metric_now: number | null;
+  metric_target: number | null;
+  metric_unit: string | null;
+  metric_direction: string | null;
+  metric_numerator: number | null;
+  metric_denominator: number | null;
+  metric_measured_at: string | null;
+  metric_gap: number | null;
+  rate_per_week: number | null;
+  eta_weeks: number | null;
+  metric_samples: number | null;
+  effort_known: boolean;
+  rank_score: number | null;
+}
+
+/**
+ * Movement, in three states that must never collapse into one another — the same discipline the
+ * seams screen applies to match rates.
+ *
+ *   unmeasured — fewer than two measurements exist. We have not watched it long enough to say.
+ *   stalled    — measured repeatedly, and it has not moved. This is the loud one.
+ *   moving     — measured repeatedly, and it is moving, in some direction.
+ *
+ * A want that has never been measured twice renders "no trend yet", not "+0/wk". Printing +0/wk
+ * for a metric we have only ever seen once would accuse the work of being stuck when the truth is
+ * that nobody has looked.
+ */
+export type Movement = 'unmeasured' | 'stalled' | 'moving';
+
+export function movement(w: Pick<WantRow, 'metric_samples' | 'rate_per_week'>): Movement {
+  if ((w.metric_samples ?? 0) < 2 || w.rate_per_week === null) return 'unmeasured';
+  return Number(w.rate_per_week) === 0 ? 'stalled' : 'moving';
+}
+
+export function movementLabel(w: WantRow): string {
+  const m = movement(w);
+  if (m === 'unmeasured') return 'no trend yet';
+  const r = Number(w.rate_per_week);
+  const unit = w.metric_unit === 'pct' ? 'pp' : '';
+  if (m === 'stalled') return `+0${unit}/wk`;
+  return `${r > 0 ? '+' : ''}${r}${unit}/wk`;
+}
+
+/**
+ * Whether the metric is moving towards its target or away from it. Direction matters: a rate of
+ * -2/wk is progress on a lower_better metric and a rout on a higher_better one.
+ */
+export function isImproving(w: WantRow): boolean | null {
+  if (movement(w) !== 'moving' || !w.metric_direction) return null;
+  const r = Number(w.rate_per_week);
+  return w.metric_direction === 'higher_better' ? r > 0 : r < 0;
+}
+
+export const EFFORT_WEIGHT: Record<'S' | 'M' | 'L', number> = { S: 1, M: 3, L: 9 };
+
+export function effortLabel(w: WantRow): string {
+  return w.effort_known && w.unlock_effort ? `EFFORT ${w.unlock_effort}` : 'NOT PRICED';
+}
+
+/**
+ * Screen order. rank_score first, then how far short the metric is in its own unit. Without the
+ * second key the ranking collapses into three effort bands — no want carries a dollar figure yet
+ * and none unlocks another question — and rows would shuffle arbitrarily inside each band on
+ * every render.
+ */
+export function rankWants(rows: WantRow[]): WantRow[] {
+  return [...rows].sort((a, b) => {
+    const r = Number(b.rank_score ?? 0) - Number(a.rank_score ?? 0);
+    if (r !== 0) return r;
+    const g = Number(b.metric_gap ?? -1) - Number(a.metric_gap ?? -1);
+    if (g !== 0) return g;
+    return a.slug.localeCompare(b.slug);
+  });
+}
+
+export function formatMetric(value: number | null, unit: string | null): string {
+  if (value === null || value === undefined) return '—';
+  const n = Number(value);
+  return unit === 'pct' ? `${n.toFixed(1)}%` : n.toLocaleString('en-AU');
+}
+
+export function targetLabel(w: WantRow): string {
+  if (w.metric_target === null) return 'no target set';
+  const arrow = w.metric_direction === 'higher_better' ? '≥' : '≤';
+  return `target ${arrow} ${formatMetric(w.metric_target, w.metric_unit)}`;
+}

--- a/supabase/migrations/20260815001700_clarity_house_and_wants.sql
+++ b/supabase/migrations/20260815001700_clarity_house_and_wants.sql
@@ -1,0 +1,330 @@
+-- /clarity slice 6 — THE WANT LIST AND THE HOUSE
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001700_clarity_house_and_wants.sql
+--
+-- Two things ship here.
+--
+-- 1. THE HOUSE SUBJECT. The 23 gap metrics stop being a private diagnostic table and become
+--    questions about ourselves, on the same board, in the same shape, with targets. "71 of 98
+--    matviews are in no refresh registry" becomes a contested card rather than a number nobody
+--    is accountable for.
+--
+-- 2. THE WANT LIST. Every question that cannot be answered, priced and ranked by what fixing it
+--    unlocks. Derived entirely from the question registry — nothing on the screen is hand-typed
+--    that the registry did not already have to hold.
+--
+-- The one judgement call recorded here: cost_class on clarity_gap_metric is the cost of MEASURING
+-- a metric, not the cost of FIXING what it measures. Deriving effort from it would have priced
+-- every want wrong and looked authoritative doing it. fix_effort is a separate, hand-entered
+-- column, and it is NULL wherever the fix is genuinely not priced yet. An unpriced want renders
+-- "not priced", never "L".
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. What it would cost to close each gap
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE clarity_gap_metric
+  ADD COLUMN IF NOT EXISTS fix_effort   clarity_effort,
+  ADD COLUMN IF NOT EXISTS fix_note     text,
+  ADD COLUMN IF NOT EXISTS fix_dollars  numeric;
+
+COMMENT ON COLUMN clarity_gap_metric.fix_effort IS
+  'Effort to CLOSE this gap. NULL means unpriced, which is not the same as large. '
+  'Distinct from cost_class, which is the cost of measuring the metric.';
+
+UPDATE clarity_gap_metric SET fix_effort = 'S', fix_note = v.note
+  FROM (VALUES
+    ('matviews_unscheduled',
+     'mv_refresh_registry and mv_refresh_plan() already exist from the 2026-08-14 migrations. '
+     'Closing this is registering the matviews, not building the mechanism.'),
+    ('matviews_stale',
+     'Downstream of matviews_unscheduled. Registering them is what schedules them.'),
+    ('estimated_row_counts',
+     'A targeted count on the objects whose size is only an estimate. Bounded work.'),
+    ('conflicting_metric_definitions',
+     'Pick the canonical expression per concept in clarity_metric_definition and mark the rest. '
+     'A decision, not an engineering job.')
+  ) AS v(k, note)
+ WHERE clarity_gap_metric.metric_key = v.k;
+
+UPDATE clarity_gap_metric SET fix_effort = 'M', fix_note = v.note
+  FROM (VALUES
+    ('described_objects',
+     '621 objects need a written purpose. Cheap per object, long in aggregate, and no tool writes '
+     'it for you honestly.'),
+    ('governed_objects',
+     'Owner, licence and PII level per object. Blocked on decisions more than on typing.'),
+    ('abn_attribution_donations',
+     'Donor names resolved against abr_registry. The name-matching is the work; the join is not.'),
+    ('abn_attribution_money',
+     'Same lane as donations, larger surface.'),
+    ('anon_readable_relations',
+     'Revoking anon on relations nothing public reads. Each revoke needs checking against the app '
+     'first, which is what makes it M rather than S.'),
+    ('anon_executable_definers',
+     'Same shape as anon_readable_relations, smaller and sharper.'),
+    ('act_business_exposed',
+     'ACT private-business objects should not be anon-readable at all. Bounded list, real care.'),
+    ('bridge_columns_populated',
+     'The 234 declared-but-never-populated seams found in slice 5. Each is its own backfill.'),
+    ('interventions_with_evidence',
+     'ALMA evidence linking through the junction tables. Judgement per intervention, no bulk path.')
+  ) AS v(k, note)
+ WHERE clarity_gap_metric.metric_key = v.k;
+
+UPDATE clarity_gap_metric SET fix_effort = 'L', fix_note = v.note
+  FROM (VALUES
+    ('justice_edge_drillthrough',
+     'gs_relationships.source_record_id is 0 of 49,426 — a dead key namespace, not a broken join. '
+     'The edge builder has to be rebuilt to carry the source record through.'),
+    ('dark_rows',
+     'Not fixable by writing code. Either something starts reading these objects or they are '
+     'retired, and both are decisions about the product.')
+  ) AS v(k, note)
+ WHERE clarity_gap_metric.metric_key = v.k;
+
+-- Everything else stays NULL on purpose: entities_placed, postcodes_placeable, freshness_knowable,
+-- countable_objects, stale_core_sources, views_unreferenced, matview_concurrent_fallback,
+-- matviews_unregistered. Each is real work nobody has scoped, and a guessed effort on a ranked
+-- list is worse than an empty cell, because the ranking would carry the guess.
+
+-- ---------------------------------------------------------------------------
+-- 2. The HOUSE subject — the gap metrics as questions about ourselves
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION clarity_sync_house()
+RETURNS TABLE (questions_upserted int, answers_written int)
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+  v_q int := 0;
+  v_a int := 0;
+BEGIN
+  -- One question per enabled metric. Disabled metrics (matviews_unregistered, which waits on a
+  -- table that does not exist yet) get no card, because a card whose number can never arrive is
+  -- the failure this whole surface exists to stop.
+  WITH upserted AS (
+    INSERT INTO clarity_question (
+      slug, stub, question, subject, state, form, honest_at, publishable,
+      caveat, exclusions, claim_phrasing, answer_sql, blocked_by, blocked_by_metric,
+      unlock_effort, unlock_note, unlock_dollars, uniqueness, uniqueness_basis, surface
+    )
+    SELECT
+      'house-' || replace(g.metric_key, '_', '-'),
+      upper(g.title),
+      g.question,
+      'HOUSE',
+      -- Provisional. Set for real below, off the latest measurement.
+      'draft'::clarity_question_state,
+      'scalar'::clarity_form_kind,
+      'none'::clarity_honest_at,
+      'internal'::clarity_publishable,
+      'Measured about this database by clarity_measure_gaps(), on the schedule in job 11. '
+        || coalesce(g.note, ''),
+      '',
+      -- HOUSE questions are internal. They get no publishable claim phrasing, and the empty
+      -- string is the honest value rather than a sentence nobody may quote.
+      '',
+      format('SELECT (%s) AS numerator, (%s) AS denominator', g.numerator_sql, g.denominator_sql),
+      -- The blocker is the metric itself, not an object in the catalog. Prefixed so it can never
+      -- be mistaken for an object_key by anything that joins on blocked_by.
+      ARRAY['metric:' || g.metric_key],
+      g.metric_key,
+      g.fix_effort,
+      g.fix_note,
+      g.fix_dollars,
+      1.0,
+      'Measured about this database and nowhere else.',
+      '/clarity/wants'
+    FROM clarity_gap_metric g
+    WHERE g.enabled
+    ON CONFLICT (slug) DO UPDATE SET
+      stub          = excluded.stub,
+      question      = excluded.question,
+      caveat        = excluded.caveat,
+      answer_sql    = excluded.answer_sql,
+      blocked_by    = excluded.blocked_by,
+      unlock_effort = excluded.unlock_effort,
+      unlock_note   = excluded.unlock_note,
+      unlock_dollars= excluded.unlock_dollars,
+      updated_at    = now()
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_q FROM upserted;
+
+  -- State off the latest measurement. Four outcomes, never collapsed:
+  --   answered     — measured, and inside target
+  --   contested    — measured, and outside target. This is the adjudication CTA.
+  --   unanswerable — never measured or the probe errored, AND somebody has priced the fix
+  --   draft        — never measured and nobody has priced the fix. Registered, not yet a want.
+  --
+  -- That last split is forced by the blocked_has_a_price constraint slice 2 put on this table,
+  -- and the constraint is right: an unanswerable question with no price is a complaint, not a
+  -- want. It stays draft until someone fills in fix_effort.
+  UPDATE clarity_question q
+     SET state = CASE
+           WHEN m.value IS NOT NULL AND m.status = 'ok' AND m.breached IS NOT TRUE THEN 'answered'
+           WHEN m.value IS NOT NULL AND m.status = 'ok'                            THEN 'contested'
+           WHEN g.fix_effort IS NOT NULL AND g.fix_note IS NOT NULL                THEN 'unanswerable'
+           ELSE 'draft'
+         END::clarity_question_state,
+         updated_at = now()
+    FROM clarity_gap_metric g
+    LEFT JOIN v_clarity_metric_latest m ON m.metric_key = g.metric_key
+   WHERE q.subject = 'HOUSE'
+     AND q.blocked_by_metric = g.metric_key;
+
+  -- A HOUSE card is a board card, so it needs an answer row like every other card. One answer per
+  -- measurement, written once — re-running this function does not fabricate a new data point.
+  WITH written AS (
+    INSERT INTO clarity_answer (
+      question_slug, computed_at, ok, headline, headline_sub, headline_num,
+      coverage_num, coverage_den, coverage_label, row_count, duration_ms
+    )
+    SELECT
+      q.slug,
+      x.measured_at,
+      x.status = 'ok',
+      CASE
+        WHEN x.value IS NULL THEN 'not measured'
+        WHEN g.unit = 'pct'  THEN round(x.value, 1)::text || '%'
+        ELSE round(x.value, 0)::text
+      END,
+      CASE
+        WHEN g.target IS NULL THEN 'no target set'
+        WHEN g.direction = 'higher_better' THEN 'target ≥ ' || g.target::text
+        ELSE 'target ≤ ' || g.target::text
+      END,
+      x.value,
+      x.numerator,
+      x.denominator,
+      g.unit,
+      NULL,
+      x.duration_ms
+    FROM clarity_gap_measurement x
+    JOIN clarity_gap_metric g   ON g.metric_key = x.metric_key
+    JOIN clarity_question q     ON q.blocked_by_metric = x.metric_key AND q.subject = 'HOUSE'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM clarity_answer a
+       WHERE a.question_slug = q.slug AND a.computed_at = x.measured_at
+    )
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_a FROM written;
+
+  RETURN QUERY SELECT v_q, v_a;
+END;
+$fn$;
+
+COMMENT ON FUNCTION clarity_sync_house() IS
+  'Registers every enabled gap metric as a HOUSE question and mirrors its measurements into '
+  'clarity_answer. Idempotent: re-running writes no duplicate answers. Called nightly by job 11.';
+
+-- ---------------------------------------------------------------------------
+-- 3. The want list
+-- ---------------------------------------------------------------------------
+
+-- Ranked by questions unlocked × dollars made legible ÷ effort, exactly as it says on the screen.
+-- Unpriced wants (fix_effort NULL) rank at the L weight but carry effort_known = false, so the
+-- screen can say "not priced" instead of implying somebody decided it was large.
+DROP VIEW IF EXISTS v_clarity_wants;
+CREATE VIEW v_clarity_wants AS
+WITH blocked AS (
+  SELECT q.*
+    FROM clarity_question q
+   WHERE q.state IN ('unanswerable', 'refused', 'contested')
+),
+blockers AS (
+  SELECT b.slug,
+         jsonb_agg(jsonb_build_object(
+           'object_key', o.object_key,
+           'object_name', o.object_name,
+           'rows', o.row_count,
+           'state', o.state
+         ) ORDER BY o.object_name) AS blocker_objects
+    FROM blocked b
+    JOIN clarity_object o ON o.object_key = ANY (b.blocked_by)
+   GROUP BY b.slug
+)
+SELECT
+  b.slug,
+  b.stub,
+  b.question,
+  b.subject,
+  b.state,
+  b.blocked_by,
+  b.blocked_by_metric,
+  b.unlock_effort,
+  b.unlock_note,
+  b.unlock_dollars,
+  b.licence_note,
+  coalesce(bl.blocker_objects, '[]'::jsonb)                     AS blocker_objects,
+  -- Other questions stalled behind the same blockers. Itself included: a want that unlocks
+  -- exactly one question still unlocks one question.
+  (SELECT count(*)::int FROM clarity_question x
+    WHERE x.slug <> b.slug
+      AND (x.blocked_by && b.blocked_by
+           OR (b.blocked_by_metric IS NOT NULL AND x.blocked_by_metric = b.blocked_by_metric)))
+                                                                AS also_blocks,
+  cardinality(b.unlocks_questions)                              AS unlocks_named,
+  m.value                                                       AS metric_now,
+  m.target                                                      AS metric_target,
+  m.unit                                                        AS metric_unit,
+  m.direction                                                   AS metric_direction,
+  m.numerator                                                   AS metric_numerator,
+  m.denominator                                                 AS metric_denominator,
+  m.measured_at                                                 AS metric_measured_at,
+  -- How far short, in the metric's own unit. Positive means the target is not met. Secondary
+  -- sort on the screen, because with no dollar figures registered yet the rank collapses to
+  -- three effort bands and would otherwise order arbitrarily inside each one.
+  CASE
+    WHEN m.value IS NULL OR m.target IS NULL THEN NULL
+    WHEN m.direction = 'higher_better' THEN round(m.target - m.value, 2)
+    ELSE round(m.value - m.target, 2)
+  END                                                           AS metric_gap,
+  bd.rate_per_week,
+  bd.eta_weeks,
+  bd.samples                                                    AS metric_samples,
+  (b.unlock_effort IS NOT NULL)                                 AS effort_known,
+  -- The ranking. Dollars are a floor and often absent, so the +1 keeps a want that unlocks three
+  -- questions above one that unlocks none rather than zeroing them both out.
+  round(
+    (coalesce(b.unlock_dollars, 0) + 1)
+    * (1 + (SELECT count(*) FROM clarity_question x
+             WHERE x.slug <> b.slug
+               AND (x.blocked_by && b.blocked_by
+                    OR (b.blocked_by_metric IS NOT NULL
+                        AND x.blocked_by_metric = b.blocked_by_metric))))
+    / CASE b.unlock_effort WHEN 'S' THEN 1 WHEN 'M' THEN 3 ELSE 9 END
+  , 2)                                                          AS rank_score
+FROM blocked b
+LEFT JOIN blockers bl                ON bl.slug = b.slug
+LEFT JOIN v_clarity_metric_latest m  ON m.metric_key = b.blocked_by_metric
+LEFT JOIN v_clarity_burndown bd      ON bd.metric_key = b.blocked_by_metric;
+
+-- ---------------------------------------------------------------------------
+-- 4. The nightly job learns the new step
+-- ---------------------------------------------------------------------------
+-- Order matters: gaps are measured first, then the HOUSE cards are synced off those fresh
+-- measurements. Reversed, every HOUSE card would show yesterday's number all day.
+SELECT cron.alter_job(
+  11,
+  command => $job$
+    SELECT clarity_refresh();
+    SELECT clarity_apply_act_flag();
+    SELECT clarity_compute_deltas();
+    SELECT clarity_measure_gaps('cheap');
+    SELECT clarity_sync_house();
+  $job$
+);
+
+COMMENT ON VIEW v_clarity_wants IS
+  'Every question that cannot be answered, with what it would cost and what it unlocks. '
+  'Derived entirely from clarity_question — nothing here is hand-maintained separately.';
+
+COMMIT;


### PR DESCRIPTION
Sixth of seven slices. The 23 gap metrics stop being a private diagnostic table and become questions about ourselves, on the same board, in the same shape, with targets.

## What ships

**The HOUSE subject.** `clarity_sync_house()` registers every enabled gap metric as a `clarity_question` and mirrors each measurement into `clarity_answer`, so they are genuine board cards with genuine history. Current state: **17 contested, 1 answered, 3 unanswerable, 1 draft.** The loud ones — matviews unscheduled 100% (target 0), governed objects 1.7% (target 60), bridge columns populated 0% (target 50), ACT private-business objects anon-readable 30.1% (target 0).

**`/clarity/wants`.** All 20 blocked questions ranked by questions unlocked × dollars made legible ÷ effort, filterable by effort and subject, each row carrying its blockers, its burn-down and its eta. Every row is derived from the registry — nothing here is hand-maintained twice.

**Contextual rendering (G15).** The same want renders on the question it blocks, with the adjudication link. A separate gaps page is a page nobody opens.

**Job 11** now runs refresh → act flag → deltas → measure gaps → **sync house**, in that order, so the cards read the fresh measurement rather than yesterday's.

## Three judgement calls

- **`cost_class` is the cost of measuring a metric, not of fixing it.** Deriving effort from it would have priced every want wrong and looked authoritative doing it. `fix_effort` is a separate hand-entered column and is **NULL on the 8 gaps nobody has scoped**; those rows read `NOT PRICED` and rank last. A guess carried into a ranking is worse than an empty cell.
- **Movement has three states, never two.** A metric measured once reads *no trend yet*, not *+0/wk*. Printing 0 for both accuses the work of being stuck when the truth is that nobody has looked. Same discipline as the seams screen applies to match rates.
- **An unpriced, unmeasured metric stays `draft`,** not `unanswerable`. Slice 2's `blocked_has_a_price` constraint is right: an unanswerable question with no price is a complaint, not a want.

## Verification

- Migration `20260815001700_clarity_house_and_wants.sql` **applied**; `clarity_sync_house()` run (22 questions upserted, 18 answers written); `v_clarity_wants` returns 20 rows; job 11 command confirmed rewritten.
- `npx tsc --noEmit` clean · `npx vitest run src/app/clarity` — 13 tests, 3 files, all pass (6 new, covering the movement states, the rank tie-breaks and the target comparator).

## Still unverified

**No `/clarity` screen has ever been rendered for a human** — this is the fifth. Vercel SSO plus the admin gate block every tool available in the session that wrote it. Everything is verified at the data layer and nothing at the pixel layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)