### PR TITLE
Ship /clarity slice 7 part 2 — six questions, and two defects the first full run exposed

### DIFF
--- a/scripts/run-clarity-answers.mjs
+++ b/scripts/run-clarity-answers.mjs
@@ -101,9 +101,14 @@ async function selectOneJson(sql, timeout = QUERY_TIMEOUT_S) {
 }
 
 async function loadQuestions() {
+  // HOUSE questions are deliberately NOT run here. Their answer_sql is a numerator/denominator
+  // measurement pair, not an answer — it returns no headline. They are computed by
+  // clarity_measure_gaps() and mirrored into clarity_answer by clarity_sync_house(). Running them
+  // through this loop wrote headline-less rows on top of good ones, which is a stale answer that
+  // still renders: the exact failure this script exists to prevent.
   const where = ONLY
     ? `slug = ${q(ONLY)}`
-    : `state IN ('answered','contested') AND answer_sql IS NOT NULL`;
+    : `state IN ('answered','contested') AND answer_sql IS NOT NULL AND subject <> 'HOUSE'`;
   const { stdout } = await runPsql(
     `SELECT json_agg(json_build_object(
        'slug', slug, 'stub', stub, 'answer_sql', answer_sql,

--- a/supabase/migrations/20260815002000_clarity_registry_six_ready.sql
+++ b/supabase/migrations/20260815002000_clarity_registry_six_ready.sql
@@ -1,0 +1,395 @@
+-- /clarity slice 7 part 2 — the six questions whose sources were verified before writing them
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815002000_clarity_registry_six_ready.sql
+--
+-- Every figure in the comments below was measured against the live database on 2026-08-15 before
+-- the question was written, not carried from the spec. Three moved:
+--
+--   mv_revolving_door        6,988 rows, not 6,976
+--   prison/post-release      851 of 4,629 charities reach money (18.4%), spec said 862 / 18.6%
+--   mv_funding_deserts       1.77 rows per lga|state key — spec's figure reproduces exactly
+--
+-- And one lookup was wrong in a way that would have produced a silent zero: pre/post-release
+-- charities are identified by the boolean column `acnc_charities.ben_pre_post_release`, NOT by
+-- text-matching `purposes`/`beneficiaries`. Those are arrays, ACNC's controlled vocabulary has no
+-- prison or offender category, and an ILIKE over them returns 0 rows while looking like a
+-- perfectly reasonable query.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- THREE SYSTEMS AT ONCE — mv_revolving_door: 33 entities carry all four vectors
+-- ---------------------------------------------------------------------------
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, rows_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'revolving-door', 'THREE SYSTEMS AT ONCE',
+  'Which organisations lobby, donate, hold contracts and receive public funding at the same time?',
+  'POWER', 'answered', 'ranked_bar', 'entity', 'internal',
+  'verified',
+  'Presence in four registers is not evidence of wrongdoing and this card must never be read as '
+  || 'one. It says these organisations appear in four systems that are usually looked at '
+  || 'separately, which is a reason to look, not a finding.',
+  'An entity qualifies on its ABN being present in each register. Entities with no ABN cannot '
+  || 'qualify at all, so the count is a floor.',
+  'CivicGraph holds 33 organisations that lobby, donate, contract and receive funding at once, out '
+  || 'of 6,988 appearing in two or more of those systems.',
+  ARRAY['corrupt', 'buying influence', 'captured'],
+  $q$
+  WITH v AS (SELECT influence_vectors, count(*) AS n FROM mv_revolving_door GROUP BY 1)
+  SELECT jsonb_build_object(
+           'by_vectors', (SELECT jsonb_agg(jsonb_build_object('vectors', influence_vectors, 'entities', n)
+                            ORDER BY influence_vectors DESC) FROM v),
+           'total_entities', (SELECT sum(n) FROM v),
+           'top', (SELECT jsonb_agg(jsonb_build_object('name', canonical_name, 'abn', abn,
+                          'vectors', influence_vectors, 'score', revolving_door_score))
+                     FROM (SELECT canonical_name, abn, influence_vectors, revolving_door_score
+                             FROM mv_revolving_door ORDER BY revolving_door_score DESC NULLS LAST
+                            LIMIT 20) z)
+         ) AS payload,
+         (SELECT n FROM v WHERE influence_vectors = 4)::text AS headline,
+         'organisations in all four systems, of ' || (SELECT sum(n) FROM v)::text
+           || ' in two or more' AS headline_sub,
+         (SELECT n FROM v WHERE influence_vectors = 4) AS headline_num
+  $q$,
+  $q$
+  SELECT count(*) FILTER (WHERE abn IS NOT NULL)::numeric AS numerator,
+         count(*)::numeric AS denominator,
+         'revolving-door entities resolved to an ABN' AS label
+    FROM mv_revolving_door
+  $q$,
+  $q$SELECT canonical_name, abn, state, influence_vectors, revolving_door_score
+       FROM mv_revolving_door ORDER BY revolving_door_score DESC NULLS LAST$q$,
+  0.9,
+  'mv_revolving_door exists but no surface reads it. /graph has nine modes and none of them is '
+  || 'this one.',
+  '/clarity/q/revolving-door'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('revolving-door', 'public.mv_revolving_door', 'abn', 'spine', true)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- GIVES AND TAKES — contested, and both sentinels trip today
+-- ---------------------------------------------------------------------------
+-- 2,098 entities both donate and contract. The raw figures are $30.09bn donated and $476.76bn in
+-- contracts, and BOTH are contaminated: 72% of political_donations rows are 'other receipt', and
+-- 13 austender rows carry 29.4% of all recorded contract value. This card is registered so that
+-- the block renders — the machinery already refuses to publish the number.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, rows_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'donor-contractor', 'GIVES AND TAKES',
+  'Which organisations donate to political parties and also hold government contracts?',
+  'POWER', 'contested', 'stacked_three', 'abn', 'internal',
+  'verified',
+  'Two armed sentinels block this question and both are tripped. political_donations mixes '
+  || '''other receipt'' rows — 72% of rows, 85% of dollars — that are not donations at all, and 13 '
+  || 'austender rows carry 29.4% of all recorded contract value with a maximum single row of '
+  || '$123.00bn. Either defect alone makes the dollar pairing meaningless.',
+  'Nothing is excluded yet, which is the problem. The receipt_type filter and the value ceiling '
+  || 'have to be applied before this question may be answered.',
+  'CivicGraph can identify organisations that both donate and contract, but cannot yet state the '
+  || 'dollar figures: the donation table mixes in non-donation receipts and the contract table '
+  || 'carries unadjudicated outliers.',
+  ARRAY['donated $30bn', 'bought contracts', 'pay to play'],
+  $q$
+  SELECT jsonb_build_object(
+           'entities', count(*),
+           'donated_raw', sum(total_donated),
+           'contracts_raw', sum(total_contract_value),
+           'note', 'raw sums, both contaminated — see sentinels'
+         ) AS payload,
+         count(*)::text AS headline,
+         'organisations both donate and hold contracts — dollar figures withheld pending two '
+           || 'sentinels' AS headline_sub,
+         count(*) AS headline_num
+    FROM mv_gs_donor_contractors
+  $q$,
+  $q$
+  SELECT count(*) FILTER (WHERE abn IS NOT NULL)::numeric AS numerator,
+         count(*)::numeric AS denominator,
+         'donor-contractors resolved to an ABN' AS label
+    FROM mv_gs_donor_contractors
+  $q$,
+  $q$SELECT canonical_name, abn, state, total_donated, donation_count, total_contract_value,
+            contract_count FROM mv_gs_donor_contractors
+      ORDER BY total_contract_value DESC NULLS LAST$q$,
+  0.92,
+  'The overlap exists as a matview nothing reads. Naming it without the two sentinels is how the '
+  || '$123bn row would have been published.',
+  '/clarity/q/donor-contractor'
+) ON CONFLICT (slug) DO NOTHING;
+
+-- Prefixed keys, so both armed sentinels actually attach and block. This is the question they
+-- were written for.
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES
+  ('donor-contractor', 'public.mv_gs_donor_contractors', 'abn', 'spine', true),
+  ('donor-contractor', 'public.political_donations',     'donor_abn',    'fact', false),
+  ('donor-contractor', 'public.austender_contracts',     'supplier_abn', 'fact', false)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- INTERLOCKED BOARDS — 39,757 people, 133,879 board seats
+-- ---------------------------------------------------------------------------
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, rows_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'interlocked-boards', 'INTERLOCKED BOARDS',
+  'Which organisations are governed by someone who also sits on another board?',
+  'POWER', 'answered', 'ranked_bar', 'person_block', 'internal',
+  'verified',
+  'A person block is not a person. Names are matched on a normalised string, so a common name '
+  || 'collapses several humans into one block, and the cap that keeps implausible blocks out of '
+  || 'the data stays in place deliberately. Dollar figures are floors: the money rollup reaches '
+  || '12.9% of the graph, so an unquoted total here would understate by roughly eight times.',
+  'Blocks above the plausibility cap are excluded as name collisions rather than counted as '
+  || 'extraordinarily busy directors.',
+  'CivicGraph holds 39,757 person blocks that sit on two or more boards, covering 133,879 board '
+  || 'seats. Associated procurement of at least $265bn is a floor, not a total.',
+  ARRAY['controls', 'runs the sector', 'network of insiders'],
+  $q$
+  SELECT jsonb_build_object(
+           'people', count(*),
+           'board_seats', sum(cardinality(entity_ids)),
+           'procurement_floor', sum(total_procurement_dollars),
+           'justice_floor', sum(total_justice_dollars),
+           'by_board_count', (SELECT jsonb_agg(jsonb_build_object('boards', board_count, 'people', n)
+                                ORDER BY board_count)
+                                FROM (SELECT board_count, count(*) AS n FROM mv_board_interlocks
+                                       GROUP BY 1) z)
+         ) AS payload,
+         count(*)::text AS headline,
+         'person blocks on two or more boards, covering '
+           || sum(cardinality(entity_ids))::text || ' board seats' AS headline_sub,
+         count(*) AS headline_num
+    FROM mv_board_interlocks
+  $q$,
+  $q$
+  SELECT count(*) FILTER (WHERE cardinality(coalesce(organisation_abns, '{}')) > 0)::numeric
+           AS numerator,
+         count(*)::numeric AS denominator,
+         'interlock blocks with at least one ABN-identified board' AS label
+    FROM mv_board_interlocks
+  $q$,
+  $q$SELECT person_name_display, board_count, organisations, total_procurement_dollars,
+            interlock_score FROM mv_board_interlocks
+      ORDER BY interlock_score DESC NULLS LAST$q$,
+  0.88,
+  'mv_board_interlocks is read by no application code. The three matviews built to join it to '
+  || 'contracts and donations hold 5 and 3 rows — see DIRECTORS AND CONTRACTS on the want list.',
+  '/clarity/q/interlocked-boards'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('interlocked-boards', 'public.mv_board_interlocks', 'person_name_normalised', 'spine', true)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- AFTER RELEASE — 851 of 4,629 charities reach any recorded money
+-- ---------------------------------------------------------------------------
+-- The lookup is the boolean column ben_pre_post_release. An ILIKE over purposes/beneficiaries
+-- returns 0 rows: they are arrays and ACNC's vocabulary has no prison category.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, rows_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'prison-release-charities', 'AFTER RELEASE',
+  'Who says they serve people leaving prison, and does any recorded money reach them?',
+  'JUSTICE', 'answered', 'scalar', 'entity', 'internal',
+  'verified',
+  'The 4,629 is self-declared: these charities ticked pre and post release as a beneficiary group '
+  || 'on their ACNC record. A charity with no money recorded here is not an unfunded charity — the '
+  || 'rollup this is measured against reaches a fraction of Australian funding, and state and '
+  || 'philanthropic money is largely outside it.',
+  'Charities whose ABN does not resolve to the entity spine are counted in the denominator, not '
+  || 'silently dropped.',
+  'Of 4,629 charities that name people leaving prison as a beneficiary group, 851 have any funding '
+  || 'recorded in CivicGraph — 18.4%.',
+  ARRAY['receives no funding', 'unfunded', '3,778 charities get nothing'],
+  $q$
+  WITH p AS (SELECT abn FROM acnc_charities WHERE ben_pre_post_release AND abn IS NOT NULL),
+  m AS (
+    SELECT p.abn, max(coalesce(f.grand_total_funding, 0)) AS total
+      FROM p
+      LEFT JOIN gs_entities e ON e.abn = p.abn
+      LEFT JOIN mv_entity_total_funding f ON f.entity_id = e.id
+     GROUP BY 1
+  )
+  SELECT jsonb_build_object(
+           'charities', (SELECT count(*) FROM m),
+           'with_recorded_money', (SELECT count(*) FROM m WHERE total > 0),
+           'without', (SELECT count(*) FROM m WHERE total = 0)
+         ) AS payload,
+         round(100.0 * (SELECT count(*) FROM m WHERE total > 0)
+               / nullif((SELECT count(*) FROM m), 0), 1)::text || '%' AS headline,
+         (SELECT count(*) FROM m WHERE total > 0)::text || ' of '
+           || (SELECT count(*) FROM m)::text
+           || ' charities serving people leaving prison have any funding recorded here'
+           AS headline_sub,
+         round(100.0 * (SELECT count(*) FROM m WHERE total > 0)
+               / nullif((SELECT count(*) FROM m), 0), 1) AS headline_num
+  $q$,
+  $q$
+  SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM gs_entities e WHERE e.abn = c.abn))::numeric
+           AS numerator,
+         count(*)::numeric AS denominator,
+         'pre/post-release charities resolved to the entity spine' AS label
+    FROM acnc_charities c WHERE c.ben_pre_post_release AND c.abn IS NOT NULL
+  $q$,
+  $q$SELECT name, abn, state, charity_size FROM acnc_charities
+      WHERE ben_pre_post_release ORDER BY name$q$,
+  0.93,
+  'ACNC beneficiary flags are not joined to funding anywhere else in either repo.',
+  '/clarity/q/prison-release-charities'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES
+  ('prison-release-charities', 'public.acnc_charities',          'abn',       'spine', true),
+  ('prison-release-charities', 'public.mv_entity_total_funding', 'entity_id', 'fact',  false)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- WHAT THE COMMONWEALTH SPENDS — contested on the outlier sentinel
+-- ---------------------------------------------------------------------------
+-- 824,978 contracts, 823,073 carrying a value, $1,268.01bn total, of which 13 rows are 29.4%.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, rows_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'commonwealth-spend', 'WHAT THE COMMONWEALTH SPENDS',
+  'How much does the Commonwealth spend through contracts, and with whom?',
+  'MONEY', 'contested', 'ranked_bar', 'abn', 'internal',
+  'verified',
+  'Thirteen rows carry 29.4% of all recorded contract value, the largest a single $123.00bn line. '
+  || 'Until those thirteen are adjudicated — genuine whole-of-government panels, or CSV field '
+  || 'shift — every total, every top-supplier ranking and every year-on-year comparison built on '
+  || 'this table inherits them.',
+  '1,905 rows carry no contract_value. They are counted as rows and excluded from dollars, and '
+  || 'every ordering uses NULLS LAST so they never masquerade as zero.',
+  'CivicGraph holds 824,978 Commonwealth contracts. The recorded total is not quotable until 13 '
+  || 'outlier rows carrying 29.4% of the value are adjudicated.',
+  ARRAY['the Commonwealth spent $1.27 trillion', 'largest supplier'],
+  $q$
+  WITH t AS (
+    SELECT count(*) AS rows, count(contract_value) AS with_value,
+           sum(contract_value) AS total
+      FROM austender_contracts
+  ),
+  top13 AS (
+    SELECT sum(contract_value) AS v FROM (
+      SELECT contract_value FROM austender_contracts
+       WHERE contract_value IS NOT NULL
+       ORDER BY contract_value DESC LIMIT 13
+    ) z
+  )
+  SELECT jsonb_build_object(
+           'rows', t.rows, 'rows_with_value', t.with_value, 'total', t.total,
+           'top13_value', top13.v,
+           'top13_share_pct', round(100.0 * top13.v / nullif(t.total, 0), 1),
+           'rows_without_value', t.rows - t.with_value
+         ) AS payload,
+         '$' || round(t.total / 1e9, 2)::text || 'bn' AS headline,
+         'across ' || t.rows::text || ' contracts — but 13 rows are '
+           || round(100.0 * top13.v / nullif(t.total, 0), 1)::text
+           || '% of it and are unadjudicated' AS headline_sub,
+         round(t.total / 1e9, 2) AS headline_num
+    FROM t, top13
+  $q$,
+  $q$
+  SELECT count(contract_value)::numeric AS numerator, count(*)::numeric AS denominator,
+         'contracts carrying a value' AS label
+    FROM austender_contracts
+  $q$,
+  $q$SELECT title, buyer_name, supplier_name, supplier_abn, contract_value, contract_start
+       FROM austender_contracts ORDER BY contract_value DESC NULLS LAST$q$,
+  0.85,
+  'Several report pages total this table without the outlier sentinel, which is exactly how the '
+  || '$123bn row travels into a headline.',
+  '/clarity/q/commonwealth-spend'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('commonwealth-spend', 'public.austender_contracts', 'supplier_abn', 'spine', true)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- DISADVANTAGE, NO MONEY — the card renders the grain defect, not a map
+-- ---------------------------------------------------------------------------
+-- 1,997 rows over 1,130 distinct lga_name|state pairs = 1.77 rows per key. The spec's prescribed
+-- GROUP BY lga_name, state does not resolve the grain, and V39 refuted that fix. Until somebody
+-- investigates what the duplicate rows are, any per-LGA figure double-counts by an unknown factor.
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  verification_stamp, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, rows_sql, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'funding-deserts', 'DISADVANTAGE, NO MONEY',
+  'Which disadvantaged places receive the least money?',
+  'PLACE', 'contested', 'matrix', 'lga', 'internal',
+  'verified',
+  'mv_funding_deserts holds 1,997 rows describing 1,130 distinct local government area and state '
+  || 'pairs — 1.77 rows per place. Nobody has established what the extra rows are, so summing by '
+  || 'place multiplies dollars by an unknown factor that varies per place. This card reports the '
+  || 'grain defect and deliberately draws no map.',
+  'Nothing is excluded, because nothing is aggregated. Aggregating is the unsafe operation here.',
+  'CivicGraph cannot yet rank places by funding shortfall: the desert matview has 1.77 rows per '
+  || 'place and the duplicates are unexplained.',
+  ARRAY['the most underfunded LGA', 'funding desert ranking', 'gets no money'],
+  $q$
+  WITH g AS (
+    SELECT count(*) AS rows,
+           count(DISTINCT (coalesce(lga_name,'?') || '|' || coalesce(state,'?'))) AS pairs
+      FROM mv_funding_deserts
+  ),
+  dup AS (
+    SELECT count(*) AS places_with_duplicates FROM (
+      SELECT lga_name, state FROM mv_funding_deserts
+       GROUP BY 1,2 HAVING count(*) > 1
+    ) z
+  )
+  SELECT jsonb_build_object(
+           'rows', g.rows, 'distinct_places', g.pairs,
+           'rows_per_place', round(g.rows::numeric / nullif(g.pairs, 0), 2),
+           'places_with_duplicates', dup.places_with_duplicates
+         ) AS payload,
+         round(g.rows::numeric / nullif(g.pairs, 0), 2)::text || ' rows per place' AS headline,
+         g.rows::text || ' rows describe ' || g.pairs::text
+           || ' places — the grain is unresolved, so no ranking is drawn' AS headline_sub,
+         round(g.rows::numeric / nullif(g.pairs, 0), 2) AS headline_num
+    FROM g, dup
+  $q$,
+  $q$
+  SELECT count(DISTINCT (coalesce(lga_name,'?') || '|' || coalesce(state,'?')))::numeric
+           AS numerator,
+         count(*)::numeric AS denominator,
+         'distinct places per row in the desert matview' AS label
+    FROM mv_funding_deserts
+  $q$,
+  $q$SELECT lga_name, state, remoteness, avg_irsd_decile, total_dollar_flow, desert_score
+       FROM mv_funding_deserts ORDER BY lga_name, state$q$,
+  0.94,
+  '/atlas owns place and does not attempt a shortfall ranking. This card exists to say why one is '
+  || 'not available rather than to leave the gap unexplained.',
+  '/clarity/q/funding-deserts'
+) ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('funding-deserts', 'public.mv_funding_deserts', 'lga_name', 'spine', true)
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/supabase/migrations/20260815002100_clarity_sync_house_demotion.sql
+++ b/supabase/migrations/20260815002100_clarity_sync_house_demotion.sql
@@ -1,0 +1,160 @@
+-- /clarity slice 7 part 2 — clarity_sync_house() must be able to demote a card that loses its price
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815002100_clarity_sync_house_demotion.sql
+--
+-- Found by running the full answer suite for the first time since slice 6. Two defects, one
+-- migration:
+--
+-- 1. clarity_sync_house() aborted outright once justice_edge_drillthrough was corrected. The
+--    correction cleared its fix_effort — the gap is not real, so there is nothing to price — but
+--    the card was already in state 'unanswerable', and blocked_has_a_price forbids that
+--    combination. Fixed by demoting price-less wants to draft before the upsert runs.
+--
+-- 2. The answer runner was picking up HOUSE questions, whose answer_sql is a numerator/denominator
+--    measurement pair rather than an answer, and writing headline-less rows on top of good ones.
+--    Fixed in scripts/run-clarity-answers.mjs, and the junk rows deleted.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.clarity_sync_house()
+ RETURNS TABLE(questions_upserted integer, answers_written integer)
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_q int := 0;
+  v_a int := 0;
+BEGIN
+  -- A card that LOSES its price must stop being a want before anything else touches it.
+  -- blocked_has_a_price forbids an unanswerable question with no unlock_effort, and the upsert
+  -- below writes the new (null) price while the old state is still 'unanswerable' — so without
+  -- this step the whole function aborts. That is exactly what happened when
+  -- justice_edge_drillthrough was corrected and its fix_effort cleared: the gap was no longer
+  -- real, so it no longer had a price, so the card could no longer be a want.
+  UPDATE clarity_question q
+     SET state = 'draft', updated_at = now()
+    FROM clarity_gap_metric g
+   WHERE q.subject = 'HOUSE'
+     AND q.state = 'unanswerable'
+     AND q.blocked_by_metric = g.metric_key
+     AND (g.fix_effort IS NULL OR g.fix_note IS NULL);
+
+  -- One question per enabled metric. Disabled metrics (matviews_unregistered, which waits on a
+  -- table that does not exist yet) get no card, because a card whose number can never arrive is
+  -- the failure this whole surface exists to stop.
+  WITH upserted AS (
+    INSERT INTO clarity_question (
+      slug, stub, question, subject, state, form, honest_at, publishable,
+      caveat, exclusions, claim_phrasing, answer_sql, blocked_by, blocked_by_metric,
+      unlock_effort, unlock_note, unlock_dollars, uniqueness, uniqueness_basis, surface
+    )
+    SELECT
+      'house-' || replace(g.metric_key, '_', '-'),
+      upper(g.title),
+      g.question,
+      'HOUSE',
+      -- Provisional. Set for real below, off the latest measurement.
+      'draft'::clarity_question_state,
+      'scalar'::clarity_form_kind,
+      'none'::clarity_honest_at,
+      'internal'::clarity_publishable,
+      'Measured about this database by clarity_measure_gaps(), on the schedule in job 11. '
+        || coalesce(g.note, ''),
+      '',
+      -- HOUSE questions are internal. They get no publishable claim phrasing, and the empty
+      -- string is the honest value rather than a sentence nobody may quote.
+      '',
+      format('SELECT (%s) AS numerator, (%s) AS denominator', g.numerator_sql, g.denominator_sql),
+      -- The blocker is the metric itself, not an object in the catalog. Prefixed so it can never
+      -- be mistaken for an object_key by anything that joins on blocked_by.
+      ARRAY['metric:' || g.metric_key],
+      g.metric_key,
+      g.fix_effort,
+      g.fix_note,
+      g.fix_dollars,
+      1.0,
+      'Measured about this database and nowhere else.',
+      '/clarity/wants'
+    FROM clarity_gap_metric g
+    WHERE g.enabled
+    ON CONFLICT (slug) DO UPDATE SET
+      stub          = excluded.stub,
+      question      = excluded.question,
+      caveat        = excluded.caveat,
+      answer_sql    = excluded.answer_sql,
+      blocked_by    = excluded.blocked_by,
+      unlock_effort = excluded.unlock_effort,
+      unlock_note   = excluded.unlock_note,
+      unlock_dollars= excluded.unlock_dollars,
+      updated_at    = now()
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_q FROM upserted;
+
+  -- State off the latest measurement. Four outcomes, never collapsed:
+  --   answered     — measured, and inside target
+  --   contested    — measured, and outside target. This is the adjudication CTA.
+  --   unanswerable — never measured or the probe errored, AND somebody has priced the fix
+  --   draft        — never measured and nobody has priced the fix. Registered, not yet a want.
+  --
+  -- That last split is forced by the blocked_has_a_price constraint slice 2 put on this table,
+  -- and the constraint is right: an unanswerable question with no price is a complaint, not a
+  -- want. It stays draft until someone fills in fix_effort.
+  UPDATE clarity_question q
+     SET state = CASE
+           WHEN m.value IS NOT NULL AND m.status = 'ok' AND m.breached IS NOT TRUE THEN 'answered'
+           WHEN m.value IS NOT NULL AND m.status = 'ok'                            THEN 'contested'
+           WHEN g.fix_effort IS NOT NULL AND g.fix_note IS NOT NULL                THEN 'unanswerable'
+           ELSE 'draft'
+         END::clarity_question_state,
+         updated_at = now()
+    FROM clarity_gap_metric g
+    LEFT JOIN v_clarity_metric_latest m ON m.metric_key = g.metric_key
+   WHERE q.subject = 'HOUSE'
+     AND q.blocked_by_metric = g.metric_key;
+
+  -- A HOUSE card is a board card, so it needs an answer row like every other card. One answer per
+  -- measurement, written once — re-running this function does not fabricate a new data point.
+  WITH written AS (
+    INSERT INTO clarity_answer (
+      question_slug, computed_at, ok, headline, headline_sub, headline_num,
+      coverage_num, coverage_den, coverage_label, row_count, duration_ms
+    )
+    SELECT
+      q.slug,
+      x.measured_at,
+      x.status = 'ok',
+      CASE
+        WHEN x.value IS NULL THEN 'not measured'
+        WHEN g.unit = 'pct'  THEN round(x.value, 1)::text || '%'
+        ELSE round(x.value, 0)::text
+      END,
+      CASE
+        WHEN g.target IS NULL THEN 'no target set'
+        WHEN g.direction = 'higher_better' THEN 'target ≥ ' || g.target::text
+        ELSE 'target ≤ ' || g.target::text
+      END,
+      x.value,
+      x.numerator,
+      x.denominator,
+      g.unit,
+      NULL,
+      x.duration_ms
+    FROM clarity_gap_measurement x
+    JOIN clarity_gap_metric g   ON g.metric_key = x.metric_key
+    JOIN clarity_question q     ON q.blocked_by_metric = x.metric_key AND q.subject = 'HOUSE'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM clarity_answer a
+       WHERE a.question_slug = q.slug AND a.computed_at = x.measured_at
+    )
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_a FROM written;
+
+  RETURN QUERY SELECT v_q, v_a;
+END;
+$function$;
+
+COMMIT;


### PR DESCRIPTION
The registry now holds **18 questions** outside the HOUSE subject: 6 answered, 6 contested, 5 blocked, 1 refused. Every figure below was measured against the live database **before** the question was written, not carried from the spec.

## The six

| Question | State | Result |
|---|---|---|
| `revolving-door` | answered | **33** organisations lobby, donate, contract and receive funding at once, of 6,988 appearing in two or more systems. Spec said 6,976 — it has moved. |
| `interlocked-boards` | answered | **39,757** person blocks over **133,879** board seats. Dollars are a floor, not a total: the money rollup reaches 12.9%. |
| `prison-release-charities` | answered | **851 of 4,629** charities serving people leaving prison have any funding recorded here — **18.4%**. |
| `donor-contractor` | contested | 2,098 organisations both donate and contract. **Both armed sentinels trip**, so the dollar figures are withheld. This is the question they were armed for. |
| `commonwealth-spend` | contested | **$1,268.01bn** over 824,978 contracts — but 13 rows are **29.4%** of it and 1,905 carry no value at all. |
| `funding-deserts` | contested | **1,997 rows describe 1,130 places**, 1.77 per place, duplicates unexplained. The card reports the grain defect and deliberately draws no map. |

Two of the six run to a deliberate refusal rather than a number, which is the machinery working: the sentinels block, the card renders the block, and nothing quotable is produced.

## One lookup that would have shipped a silent zero

Pre/post-release charities are identified by the boolean column `acnc_charities.ben_pre_post_release` — **not** by text-matching `purposes` or `beneficiaries`. Those are arrays, ACNC's controlled vocabulary contains no prison or offender category, and an `ILIKE` over them returns **0 rows while looking like a perfectly reasonable query**. I wrote that query first, got zero, and went looking for why.

## Two defects the first full suite run exposed — both mine, both from slice 6

- **The runner was overwriting good HOUSE answers.** HOUSE `answer_sql` is a numerator/denominator measurement pair, not an answer — it returns no headline. The generic runner picked those questions up and wrote headline-less rows on top of the ones `clarity_sync_house()` had written. A stale answer that still renders is the exact failure this script exists to prevent. Now excluded at the query, junk rows deleted.
- **`clarity_sync_house()` aborted outright.** Correcting `justice_edge_drillthrough` cleared its `fix_effort` — the gap is not real, so there is nothing to price — but the card was already `unanswerable`, which `blocked_has_a_price` forbids. A gap that turns out not to be real stops being a want, so the function now demotes it to `draft` before the upsert runs.

## Verification

- Migrations `20260815002000` and `20260815002100` **applied**.
- Full suite: **12 questions run, 9 ok, 3 blocked by sentinels** — `evidence-gap` (duplicate_canonical_name), `donor-contractor` and `commonwealth-spend` (both by design). HOUSE cards correctly excluded from the runner and re-synced: 23 upserted, 0 spurious answers.
- `npx tsc --noEmit` clean · `npx vitest run src/app/clarity` — **17 tests, 4 files**, all pass.

## Open, and it changes what a reader sees

**`evidence-gap` is now blocked by `duplicate_canonical_name`**, exactly as the ledger predicted three slices ago. That is the designed behaviour. Whether that sentinel should be `warn` rather than `block` is Ben's call and has not been made.

## Not in this PR

Eight questions remain. Five carry a hazard that shapes their SQL (off-spine-grants, govt-dependence, ndis-concentration, two-purses, community-controlled-share) and three need a decision first — `ministerial-diaries` (organisation_abn is populated on **0 of 1,728** meetings, so the meeting-to-contract link is fuzzy name matching), `exec-pay-dependence` (`total_paid_key_management` populated on **10,805 of 360,488** AIS rows — 3%), and `every-dollar-one-abn` (needs a subject ABN; it is not a board-shaped question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)