### PR TITLE
Ship /clarity slice 7 part 1 — the refusal, the stamps, and a spec claim that was false

### DIFF
--- a/apps/web/src/app/clarity/board-types.ts
+++ b/apps/web/src/app/clarity/board-types.ts
@@ -29,6 +29,13 @@ export interface SentinelFlag {
   /** whether this sentinel can block THIS question — see clarity_sentinel.guards_objects */
   blocking?: boolean;
   scope?: 'unscoped' | 'named' | 'ingredient' | 'not-applicable';
+  /**
+   * Written, per-question reason this tripped sentinel does not block. Set from
+   * clarity_sentinel_exemption. Its presence is why `blocking` is false — the flag still records
+   * that the defect is real, because an exemption nobody can read is indistinguishable from a
+   * guard somebody quietly switched off.
+   */
+  exempt_reason?: string;
   error?: string;
 }
 
@@ -50,6 +57,8 @@ export interface BoardCard {
   uniqueness_basis: string | null;
   live_rerun_ok: boolean;
   measured_ms: number | null;
+  /** Prose condition under which this question refuses to render. Only set on form='refused'. */
+  refuses_when: string | null;
 
   /** null until the runner has ever produced an answer. Renders NEVER RUN, never a zero. */
   headline: string | null;
@@ -99,4 +108,30 @@ export function coverageText(card: Pick<BoardCard, 'coverage_num' | 'coverage_de
   if (card.coverage_num == null || card.coverage_den == null || !card.coverage_den) return null;
   const pct = (card.coverage_num / card.coverage_den) * 100;
   return `${card.coverage_num.toLocaleString()} of ${card.coverage_den.toLocaleString()} · ${pct.toFixed(1)}%`;
+}
+
+/**
+ * A refused question renders no chart, no number and no copyable claim. Both the state and the
+ * form carry the fact, and they can disagree: a question can be registered `refused` before its
+ * form is set, and a `refused` form is meaningless on any other state. Either one is enough.
+ */
+export function isRefusedCard(
+  card: Pick<BoardCard, 'form' | 'state'>,
+): boolean {
+  return card.form === 'refused' || card.state === 'refused';
+}
+
+/**
+ * UNVERIFIED and PILOT are stamps that travel with the number. `verified` is the absence of a
+ * stamp, not a badge — stamping the normal case teaches readers to ignore stamps. A missing
+ * verification_stamp is also unstamped: the registry requires the value where it matters, and a
+ * card is not made more trustworthy by a label the author never wrote.
+ */
+export function stampLabel(
+  card: Pick<BoardCard, 'verification_stamp'>,
+): 'UNVERIFIED' | 'PILOT' | null {
+  const v = card.verification_stamp?.toLowerCase();
+  if (v === 'unverified') return 'UNVERIFIED';
+  if (v === 'pilot') return 'PILOT';
+  return null;
 }

--- a/apps/web/src/app/clarity/q/[slug]/page.tsx
+++ b/apps/web/src/app/clarity/q/[slug]/page.tsx
@@ -2,7 +2,14 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getDirectServiceSupabase } from '@/lib/supabase';
-import { blockingSentinels, coverageText, type BoardCard, type Ingredient } from '../../board-types';
+import {
+  blockingSentinels,
+  coverageText,
+  isRefusedCard,
+  stampLabel,
+  type BoardCard,
+  type Ingredient,
+} from '../../board-types';
 import CopyClaim from './CopyClaim';
 import {
   effortLabel,
@@ -75,6 +82,9 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
 
   const { card, ingredients, want } = loaded;
   const blocked = blockingSentinels(card);
+  const isRefused = isRefusedCard(card);
+  // UNVERIFIED and PILOT are stamps, not footnotes. A number carrying either one travels with it.
+  const stamp = stampLabel(card);
   const coverage = coverageText(card);
   const flags = Object.entries(card.sentinel_flags ?? {});
 
@@ -93,7 +103,22 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
           </h1>
           <p className="mt-2 max-w-3xl text-sm text-bauhaus-black">{card.question}</p>
 
+          {stamp ? (
+            <p className="mt-3 inline-block border-4 border-bauhaus-red px-3 py-1 font-mono text-[11px] font-black uppercase tracking-[0.2em] text-bauhaus-red">
+              {stamp} — {stamp === 'PILOT'
+                ? 'a worked example, not a corpus. Do not quote it as coverage.'
+                : 'nobody has reproduced this number against its source.'}
+            </p>
+          ) : null}
+
           <div className="mt-4 flex flex-wrap items-center gap-3">
+            {isRefused ? (
+              /* No claim to copy. A refusal offering a clipboard button is offering the reader a
+                 sentence to paste somewhere it will be read as a finding. */
+              <span className="border-2 border-bauhaus-red bg-bauhaus-red px-3 py-1.5 font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-canvas">
+                Refused · no claim to copy
+              </span>
+            ) : (
             <CopyClaim
               claim={card.claim_phrasing}
               headline={blocked.length ? null : card.headline}
@@ -104,7 +129,8 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
               computedAt={card.computed_at}
               url={`/clarity/q/${card.slug}`}
             />
-            {card.row_count != null && (
+            )}
+            {!isRefused && card.row_count != null && (
               <Link
                 href={`/clarity/q/${card.slug}/rows`}
                 className="border-2 border-bauhaus-black bg-bauhaus-white px-3 py-1.5 font-mono text-[11px] font-black uppercase tracking-widest hover:bg-bauhaus-yellow"
@@ -124,6 +150,50 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
 
         <div className="mt-6 grid gap-6 lg:grid-cols-3">
           <div className="space-y-6 lg:col-span-2">
+            {isRefused ? (
+              /*
+               * THE REFUSED FORM. No chart, no number, no struck-through headline — a refusal that
+               * renders a greyed-out version of the thing it is refusing to draw is still drawing
+               * it. This is the only place in either repo where a refusal has its own URL, and the
+               * page continues the journey rather than dead-ending: what we can honestly show sits
+               * directly under why we will not show this.
+               */
+              <section className="border-4 border-bauhaus-red bg-bauhaus-white">
+                <h2 className="border-b-2 border-bauhaus-red bg-bauhaus-red px-4 py-2 font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-canvas">
+                  This view refuses to render
+                </h2>
+                <div className="space-y-4 p-5">
+                  <p className="max-w-[70ch] text-sm leading-relaxed text-bauhaus-black">
+                    {card.refuses_when}
+                  </p>
+                  <div>
+                    <h3 className="font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-black">
+                      What we can honestly show instead
+                    </h3>
+                    <ul className="mt-2 space-y-1.5 text-sm text-bauhaus-black">
+                      <li>
+                        ▸ {card.honest_at} ÷ {card.honest_at === 'state' ? 'LGA' : 'finer'} framing,
+                        labelled as such — {card.claim_phrasing}
+                      </li>
+                      <li>
+                        ▸{' '}
+                        <Link
+                          href="/clarity/q/watchhouse-children"
+                          className="font-black underline hover:text-bauhaus-blue"
+                        >
+                          WATCHHOUSE CHILDREN
+                        </Link>{' '}
+                        — facility-level, near-daily, roughly one day lagged. Police custody, not
+                        detention. Not comparable to AIHW figures without saying so.
+                      </li>
+                    </ul>
+                  </div>
+                  <p className="border-t-2 border-bauhaus-muted pt-3 text-xs leading-relaxed text-bauhaus-black">
+                    {card.caveat}
+                  </p>
+                </div>
+              </section>
+            ) : (
             <Panel title="The answer">
               {card.ok === false ? (
                 <div className="border-2 border-bauhaus-red p-3">
@@ -155,6 +225,7 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
                 </p>
               )}
             </Panel>
+            )}
 
             {want ? (
               <Panel title="What would make this answerable">
@@ -272,8 +343,19 @@ export default async function WorkedAnswerPage({ params }: { params: Promise<{ s
                       </span>
                       {/* A tripped-but-not-blocking sentinel is stated plainly rather than hidden:
                           the contamination is real, it just is not in this question's path. */}
-                      {f.tripped && !f.blocking && (
+                      {f.tripped && !f.blocking && !f.exempt_reason && (
                         <span className="text-bauhaus-muted"> — tripped, not in this question&rsquo;s path</span>
+                      )}
+                      {/* An exemption is a decision somebody made in writing, so it is shown in
+                          full rather than as the word "exempt". A reader who disagrees with the
+                          reasoning can see the reasoning. */}
+                      {f.tripped && f.exempt_reason && (
+                        <>
+                          <span className="text-bauhaus-blue"> — exempted from this question</span>
+                          <span className="mt-1 block max-w-[46ch] font-sans text-[11px] leading-snug text-bauhaus-muted">
+                            {f.exempt_reason}
+                          </span>
+                        </>
                       )}
                       {f.n != null && <span className="text-bauhaus-muted"> · n={f.n.toLocaleString()}</span>}
                     </li>

--- a/apps/web/src/app/clarity/q/refusal.test.ts
+++ b/apps/web/src/app/clarity/q/refusal.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isRefusedCard, stampLabel } from '../board-types';
+
+describe('isRefusedCard', () => {
+  it('refuses on either the form or the state', () => {
+    expect(isRefusedCard({ form: 'refused', state: 'refused' })).toBe(true);
+    expect(isRefusedCard({ form: 'scalar', state: 'refused' })).toBe(true);
+    expect(isRefusedCard({ form: 'refused', state: 'draft' })).toBe(true);
+  });
+
+  it('leaves every answerable card alone', () => {
+    expect(isRefusedCard({ form: 'scalar', state: 'answered' })).toBe(false);
+    // Contested is NOT refused. A contested card still renders its number, struck through with
+    // the defect named — collapsing the two would hide 45.3× measure_kind inflation behind a
+    // blank page instead of showing it.
+    expect(isRefusedCard({ form: 'stacked_three', state: 'contested' })).toBe(false);
+    expect(isRefusedCard({ form: 'scalar', state: 'unanswerable' })).toBe(false);
+  });
+});
+
+describe('stampLabel', () => {
+  it('stamps only the two states that need one', () => {
+    expect(stampLabel({ verification_stamp: 'unverified' })).toBe('UNVERIFIED');
+    expect(stampLabel({ verification_stamp: 'pilot' })).toBe('PILOT');
+  });
+
+  it('does not stamp the normal case', () => {
+    expect(stampLabel({ verification_stamp: 'verified' })).toBeNull();
+    expect(stampLabel({ verification_stamp: null })).toBeNull();
+  });
+});

--- a/scripts/run-clarity-answers.mjs
+++ b/scripts/run-clarity-answers.mjs
@@ -165,28 +165,49 @@ async function probeSentinels(sentinels) {
  * sentinel is still RECORDED on the answer so it stays visible, but it does not block: a guard
  * that refuses every question is a guard that gets switched off.
  */
-function flagsFor(slug, ingredients, probes) {
+function flagsFor(slug, ingredients, probes, exemptions = {}) {
   const out = {};
   const reads = new Set(ingredients ?? []);
   for (const [key, r] of Object.entries(probes)) {
     const named = r.applies_to?.includes(slug) ?? false;
     const guarded = (r.guards_objects ?? []).some((o) => reads.has(o));
     const scoped = Boolean(r.applies_to?.length) || Boolean(r.guards_objects?.length);
+    // An exemption is a written, per-question decision that this defect cannot reach this answer.
+    // It never hides the sentinel — the flag still records that it tripped, and carries the reason
+    // so the card can state it. A guard silently detached is the failure mode this replaces.
+    const exemptReason = exemptions[`${key}|${slug}`] ?? null;
     out[key] = {
       tripped: r.tripped,
       n: r.n ?? null,
       share: r.share ?? null,
       severity: r.severity,
       // blocking is a property of THIS question, not of the sentinel alone
-      blocking: r.severity === 'block' && (named || guarded),
+      blocking: r.severity === 'block' && (named || guarded) && !exemptReason,
       scope: !scoped ? 'unscoped' : (named ? 'named' : (guarded ? 'ingredient' : 'not-applicable')),
+      ...(exemptReason ? { exempt_reason: exemptReason } : {}),
       ...(r.error ? { error: r.error } : {}),
     };
   }
   return out;
 }
 
-async function runOne(question, probes) {
+/**
+ * Per-question sentinel exemptions, keyed `sentinelKey|questionSlug`. The reason is NOT NULL in the
+ * schema and is carried onto the answer, because an exemption nobody can read is indistinguishable
+ * from a guard somebody quietly switched off.
+ */
+async function loadExemptions() {
+  const { stdout } = await runPsql(
+    `SELECT coalesce(json_agg(json_build_object(
+       'k', sentinel_key || '|' || question_slug, 'reason', reason)), '[]'::json)
+     FROM clarity_sentinel_exemption`,
+    { tuplesOnly: true },
+  );
+  const line = stdout.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('[')).pop();
+  return Object.fromEntries((line ? JSON.parse(line) : []).map((e) => [e.k, e.reason]));
+}
+
+async function runOne(question, probes, exemptions) {
   const { slug } = question;
   log(`${slug} …`);
   const started = Date.now();
@@ -221,7 +242,7 @@ async function runOne(question, probes) {
     }
   }
 
-  const flags = flagsFor(slug, question.ingredients, probes);
+  const flags = flagsFor(slug, question.ingredients, probes, exemptions);
   const blocked = Object.entries(flags)
     .filter(([, f]) => f.tripped && f.blocking)
     .map(([k]) => k);
@@ -271,9 +292,11 @@ async function main() {
   const sentinels = await loadSentinels();
   log(`probing ${sentinels.length} sentinel(s)`);
   const probes = await probeSentinels(sentinels);
+  const exemptions = await loadExemptions();
+  if (Object.keys(exemptions).length) log(`${Object.keys(exemptions).length} sentinel exemption(s) in force`);
 
   const results = [];
-  for (const question of questions) results.push(await runOne(question, probes));
+  for (const question of questions) results.push(await runOne(question, probes, exemptions));
 
   const failed = results.filter((r) => !r.ok);
   log(`done — ${results.length - failed.length}/${results.length} ok`

--- a/supabase/migrations/20260815001800_clarity_registry_blocked_seven.sql
+++ b/supabase/migrations/20260815001800_clarity_registry_blocked_seven.sql
@@ -1,0 +1,309 @@
+-- /clarity slice 7 (part 1) — FILL THE REGISTRY: the blocked questions, and one that was not
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001800_clarity_registry_blocked_seven.sql
+--
+-- THE FINDING THAT CHANGED THIS MIGRATION.
+--
+-- The spec registers `grant-behind-this-edge` as blocked, on research finding V38: "
+-- gs_relationships.source_record_id is a dead key namespace — 100% orphaned on a 200,000-row
+-- anti-join". That figure has been repeated in four slices, on the seams screen, in the want
+-- list's fix_note and in this spec's own §7.3 refusal to build a record-level provenance drill.
+--
+-- It is wrong today. Measured 2026-08-15 over the full population:
+--
+--     144,901 of 144,901 justice_funding edges resolve to their funding record  =  100.0%
+--
+-- The 0% comes from joining EVERY dataset's source_record_id against justice_funding. aec_donations
+-- keys point at aec rows, austender keys at austender rows; testing them against justice_funding
+-- returns zero, correctly, for the wrong question. The gap metric `justice_edge_drillthrough`
+-- carries that bug in its own SQL, which is why it has never produced a measurement anybody
+-- questioned. Both are fixed below.
+--
+-- The real defect in the same neighbourhood is different and worth naming: 761,801 edges —
+-- person_roles, acnc_register, foundation_board and 40-odd small grantee datasets — carry no
+-- source key at all. Drill-through is not broken there, it was never built.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. A sentinel may be exempted from a question, in writing
+-- ---------------------------------------------------------------------------
+-- `duplicate_canonical_name` and `category_node_hub` both guard gs_relationships, so every
+-- question that reads the graph inherits a block. For a question that counts whether a KEY
+-- resolves, a name-collision defect is real and irrelevant — and a guard that refuses every
+-- question is a guard somebody switches off. The exemption is per-question, requires a written
+-- reason, and renders on the card. Silence is not an option the schema offers.
+CREATE TABLE IF NOT EXISTS clarity_sentinel_exemption (
+  sentinel_key  text NOT NULL REFERENCES clarity_sentinel(key) ON DELETE CASCADE,
+  question_slug text NOT NULL REFERENCES clarity_question(slug) ON DELETE CASCADE,
+  reason        text NOT NULL CHECK (length(btrim(reason)) > 30),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (sentinel_key, question_slug)
+);
+
+COMMENT ON TABLE clarity_sentinel_exemption IS
+  'Per-question sentinel exemptions. The reason is mandatory and is rendered on the answer card: '
+  'an exemption nobody can read is indistinguishable from a guard that was quietly disabled.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Fix the drill-through metric, which was measuring the wrong population
+-- ---------------------------------------------------------------------------
+UPDATE clarity_gap_metric SET
+  title = 'Justice graph edges that resolve to a funding record',
+  numerator_sql = $s$
+    SELECT count(j.id) FROM (
+      SELECT source_record_id::uuid AS rid FROM gs_relationships
+       WHERE dataset = 'justice_funding' AND source_record_id ~ '^[0-9a-f]{8}-'
+    ) s LEFT JOIN justice_funding j ON j.id = s.rid
+  $s$,
+  denominator_sql = $s$
+    SELECT count(*) FROM gs_relationships
+     WHERE dataset = 'justice_funding' AND source_record_id ~ '^[0-9a-f]{8}-'
+  $s$,
+  fix_effort = NULL,
+  fix_note = NULL,
+  note = 'Scoped to dataset = ''justice_funding''. The previous SQL tested every dataset''s '
+      || 'source_record_id against justice_funding and reported 0%, which is true of aec_donations '
+      || 'keys and meaningless as a measure of drill-through. Corrected 2026-08-15.'
+WHERE metric_key = 'justice_edge_drillthrough';
+
+-- The unscoped-edge problem is real, and it is a different metric. Registered rather than folded
+-- into the one above, because 761,801 edges with no key at all is not a low match rate.
+INSERT INTO clarity_gap_metric (
+  metric_key, title, family, question, numerator_sql, denominator_sql,
+  unit, direction, target, cost_class, enabled, note, fix_effort, fix_note
+) VALUES (
+  'edges_without_source_key',
+  'Graph edges carrying no source record key at all',
+  'join_integrity',
+  'What share of the graph can never be drilled back to the record that made it?',
+  $s$SELECT count(*) FROM gs_relationships WHERE source_record_id IS NULL$s$,
+  $s$SELECT count(*) FROM gs_relationships$s$,
+  'pct', 'lower_better', 10, 'medium', true,
+  'person_roles, acnc_register, foundation_board and ~40 small grantee datasets build edges with '
+  || 'no key back to their source row. Not a broken join — a drill-through nobody built.',
+  'M',
+  'Each builder has to carry its source row id through. Bounded per dataset, and the three '
+  || 'largest cover 92% of the affected edges.'
+) ON CONFLICT (metric_key) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 3. THE ANSWER THAT WAS FILED AS A WANT — `grant-behind-this-edge`
+-- ---------------------------------------------------------------------------
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'grant-behind-this-edge',
+  'THE RECEIPT',
+  'Can you click a funding edge in the graph and see the grant record behind it?',
+  'MONEY',
+  'answered', 'scalar', 'entity', 'internal',
+  'verified',
+  'True of justice_funding edges only. 761,801 edges — person_roles, acnc_register, '
+  || 'foundation_board and about forty small grantee datasets — carry no source key at all, so '
+  || 'the drill-through does not fail there, it was never built.',
+  'Edges whose source_record_id is not uuid-shaped are excluded from the denominator rather than '
+  || 'counted as failures; they belong to datasets keyed some other way.',
+  'Every justice funding edge in CivicGraph resolves to the funding record that created it '
+  || '(144,901 of 144,901, measured 2026-08-15).',
+  ARRAY['the graph has no provenance', 'source_record_id is dead'],
+  $q$
+  WITH e AS (
+    SELECT source_record_id::uuid AS rid FROM gs_relationships
+     WHERE dataset = 'justice_funding' AND source_record_id ~ '^[0-9a-f]{8}-'
+  ),
+  r AS (SELECT count(*) AS den, count(j.id) AS num FROM e LEFT JOIN justice_funding j ON j.id = e.rid),
+  ds AS (SELECT dataset, count(*) AS edges, count(source_record_id) AS with_key
+           FROM gs_relationships GROUP BY 1)
+  SELECT jsonb_build_object(
+           'resolved', r.num, 'edges', r.den,
+           'datasets', (SELECT jsonb_agg(jsonb_build_object('dataset', dataset, 'edges', edges,
+                                'with_key', with_key) ORDER BY edges DESC) FROM ds),
+           'edges_without_any_key', (SELECT sum(edges - with_key) FROM ds)
+         ) AS payload,
+         round(100.0 * r.num / nullif(r.den, 0), 1)::text || '%' AS headline,
+         r.num::text || ' of ' || r.den::text || ' justice edges resolve to their funding record'
+           AS headline_sub,
+         round(100.0 * r.num / nullif(r.den, 0), 1) AS headline_num
+    FROM r
+  $q$,
+  $q$
+  SELECT count(source_record_id)::numeric AS numerator, count(*)::numeric AS denominator,
+         'graph edges carrying any source record key' AS label
+    FROM gs_relationships
+  $q$,
+  0.95,
+  'No other surface in either repo measures whether the graph can be walked back to its sources.',
+  '/clarity/q/grant-behind-this-edge'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES
+  -- The `public.` prefix is mandatory: clarity_sentinel.guards_objects is compared against THIS
+  -- column, and an unprefixed key silently detaches every sentinel from the question. My first
+  -- version of this insert did exactly that and the answer ran green with two block sentinels
+  -- tripped and unnoticed.
+  ('grant-behind-this-edge', 'public.gs_relationships', 'source_record_id', 'fact',      true),
+  ('grant-behind-this-edge', 'public.justice_funding',  'id',               'reference', false)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO clarity_sentinel_exemption (sentinel_key, question_slug, reason) VALUES
+  ('duplicate_canonical_name', 'grant-behind-this-edge',
+   'This question counts whether a key resolves, not who the endpoints are. 9,607 duplicate '
+   || 'canonical names corrupt centrality and merge nothing about source_record_id.'),
+  ('category_node_hub', 'grant-behind-this-edge',
+   'Two category nodes carrying 17.6% of edges skews degree, not key resolution. Every edge is '
+   || 'counted once here regardless of which node it hangs off.')
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 4. THE SIX THAT ARE GENUINELY BLOCKED
+-- ---------------------------------------------------------------------------
+-- Every blocking defect below was re-measured against the live database on 2026-08-15 rather than
+-- carried from the spec. Two numbers moved: mv_board_contractor_links is 5 rows, not 4, and
+-- mv_board_donor_links is 3, not 2.
+
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  caveat, exclusions, claim_phrasing, blocked_by, blocked_by_metric,
+  unlock_effort, unlock_note, licence_note, uniqueness, uniqueness_basis, surface
+) VALUES
+
+('indigenous-over-rep', 'OVER-REPRESENTATION',
+ 'How over-represented are Aboriginal and Torres Strait Islander young people in this place, against the population that lives there?',
+ 'JUSTICE', 'unanswerable', 'scalar', 'lga', 'internal',
+ 'Every per-capita Indigenous rate below state level depends on a denominator this database does '
+ || 'not hold. Without it, a rate can be computed and every one of them would be wrong.',
+ '',
+ '',
+ ARRAY['abs_indigenous_population_by_lga'], NULL,
+ 'S',
+ 'abs_indigenous_population_by_lga exists and holds 0 rows. One ABS download, CC-BY-4.0, no '
+ || 'licence negotiation and no scraping.',
+ 'CC-BY-4.0 · ABS Census, freely redistributable',
+ 0.9,
+ 'The rate is computable in several places once the denominator exists; the point is that nowhere '
+ || 'in either repo is it currently computed honestly.',
+ '/clarity/wants'),
+
+('board-to-contractor', 'DIRECTORS AND CONTRACTS',
+ 'Which organisations share a director with a company that holds a government contract?',
+ 'POWER', 'unanswerable', 'ranked_bar', 'person_block', 'internal',
+ 'The interlock substrate is real — mv_board_interlocks holds 39,757 people across multiple '
+ || 'boards. What is missing is the join from those people to contract holders, and the three '
+ || 'matviews that were built to carry it are empty in all but a handful of rows.',
+ '',
+ '',
+ ARRAY['mv_board_contractor_links', 'mv_board_donor_links'], NULL,
+ 'S',
+ 'mv_board_contractor_links holds 5 rows and mv_board_donor_links 3, against mv_board_interlocks '
+ || 'at 39,757 with the same person columns. That shape is a predicate bug in the matview '
+ || 'definitions, not an absence of data. Re-measured 2026-08-15; the spec said 4 and 2.',
+ NULL,
+ 0.95,
+ 'Two flagship cross-sections on /clarity/cross depend on these and currently render nothing.',
+ '/clarity/wants'),
+
+('national-crime-map', 'CRIME, NATIONALLY',
+ 'How does recorded crime by local government area compare with where the money goes, across the country?',
+ 'JUSTICE', 'unanswerable', 'matrix', 'lga', 'internal',
+ 'crime_stats_lga holds 58,125 rows and reads as a national dataset. It is not: NSW alone is '
+ || '51,480 of them, and Western Australia and Tasmania have zero. A national map drawn from this '
+ || 'would silently invent two states and drown five others.',
+ '',
+ '',
+ ARRAY['crime_stats_lga'], NULL,
+ 'M',
+ 'BOCSAR covers NSW well. WA and TAS need their own ingests, each with its own offence '
+ || 'classification to reconcile — that reconciliation is the work, not the download.',
+ 'Mostly open; WA and TAS publish under varying terms',
+ 0.85,
+ 'No other surface attempts crime against funding at LGA grain, precisely because of this gap.',
+ '/clarity/wants'),
+
+('anything-at-sa2', 'SA2 GRAIN',
+ 'Can any claim in this product be made below the local government area?',
+ 'PLACE', 'unanswerable', 'scalar', 'postcode', 'internal',
+ 'gs_entities.sa2_code is populated on 87,800 of 609,405 rows — 14.4%. postcode_geo carries an '
+ || 'sa2_code but is a postcode register, not a complete SA2 one, so it cannot fill the gap.',
+ '',
+ '',
+ ARRAY['gs_entities'], NULL,
+ 'M',
+ 'An ABS SA2 boundary ingest plus a point-in-polygon pass over the entities that have an address. '
+ || 'The /atlas place work has already built the harder half of this for LGAs.',
+ 'CC-BY-4.0 · ABS ASGS',
+ 0.8,
+ 'Every sub-LGA claim anywhere in either product waits on this one column.',
+ '/clarity/wants'),
+
+('nz-crosswalk', 'ACROSS THE TASMAN',
+ 'Which New Zealand charities are the same organisation as an Australian one we already hold?',
+ 'CHARITY', 'unanswerable', 'scalar', 'entity', 'internal',
+ 'nz_charities holds 45,192 rows and every one of them has a null gs_entity_id. The table was '
+ || 'ingested and never crosswalked, so it is present, sizeable, and joins to nothing.',
+ '',
+ '',
+ ARRAY['nz_charities'], NULL,
+ 'S',
+ 'Name-and-registration matching against the spine, the same shape as the ORIC and ACNC '
+ || 'crosswalks that already exist. 0 of 45,192 linked today.',
+ 'NZ Charities Register, open data',
+ 0.7,
+ 'A trans-Tasman view exists nowhere in either repo.',
+ '/clarity/wants')
+
+ON CONFLICT (slug) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 5. THE REFUSAL — the most important state in the set
+-- ---------------------------------------------------------------------------
+-- A refused question gets a full card AND a full page and renders no chart at all. It is the only
+-- place in either repo where a refusal has its own URL. `refuses_when` carries the condition in
+-- prose so the page states the rule rather than implying the data is merely missing.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  caveat, exclusions, claim_phrasing, refuses_when,
+  blocked_by, unlock_effort, unlock_note, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'detention-by-lga', 'DETENTION BY PLACE',
+  'What is the youth detention rate in this local government area?',
+  'JUSTICE', 'refused', 'refused', 'state', 'internal',
+  'AIHW publishes youth justice at state level, quarterly, roughly two quarters lagged, by '
+  || 'design. That is not a defect in their collection and no amount of work here turns it into '
+  || 'an LGA figure.',
+  'Nothing is excluded, because nothing is drawn.',
+  'Youth detention in this database is honest at state level and nowhere finer.',
+  'Asked for any grain below the state. aihw_youth_justice_stats holds 13 rows, one year, '
+  || 'source_table = ''PDF_HEADLINE'', and the Northern Territory is missing entirely — an LGA '
+  || 'choropleth built on it would be a fabrication with a legend.',
+  ARRAY['aihw_youth_justice_stats'],
+  'L',
+  'Per-LGA detention counts do not exist in any published Australian source. Nothing cheap exists, '
+  || 'and pretending otherwise on a want list is its own kind of dishonesty.',
+  0.98,
+  'Every place surface in either repo would draw this map if the data allowed it. This is the '
+  || 'registry saying no, once, with its reasons, at a URL that can be linked.',
+  '/clarity/q/detention-by-lga'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('detention-by-lga', 'public.aihw_youth_justice_stats', 'state', 'fact', true)
+ON CONFLICT DO NOTHING;
+
+-- The convention that bit me, now enforced by the schema instead of by memory. clarity_object
+-- keys are bare; clarity_question_ingredient keys carry `public.` because they are compared
+-- against clarity_sentinel.guards_objects. Two conventions, one comparison, and the failure mode
+-- is silent: the answer runs green with its guards detached.
+ALTER TABLE clarity_question_ingredient
+  DROP CONSTRAINT IF EXISTS ingredient_object_key_is_qualified;
+ALTER TABLE clarity_question_ingredient
+  ADD CONSTRAINT ingredient_object_key_is_qualified
+  CHECK (object_key LIKE 'public.%');
+
+COMMIT;

--- a/supabase/migrations/20260815001900_clarity_registry_two_contested.sql
+++ b/supabase/migrations/20260815001900_clarity_registry_two_contested.sql
@@ -1,0 +1,135 @@
+-- /clarity slice 7 (part 2) — two contested questions whose defects were re-measured today
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815001900_clarity_registry_two_contested.sql
+--
+-- CONTESTED means: answerable, and a named defect must be fixed before the number may be quoted.
+-- The card renders the defect, not a clean figure with a footnote. Both defects below were
+-- re-measured against the live database on 2026-08-15 and both reproduce exactly.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- YOUTH JUSTICE MONEY — measure_kind mixing inflates the topic total 45.3×
+-- ---------------------------------------------------------------------------
+-- Measured today over topics @> ARRAY['youth-justice']:
+--   expenditure_aggregate   848 rows   $66.126bn   ← whole-of-state budgets, not money to anyone
+--   budget_announcement      57 rows    $1.583bn
+--   grant                 4,111 rows    $1.534bn   ← the only kind that is money to an organisation
+--   contract_value          564 rows    $0.195bn
+-- Summed blind: $69.44bn. The honest figure is $1.534bn, and the ratio is 45.3×.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'youth-justice-total', 'YOUTH JUSTICE MONEY',
+  'How much money is recorded against youth justice, and to whom?',
+  'JUSTICE', 'contested', 'stacked_three', 'entity', 'internal',
+  'verified',
+  'measure_kind is a required facet on this question, never a default. Four incompatible measures '
+  || 'share one amount column: whole-of-state expenditure aggregates, budget announcements, grants '
+  || 'to organisations, and contract values. Summing them is not slightly wrong, it is wrong by '
+  || '45.3× and the error runs in the direction that flatters the total.',
+  'Nothing is excluded. Every measure_kind is shown, separately, because the exclusion IS the '
+  || 'answer here.',
+  'CivicGraph records $1.53bn in youth justice grants to organisations. A larger figure circulating '
+  || 'from this database is almost certainly whole-of-state expenditure aggregates counted as grants.',
+  ARRAY['$69bn goes to youth justice', 'total youth justice funding'],
+  $q$
+  WITH k AS (
+    SELECT measure_kind, count(*) AS rows, sum(amount_dollars) AS dollars
+      FROM justice_funding
+     WHERE topics @> ARRAY['youth-justice']
+     GROUP BY 1
+  ),
+  g AS (SELECT dollars, rows FROM k WHERE measure_kind = 'grant'),
+  t AS (SELECT sum(dollars) AS all_dollars FROM k)
+  SELECT jsonb_build_object(
+           'kinds', (SELECT jsonb_agg(jsonb_build_object('measure_kind', measure_kind,
+                              'rows', rows, 'dollars', dollars) ORDER BY dollars DESC) FROM k),
+           'grant_dollars', (SELECT dollars FROM g),
+           'all_dollars', (SELECT all_dollars FROM t),
+           'inflation_factor', round((SELECT all_dollars FROM t) / nullif((SELECT dollars FROM g), 0), 1)
+         ) AS payload,
+         '$' || round((SELECT dollars FROM g) / 1e9, 3)::text || 'bn' AS headline,
+         'grants only · summing every measure_kind would report $'
+           || round((SELECT all_dollars FROM t) / 1e9, 2)::text || 'bn, which is '
+           || round((SELECT all_dollars FROM t) / nullif((SELECT dollars FROM g), 0), 1)::text
+           || '× too high' AS headline_sub,
+         round((SELECT dollars FROM g) / 1e9, 3) AS headline_num
+  $q$,
+  $q$
+  SELECT count(*) FILTER (WHERE measure_kind = 'grant')::numeric AS numerator,
+         count(*)::numeric AS denominator,
+         'youth-justice rows that are grants to an organisation' AS label
+    FROM justice_funding WHERE topics @> ARRAY['youth-justice']
+  $q$,
+  0.97,
+  'Every other surface that totals justice_funding does so without the measure_kind facet, which '
+  || 'is precisely how the 45.3× error travels.',
+  '/clarity/q/youth-justice-total'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('youth-justice-total', 'public.justice_funding', 'measure_kind', 'fact', true)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- WHAT HAS THIS ORG RECEIVED — the rollup's grant lane is empty in every row
+-- ---------------------------------------------------------------------------
+-- Measured today: mv_entity_total_funding holds 94,088 rows and grants_total is exactly zero in
+-- all 94,088. Not sparse, not mostly-zero — zero, everywhere. Any org total read from this MV
+-- understates by the whole grant lane and looks like a real number while doing it.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'org-total-funding', 'WHAT HAS THIS ORG RECEIVED',
+  'What has one organisation received, across every source this database holds?',
+  'MONEY', 'contested', 'stacked_three', 'abn', 'internal',
+  'verified',
+  'mv_entity_total_funding.grants_total is exactly 0 across all 94,088 rows, so any per-org total '
+  || 'read from it silently omits grants entirely. Until the matview is rebuilt this question '
+  || 'shows contracts and justice funding only, and says so on the card rather than in a footnote.',
+  'Grants are excluded because the column that should carry them carries nothing. This is a '
+  || 'defect being reported, not a scope decision.',
+  'Organisation totals in CivicGraph currently cover contracts and justice funding. The grant lane '
+  || 'of the rollup matview is empty and is not included.',
+  ARRAY['total funding received', 'all money this org has received'],
+  $q$
+  WITH m AS (
+    SELECT count(*) AS rows,
+           count(*) FILTER (WHERE grants_total <> 0) AS with_grants,
+           sum(contracts_total) AS contracts, sum(justice_total) AS justice
+      FROM mv_entity_total_funding
+  )
+  SELECT jsonb_build_object(
+           'rows', rows, 'rows_with_grants', with_grants,
+           'contracts_total', contracts, 'justice_total', justice
+         ) AS payload,
+         with_grants::text || ' of ' || rows::text AS headline,
+         'rows in the org rollup carry any grant total — the grant lane of this matview is empty'
+           AS headline_sub,
+         with_grants AS headline_num
+    FROM m
+  $q$,
+  $q$
+  SELECT count(*) FILTER (WHERE grants_total <> 0)::numeric AS numerator,
+         count(*)::numeric AS denominator,
+         'rollup rows carrying a grant total' AS label
+    FROM mv_entity_total_funding
+  $q$,
+  0.9,
+  '/entity/[gsId] and several report pages read this matview and present its totals as complete.',
+  '/clarity/q/org-total-funding'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('org-total-funding', 'public.mv_entity_total_funding', 'entity_id', 'spine', true)
+ON CONFLICT DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
Last of the seven slices, in two parts. This is part one: the registry goes from 3 questions to 12 — four answered, two contested, five blocked, one **refused**.

## The finding that changed this slice

The spec files `grant-behind-this-edge` as blocked, on research finding V38: `gs_relationships.source_record_id` is *"a dead key namespace — 100% orphaned on a 200,000-row anti-join"*. That figure has ridden along through four slices. It is on the seams screen, in the want list's `fix_note`, and it is the stated reason §7.3 refuses to build a record-level provenance drill at all.

Measured today, over the full population:

> **144,901 of 144,901 justice edges resolve to their funding record — 100.0%**

The 0% comes from testing **every** dataset's `source_record_id` against `justice_funding`. aec_donations keys point at aec rows, austender keys at austender rows; testing them against justice_funding returns zero, correctly, for the wrong question. The gap metric `justice_edge_drillthrough` carried the same bug in its own SQL, which is why its number was never questioned. Both are fixed and the want is now an answered question.

The real defect next door is different and now has its own metric: **761,801 edges carry no source key at all** — person_roles, acnc_register, foundation_board and ~40 small grantee datasets. Not a broken join. A drill-through nobody built.

## What ships

**The refused form.** `detention-by-lga` renders no chart, no number and no copyable claim — a refusal that draws a greyed-out version of the thing it is refusing to draw is still drawing it. It carries `refuses_when` in prose, what we can honestly show instead, and a live link onward. The only place in either repo where a refusal has its own URL.

**UNVERIFIED / PILOT stamps.** Stamped where it matters, and deliberately absent on `verified` — stamping the normal case teaches readers to ignore stamps.

**Five blocked questions**, every blocking defect re-measured against the live database rather than carried from the spec. Two numbers moved: `mv_board_contractor_links` is 5 rows, not 4; `mv_board_donor_links` is 3, not 2. They flow straight onto `/clarity/wants` from slice 6.

**Two contested questions**, both reproducing exactly:
- `youth-justice-total` — mixing `measure_kind` inflates the topic total **45.3×** ($69.44bn against $1.534bn in actual grants). The facet is required, never defaulted.
- `org-total-funding` — `mv_entity_total_funding.grants_total` is exactly **0 across all 94,088 rows**, so every per-org total in the product omits the grant lane while looking complete.

## Two bugs in my own work, both now structurally impossible

- My first ingredient rows omitted the `public.` prefix. `clarity_sentinel.guards_objects` is compared against that column, so the sentinels **silently detached** and the answer ran green with two block sentinels tripped and unnoticed. Now a CHECK constraint.
- Both graph sentinels guard `gs_relationships`, so every question reading the graph inherits a block — including one that counts whether a *key* resolves, where a name-collision defect is real and irrelevant. Rather than detach the guard, `clarity_sentinel_exemption` records a per-question exemption with a **mandatory written reason**, rendered in full on the card. A guard that refuses everything is a guard somebody switches off.

## Verification

- Migrations `20260815001800` and `20260815001900` **applied**. All three new answers computed through `run-clarity-answers.mjs`: `grant-behind-this-edge` 100.0% / 4.7s, `youth-justice-total` $1.534bn / 257ms, `org-total-funding` 0 of 94,088 / 279ms.
- `npx tsc --noEmit` clean · `npx vitest run src/app/clarity` — **17 tests, 4 files**, all pass.

## What is NOT in this PR

Fourteen questions remain — the rest of the answered set (interlocked boards, off-spine grants, revolving door, government dependence, every-dollar-one-ABN and friends) plus three more contested. Each needs its own SQL authored and verified against real tables, one at a time. That is the "and ongoing" half of a slice the spec prices at three days, and seeding fourteen half-verified cards is the exact failure this surface exists to prevent.

## Still unverified

**No `/clarity` screen has ever been rendered for a human** — this is the sixth slice with that caveat, and it now includes the refusal, which is a screen whose whole job is how it reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)