### PR TITLE
Lower duplicate_canonical_name from block to warn

### DIFF
--- a/supabase/migrations/20260815002200_clarity_duplicate_name_sentinel_warn.sql
+++ b/supabase/migrations/20260815002200_clarity_duplicate_name_sentinel_warn.sql
@@ -1,0 +1,38 @@
+-- duplicate_canonical_name: block → warn (Ben's decision, 2026-08-15)
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260815002200_clarity_duplicate_name_sentinel_warn.sql
+--
+-- The defect is real and unchanged: 9,607 canonical names cover 25,059 rows, 4.1% of gs_entities,
+-- and they split organisations across nodes. Nothing about this migration says otherwise, and the
+-- sentinel keeps firing, keeps its n, and keeps rendering on every card that reads the objects it
+-- guards.
+--
+-- What changes is the consequence. At `block` it refused `evidence-gap` — the flagship question —
+-- and would refuse every future question touching gs_entities, gs_relationships or
+-- mv_entity_power_index, which is most of them. A guard that refuses most of the board is a guard
+-- somebody switches off, and the thing that then gets switched off is the visibility, not the
+-- defect. At `warn` the number renders with the contamination named beside it, which is a reader
+-- who can see both.
+--
+-- The reverse is one line, and it is the right move the moment a question is registered whose
+-- answer genuinely inverts under name collisions — a centrality ranking, a "most connected"
+-- list. Those are exactly the questions this sentinel was written for, and none of them exists
+-- yet.
+
+BEGIN;
+
+UPDATE clarity_sentinel
+   SET severity = 'warn',
+       description = description
+         || ' Severity lowered from block to warn on 2026-08-15: the defect is real but it does '
+         || 'not invert most answers, and at block it refused the flagship question and would '
+         || 'have refused most of the board. Raise it back to block when a question is registered '
+         || 'whose answer actually inverts under name collisions — a centrality ranking or a '
+         || '"most connected" list.'
+ WHERE key = 'duplicate_canonical_name'
+   AND severity = 'block';
+
+COMMIT;


### PR DESCRIPTION
Ben's call, made 2026-08-15. One statement, no code change. **Already applied to the database** — this PR is the record and the reproducibility.

## What does not change

The defect. **9,607 canonical names over 25,059 rows, 4.1% of `gs_entities`**, splitting organisations across nodes. The sentinel keeps firing, keeps its `n`, and keeps rendering on every card that reads `gs_entities`, `gs_relationships` or `mv_entity_power_index` — now as *tripped, not in this question's path* rather than as a struck-through number.

## What changes

The consequence. At `block` it refused `evidence-gap` — the flagship question — and would have refused every future question touching those three objects, which is most of them. A guard that refuses most of the board is a guard somebody switches off, and the thing that then gets switched off is the visibility, not the defect. At `warn` the number renders with the contamination named beside it, and the reader sees both.

## Verification

- `evidence-gap` answers again: **85.1%, 662 of 778 organisations**, reproducing the V19-confirmed figure exactly.
- Full suite: **12 questions, 10 ok, 2 blocked** — `donor-contractor` and `commonwealth-spend`, both on `contract_value_ceiling`, both by design.

## When to reverse it

One line, and it is the right move the moment a question is registered whose answer genuinely **inverts** under name collisions — a centrality ranking, a "most connected" list. Those are exactly the questions this sentinel was written for, and none of them exists yet. The reasoning and that trigger are appended to the sentinel's own `description`, so the next person to read the row sees why it was lowered without finding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)