### PR TITLE
Clarity console slices 1 and 3 — a page for every object, and an index above them

### DIFF
--- a/apps/web/src/app/clarity/LedgerClient.tsx
+++ b/apps/web/src/app/clarity/LedgerClient.tsx
@@ -362,8 +362,24 @@ export default function LedgerClient({ rows, stats }: { rows: LedgerRow[]; stats
                             }}
                             className="cursor-pointer border-t border-bauhaus-black/10 hover:bg-bauhaus-canvas"
                           >
-                            <td className="break-all px-2.5 py-1.5 text-[13px] font-semibold">
-                              <span className="font-mono">{r.n}</span>
+                            {/* break-words, not break-all: break-all was shredding the human
+                                question titles mid-word (`OBJECTS WITH A WRITTEN PURPOS / E`).
+                                snake_case object names still wrap fine on the underscores. */}
+                            <td className="break-words px-2.5 py-1.5 text-[13px] font-semibold">
+                              {r.qs ? (
+                                <span className="font-mono">{r.n}</span>
+                              ) : (
+                                // The row still expands on click; the name is the way through to
+                                // the object's own page. Until this existed, a click on
+                                // `austender_contracts` went nowhere.
+                                <Link
+                                  href={`/clarity/o/${encodeURIComponent(r.n)}`}
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="font-mono underline decoration-bauhaus-black/25 underline-offset-2 hover:decoration-bauhaus-black"
+                                >
+                                  {r.n}
+                                </Link>
+                              )}
                               {r.qs ? (
                                 <span className="ml-1.5 border border-bauhaus-blue px-1 text-[9px] font-extrabold uppercase tracking-wider text-bauhaus-blue">
                                   question

--- a/apps/web/src/app/clarity/catalogue/LedgerClient.tsx
+++ b/apps/web/src/app/clarity/catalogue/LedgerClient.tsx
@@ -3,8 +3,8 @@
 import { Fragment, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { BASELINES, BASELINE_LABEL, type Baseline } from './changes/types';
-import type { LedgerRow, LedgerStats, FreshnessProbe } from './types';
+import { BASELINES, BASELINE_LABEL, type Baseline } from '../changes/types';
+import type { LedgerRow, LedgerStats, FreshnessProbe } from '../types';
 
 // QUESTIONS sits FIRST and ALL stays the default. A question is the only row here that answers
 // something about the world rather than describing our estate, so it leads the segment list —

--- a/apps/web/src/app/clarity/catalogue/page.tsx
+++ b/apps/web/src/app/clarity/catalogue/page.tsx
@@ -1,0 +1,286 @@
+import type { Metadata } from 'next';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import LedgerClient from './LedgerClient';
+import { parseBaseline, type Baseline } from '../changes/types';
+import type { LedgerRow, LedgerStats, ObjectKind, FreshnessProbe } from '../types';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Clarity',
+  description: 'Everything CivicGraph holds, and the questions it can answer, in one index.',
+};
+
+const SEGMENT: Record<ObjectKind, string> = {
+  table: 'SOURCES',
+  matview: 'DERIVED',
+  view: 'LENSES',
+  function: 'ROUTINES',
+  question: 'QUESTIONS',
+};
+
+interface CatalogRow {
+  object_name: string;
+  object_kind: Exclude<ObjectKind, 'question'>;
+  row_count: number | null;
+  row_count_is_estimate: boolean | null;
+  bytes: number | null;
+  domain: string | null;
+  lifecycle: string | null;
+  freshness_probe: FreshnessProbe | null;
+  last_write_at: string | null;
+  act_business: boolean | null;
+  degree: number | null;
+  column_count: number | null;
+  importance: number | null;
+  purpose: string | null;
+  join_keys: string | null;
+  caveat: string | null;
+  rls_enabled: boolean | null;
+  anon_readable: boolean | null;
+  refreshed_at: string | null;
+}
+
+interface QuestionRow {
+  slug: string;
+  stub: string;
+  question: string;
+  subject: string;
+  state: string;
+  caveat: string;
+  exclusions: string;
+  headline: string | null;
+  headline_sub: string | null;
+  computed_at: string | null;
+  ok: boolean | null;
+  row_count: number | null;
+  binding_object: string | null;
+}
+
+async function loadIndex(
+  baseline: Baseline,
+): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
+  // getDirectServiceSupabase, NOT getServiceSupabase — the latter sniffs the call stack for
+  // '/app/reports/' and returns a stub resolving every query to { data: null }, i.e. a silent [].
+  const supabase = getDirectServiceSupabase();
+
+  // PostgREST caps a page at 1,000 rows and the catalog is ~1,455, so paginate explicitly
+  // rather than silently receiving a truncated ledger that renders as if it were complete.
+  const PAGE = 1000;
+  const all: CatalogRow[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('clarity_object')
+      .select(
+        'object_name,object_kind,row_count,row_count_is_estimate,bytes,domain,lifecycle,' +
+          'freshness_probe,last_write_at,act_business,degree,column_count,importance,' +
+          'purpose,join_keys,caveat,rls_enabled,anon_readable,refreshed_at',
+      )
+      .order('importance', { ascending: false, nullsFirst: false })
+      .range(from, from + PAGE - 1);
+
+    if (error) throw new Error(`clarity_object query failed: ${error.message}`);
+    if (!data?.length) break;
+    all.push(...(data as unknown as CatalogRow[]));
+    if (data.length < PAGE) break;
+  }
+
+  // Questions live in the same index as the objects they are computed from. A failure here must
+  // not blank the catalog — the index is still worth having without them.
+  let questions: QuestionRow[] = [];
+  try {
+    const { data } = await supabase
+      .from('v_clarity_board_cards')
+      .select(
+        'slug,stub,question,subject,state,caveat,exclusions,headline,headline_sub,' +
+          'computed_at,ok,row_count,binding_object',
+      );
+    questions = (data ?? []) as unknown as QuestionRow[];
+  } catch {
+    questions = [];
+  }
+
+  // Movement against the selected baseline (slice 3). Objects with no baseline row
+  // are absent from this map on purpose — the ledger renders `?` for them rather
+  // than a zero that would read as "did not move".
+  const moves = new Map<string, number>();
+  let measurable = 0;
+  let moved = 0;
+  try {
+    for (let from = 0; ; from += PAGE) {
+      const { data } = await supabase
+        .from('clarity_delta')
+        .select('object_key,row_delta_pct,baseline_at')
+        .eq('baseline', baseline)
+        .not('baseline_at', 'is', null)
+        .range(from, from + PAGE - 1);
+      if (!data?.length) break;
+      for (const d of data as unknown as {
+        object_key: string;
+        row_delta_pct: number | null;
+      }[]) {
+        measurable += 1;
+        if (d.row_delta_pct === null) continue;
+        const pct = Number(d.row_delta_pct);
+        moves.set(d.object_key, pct);
+        if (Math.abs(pct) > 10) moved += 1;
+      }
+      if (data.length < PAGE) break;
+    }
+  } catch {
+    // The change log is a slice-3 addition. Before its migrations are applied the
+    // ledger is still worth having, so a missing table costs the delta column and
+    // nothing else.
+  }
+
+  let unexplained = 0;
+  try {
+    const { count } = await supabase
+      .from('clarity_event')
+      .select('id', { count: 'exact', head: true })
+      .eq('severity', 'critical')
+      .is('reason', null);
+    unexplained = count ?? 0;
+  } catch {
+    unexplained = 0;
+  }
+
+  const objectRows: LedgerRow[] = all.map((o) => ({
+    n: o.object_name,
+    k: o.object_kind,
+    s: SEGMENT[o.object_kind] ?? 'SOURCES',
+    r: o.row_count,
+    e: Boolean(o.row_count_is_estimate),
+    b: o.bytes ?? 0,
+    d: o.domain ?? '',
+    l: o.lifecycle ?? '',
+    f: o.freshness_probe ?? 'not_applicable',
+    w: o.last_write_at ? o.last_write_at.slice(0, 10) : '',
+    a: Boolean(o.act_business),
+    g: o.degree ?? 0,
+    c: o.column_count ?? 0,
+    i: Number(o.importance ?? 0),
+    p: o.purpose ?? '',
+    j: o.join_keys ?? '',
+    v: o.caveat ?? '',
+    rls: Boolean(o.rls_enabled),
+    an: Boolean(o.anon_readable),
+    dp: moves.get(o.object_name),
+  }));
+
+  const questionRows: LedgerRow[] = questions.map((q) => ({
+    n: q.stub,
+    k: 'question',
+    s: 'QUESTIONS',
+    // The row count of a question is the size of the answer behind it, so "see the 775 rows"
+    // and this column agree rather than telling two different stories.
+    r: q.row_count,
+    e: false,
+    b: 0,
+    d: q.subject.toLowerCase(),
+    l: q.state,
+    f: q.computed_at ? 'ok' : 'not_applicable',
+    w: q.computed_at ? q.computed_at.slice(0, 10) : '',
+    a: false,
+    g: 0,
+    c: 0,
+    // Questions rank above every object on the default sort. They are the only rows here that
+    // answer something about the world; everything else describes our estate.
+    i: 1000,
+    p: q.question,
+    j: q.binding_object ?? '',
+    v: q.caveat,
+    rls: false,
+    an: false,
+    qs: q.slug,
+    qh: q.ok === false ? null : q.headline,
+    qsub: q.ok === false ? 'last run failed' : q.headline_sub,
+  })) as LedgerRow[];
+
+  const rows = [...questionRows, ...objectRows];
+  const relations = objectRows.filter((r) => r.k !== 'function');
+  const described = relations.filter((r) => r.d).length;
+
+  return {
+    rows,
+    stats: {
+      catalogued: objectRows.length,
+      relations: relations.length,
+      routines: objectRows.length - relations.length,
+      described,
+      // Denominator is relations, not everything. Routines were never in scope to describe,
+      // so counting them would punish us for a decision we made on purpose. Issue #193.
+      coveragePct: relations.length ? Math.round((described / relations.length) * 100) : 0,
+      noTimestampCol: objectRows.filter((r) => r.f === 'no_column').length,
+      anonReadable: objectRows.filter((r) => r.an).length,
+      actBusiness: objectRows.filter((r) => r.a).length,
+      refreshedAt: all[0]?.refreshed_at ?? null,
+      baseline,
+      moved,
+      unexplained,
+      measurable,
+    },
+  };
+}
+
+export default async function ClarityPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ b?: string }>;
+}) {
+  const { b } = await searchParams;
+  const baseline = parseBaseline(b);
+
+  let rows: LedgerRow[] = [];
+  let stats: LedgerStats | null = null;
+  let error: string | null = null;
+
+  try {
+    ({ rows, stats } = await loadIndex(baseline));
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  if (error || !stats) {
+    return (
+      <main className="clarity-dark min-h-screen px-5 py-16">
+        <div className="mx-auto max-w-3xl border-4 border-bauhaus-red bg-bauhaus-white p-8">
+          <h1 className="text-2xl font-black uppercase tracking-widest text-bauhaus-red">
+            Catalog unavailable
+          </h1>
+          <p className="mt-4 text-sm text-bauhaus-black">
+            <code className="font-mono">clarity_object</code> could not be read. The catalog is
+            built by <code className="font-mono">clarity_refresh()</code>; if it has never run,
+            there is nothing to show yet.
+          </p>
+          <pre className="mt-4 overflow-x-auto border-2 border-bauhaus-muted bg-bauhaus-canvas p-3 font-mono text-xs">
+            {error}
+          </pre>
+        </div>
+      </main>
+    );
+  }
+
+  if (!rows.length) {
+    return (
+      <main className="clarity-dark min-h-screen px-5 py-16">
+        <div className="mx-auto max-w-3xl border-4 border-bauhaus-black bg-bauhaus-white p-8">
+          <h1 className="text-2xl font-black uppercase tracking-widest">Catalog is empty</h1>
+          <p className="mt-4 text-sm text-bauhaus-muted">
+            The table exists but holds no rows. Run{' '}
+            <code className="font-mono text-bauhaus-black">SELECT clarity_refresh();</code> and
+            reload — it takes about 37 seconds.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // The dark scope is applied here, not in the client, so the ground is painted server-side and
+  // the page never flashes light on first paint.
+  return (
+    <div className="clarity-dark">
+      <LedgerClient rows={rows} stats={stats} />
+    </div>
+  );
+}

--- a/apps/web/src/app/clarity/nouns.test.ts
+++ b/apps/web/src/app/clarity/nouns.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { NOUN_ORDER, SECTOR_DOMAINS, nounFor, parseSort, unfiledReason } from './nouns';
+
+/**
+ * The mapping is the honest core of the index. These tests exist to stop the two failure modes
+ * that would quietly ruin it: a domain being guessed into a subject bucket, and the two causes of
+ * "unfiled" collapsing into one.
+ */
+describe('nounFor', () => {
+  it('files the unambiguous domains', () => {
+    expect(nounFor('grants_funding')).toBe('money');
+    expect(nounFor('government_spend_procurement')).toBe('money');
+    expect(nounFor('political_influence')).toBe('money');
+    expect(nounFor('corporate_registry')).toBe('organisations');
+    expect(nounFor('people_directors_governance')).toBe('people');
+    expect(nounFor('geography_place')).toBe('places');
+    expect(nounFor('storytelling_consent')).toBe('evidence');
+    expect(nounFor('platform_ops_auth')).toBe('machine');
+  });
+
+  it('never guesses a sector into a subject noun', () => {
+    // A sector spans several nouns at once — justice_funding is money, youth-justice entity views
+    // are organisations, detention statistics are evidence. Filing the sector under any one of
+    // them would be a guess, and this project renders unfiled rather than guessing.
+    for (const sector of SECTOR_DOMAINS) {
+      expect(nounFor(sector)).toBe('unfiled');
+    }
+  });
+
+  it('files an object with no domain as unfiled', () => {
+    expect(nounFor(null)).toBe('unfiled');
+    expect(nounFor(undefined)).toBe('unfiled');
+    expect(nounFor('')).toBe('unfiled');
+  });
+
+  it('files an unrecognised domain as unfiled rather than into The Machine', () => {
+    // The Machine is a noun with a meaning (auth, agents, pipeline). Using it as a catch-all
+    // would hide new domains and let the unfiled count — the progress bar — read low.
+    expect(nounFor('some_new_domain_shipped_next_week')).toBe('unfiled');
+  });
+});
+
+describe('unfiledReason', () => {
+  it('keeps the two causes of unfiled distinct', () => {
+    expect(unfiledReason(null)).toBe('no domain');
+    expect(unfiledReason('justice_youth_detention')).toMatch(/^sector: /);
+    expect(unfiledReason('child_protection')).toMatch(/^sector: /);
+    // Distinct strings, not merely both truthy — collapsing them is the failure being guarded.
+    expect(unfiledReason(null)).not.toBe(unfiledReason('justice_youth_detention'));
+  });
+
+  it('gives no reason for an object that is filed', () => {
+    expect(unfiledReason('grants_funding')).toBeNull();
+  });
+
+  it('names an unmapped domain rather than calling it undomained', () => {
+    expect(unfiledReason('brand_new_domain')).toBe('domain not mapped: brand new domain');
+  });
+});
+
+describe('parseSort', () => {
+  it('defaults to alphabetical', () => {
+    // Stable position beats optimal ranking on a page visited daily; `importance` is tied at
+    // 0.0225 for 424 objects and cannot rank anything.
+    expect(parseSort(undefined)).toBe('name');
+    expect(parseSort('nonsense')).toBe('name');
+    expect(parseSort(['rows', 'degree'])).toBe('rows');
+    expect(parseSort('degree')).toBe('degree');
+  });
+});
+
+describe('NOUN_ORDER', () => {
+  it('puts The Machine and Unfiled last, so plumbing never leads', () => {
+    expect(NOUN_ORDER.slice(-2)).toEqual(['machine', 'unfiled']);
+    expect(NOUN_ORDER[0]).toBe('money');
+  });
+});

--- a/apps/web/src/app/clarity/nouns.ts
+++ b/apps/web/src/app/clarity/nouns.ts
@@ -1,0 +1,130 @@
+/**
+ * The six nouns — the spine of the index.
+ *
+ * WHY NOT THE EXISTING DOMAINS
+ *
+ * `clarity_object.domain` has 17 values and is a *schema* taxonomy wearing subject clothing. Its
+ * largest member is `platform_ops_auth` at 215 objects, more than double the next, so an index
+ * sorted by domain puts auth tables above every dollar in the country. The nouns below are what a
+ * person is actually looking for: a kind of thing, not a kind of table.
+ *
+ * WHY SOME DOMAINS DO NOT MAP
+ *
+ * Three domains — justice_youth_detention, social_services, child_protection — are *sectors*, not
+ * nouns. A sector's objects span several nouns at once: `justice_funding` is money,
+ * `mv_youth_justice_entities` is organisations, detention statistics are evidence. Filing a sector
+ * under one noun would be a guess, and this project's rule is that an object with no confirmed
+ * noun renders as UNFILED rather than being quietly mis-filed. So they sit in Unfiled with a
+ * reason on screen, alongside the 667 objects that carry no domain at all.
+ *
+ * That produces a large honest number — see UNFILED_NOTE — and that number is the point. It is the
+ * progress bar for slice 4, where rules propose a noun and a human confirms it via the
+ * `verdict`/`verdict_by`/`verdict_at` columns that already exist and have never been used.
+ *
+ * This mapping is DELIBERATELY a hand-written table and not an algorithm. See
+ * `thoughts/shared/plans/clarity-console.md`.
+ */
+
+export type Noun =
+  | 'money'
+  | 'organisations'
+  | 'people'
+  | 'places'
+  | 'evidence'
+  | 'machine'
+  | 'unfiled';
+
+export const NOUN_ORDER: Noun[] = [
+  'money',
+  'organisations',
+  'people',
+  'places',
+  'evidence',
+  'machine',
+  'unfiled',
+];
+
+export const NOUN_LABEL: Record<Noun, string> = {
+  money: 'Money',
+  organisations: 'Organisations',
+  people: 'People',
+  places: 'Places',
+  evidence: 'Evidence',
+  machine: 'The Machine',
+  unfiled: 'Unfiled',
+};
+
+export const NOUN_BLURB: Record<Noun, string> = {
+  money: 'Grants, contracts, donations, budgets — every dollar the system can see.',
+  organisations: 'Entities, charities, companies, the ABN register.',
+  people: 'Persons, directors, boards, roles.',
+  places: 'Postcodes, LGAs, SEIFA, geography.',
+  evidence: 'Outcomes, interventions, stories, consent, media.',
+  machine: 'Auth, agents, pipeline, staging. What runs the thing rather than what it is about.',
+  unfiled: 'No noun confirmed yet. Shown, never guessed.',
+};
+
+/**
+ * The reason an object is unfiled, rendered on the group so the number is legible rather than
+ * looking like neglect. Two distinct causes that must not collapse into one.
+ */
+export const UNFILED_NOTE =
+  'Two causes, kept apart: objects with no domain at all, and objects filed by SECTOR ' +
+  '(justice, social services, child protection) — a sector spans several nouns, so filing it ' +
+  'under one would be a guess.';
+
+/** The unambiguous half. A domain absent from this map is unfiled BY DESIGN, not by omission. */
+const DOMAIN_TO_NOUN: Record<string, Noun> = {
+  grants_funding: 'money',
+  philanthropy_giving: 'money',
+  government_spend_procurement: 'money',
+  political_influence: 'money',
+
+  charities_ngo: 'organisations',
+  corporate_registry: 'organisations',
+
+  people_directors_governance: 'people',
+
+  geography_place: 'places',
+
+  evidence_outcomes_alma: 'evidence',
+  storytelling_consent: 'evidence',
+  media_narrative: 'evidence',
+
+  platform_ops_auth: 'machine',
+  ai_agents_pipeline: 'machine',
+};
+
+/** Sectors are filed, but not by noun. Tracked separately so the Unfiled group can explain itself. */
+export const SECTOR_DOMAINS = new Set([
+  'justice_youth_detention',
+  'social_services',
+  'child_protection',
+  'unknown',
+]);
+
+export function nounFor(domain: string | null | undefined): Noun {
+  if (!domain) return 'unfiled';
+  return DOMAIN_TO_NOUN[domain] ?? 'unfiled';
+}
+
+/** Why this object landed in Unfiled — shown on the row so the state is never mysterious. */
+export function unfiledReason(domain: string | null | undefined): string | null {
+  if (!domain) return 'no domain';
+  if (DOMAIN_TO_NOUN[domain]) return null;
+  if (SECTOR_DOMAINS.has(domain)) return `sector: ${domain.replace(/_/g, ' ')}`;
+  return `domain not mapped: ${domain.replace(/_/g, ' ')}`;
+}
+
+export type IndexSort = 'name' | 'rows' | 'degree';
+
+export const SORT_LABEL: Record<IndexSort, string> = {
+  name: 'A–Z',
+  rows: 'Rows',
+  degree: 'Degree',
+};
+
+export function parseSort(v: string | string[] | undefined): IndexSort {
+  const s = Array.isArray(v) ? v[0] : v;
+  return s === 'rows' || s === 'degree' ? s : 'name';
+}

--- a/apps/web/src/app/clarity/o/[key]/page.tsx
+++ b/apps/web/src/app/clarity/o/[key]/page.tsx
@@ -1,0 +1,554 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import {
+  formatBytes,
+  formatCount,
+  formatRate,
+  isStub,
+  usageMeasurement,
+  type CodeRefRow,
+  type ColumnRow,
+  type EdgeRow,
+  type ObjectRow,
+  type QuestionUse,
+} from './types';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ key: string }>;
+}): Promise<Metadata> {
+  const { key } = await params;
+  return { title: `Clarity · ${decodeURIComponent(key)}` };
+}
+
+interface Loaded {
+  object: ObjectRow;
+  columns: ColumnRow[];
+  edges: EdgeRow[];
+  codeRefs: CodeRefRow[];
+  questions: QuestionUse[];
+}
+
+/**
+ * A secondary panel degrades to empty rather than taking the page down. PostgREST builders are
+ * PromiseLike, not Promise, so they need wrapping before they can be caught.
+ */
+async function safe<T>(builder: PromiseLike<{ data: unknown }>): Promise<T[]> {
+  try {
+    const { data } = await builder;
+    return (data ?? []) as T[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The object row is the page; everything else is a panel that degrades to empty rather than
+ * taking the page down. Same rule as the worked-answer page after the 15 Aug pool incident — a
+ * secondary query losing its connection must not 500 the thing the reader came for.
+ */
+async function load(key: string): Promise<Loaded | null> {
+  const supabase = getDirectServiceSupabase();
+
+  const { data: rows, error } = await supabase
+    .from('clarity_object')
+    .select('*')
+    .eq('object_key', key)
+    .limit(1);
+  if (error) throw new Error(`object query failed: ${error.message}`);
+  if (!rows?.length) return null;
+
+  const object = rows[0] as unknown as ObjectRow;
+
+  const columns = await safe<ColumnRow>(
+    supabase
+      .from('clarity_column')
+      .select('ordinal,column_name,data_type,is_nullable,is_pk,is_indexed,is_vector,vector_dim')
+      .eq('object_key', key)
+      .order('ordinal'),
+  );
+
+  // Both directions in one pass. `clarity_edge` uses BARE object names, matching
+  // `clarity_object.object_key` — see the key-forms note in ./types.ts.
+  const edges = await safe<EdgeRow>(
+    supabase
+      .from('clarity_edge')
+      .select(
+        'src_object,src_column,tgt_object,tgt_column,mechanism,declared,match_rate,match_numerator,match_denominator,rows_at_stake,note',
+      )
+      .or(`src_object.eq.${key},tgt_object.eq.${key}`),
+  );
+
+  const codeRefs = await safe<CodeRefRow>(
+    supabase
+      .from('clarity_code_ref')
+      .select('ref_class,repo,file_path,hits')
+      .eq('object_key', key)
+      .order('hits', { ascending: false }),
+  );
+
+  // The ONE place the prefixed key form is correct. `public.` is CHECK-constrained on this table.
+  const questions = await safe<QuestionUse>(
+    supabase
+      .from('clarity_question_ingredient')
+      .select('question_slug,role')
+      .eq('object_key', `public.${key}`),
+  );
+
+  return { object, columns, edges, codeRefs, questions };
+}
+
+function Panel({
+  title,
+  note,
+  children,
+}: {
+  title: string;
+  note?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="border-4 border-bauhaus-black bg-bauhaus-white">
+      <h2 className="flex flex-wrap items-baseline gap-x-3 border-b-2 border-bauhaus-black px-4 py-2 font-mono text-[11px] font-black uppercase tracking-widest">
+        {title}
+        {note ? <span className="font-normal normal-case text-neutral-500">{note}</span> : null}
+      </h2>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+/**
+ * The curated prose is written in markdown — 467 caveats and 84 purposes contain `**bold**` or
+ * backtick code. Rendered as plain text it reads as broken formatting, which is how it looked the
+ * first time this page was opened. Only two inline forms are supported on purpose: no dependency,
+ * no `dangerouslySetInnerHTML`, and nothing here can inject markup.
+ */
+function Prose({ text, className }: { text: string; className?: string }) {
+  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
+  return (
+    <p className={className}>
+      {parts.map((part, i) => {
+        if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+          return <strong key={i}>{part.slice(2, -2)}</strong>;
+        }
+        if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
+          return (
+            <code key={i} className="bg-bauhaus-canvas px-1 font-mono text-[0.92em]">
+              {part.slice(1, -1)}
+            </code>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
+    </p>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="border-b border-neutral-200 py-2 last:border-b-0">
+      <dt className="font-mono text-[10px] font-black uppercase tracking-widest text-neutral-500">
+        {label}
+      </dt>
+      <dd className="mt-0.5 font-mono text-[12.5px] break-words">{children}</dd>
+    </div>
+  );
+}
+
+function Flag({ on, label }: { on: boolean | null; label: string }) {
+  if (on === null) return null;
+  return (
+    <span
+      className={`inline-block border-2 px-1.5 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest ${
+        on
+          ? 'border-bauhaus-red bg-bauhaus-red text-white'
+          : 'border-neutral-300 text-neutral-400'
+      }`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default async function ObjectPage({ params }: { params: Promise<{ key: string }> }) {
+  const { key: rawKey } = await params;
+  const key = decodeURIComponent(rawKey);
+  const loaded = await load(key);
+  if (!loaded) notFound();
+
+  const { object: o, columns, edges, codeRefs, questions } = loaded;
+  const stub = isStub(o);
+  const usage = usageMeasurement(o);
+  const isRoutine = o.object_kind === 'function';
+
+  return (
+    <main className="mx-auto max-w-[1180px] px-4 py-8">
+      <Link
+        href="/clarity"
+        className="font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-blue"
+      >
+        ◂ Clarity
+      </Link>
+
+      <header className="mt-3 border-4 border-bauhaus-black bg-bauhaus-white p-5">
+        <h1 className="font-mono text-2xl font-black break-words">{o.object_name}</h1>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="border-2 border-bauhaus-black px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest">
+            {o.object_kind}
+          </span>
+          {/* An object with no domain is UNFILED, never guessed into a bucket. 667 of 1,479. */}
+          <span
+            className={`border-2 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest ${
+              o.domain ? 'border-bauhaus-black' : 'border-neutral-400 text-neutral-500'
+            }`}
+          >
+            {o.domain ?? 'unfiled'}
+          </span>
+          {o.lifecycle ? (
+            <span className="border-2 border-neutral-300 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest text-neutral-600">
+              {o.lifecycle}
+            </span>
+          ) : null}
+          {o.act_business ? (
+            <span className="border-2 border-bauhaus-blue bg-bauhaus-blue px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest text-white">
+              ACT business
+            </span>
+          ) : null}
+          {o.missing_since ? (
+            <span className="border-2 border-bauhaus-red bg-bauhaus-red px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest text-white">
+              missing since {o.missing_since.slice(0, 10)}
+            </span>
+          ) : null}
+        </div>
+
+        {stub ? (
+          <p className="mt-4 border-l-4 border-neutral-400 pl-3 text-[14px] text-neutral-600">
+            This object has no purpose, grain or join keys recorded. It is one of{' '}
+            <strong>667 stubs</strong> in a catalogue of 1,479 — described objects carry all three
+            fields, so nothing here is half-written. Everything below is measured rather than
+            curated.
+          </p>
+        ) : (
+          <>
+            {o.purpose ? (
+              <Prose text={o.purpose} className="mt-4 text-[15px] leading-relaxed" />
+            ) : null}
+            {o.caveat ? (
+              <Prose
+                text={o.caveat}
+                className="mt-3 border-l-4 border-bauhaus-red pl-3 text-[14px] leading-relaxed"
+              />
+            ) : null}
+          </>
+        )}
+      </header>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="grid gap-4">
+          <Panel
+            title="Columns"
+            note={
+              columns.length
+                ? `${columns.length} of ${o.column_count ?? '?'}`
+                : 'not catalogued for this object'
+            }
+          >
+            {columns.length === 0 ? (
+              <p className="font-mono text-[12px] text-neutral-500">
+                No column catalogue. 1,056 of 1,479 objects have one; routines never do.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-left font-mono text-[12px]">
+                  <thead>
+                    <tr className="border-b-2 border-bauhaus-black">
+                      <th className="py-1.5 pr-3 font-black uppercase tracking-widest">#</th>
+                      <th className="py-1.5 pr-3 font-black uppercase tracking-widest">Column</th>
+                      <th className="py-1.5 pr-3 font-black uppercase tracking-widest">Type</th>
+                      <th className="py-1.5 pr-3 font-black uppercase tracking-widest">Null</th>
+                      <th className="py-1.5 font-black uppercase tracking-widest">Keys</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {columns.map((c) => (
+                      <tr key={c.ordinal} className="border-b border-neutral-200">
+                        <td className="py-1.5 pr-3 text-neutral-400">{c.ordinal}</td>
+                        <td className="py-1.5 pr-3 font-semibold">{c.column_name}</td>
+                        <td className="py-1.5 pr-3 text-neutral-600">{c.data_type}</td>
+                        <td className="py-1.5 pr-3 text-neutral-500">
+                          {c.is_nullable ? 'null' : 'not null'}
+                        </td>
+                        <td className="py-1.5">
+                          <span className="flex flex-wrap gap-1">
+                            {c.is_pk ? <Flag on label="pk" /> : null}
+                            {c.is_indexed ? <Flag on label="idx" /> : null}
+                            {c.is_vector ? <Flag on label={`vec ${c.vector_dim ?? ''}`} /> : null}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </Panel>
+
+          <Panel
+            title="What it connects to"
+            note={edges.length ? `${edges.length} edges` : 'no declared edges'}
+          >
+            {edges.length === 0 ? (
+              <p className="font-mono text-[12px] text-neutral-500">
+                Nothing in <code>clarity_edge</code> touches this object. 1,367 edges are declared
+                across the whole catalogue, so an absence here is measured, not assumed.
+              </p>
+            ) : (
+              <ul className="grid gap-2">
+                {edges.map((e, i) => {
+                  const outbound = e.src_object === key;
+                  const other = outbound ? e.tgt_object : e.src_object;
+                  return (
+                    <li
+                      key={`${e.src_object}.${e.src_column ?? ''}→${e.tgt_object}.${e.tgt_column ?? ''}#${i}`}
+                      className="border-b border-neutral-200 pb-2 last:border-b-0 last:pb-0"
+                    >
+                      <div className="flex flex-wrap items-baseline gap-2 font-mono text-[12.5px]">
+                        <span className="text-neutral-400">{outbound ? '→' : '←'}</span>
+                        <Link
+                          href={`/clarity/o/${encodeURIComponent(other)}`}
+                          className="font-semibold text-bauhaus-blue underline"
+                        >
+                          {other}
+                        </Link>
+                        <span className="text-neutral-500">
+                          {outbound ? e.src_column : e.tgt_column} ↔{' '}
+                          {outbound ? e.tgt_column : e.src_column}
+                        </span>
+                        {/* A seam we never measured renders `?`, never 0. */}
+                        <span
+                          className={
+                            e.match_rate !== null && Number(e.match_rate) < 0.9
+                              ? 'font-black text-bauhaus-red'
+                              : 'text-neutral-600'
+                          }
+                        >
+                          {formatRate(e.match_rate)}
+                        </span>
+                        {e.declared ? null : (
+                          <span className="text-[10px] uppercase tracking-widest text-neutral-400">
+                            inferred
+                          </span>
+                        )}
+                      </div>
+                      {e.note ? (
+                        <p className="mt-1 text-[12px] text-neutral-600">{e.note}</p>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </Panel>
+
+          <Panel title="What uses it">
+            <dl className="grid gap-0">
+              {(
+                [
+                  ['App', usage.app],
+                  ['Scripts', usage.script],
+                  ['Migrations', usage.migration],
+                  ['DB functions', usage.dbFunction],
+                ] as const
+              ).map(([label, m]) => (
+                <Field key={label} label={label}>
+                  {m.state === 'measured' ? (
+                    <span className={m.value === 0 ? 'text-neutral-500' : ''}>
+                      {m.value === 0 ? 'nothing references it' : `${m.value} references`}
+                    </span>
+                  ) : (
+                    // Never render 0 for a probe that never ran. Doing so would call 1,151
+                    // objects orphans on the strength of an unrun scanner.
+                    <span className="text-neutral-500">
+                      <strong className="text-bauhaus-red">UNMEASURED</strong> — {m.why}
+                    </span>
+                  )}
+                </Field>
+              ))}
+            </dl>
+            {codeRefs.length > 0 ? (
+              <ul className="mt-3 grid gap-1 font-mono text-[12px]">
+                {codeRefs.map((r, i) => (
+                  <li key={`${r.ref_class}:${r.file_path ?? ''}#${i}`} className="break-words">
+                    <span className="mr-2 text-[10px] uppercase tracking-widest text-neutral-500">
+                      {r.ref_class}
+                    </span>
+                    {r.file_path ?? r.repo ?? '—'}
+                    {r.hits ? <span className="ml-2 text-neutral-400">×{r.hits}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </Panel>
+        </div>
+
+        <div className="grid content-start gap-4">
+          <Panel title="Shape">
+            <dl>
+              <Field label="Rows">
+                {formatCount(o.row_count, o.row_count_is_estimate)}
+                {o.row_count_is_estimate ? (
+                  <span className="ml-2 text-[10px] uppercase tracking-widest text-neutral-500">
+                    estimate
+                  </span>
+                ) : null}
+              </Field>
+              <Field label="Size">{formatBytes(o.bytes)}</Field>
+              <Field label="Columns">
+                {o.column_count ?? '—'}
+                {o.nullable_columns !== null ? (
+                  <span className="text-neutral-500"> · {o.nullable_columns} nullable</span>
+                ) : null}
+              </Field>
+              <Field label="Grain">{o.grain ?? <span className="text-neutral-400">—</span>}</Field>
+              <Field label="Join keys">
+                {o.join_keys ?? <span className="text-neutral-400">—</span>}
+              </Field>
+              <Field label="Degree">
+                {o.degree ?? '—'}
+                <span className="text-neutral-500">
+                  {' '}
+                  · fk {o.fk_in ?? 0}/{o.fk_out ?? 0} · join {o.join_in ?? 0}/{o.join_out ?? 0} ·
+                  lineage {o.lineage_in ?? 0}/{o.lineage_out ?? 0}
+                </span>
+              </Field>
+            </dl>
+          </Panel>
+
+          <Panel title="Freshness">
+            <dl>
+              <Field label="Probe">{o.freshness_probe ?? '—'}</Field>
+              <Field label="Last write">
+                {o.last_write_at ? (
+                  o.last_write_at.slice(0, 10)
+                ) : (
+                  <span className="text-neutral-500">
+                    {o.freshness_probe === 'no_column'
+                      ? 'no timestamp column — our omission, not the data’s'
+                      : 'unknown'}
+                  </span>
+                )}
+              </Field>
+              <Field label="Column">{o.freshness_column ?? '—'}</Field>
+              <Field label="First seen">{o.first_seen_at?.slice(0, 10) ?? '—'}</Field>
+            </dl>
+          </Panel>
+
+          <Panel title="Access">
+            <div className="flex flex-wrap gap-1.5">
+              <Flag on={o.rls_enabled} label="RLS" />
+              <Flag on={o.anon_readable} label="anon read" />
+              <Flag on={o.anon_grant} label="anon grant" />
+              <Flag on={o.authenticated_grant} label="auth grant" />
+              <Flag on={o.security_definer} label="sec definer" />
+              <Flag on={o.security_invoker} label="sec invoker" />
+              <Flag on={o.anon_execute} label="anon exec" />
+            </div>
+            <dl className="mt-2">
+              <Field label="Policies">
+                {o.policy_count ?? 0}
+                {o.anon_open_policies ? (
+                  <span className="text-bauhaus-red"> · {o.anon_open_policies} open to anon</span>
+                ) : null}
+              </Field>
+            </dl>
+          </Panel>
+
+          {isRoutine ? (
+            <Panel title="Routine">
+              <dl>
+                <Field label="Language">{o.routine_language ?? '—'}</Field>
+                <Field label="Kind">{o.routine_kind ?? '—'}</Field>
+                <Field label="Returns">{o.routine_returns ?? '—'}</Field>
+                <Field label="Volatility">{o.routine_volatility ?? '—'}</Field>
+                <Field label="Source">{formatBytes(o.routine_src_bytes)}</Field>
+                <Field label="Triggers">{o.trigger_attachments ?? 0}</Field>
+              </dl>
+            </Panel>
+          ) : null}
+
+          {questions.length > 0 ? (
+            <Panel title="Questions built on it">
+              <ul className="grid gap-1.5">
+                {questions.map((q) => (
+                  <li key={q.question_slug}>
+                    <Link
+                      href={`/clarity/q/${q.question_slug}`}
+                      className="font-mono text-[12.5px] font-semibold text-bauhaus-blue underline"
+                    >
+                      {q.question_slug}
+                    </Link>
+                    {q.role ? (
+                      <span className="ml-2 font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+                        {q.role}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </Panel>
+          ) : null}
+
+          <Panel title="Provenance">
+            <dl>
+              <Field label="Owner app">
+                {/* 'neither' on all 1,479 rows — the column exists and has never been populated. */}
+                {o.owner_app && o.owner_app !== 'neither' ? (
+                  o.owner_app
+                ) : (
+                  <span className="text-neutral-500">
+                    <strong className="text-bauhaus-red">UNMEASURED</strong> — owner_app is
+                    &lsquo;neither&rsquo; on all 1,479 objects
+                  </span>
+                )}
+              </Field>
+              <Field label="ACT business">
+                {o.act_business ? 'yes' : 'no'}
+                {o.act_business_source ? (
+                  <span className="text-neutral-500"> · via {o.act_business_source}</span>
+                ) : null}
+              </Field>
+              <Field label="Verdict">
+                {o.verdict ? (
+                  <>
+                    {o.verdict}
+                    {o.verdict_by ? (
+                      <span className="text-neutral-500">
+                        {' '}
+                        · {o.verdict_by} {o.verdict_at?.slice(0, 10)}
+                      </span>
+                    ) : null}
+                    {o.verdict_reason ? (
+                      <p className="mt-1 font-sans text-[12px] text-neutral-600">
+                        {o.verdict_reason}
+                      </p>
+                    ) : null}
+                  </>
+                ) : (
+                  <span className="text-neutral-500">never adjudicated</span>
+                )}
+              </Field>
+              <Field label="State">{o.state ?? '—'}</Field>
+              <Field label="Catalogue refreshed">{o.refreshed_at?.slice(0, 10) ?? '—'}</Field>
+            </dl>
+          </Panel>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/clarity/o/[key]/types.ts
+++ b/apps/web/src/app/clarity/o/[key]/types.ts
@@ -1,0 +1,194 @@
+/**
+ * The object page — the article for one catalogued object.
+ *
+ * WHY THIS EXISTS
+ *
+ * `clarity_object` carries ~60 curated fields per object: purpose, caveat, grain, join_keys,
+ * the reference counts, the link-graph degrees, the access posture. Until this page there was
+ * nowhere to read any of it. All 1,479 objects rendered as three-line rows in a single
+ * 1,222-row table, six columns wide. The content was an encyclopedia and the surface was a
+ * spreadsheet. See `thoughts/shared/plans/clarity-console.md`.
+ *
+ * KEY FORMS — the trap this codebase has already fallen into once
+ *
+ * `clarity_object.object_key` and `clarity_edge.src_object`/`tgt_object` are BARE names
+ * (`gs_entities`), verified across all 1,479 rows. `clarity_question_ingredient.object_key` is
+ * PREFIXED (`public.gs_entities`) and is CHECK-constrained to stay that way, because it is
+ * compared against `clarity_sentinel.guards_objects`. Joining the two needs `'public.' || key`.
+ * Getting this wrong does not error — it silently returns nothing.
+ */
+
+export type ObjectKind = 'table' | 'matview' | 'view' | 'function';
+
+/**
+ * Three states that must never collapse into one, the same rule the seams and wants screens
+ * already follow. A count of zero from a probe that ran means nothing uses this. A count of
+ * zero from a probe that never ran means we do not know.
+ */
+export type Measured<T> =
+  | { state: 'measured'; value: T }
+  | { state: 'unmeasured'; why: string };
+
+export interface ObjectRow {
+  object_key: string;
+  object_name: string;
+  object_kind: ObjectKind;
+  row_count: number | null;
+  row_count_is_estimate: boolean | null;
+  bytes: number | null;
+  column_count: number | null;
+  nullable_columns: number | null;
+
+  fk_out: number | null;
+  fk_in: number | null;
+  lineage_out: number | null;
+  lineage_in: number | null;
+  join_out: number | null;
+  join_in: number | null;
+  degree: number | null;
+
+  freshness_column: string | null;
+  freshness_source: string | null;
+  last_write_at: string | null;
+  freshness_probe: string | null;
+
+  routine_language: string | null;
+  routine_kind: string | null;
+  routine_returns: string | null;
+  routine_volatility: string | null;
+  routine_src_bytes: number | null;
+  trigger_attachments: number | null;
+
+  rls_enabled: boolean | null;
+  policy_count: number | null;
+  anon_grant: boolean | null;
+  anon_open_policies: number | null;
+  anon_readable: boolean | null;
+  authenticated_grant: boolean | null;
+  security_invoker: boolean | null;
+  security_definer: boolean | null;
+  anon_execute: boolean | null;
+
+  domain: string | null;
+  lifecycle: string | null;
+  grain: string | null;
+  purpose: string | null;
+  caveat: string | null;
+  join_keys: string | null;
+
+  act_business: boolean | null;
+  act_business_source: string | null;
+
+  refs_app: number | null;
+  refs_script: number | null;
+  refs_migration: number | null;
+  refs_db_function: number | null;
+  owner_app: string | null;
+
+  state: string | null;
+  importance: number | null;
+  verdict: string | null;
+  verdict_reason: string | null;
+  verdict_by: string | null;
+  verdict_at: string | null;
+  first_seen_at: string | null;
+  refreshed_at: string | null;
+  missing_since: string | null;
+}
+
+export interface ColumnRow {
+  ordinal: number;
+  column_name: string;
+  data_type: string;
+  is_nullable: boolean | null;
+  is_pk: boolean | null;
+  is_indexed: boolean | null;
+  is_vector: boolean | null;
+  vector_dim: number | null;
+}
+
+export interface EdgeRow {
+  src_object: string;
+  src_column: string | null;
+  tgt_object: string;
+  tgt_column: string | null;
+  mechanism: string | null;
+  declared: boolean | null;
+  match_rate: number | null;
+  match_numerator: number | null;
+  match_denominator: number | null;
+  rows_at_stake: number | null;
+  note: string | null;
+}
+
+export interface CodeRefRow {
+  ref_class: string;
+  repo: string | null;
+  file_path: string | null;
+  hits: number | null;
+}
+
+export interface QuestionUse {
+  question_slug: string;
+  role: string | null;
+}
+
+/**
+ * A stub is an object with none of the three curated fields. It is not a broken page — it is an
+ * honest one, and 667 of 1,479 objects are in this state. The page says so plainly rather than
+ * rendering empty panels that read like a bug.
+ */
+export function isStub(o: ObjectRow): boolean {
+  return !o.purpose && !o.grain && !o.join_keys;
+}
+
+/**
+ * `refs_app`, `refs_script` and `refs_migration` are 0 on ALL 1,479 rows — the code scanner that
+ * populates them has never run. Only `refs_db_function` (328 objects) and the trigger/db_function
+ * rows in `clarity_code_ref` are real.
+ *
+ * So a naive "nothing uses this" would be wrong about 1,151 objects, and wrong in the most
+ * expensive direction: it would read as evidence of an orphan when it is only evidence of an
+ * unrun scanner. Until the scanner ships, these three report UNMEASURED.
+ */
+export function usageMeasurement(o: ObjectRow): {
+  app: Measured<number>;
+  script: Measured<number>;
+  migration: Measured<number>;
+  dbFunction: Measured<number>;
+} {
+  const never = (what: string): Measured<number> => ({
+    state: 'unmeasured',
+    why: `the ${what} scanner has never run — 0 here means unknown, not unused`,
+  });
+  return {
+    app: never('app'),
+    script: never('script'),
+    migration: never('migration'),
+    dbFunction: { state: 'measured', value: o.refs_db_function ?? 0 },
+  };
+}
+
+export function formatBytes(b: number | null): string {
+  if (b === null || b === 0) return '—';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let v = b;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v < 10 && i > 0 ? v.toFixed(1) : Math.round(v)} ${units[i]}`;
+}
+
+export function formatCount(n: number | null, isEstimate: boolean | null): string {
+  if (n === null) return '—';
+  const s = new Intl.NumberFormat('en-AU').format(n);
+  return isEstimate ? `~${s}` : s;
+}
+
+/** Percentage for a seam's match rate. A rate we never measured renders `?`, never 0. */
+export function formatRate(r: number | null): string {
+  if (r === null || Number.isNaN(Number(r))) return '?';
+  return `${(Number(r) * 100).toFixed(1)}%`;
+}

--- a/apps/web/src/app/clarity/page.tsx
+++ b/apps/web/src/app/clarity/page.tsx
@@ -1,286 +1,296 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { getDirectServiceSupabase } from '@/lib/supabase';
-import LedgerClient from './LedgerClient';
-import { parseBaseline, type Baseline } from './changes/types';
-import type { LedgerRow, LedgerStats, ObjectKind, FreshnessProbe } from './types';
+import {
+  NOUN_BLURB,
+  NOUN_LABEL,
+  NOUN_ORDER,
+  SORT_LABEL,
+  UNFILED_NOTE,
+  nounFor,
+  parseSort,
+  unfiledReason,
+  type IndexSort,
+  type Noun,
+} from './nouns';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'Clarity',
-  description: 'Everything CivicGraph holds, and the questions it can answer, in one index.',
+  description: 'Everything CivicGraph holds, on one page.',
 };
 
-const SEGMENT: Record<ObjectKind, string> = {
-  table: 'SOURCES',
-  matview: 'DERIVED',
-  view: 'LENSES',
-  function: 'ROUTINES',
-  question: 'QUESTIONS',
-};
+/**
+ * The index — the front door.
+ *
+ * Craigslist's trick is that the whole taxonomy is on one screen and nothing is behind a click.
+ * The previous front door was the object catalogue: a 1,222-row table, 70,614px tall, sorted by an
+ * `importance` score that is tied at 0.0225 for 424 objects. It showed everything and let you see
+ * nothing. That table still exists, demoted to /clarity/catalogue where its filters and its
+ * segment tabs are the right tool.
+ *
+ * Terse links, alphabetical, six nouns and an honest Unfiled group. See ./nouns.ts for why the
+ * mapping is a hand-written table, and `thoughts/shared/plans/clarity-console.md` for the rest.
+ */
 
-interface CatalogRow {
+interface IndexObject {
+  object_key: string;
   object_name: string;
-  object_kind: Exclude<ObjectKind, 'question'>;
+  object_kind: string;
+  domain: string | null;
   row_count: number | null;
   row_count_is_estimate: boolean | null;
-  bytes: number | null;
-  domain: string | null;
-  lifecycle: string | null;
-  freshness_probe: FreshnessProbe | null;
-  last_write_at: string | null;
-  act_business: boolean | null;
   degree: number | null;
-  column_count: number | null;
-  importance: number | null;
   purpose: string | null;
-  join_keys: string | null;
-  caveat: string | null;
-  rls_enabled: boolean | null;
-  anon_readable: boolean | null;
   refreshed_at: string | null;
 }
 
-interface QuestionRow {
-  slug: string;
-  stub: string;
-  question: string;
-  subject: string;
-  state: string;
-  caveat: string;
-  exclusions: string;
-  headline: string | null;
-  headline_sub: string | null;
-  computed_at: string | null;
-  ok: boolean | null;
-  row_count: number | null;
-  binding_object: string | null;
+interface Loaded {
+  byNoun: Map<Noun, IndexObject[]>;
+  total: number;
+  described: number;
+  questionStates: [string, number][];
+  refreshedAt: string | null;
 }
 
-async function loadIndex(
-  baseline: Baseline,
-): Promise<{ rows: LedgerRow[]; stats: LedgerStats }> {
-  // getDirectServiceSupabase, NOT getServiceSupabase — the latter sniffs the call stack for
-  // '/app/reports/' and returns a stub resolving every query to { data: null }, i.e. a silent [].
+const nf = new Intl.NumberFormat('en-AU');
+
+/** Terse by design: 1,024 of these render at once, so `824K` beats `824,978`. */
+function terse(n: number | null, estimate: boolean | null): string {
+  if (n === null) return '';
+  const s =
+    n >= 1_000_000
+      ? `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`
+      : n >= 1_000
+        ? `${Math.round(n / 1000)}K`
+        : String(n);
+  return estimate ? `~${s}` : s;
+}
+
+async function load(sort: IndexSort): Promise<Loaded> {
   const supabase = getDirectServiceSupabase();
 
-  // PostgREST caps a page at 1,000 rows and the catalog is ~1,455, so paginate explicitly
-  // rather than silently receiving a truncated ledger that renders as if it were complete.
+  // PostgREST caps a page at 1,000 and the catalogue is ~1,479. Paginate explicitly rather than
+  // silently rendering a truncated index that looks complete — the same trap the ledger documents.
   const PAGE = 1000;
-  const all: CatalogRow[] = [];
+  const all: IndexObject[] = [];
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('clarity_object')
       .select(
-        'object_name,object_kind,row_count,row_count_is_estimate,bytes,domain,lifecycle,' +
-          'freshness_probe,last_write_at,act_business,degree,column_count,importance,' +
-          'purpose,join_keys,caveat,rls_enabled,anon_readable,refreshed_at',
+        'object_key,object_name,object_kind,domain,row_count,row_count_is_estimate,degree,purpose,refreshed_at',
       )
-      .order('importance', { ascending: false, nullsFirst: false })
+      .order('object_name')
       .range(from, from + PAGE - 1);
-
-    if (error) throw new Error(`clarity_object query failed: ${error.message}`);
-    if (!data?.length) break;
-    all.push(...(data as unknown as CatalogRow[]));
-    if (data.length < PAGE) break;
+    if (error) throw new Error(`index query failed: ${error.message}`);
+    const page = (data ?? []) as unknown as IndexObject[];
+    all.push(...page);
+    if (page.length < PAGE) break;
   }
 
-  // Questions live in the same index as the objects they are computed from. A failure here must
-  // not blank the catalog — the index is still worth having without them.
-  let questions: QuestionRow[] = [];
-  try {
-    const { data } = await supabase
-      .from('v_clarity_board_cards')
-      .select(
-        'slug,stub,question,subject,state,caveat,exclusions,headline,headline_sub,' +
-          'computed_at,ok,row_count,binding_object',
-      );
-    questions = (data ?? []) as unknown as QuestionRow[];
-  } catch {
-    questions = [];
-  }
+  const byNoun = new Map<Noun, IndexObject[]>();
+  for (const n of NOUN_ORDER) byNoun.set(n, []);
+  for (const o of all) byNoun.get(nounFor(o.domain))!.push(o);
 
-  // Movement against the selected baseline (slice 3). Objects with no baseline row
-  // are absent from this map on purpose — the ledger renders `?` for them rather
-  // than a zero that would read as "did not move".
-  const moves = new Map<string, number>();
-  let measurable = 0;
-  let moved = 0;
+  const cmp: Record<IndexSort, (a: IndexObject, b: IndexObject) => number> = {
+    name: (a, b) => a.object_name.localeCompare(b.object_name),
+    rows: (a, b) => (b.row_count ?? -1) - (a.row_count ?? -1),
+    degree: (a, b) => (b.degree ?? -1) - (a.degree ?? -1),
+  };
+  for (const list of byNoun.values()) list.sort(cmp[sort]);
+
+  // The questions strip degrades to empty rather than taking the front door down with it.
+  let questionStates: [string, number][] = [];
   try {
-    for (let from = 0; ; from += PAGE) {
-      const { data } = await supabase
-        .from('clarity_delta')
-        .select('object_key,row_delta_pct,baseline_at')
-        .eq('baseline', baseline)
-        .not('baseline_at', 'is', null)
-        .range(from, from + PAGE - 1);
-      if (!data?.length) break;
-      for (const d of data as unknown as {
-        object_key: string;
-        row_delta_pct: number | null;
-      }[]) {
-        measurable += 1;
-        if (d.row_delta_pct === null) continue;
-        const pct = Number(d.row_delta_pct);
-        moves.set(d.object_key, pct);
-        if (Math.abs(pct) > 10) moved += 1;
-      }
-      if (data.length < PAGE) break;
+    const { data } = await supabase.from('v_clarity_board_cards').select('state');
+    const counts = new Map<string, number>();
+    for (const r of (data ?? []) as { state: string }[]) {
+      counts.set(r.state, (counts.get(r.state) ?? 0) + 1);
     }
+    questionStates = [...counts.entries()].sort((a, b) => b[1] - a[1]);
   } catch {
-    // The change log is a slice-3 addition. Before its migrations are applied the
-    // ledger is still worth having, so a missing table costs the delta column and
-    // nothing else.
+    questionStates = [];
   }
-
-  let unexplained = 0;
-  try {
-    const { count } = await supabase
-      .from('clarity_event')
-      .select('id', { count: 'exact', head: true })
-      .eq('severity', 'critical')
-      .is('reason', null);
-    unexplained = count ?? 0;
-  } catch {
-    unexplained = 0;
-  }
-
-  const objectRows: LedgerRow[] = all.map((o) => ({
-    n: o.object_name,
-    k: o.object_kind,
-    s: SEGMENT[o.object_kind] ?? 'SOURCES',
-    r: o.row_count,
-    e: Boolean(o.row_count_is_estimate),
-    b: o.bytes ?? 0,
-    d: o.domain ?? '',
-    l: o.lifecycle ?? '',
-    f: o.freshness_probe ?? 'not_applicable',
-    w: o.last_write_at ? o.last_write_at.slice(0, 10) : '',
-    a: Boolean(o.act_business),
-    g: o.degree ?? 0,
-    c: o.column_count ?? 0,
-    i: Number(o.importance ?? 0),
-    p: o.purpose ?? '',
-    j: o.join_keys ?? '',
-    v: o.caveat ?? '',
-    rls: Boolean(o.rls_enabled),
-    an: Boolean(o.anon_readable),
-    dp: moves.get(o.object_name),
-  }));
-
-  const questionRows: LedgerRow[] = questions.map((q) => ({
-    n: q.stub,
-    k: 'question',
-    s: 'QUESTIONS',
-    // The row count of a question is the size of the answer behind it, so "see the 775 rows"
-    // and this column agree rather than telling two different stories.
-    r: q.row_count,
-    e: false,
-    b: 0,
-    d: q.subject.toLowerCase(),
-    l: q.state,
-    f: q.computed_at ? 'ok' : 'not_applicable',
-    w: q.computed_at ? q.computed_at.slice(0, 10) : '',
-    a: false,
-    g: 0,
-    c: 0,
-    // Questions rank above every object on the default sort. They are the only rows here that
-    // answer something about the world; everything else describes our estate.
-    i: 1000,
-    p: q.question,
-    j: q.binding_object ?? '',
-    v: q.caveat,
-    rls: false,
-    an: false,
-    qs: q.slug,
-    qh: q.ok === false ? null : q.headline,
-    qsub: q.ok === false ? 'last run failed' : q.headline_sub,
-  })) as LedgerRow[];
-
-  const rows = [...questionRows, ...objectRows];
-  const relations = objectRows.filter((r) => r.k !== 'function');
-  const described = relations.filter((r) => r.d).length;
 
   return {
-    rows,
-    stats: {
-      catalogued: objectRows.length,
-      relations: relations.length,
-      routines: objectRows.length - relations.length,
-      described,
-      // Denominator is relations, not everything. Routines were never in scope to describe,
-      // so counting them would punish us for a decision we made on purpose. Issue #193.
-      coveragePct: relations.length ? Math.round((described / relations.length) * 100) : 0,
-      noTimestampCol: objectRows.filter((r) => r.f === 'no_column').length,
-      anonReadable: objectRows.filter((r) => r.an).length,
-      actBusiness: objectRows.filter((r) => r.a).length,
-      refreshedAt: all[0]?.refreshed_at ?? null,
-      baseline,
-      moved,
-      unexplained,
-      measurable,
-    },
+    byNoun,
+    total: all.length,
+    described: all.filter((o) => o.purpose).length,
+    questionStates,
+    refreshedAt: all.reduce<string | null>(
+      (max, o) => (o.refreshed_at && (!max || o.refreshed_at > max) ? o.refreshed_at : max),
+      null,
+    ),
   };
 }
 
-export default async function ClarityPage({
+function SortLink({ sort, current }: { sort: IndexSort; current: IndexSort }) {
+  const active = sort === current;
+  return (
+    <Link
+      href={sort === 'name' ? '/clarity' : `/clarity?sort=${sort}`}
+      className={`border-2 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest ${
+        active
+          ? 'border-bauhaus-black bg-bauhaus-black text-bauhaus-canvas'
+          : 'border-bauhaus-black/25 text-bauhaus-black/60 hover:border-bauhaus-black'
+      }`}
+    >
+      {SORT_LABEL[sort]}
+    </Link>
+  );
+}
+
+export default async function ClarityIndexPage({
   searchParams,
 }: {
-  searchParams: Promise<{ b?: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const { b } = await searchParams;
-  const baseline = parseBaseline(b);
+  const sp = await searchParams;
+  const sort = parseSort(sp.sort);
+  const { byNoun, total, described, questionStates, refreshedAt } = await load(sort);
 
-  let rows: LedgerRow[] = [];
-  let stats: LedgerStats | null = null;
-  let error: string | null = null;
+  const unfiled = byNoun.get('unfiled')!.length;
 
-  try {
-    ({ rows, stats } = await loadIndex(baseline));
-  } catch (e) {
-    error = e instanceof Error ? e.message : String(e);
-  }
-
-  if (error || !stats) {
-    return (
-      <main className="clarity-dark min-h-screen px-5 py-16">
-        <div className="mx-auto max-w-3xl border-4 border-bauhaus-red bg-bauhaus-white p-8">
-          <h1 className="text-2xl font-black uppercase tracking-widest text-bauhaus-red">
-            Catalog unavailable
-          </h1>
-          <p className="mt-4 text-sm text-bauhaus-black">
-            <code className="font-mono">clarity_object</code> could not be read. The catalog is
-            built by <code className="font-mono">clarity_refresh()</code>; if it has never run,
-            there is nothing to show yet.
-          </p>
-          <pre className="mt-4 overflow-x-auto border-2 border-bauhaus-muted bg-bauhaus-canvas p-3 font-mono text-xs">
-            {error}
-          </pre>
-        </div>
-      </main>
-    );
-  }
-
-  if (!rows.length) {
-    return (
-      <main className="clarity-dark min-h-screen px-5 py-16">
-        <div className="mx-auto max-w-3xl border-4 border-bauhaus-black bg-bauhaus-white p-8">
-          <h1 className="text-2xl font-black uppercase tracking-widest">Catalog is empty</h1>
-          <p className="mt-4 text-sm text-bauhaus-muted">
-            The table exists but holds no rows. Run{' '}
-            <code className="font-mono text-bauhaus-black">SELECT clarity_refresh();</code> and
-            reload — it takes about 37 seconds.
-          </p>
-        </div>
-      </main>
-    );
-  }
-
-  // The dark scope is applied here, not in the client, so the ground is painted server-side and
-  // the page never flashes light on first paint.
   return (
-    <div className="clarity-dark">
-      <LedgerClient rows={rows} stats={stats} />
-    </div>
+    <main className="mx-auto max-w-[1180px] px-4 py-8">
+      <header className="border-4 border-bauhaus-black bg-bauhaus-black p-5 text-bauhaus-canvas">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="border-2 border-bauhaus-canvas/40 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest">
+            Admin only
+          </span>
+          {refreshedAt ? (
+            <span className="border-2 border-bauhaus-canvas/40 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest">
+              Refreshed {refreshedAt.slice(0, 10)}
+            </span>
+          ) : null}
+          {(
+            [
+              ['/clarity/catalogue', 'The catalogue'],
+              ['/clarity/seams', 'The seams'],
+              ['/clarity/cross', 'Cross-sections'],
+              ['/clarity/wants', 'The want list'],
+              ['/clarity/changes', 'What changed'],
+            ] as const
+          ).map(([href, label]) => (
+            <Link
+              key={href}
+              href={href}
+              className="border-2 border-bauhaus-canvas/40 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest hover:border-bauhaus-canvas"
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+
+        <h1 className="mt-4 font-display text-5xl font-black uppercase tracking-tight">Clarity</h1>
+        <p className="mt-2 max-w-[70ch] text-[14px] text-bauhaus-canvas/70">
+          Everything CivicGraph holds, on one page. {nf.format(total)} objects,{' '}
+          {nf.format(described)} of them described. The count beside each name is rows, from last
+          night&rsquo;s snapshot.
+        </p>
+
+        {questionStates.length > 0 ? (
+          <div className="mt-4 flex flex-wrap items-center gap-2 border-t-2 border-bauhaus-canvas/25 pt-3">
+            <span className="font-mono text-[10px] font-black uppercase tracking-widest text-bauhaus-canvas/60">
+              Questions
+            </span>
+            {questionStates.map(([state, n]) => (
+              <span
+                key={state}
+                className={`border-2 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest ${
+                  state === 'refused'
+                    ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                    : 'border-bauhaus-canvas/40'
+                }`}
+              >
+                {n} {state}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </header>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[10px] font-black uppercase tracking-widest text-bauhaus-black/50">
+          Sort
+        </span>
+        <SortLink sort="name" current={sort} />
+        <SortLink sort="rows" current={sort} />
+        <SortLink sort="degree" current={sort} />
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-widest text-bauhaus-black/50">
+          {nf.format(unfiled)} unfiled
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-4">
+        {NOUN_ORDER.map((noun) => {
+          const list = byNoun.get(noun)!;
+          if (list.length === 0) return null;
+          const isUnfiled = noun === 'unfiled';
+          return (
+            <section
+              key={noun}
+              className="border-4 border-bauhaus-black bg-bauhaus-white"
+              id={noun}
+            >
+              <h2 className="flex flex-wrap items-baseline gap-x-3 border-b-2 border-bauhaus-black px-4 py-2">
+                <span className="font-display text-lg font-black uppercase tracking-widest">
+                  {NOUN_LABEL[noun]}
+                </span>
+                <span className="font-mono text-[12px] font-black">{nf.format(list.length)}</span>
+                <span className="text-[12px] text-bauhaus-black/50">{NOUN_BLURB[noun]}</span>
+              </h2>
+
+              {isUnfiled ? (
+                <p className="border-b border-bauhaus-black/15 bg-bauhaus-canvas px-4 py-2 text-[12px] text-bauhaus-black/70">
+                  {UNFILED_NOTE}
+                </p>
+              ) : null}
+
+              <ul className="grid gap-x-6 gap-y-0.5 p-4 sm:grid-cols-2 lg:grid-cols-3">
+                {list.map((o) => {
+                  const reason = isUnfiled ? unfiledReason(o.domain) : null;
+                  return (
+                    <li
+                      key={o.object_key}
+                      className="flex items-baseline gap-2 font-mono text-[12.5px] leading-6"
+                    >
+                      <Link
+                        href={`/clarity/o/${encodeURIComponent(o.object_key)}`}
+                        className={`truncate underline decoration-bauhaus-black/20 underline-offset-2 hover:decoration-bauhaus-black ${
+                          o.purpose ? '' : 'text-bauhaus-black/55'
+                        }`}
+                        title={o.purpose ?? reason ?? o.object_name}
+                      >
+                        {o.object_name}
+                      </Link>
+                      {/* The two causes of Unfiled must stay visibly apart. A tooltip is not
+                          apart — it is the same collapse in a costume. Only ~80 objects carry a
+                          sector, so naming it inline costs nothing and makes the group legible. */}
+                      {reason?.startsWith('sector:') ? (
+                        <span className="shrink-0 border border-bauhaus-black/25 px-1 text-[9px] uppercase tracking-wider text-bauhaus-black/50">
+                          {reason.slice(8)}
+                        </span>
+                      ) : null}
+                      <span className="ml-auto shrink-0 text-[11px] text-bauhaus-black/45">
+                        {sort === 'degree'
+                          ? (o.degree ?? 0)
+                          : terse(o.row_count, o.row_count_is_estimate)}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+
+      <p className="mt-4 text-[12px] text-bauhaus-black/50">
+        A name in grey has no purpose recorded — {nf.format(total - described)} of{' '}
+        {nf.format(total)} objects. Nothing here is hidden for being undocumented.
+      </p>
+    </main>
   );
 }

--- a/thoughts/shared/plans/clarity-console-part-2.md
+++ b/thoughts/shared/plans/clarity-console-part-2.md
@@ -1,0 +1,372 @@
+# The Clarity Console, part 2 — connection
+
+**Status:** plan, agreed 2026-08-16 via a second design grilling. Not started.
+**Companion to:** `clarity-console.md`, which stands. This does not replace it; it answers a
+different question that the first plan did not ask.
+**Scope:** grantscope. One declaration file in `act-global-infrastructure`. Nothing in
+empathy-ledger-v2 or act-regenerative-studio.
+
+---
+
+## The reframe
+
+The first plan built a catalogue of the database and it is correct. Slices 1 and 3 shipped and
+work. Then the feedback was: *"very code tech speak… wanna keep thinking about how I can see real
+data and how it all starts to connect and asks real questions and shows real data."*
+
+That is not a request for a better catalogue. Going looking for what to build, three separate
+times the answer came back the same:
+
+| Looked for | Found |
+|---|---|
+| A real-data surface to build | **54 report directories**, grouped into **13 themes**, with `qld-youth-justice`, `child-protection`, `donor-contractors`, `board-interlocks`, `who-runs-australia`, `procurement-oligopoly` already written |
+| A way to show connection | **`/entity/[gsId]`, 958 lines**, firing 16 parallel queries across justice funding, procurement, donations, ACNC, ATO, board interlocks, revolving door, ALMA — the cross-system resolution, built |
+| A search to build | **`unified-search.tsx`, 495 lines**, already grouped by kind |
+| An ACT workspace to build | **62 pages under `/org/[slug]`** — desk, funding, contacts, communities, ecosystem, explore, and a full goods suite |
+
+**276 page routes exist. The `/clarity` index indexes 1,479 database objects and zero of them.**
+
+So the diagnosis is not "the real-data views are thin". It is:
+
+> **The console is a map of the shelves. The books are one directory away, unindexed.**
+
+This plan is therefore mostly **connection and deletion**, not construction. It will feel like
+less building than part 1. That is the point.
+
+---
+
+## What it is for
+
+Unchanged from part 1, and it is what forced this correction:
+
+> Keep surfacing what makes sense, what is matched, and what is still not working. Build the
+> process that surfaces all related things **so community can make better decisions** — better
+> relationships with funding, philanthropy and grants — and build the system to see what is
+> actually happening in Australia across justice, child protection and health.
+
+Part 1 served the operator finding a table. That is a legitimate need and it is not this need.
+
+---
+
+## The four decisions that govern everything else
+
+### 1. One visibility vocabulary
+
+`/atlas` already had one — `public` / `org` / `withheld`, with two rules in its code: *withheld
+renders nowhere*, and *only a server component behind the right gate may pass org data*. Meanwhile
+this grilling invented a fourth model one question at a time (public reports, admin console, ACT
+login, consent-refused), and there is a separate commercial `Tier` ladder that is a different axis
+entirely.
+
+Extend the Atlas model with exactly one addition:
+
+```
+public  →  org  →  operator  →  withheld
+```
+
+`operator` is for things true about the **estate** rather than the **world**: unfiled counts,
+review status, the 1,151 objects whose usage was never measured.
+
+### 2. Data declares a floor; a screen may be stricter, never looser
+
+A screen may always be more restrictive than the data it reads. It may never be less. That single
+asymmetry means a consent-governed table cannot leak onto a public page no matter who writes that
+page later — which matters because the stories and the 52.3M rows share one Supabase project.
+
+It is also **testable**: assert that no `public` surface reads an object above `public`.
+
+### 3. Absence is always stated, never silent
+
+A rule now, not three coincidences. A public page says "3 more reports in review — not published".
+The console says "rows withheld, consent-governed". A theme page says "no registered question
+answers this yet".
+
+Same principle as the refusal cards and the `?`-never-`0` rule already running through everything
+built: **the shape of what you cannot see is itself information, and hiding it is the one thing
+that makes a system untrustworthy.**
+
+The exception that proves it: withheld content is never counted in a way that re-identifies
+anyone. **A count of 1 in a small community is a name.**
+
+### 4. Findings first, plumbing last
+
+On every surface. Reports and questions at the top; the data objects at the bottom under "what
+this is built from". The tech-speak stays — it is honest, and part 1 exists to make it available —
+but it is never the first thing read.
+
+---
+
+## Search
+
+**One page at `/search`**, grouped by kind, with a shareable URL. The nav box and ⌘K become entry
+points to it rather than three separate rankings.
+
+Reconcile the two components that already exist — `unified-search.tsx` (495 lines, 3 kinds:
+entity, foundation, grant) and `global-search.tsx` (400 lines) — rather than adding a third.
+Extend from 3 kinds to ~8: **reports · questions · themes · entities · people · places · grants ·
+objects**.
+
+**Grouped, not one ranked list.** A flat list must decide whether `/reports/youth-justice` beats an
+organisation named "Youth Justice NSW", and it will get that wrong constantly because they are
+incomparable. Grouping also lets a group say *"no reports match"* — which is information.
+
+**Hybrid index.** The small kinds — 54 reports, 26 questions, 13 themes, 1,479 objects ≈ 1,575
+items — ship to the client and filter in memory. That is smaller than the catalogue the ledger
+already inlines (verified ~500KB), so it is instant, offline and free, and "nothing matches" is
+answerable without a round trip. Entities and grants stay live queries; they already work.
+
+---
+
+## Theme pages
+
+**At `/reports/[section]`.** The 13 sections already exist in `reports/_components/sidebar-nav-data.ts`
+— Current Map · State Dashboards · **Youth Justice** · **Child Protection** · **Disability** ·
+Education · Cross-System · Accountability & Power · Funding & Equity · Social Sector · Philanthropy
+& Corporate · Research & Procurement · Data & System. Making them real pages fills a hole users
+already walk past. It is not a new concept, and `/reports` gets a purpose beyond being a list.
+
+Not `/themes/[slug]` (a 15th navigational concept) and **not** under `/clarity` — that layout is
+admin-gated, and an auth gate with an exception inside it is the shape of a future accident.
+
+### Three taxonomies, and which one wins
+
+| Taxonomy | Count | Role |
+|---|---|---|
+| Report sections | 13 | **The spine.** The only one written in the language a human uses about the world |
+| ACT project categories | 11 | **Aligned to, not navigated by.** A theme says "ACT-JH works here" |
+| Database domains | 17 | Rejected in part 1 — a schema taxonomy in subject clothing |
+
+Do not build a fourth to unify the three. A fourth taxonomy to unify three is how you get five.
+
+### What is on the page
+
+In this order:
+
+1. **The reports in that section**, each carrying its status at the link
+2. **The registered questions** on that theme
+3. **The key numbers** — from registered questions only, see below
+4. **The real money and the real organisations** — see below
+5. **One line** acknowledging ACT works in this area, linking to the studio
+6. **What this is built from** — the data objects, last
+7. **What's missing** — `operator` tier, visibly withheld from the public view
+
+### Key numbers come only from registered questions
+
+Strictly. A theme with no registered question shows **no number at all** rather than borrowing one
+from report prose. This is the entire point of the eight slices: a number on a public page carries
+a sentinel, a coverage figure and an exclusions note, or it is not shown.
+
+An empty key-numbers slot is an honest advertisement for which question to register next — which
+makes the theme page a work queue, which is what was asked for.
+
+Pulling figures out of report prose is the tempting option and it is how a stale figure gets quoted
+back at you by a funder. 20 reports are flagged as needing figure review; their numbers are exactly
+the ones that must not be lifted.
+
+### Real money, real organisations
+
+`justice_funding.topics` is already tagged, and the tags line up with the sector themes:
+
+| Tag | Rows |
+|---|---|
+| `child-protection` | 16,418 |
+| `family-services` | 7,102 |
+| `youth-justice` | 5,580 |
+| `ndis` | 4,555 |
+| `indigenous` | 2,595 |
+| `community-led` | 1,440 |
+| `legal-services` | 935 |
+| `diversion` | 863 |
+| `prevention` | 326 |
+
+So a Youth Justice page showing *"$X across N grants, and here are the 20 organisations receiving
+most of it"* — each name linking into the entity page that already resolves them across seven
+registers — is one `WHERE` clause and a link. **This is the moment the system stops being
+tech-speak.**
+
+Two hard constraints:
+
+- **`measure_kind = 'grant'` is mandatory.** Without it the 848 whole-of-state budget rows turn
+  $46.1bn into $66.1bn of nonsense. Same for `receipt_type = 'donation received'` on donations.
+- Topics use **hyphens**. `topics @> ARRAY['youth_justice']` returns zero rows silently.
+
+The **power themes have no tags at all** — there is no tag for Accountability & Power, Philanthropy
+or Procurement. Those pages show reports and questions only, and **say why there are no figures**.
+
+### Report status becomes visible at the link
+
+`sidebar-nav-data.ts` already carries a status on 74 nav items: **27 `current` · 27 `reference` ·
+20 `review`**, where `review` means *"needs source-date, figure, and framing review before quoting
+externally"*.
+
+Surface it everywhere a report is linked — search results, theme pages, the index — so you never
+click into something without knowing it needs review. Moving it into the database alongside the
+question registry is right eventually, and should wait until the adjudication pattern from part 1
+is built once rather than twice.
+
+### The review-status restriction
+
+**10 of the 20 `review` reports are in Accountability & Power** — the section holding
+`who-runs-australia`, `donor-contractors`, `board-interlocks`, `consulting-class`. Youth Justice
+and Child Protection carry **zero**.
+
+So:
+
+- **Accountability & Power:** review-status reports are **counted, not linked**. "3 more in review."
+- **Everywhere else:** listed with a visible warning label.
+
+A framing-unreviewed report about disability funding is a quality problem. A framing-unreviewed
+report naming individuals and their board seats is a defamation problem — and this project already
+refused an entire registered question, ministerial diaries, on exactly that reasoning.
+
+This is a real editorial restriction on the most striking work in the repo. It was accepted with
+that named.
+
+---
+
+## ACT
+
+### The workspace already exists
+
+`/org/[slug]` has **62 pages**: desk, funding, contacts, communities, ecosystem, explore,
+per-project funding and journeys, and a goods suite (buyers, capital, foundations, applications,
+campaign, channels, engagement), with an `ActWorkspaceShell` and `isAdminEmail` wired.
+
+*"All behind a login with data for all projects"* is a description of this. **Extend it.** Do not
+build a parallel ACT surface — it would be the fourth front door — and do not split ACT across two
+logins for a distinction only we would understand.
+
+The two gaps: **no cross-project view**, and **no route into the 52.3M rows**.
+
+### Auth: admin now
+
+The four admin emails; only two have accounts. `org_profiles` has **3 rows** with 24 tables
+FK'd to them — load-bearing but not yet a tenancy model. Adding membership for a workspace with one
+occupant is work that will be wrong by the time a second person arrives.
+
+**Named explicitly:** if a community organisation is ever meant to log in and see *their own* data,
+that is a different product with real RLS consequences and it must be a deliberate decision, not
+something that grows out of this.
+
+### "Query all of this data" — without breaking the refusal apparatus
+
+The ask was access to query everything from grants to philanthropy to buyers to reporting to
+people. Free-text asking over 52.3M rows was ruled out in this same grilling, because an ad-hoc
+answer carries no sentinel, no coverage caveat, no exclusions and no verdict — everything eight
+slices were spent building.
+
+The honest version is two things together:
+
+1. **Saved parameterised queries** — the questions ACT actually asks, written once, audited once,
+   re-run with your inputs, with the mandatory filters baked in so they cannot be forgotten. This
+   is where *"relevant to what we are working to do"* lives.
+2. **The generic row viewer** from part 1 — the escape hatch for everything unanticipated, with its
+   consent refusal, still shipping in the same slice as the viewer itself.
+
+The difference between these and free-text is that **these carry their caveats with them.** A
+funder email quoting a number from an unaudited query is the failure this system exists to prevent.
+
+### What is public about ACT
+
+**One sentence.** "A Curious Tractor works in this area", linking to the studio. It is true, it is
+already public there, and it is honest disclosure that the people running this atlas also work in
+the field — which a community organisation reading a youth justice page has a legitimate interest
+in knowing.
+
+Everything with substance — which projects, what evidence, what money, and above all **what's
+missing** — is behind the login. Publishing your own to-do list as though it were findings is a
+different product, and "ACT-GD has zero evidence" hands a funder a stick.
+
+---
+
+## Research
+
+Everything above serves browsing and deciding. Research needs different things, and this system is
+closer than any comparable one because every registered question already carries its SQL, its
+ingredients, its sentinels, its coverage and its exclusions.
+
+What is missing is that **none of it is addressable.**
+
+1. **Stable citable claim URLs** — "this claim, as at 2026-08-16". `clarity_answer` already stores
+   **89 historical answers**, which makes this close to free. First priority.
+2. **Provenance you can follow to source.** Largely present; needs surfacing.
+3. **Export** — CSV, and the query that produced it. Second, and cheap.
+4. **Reproducibility** — the hard one, and worth being honest about. The snapshot moves and the
+   matviews refresh nightly, so a 2026 answer will not reproduce in 2027 unless the answer is
+   pinned. Those 89 stored answers are exactly what pinning means.
+
+---
+
+## Build order
+
+Ordered so the first three slices are the ones that make the system feel connected.
+
+| # | Slice | Notes |
+|---|---|---|
+| A | **Merge PR #216** | Green, coherent, admin-only, nothing public depends on it. Holding it while this lands is how a branch goes stale through three more slices. |
+| B | **Theme pages at `/reports/[section]`** — reports with status, questions, "built from", the ACT line | No new data. The single biggest legibility win. |
+| C | **Real money on sector theme pages** — topic-filtered aggregates + top recipients linking to entity pages | `measure_kind = 'grant'` mandatory. Where tech-speak ends. |
+| D | **`/search`** — reconcile the two components, extend to ~8 kinds, hybrid index | Shareable result URLs. |
+| E | **The visibility model** — `public`/`org`/`operator`/`withheld` as one vocabulary, plus the floor/stricter test | Do before anything else goes public. |
+| F | **Report status surfaced at every link**, and the Accountability & Power count-only rule | Small, and it changes what you'd trust. |
+| G | **Themes above the noun index** on `/clarity` — the demotion from part 1's Q10 | One section move. |
+| H | **ACT cross-project view** in `/org/act` | Extends 62 existing pages. |
+| I | **Saved parameterised queries** for ACT | Mandatory filters baked in. |
+| J | **Citable claim URLs** off the 89 stored answers | The research unlock. |
+| K | **Deletions** — `/discover`, `/dashboard`, `/start`, and whatever B–D orphan | Part 1's slice 0, now with more evidence about what is redundant. |
+
+**E should arguably run first.** It is listed fifth because B and C are what you want to see, but
+nothing new should reach a public surface before the visibility vocabulary exists — the current
+state is per-screen decisions, which is how this grilling ended up re-deciding visibility in every
+second question.
+
+---
+
+## Deliberately not being built
+
+- **Free-text natural-language querying.** Ruled out twice, for the same reason both times.
+- **A fourth taxonomy** unifying report sections, ACT categories and DB domains.
+- **A new ACT surface** parallel to `/org/act`.
+- **A network-graph visualisation** of connection. `/graph` exists at 2,149 lines; connection is
+  the entity spine walked as links, not a 3.4M-edge hairball.
+- **Membership/tenancy auth.** Admin allowlist until a second person needs in.
+- **Figures lifted from report prose.** Registered questions only.
+
+---
+
+## Open
+
+- Whether the Accountability & Power count-only rule survives contact with seeing it applied.
+- Which of the 276 routes are genuinely dead. B–D will reveal more than guessing can.
+- Whether `/insights` (323 lines) lives or dies — still unread.
+- The commercial `Tier` ladder (`community`/`professional`/`organisation`/`funder`/`enterprise`) is
+  a separate axis from the visibility vocabulary and has not been reconciled with it. It will need
+  to be before anything is sold.
+
+---
+
+## Measured facts behind this plan
+
+All measured 2026-08-16. Re-measure before trusting again.
+
+| Fact | Value |
+|---|---|
+| Page routes in the app | **276** |
+| Report directories | 54 |
+| Report nav items carrying a status | 74 — 27 current, 27 reference, **20 review** |
+| Review-status reports in Accountability & Power | **10 of 20** |
+| Review-status in Youth Justice / Child Protection | **0** |
+| Report sections (the theme spine) | 13 |
+| ACT project codes / categories | 74 / 11 |
+| Pages under `/org/[slug]` | **62** |
+| `/entity/[gsId]` | 958 lines, 16 parallel cross-system queries |
+| `/places/[postcode]` | 1,332 lines |
+| `/graph` | 2,149 lines |
+| `unified-search.tsx` / `global-search.tsx` | 495 / 400 lines, 3 kinds |
+| `justice_funding` topic tags | 9, led by child-protection 16,418 and youth-justice 5,580 |
+| Power themes with topic tags | **0** |
+| `clarity_answer` stored answers | 89 |
+| Catalogued objects / unfiled | 1,479 / **747** |
+| Small-kind search index size | ~1,575 items |
+| Existing visibility model | `/atlas`: public / org / withheld |
+| Commercial tier ladder | community / professional / organisation / funder / enterprise |

--- a/thoughts/shared/plans/clarity-console.md
+++ b/thoughts/shared/plans/clarity-console.md
@@ -14,6 +14,32 @@ Turn `/clarity` from a 1,222-row admin table into an operator's console over the
 estate: a page for every object, one index above them, a row viewer that reaches the actual rows,
 and a findings stream so that working the data compounds instead of evaporating.
 
+## What it is for
+
+Stated by Ben, 2026-08-16, and it governs every trade-off below:
+
+> Keep surfacing what makes sense, what is matched, and what is still not working. Build the
+> process that surfaces all related things **so community can make better decisions** — better
+> relationships with funding, philanthropy and grants — and build the system to see what is
+> actually happening in Australia across justice, child protection, health, so we can build better
+> systems.
+
+Three consequences worth holding on to, because they decide arguments later:
+
+1. **Three states, never two.** What makes sense · what is matched · what is still not working.
+   A console that only shows the working parts is a brochure. The unmeasured, the unfiled, the
+   weak seams and the refusals are first-class content here, not blemishes to be cleaned up before
+   showing anyone.
+2. **Community is the destination, the operator is the first user.** Q2 settled operator-first and
+   that stands — you cannot design a surface for community decisions until you can see the corpus
+   yourself. But "admin-gated" is a stage, not the goal, and it is why the refusal ethos and the
+   consent exception are load-bearing rather than decorative: everything built here should be able
+   to survive being looked at by the people it is about.
+3. **Cross-sector by construction.** Justice, child protection and health are separate domains in
+   the catalogue and the same money, the same organisations and the same people run through all of
+   them. The value is in the linkages, which is why the undiscovered-join detector and the seam
+   match rates matter more than any single domain's completeness.
+
 ---
 
 ## The diagnosis
@@ -206,7 +232,13 @@ Ship first, both computable from data already held:
 1. **Undiscovered join** — two objects share a column name and have no edge between them. Runs off
    `clarity_column` (**16,124 columns catalogued**) against `clarity_edge` (1,367 edges). One query.
 2. **Orphan** — a populated relation that nothing in the app, scripts or migrations references.
-   `clarity_code_ref` (816 refs) already knows.
+   **BLOCKED, corrected 2026-08-16 during slice 1.** `refs_app`, `refs_script` and `refs_migration`
+   are 0 on **all 1,479 rows** — the code scanner that populates them has never run. Only
+   `refs_db_function` (328 objects) and the `db_function`/`trigger` rows in `clarity_code_ref` are
+   real. Shipping this detector today would report **1,151 orphans**, every one of them an artefact
+   of an unrun probe rather than a fact about the corpus — the exact `unmeasured` vs
+   `never_populated` vs `dead` collapse this project already ruled out. **The code scanner is now a
+   prerequisite slice.** Until it runs, the object page renders these UNMEASURED.
 
 Later, in rough value order:
 
@@ -353,7 +385,8 @@ what make it compound. Stopping after 5 leaves something coherent and much bette
 | 4 | **Nouns** — `noun` column, rules propose, human confirms, unfiled counter | First use of `verdict` in anger. |
 | 5 | **Row viewer** — guarded RPC **plus consent refusal in the same slice** | The refusal must never ship a release later than the reader. |
 | 6 | **Fold `seams` and `changes` into the object page**; delete both screens | Keep `wants` (a real work queue) and `cross` (genuinely about many objects). |
-| 7 | **Findings** — `clarity_finding` table, detectors 1 and 2, adjudication, age-out | The compounding layer. |
+| 6b | **Code scanner** — populate `refs_app` / `refs_script` / `refs_migration` | Added 2026-08-16. Prerequisite for the orphan detector; without it slice 7 reports 1,151 false orphans. |
+| 7 | **Findings** — `clarity_finding` table, detector 1 (undiscovered join), adjudication, age-out | The compounding layer. Detector 2 (orphan) only after 6b. |
 | 8 | **`owner_app`** — propose and confirm across all 1,479 | Unlocks the cross-product view. |
 | 9 | **Project codes** — wiki-side declaration, mirror to `clarity_object`, zero-evidence report | Cross-repo: one declaration file in `act-global-infrastructure`. |
 | 10 | **Stories** — story ↔ project link, project-mediated only | Consent-critical. Day shift, human in the loop. |
@@ -408,7 +441,10 @@ All queried 2026-08-16 against `tednluwflfhxyucgwigh`. Re-measure before trustin
 | `act_business_source` | `scope_table` 299, `name_rule` 7 |
 | Largest domain | `platform_ops_auth` 215 |
 | Objects carrying any domain | 812 of 1,479 |
-| `clarity_column` | 16,124 |
+| `clarity_column` | 16,124 — but `null_pct` is NULL on every one; never profiled |
+| Objects with a column catalogue | 1,056 of 1,479 (routines never have one) |
+| `refs_app` / `refs_script` / `refs_migration` > 0 | **0 / 0 / 0** — scanner never run |
+| `refs_db_function` > 0 | 328 |
 | `clarity_edge` | 1,367 |
 | `clarity_code_ref` | 816 |
 | `clarity_answer` | 89 |

--- a/thoughts/shared/plans/clarity-console.md
+++ b/thoughts/shared/plans/clarity-console.md
@@ -1,0 +1,421 @@
+# The Clarity Console
+
+**Status:** plan, agreed 2026-08-16 via a design grilling. Not started.
+**Supersedes:** the `/clarity` front door shipped across issue #190 slices 1–7 (PRs #204–#215). The
+questions, sentinels, seams, wants and refusals all survive. The *front door* does not.
+**Scope:** grantscope only. Reads across the shared database; writes nothing outside this repo
+except one declaration file in `act-global-infrastructure`.
+
+---
+
+## One line
+
+Turn `/clarity` from a 1,222-row admin table into an operator's console over the whole data
+estate: a page for every object, one index above them, a row viewer that reaches the actual rows,
+and a findings stream so that working the data compounds instead of evaporating.
+
+---
+
+## The diagnosis
+
+`/clarity` renders, is fast, and passes its tests. It still feels clunky, and the reason is
+specific rather than aesthetic.
+
+`clarity_object` carries about 60 columns per object — `purpose`, `caveat`, `grain`, `join_keys`,
+`owner_app`, `importance`, `verdict`, `refs_app`, `refs_script`, `refs_migration`,
+`refs_db_function`, `fk_in`/`fk_out`, `join_in`/`join_out`, `lineage_in`/`lineage_out`, `degree`,
+`rls_enabled`, `anon_readable`, `first_seen_at`, `missing_since`. That is an encyclopedia article
+per object, and it is already written for 812 of them.
+
+**There is no page for an object.** `/clarity/q/[slug]` exists for questions. Nothing exists for
+objects. So sixty curated fields per object render as one three-line row in a 1,222-row table, six
+columns wide, in a page 70,614 pixels tall.
+
+The content is Wikipedia. It shipped as a spreadsheet. Everything below follows from fixing that.
+
+A second, smaller diagnosis: the default sort is `importance`, which is populated on all 1,479
+objects and **tied for 424 of them at the single value `0.0225`**. For a third of the corpus the
+"ranked" order is arbitrary, which is exactly how it reads.
+
+---
+
+## The shape
+
+Craigslist and Wikipedia were both named as the target. They are opposites, and the useful
+observation is that **the Wikipedia half already exists** — there is already a page per entity,
+person, postcode and council (`/entity/[gsId]`, `/person/[name]`, `/places/[postcode]`,
+`/place/council/[slug]`, plus per-entity `investigate`, `funding-flow`, `due-diligence`, `print`,
+`compare`). What is missing is the Craigslist half: a complete, honest index that shows the shape
+of the corpus and makes all of it reachable.
+
+So: **build the index, and the object pages it points at. Do not rebuild the semantic pages.**
+
+### The governing principle
+
+> **Completeness at the index layer. Refusal at the claim layer.**
+
+You may always see that an object exists, how many rows it has, and how bad it is. You are not
+always handed a sentence you can quote from it. The index shows everything; the pages still refuse.
+This reconciles "see it all like Craigslist" with the refusal ethos that eight slices of `/clarity`
+were spent establishing, and it is the rule that settles every hard case below — including the one
+hard exception, consent.
+
+### Audience
+
+**Operator-facing, admin-gated, garbage included** — optimised for one person finding things across
+52.3M rows. A public civic encyclopedia is the eventual destination and is explicitly *not* this
+build. You cannot design the public index until you can see the corpus yourself, and you currently
+cannot.
+
+---
+
+## Architecture
+
+### The spine — six nouns
+
+Real-world nouns, not database domains. The existing 17-domain taxonomy is a *schema* taxonomy in
+subject clothing: its largest member is `platform_ops_auth` at 215 objects, more than double the
+next, so sorting the civic-money index by it puts auth tables first.
+
+| Noun | Holds |
+|---|---|
+| **Money** | grants, contracts, donations, budgets |
+| **Organisations** | entities, charities, companies, ABR |
+| **People** | persons, directors, boards, roles |
+| **Places** | postcodes, LGAs, SEIFA, geography |
+| **Evidence** | ALMA, outcomes, stories, consent |
+| **The Machine** | auth, agents, pipeline, staging, and everything unfiled |
+
+Second axis is **source system** (ACNC, AusTender, ABR, ASIC, GrantConnect, AEC, state portals) —
+nouns are what you look for, source is how you decide whether to trust it.
+
+Open judgement, deferred to first contact: **split Money into Money In / Money Out** if, looking at
+the 71 `grants_funding` and 32 `government_spend_procurement` objects on one shelf, they don't
+belong together. Grants and procurement behave nothing alike.
+
+No Time bucket. Change is a lens over every noun, not a noun.
+
+### Assignment, and the honest gap
+
+667 of 1,479 objects have no domain at all, and description is all-or-nothing — the same 812
+objects carry `purpose`, `grain` and `join_keys`, so nobody has half-documented anything.
+
+Rules **propose** a noun; a human **confirms** it. `verdict` / `verdict_by` / `verdict_at` already
+exist in the schema for exactly this and are populated on **0 of 1,479** rows — the mechanism is
+built and has never been used.
+
+An object with no confirmed noun renders as **unfiled**. Never guessed into a bucket. An index that
+quietly mis-files is worse than one that admits to 667 unfiled objects, and **the unfiled count is
+the honest progress bar for the whole effort.**
+
+### The front door — one page
+
+One page, all ~1,024 relations, grouped under the six nouns, terse links, no pagination. You scroll
+once and you have genuinely seen the corpus.
+
+- **Alphabetical within a bucket**, with row-count and degree as one-click re-sorts. Craigslist is
+  alphabetical for a reason: on a page visited daily, stable position beats optimal ranking, because
+  you navigate by muscle memory rather than by reading. Smart rankings make the page move under you.
+- The **questions strip sits above the corpus** — 12 answered, 6 contested, 3 refused, 5 blocked.
+  They are the only place in the system where the data has been made to *mean* something. Small
+  strip, though: the corpus is the body of the page.
+- The current 70,614px height stops being a problem once rows stop being three-line cards. As terse
+  links, 1,024 objects fit in roughly a fifth of that, and the unvirtualized table is fine.
+
+### The object page — `/clarity/o/[object_key]`
+
+The missing half, and **built first**. The index is navigation; this is the thing being navigated
+to. Today a click on `austender_contracts` goes nowhere.
+
+Renders the ~60 fields as an article: `purpose` and `caveat` as prose; `grain` and `join_keys` as an
+infobox; `refs_app` / `refs_script` / `refs_migration` / `refs_db_function` as "what uses this";
+`fk` / `join` / `lineage` / `degree` as "what it connects to" — the Wikipedia link graph, already
+present as 1,367 rows in `clarity_edge`.
+
+**Stubs are editable in place.** 667 near-empty pages will never be cleared by hand-written
+migrations; they will be cleared in the two minutes after you look at a table and think "oh, that's
+what this is." The page must capture that thought where it happens, writing `purpose` / `grain` /
+`caveat` / `join_keys` directly. This is what makes the build compound instead of decay.
+
+Also absorbs `seams` and `changes` — a seam is a fact about two objects, a change is a fact about
+one. They belong on the object's page, not in a screen you must remember to visit.
+
+### The row viewer
+
+One component, not 1,024 pages. It is what converts "52.3M rows" from a claim into something you can
+put your eye on.
+
+Extends the pattern already shipped at `/clarity/q/[slug]/rows` (RPC `clarity_question_rows` —
+refuses anything that isn't a single SELECT, clamps the limit, migration `20260815000700`).
+
+- New guarded RPC: `SELECT * FROM <object> ORDER BY <pk or ctid> LIMIT 100 OFFSET n`
+- Limit clamped **server-side**; object key checked against `clarity_object`, so it can only ever
+  read catalogued relations
+- **No free-text WHERE in v1** — column filters only, from the known column list
+- **No `count(*)`** — use the nightly snapshot count
+- First page always cheap. `abr_registry` is 20.0M rows and project rules already forbid unfiltered
+  scans on exactly these tables.
+
+**Cross-links out** by a small hard-coded convention table of about six rules: `gs_id` →
+`/entity/[gsId]`, `abn` → entity by ABN, `postcode` → `/places/[postcode]`, `person_name` →
+`/person/[name]`. Conventions beat declarations here because they work on all 1,479 objects
+including the 667 stubs; let declared `join_keys` override later where present.
+
+### Counts
+
+Nightly snapshot with the age stamped on the page — which `/clarity` already does ("REFRESHED
+2026-08-15"). Plus one deliberate exception: a **recount-this button per object**, so when a number
+looks wrong you can force truth on demand rather than distrusting the whole page.
+
+---
+
+## The findings stream
+
+This is the part that makes the console compound rather than just display, and it is the part the
+existing schema cannot hold.
+
+`clarity_event` has 10 rows and is the wrong shape: `before_value` / `after_value` / `delta_pct` /
+`severity` / `reason`. It is a log of **numbers that moved**. It cannot hold "these two tables share
+a key and have never been joined", or "this LGA has deep disadvantage, no funding, and a
+community-controlled org sitting right there."
+
+**There is nowhere in the schema to put a finding.** That gap is the work.
+
+### Direction of learning
+
+Both directions eventually — the pages teach you the real systems behind the data, and what you
+notice accumulates — but built **capture-first**. The teaching content is 1,479 essays that don't
+exist yet and can only be written by someone noticing things. Build the box before the thing that
+fills it, or "learning modules" becomes a documentation project that stalls at 5%, which is already
+the fate of the 667 stubs.
+
+### Who notices
+
+The system proposes; you adjudicate. Same `verdict` mechanism as noun assignment, so **one
+adjudication surface serves both**.
+
+- A machine-proposed finding starts **unconfirmed** and never counts as true.
+- Confirmation promotes it.
+- **Unconfirmed findings age out** after N days rather than piling up — otherwise the findings list
+  becomes another 1,222-row table nobody reads and we have gone in a circle.
+
+### Detectors
+
+Ship first, both computable from data already held:
+
+1. **Undiscovered join** — two objects share a column name and have no edge between them. Runs off
+   `clarity_column` (**16,124 columns catalogued**) against `clarity_edge` (1,367 edges). One query.
+2. **Orphan** — a populated relation that nothing in the app, scripts or migrations references.
+   `clarity_code_ref` (816 refs) already knows.
+
+Later, in rough value order:
+
+3. **Weak seam** — a declared join that resolves poorly (3 seams currently sit at 21–75%).
+4. **Contradiction** — two sources disagreeing about the same ABN's name, state or size. The
+   highest-value detector in the list and the one most likely to find something true about the real
+   world. Needs per-source name normalisation, so it is a later slice, not a first one.
+5. **Dead end** — an entity present in five systems whose graph node has no edges.
+6. **Community-led opportunity** — high disadvantage, low funding, community-controlled org present.
+   Substrate exists (`mv_funding_deserts`, `is_community_controlled`, the place-attribution work).
+
+Community-led opportunity is **a detector in the one stream, never its own surface.** The moment it
+gets its own screen it acquires its own ranking and its own rot, and that instinct is why there are
+ten front doors already. It also **carries the confirmation gate more strictly than any other
+detector**: naming a community as an "opportunity" on bad place attribution — when hub-address
+attribution is still known to push the wrong way — is a real-world harm, not just a wrong number.
+
+---
+
+## ACT's own work
+
+### ACT is a lens, never a bucket
+
+`act_business` is a boolean — a lens by construction. Making it a seventh noun would tear the corpus
+along the wrong seam: `justice_funding` is both civic infrastructure *and* ACT's work and cannot
+live on one shelf.
+
+The flag needs repair before it means anything. It is true on 306 of 1,479, but **132 of those are
+`platform_ops_auth` and 91 are unfiled — 73% of the "ACT business" flag is plumbing.** Source is
+`scope_table` (299) and `name_rule` (7): entirely rule-derived, never adjudicated.
+
+### Project codes
+
+Add **`project_codes text[]`** to `clarity_object`, drawn from the 74 canonical codes in
+`act-global-infrastructure/config/project-codes.json` (11 categories: justice, indigenous, stories,
+enterprise, regenerative, health, community, arts, events, funding, tech). An object can evidence
+several projects.
+
+**Declared from the project side.** The claim "these tables evidence Goods" is a statement about the
+work, and belongs in the wiki under version control next to the decision that created it. Mirror it
+onto `clarity_object` as an array for fast filtering. Same edge, stored once, written from the end
+that owns the meaning.
+
+Then "shed light on Goods" becomes a real query: every object evidencing ACT-GD, its freshness, its
+gaps, its unconfirmed findings, on one page.
+
+And the reverse is **the single most useful number in this design**:
+
+> **Of 74 project codes, how many have zero evidence?**
+
+That is the list of projects the data cannot currently speak about at all.
+
+### `owner_app` — populate it
+
+`owner_app` is `'neither'` on **all 1,479 rows**. The column exists, the enum plainly anticipates
+grantscope / justicehub / both, and in a Supabase project shared by CivicGraph, JusticeHub and
+empathy-ledger, the catalogue cannot say which product owns a single object.
+
+Populating it via the same propose-then-confirm path is close to free and is what makes the whole
+ACT ambition possible: "shed light on justice and stories and Goods" is unachievable from a
+CivicGraph-only catalogue, because justice lives partly in JusticeHub's tables (`organizations`
+104K at 99.72% bridged, `state_tenders` 200K) and stories live in the consent-tiered storytelling
+tables — and right now nothing knows that.
+
+### What ACT should look at first
+
+Not "which data serves our work" (a filter) and not "opportunities for ACT" (exists already, and
+mostly disappoints — `fit_score ≥85` funders are noise, and 348 grants close in 60 days, not
+25,879).
+
+**Turn the graph on yourselves.** A Curious Tractor Pty Ltd, The Butterfly Movement and A Kind
+Tractor are real ABNs in a 20M-row register, sitting in a network of donations, contracts, board
+interlocks and funding that has never once been looked at from the outside. That is the only one of
+the three that can surprise you.
+
+---
+
+## Stories, and the one hard exception
+
+empathy-ledger-v2 points at **`tednluwflfhxyucgwigh` — the same Supabase project as CivicGraph.**
+The stories and the 52.3M rows of public money are already in one database. Nothing needs to be
+joined for the risk to exist; it exists now.
+
+That repo carries **21 consent migrations**, the newest dated 2026-08-14 and 2026-08-15. Their names
+are the design: `every_named_person_consents`, `public_storytellers_requires_consent`,
+`org_consent_needs_human_confirmation`, `consents_record_who_gave_them`,
+`syndication_consent_who_granted`, `article_consent_requires_single_subject`.
+
+`clarity_object` already catalogues 49 `storytelling_consent` objects. The row viewer as designed
+would open them.
+
+### The link is project-mediated, and only project-mediated
+
+A story links to a **project code**; a project code links to the **objects that evidence it**; data
+is reached only through the project.
+
+Direct story→data linkage is how re-identification gets built: a story from a young person in Alice
+Springs, joined to `justice_funding`, `person_roles` and a 20M-row ABN register, can name someone the
+storyteller never agreed to name — and the rule shipped two days ago is that *every named person
+consents*. Place-mediation is the more dangerous version of the same mistake: place is a
+quasi-identifier, and at postcode grain in remote communities it is often *the* identifier.
+
+Project-mediation also happens to be what was actually asked for — stories overtly about the
+projects we do. A story says "this is about Goods"; Goods says "this is my evidence"; the reader
+sees both; nobody is triangulated.
+
+**Now:** story ↔ project only.
+**Later, deliberately:** project + coarse place, grain fixed at LGA, never postcode, with a
+minimum-count suppression rule.
+**Later still, and narrowly:** project + organisation, only for organisations that are parties to
+the work and have consented *as organisations* — which is what `org_consent_needs_human_confirmation`
+was built for.
+
+Do not design the later two yet. Get story↔project working and see whether "here is what we say
+about Goods, and here is what the data says about Goods, on one page" is already 90% of it.
+
+### The console refuses consent-governed rows
+
+**This is the single hard exception in the design**, and it is the governing principle applied
+rather than an exception to it: the index shows everything, the pages still refuse.
+
+For a consent-governed object the console shows that it exists, its row count, grain, freshness,
+RLS posture, owner — everything *about* it — and **refuses the rows**, with the reason rendered on
+the card the way `/clarity` already refuses claims.
+
+"Admin-only" is not a consent basis. A storyteller consented to their story being used a particular
+way, not to it being browsable by whoever holds the admin session.
+
+**Enforced in the RPC, not the UI.** The UI is one query parameter away from being bypassed.
+
+---
+
+## Build order
+
+Eleven slices. That is a lot, and slices 0–5 are the ones that change how the system feels; 6–10 are
+what make it compound. Stopping after 5 leaves something coherent and much better than today.
+
+| # | Slice | Notes |
+|---|---|---|
+| 0 | **Deletions** — `/discover` (118), `/dashboard` (278), `/start` (108) | Check inbound links first. Own PR, trivially revertible. Keep `/home` (public marketing) and `/rankings` (real content). Read `/insights` (323) before judging it. |
+| 1 | **Object page** `/clarity/o/[object_key]`, read-only | No new schema. Highest value in the build. |
+| 2 | **Inline edit** on the object page | Write path. Three `/api/clarity` routes already exist and have **never served a request** — this needs real HTTP verification, not a typecheck. |
+| 3 | **The index** — one page, six nouns, alphabetical, terse links, questions strip on top | Cheap once objects have pages. |
+| 4 | **Nouns** — `noun` column, rules propose, human confirms, unfiled counter | First use of `verdict` in anger. |
+| 5 | **Row viewer** — guarded RPC **plus consent refusal in the same slice** | The refusal must never ship a release later than the reader. |
+| 6 | **Fold `seams` and `changes` into the object page**; delete both screens | Keep `wants` (a real work queue) and `cross` (genuinely about many objects). |
+| 7 | **Findings** — `clarity_finding` table, detectors 1 and 2, adjudication, age-out | The compounding layer. |
+| 8 | **`owner_app`** — propose and confirm across all 1,479 | Unlocks the cross-product view. |
+| 9 | **Project codes** — wiki-side declaration, mirror to `clarity_object`, zero-evidence report | Cross-repo: one declaration file in `act-global-infrastructure`. |
+| 10 | **Stories** — story ↔ project link, project-mediated only | Consent-critical. Day shift, human in the loop. |
+
+Sequencing notes worth keeping:
+
+- **Slice 5 is atomic.** The row viewer and the consent refusal ship together or neither ships.
+- **Slice 2 before slice 3.** Capture before navigation — the box before the thing that fills it.
+- Slices 9 and 10 touch other repos and cross into consent territory. Day-shift work, not AFK.
+
+---
+
+## What is deliberately not being built
+
+- A **public** civic encyclopedia. Destination, not this build.
+- A **community-led opportunities screen**. It is a detector in the one stream.
+- **Contradiction detection.** Highest value, needs name normalisation first.
+- **Story ↔ place** and **story ↔ organisation** links.
+- **Teaching content** (the 1,479 essays). The capture mechanism comes first; the essays are what
+  accumulates through it.
+- Any change to the **26 questions, sentinels, refusals or the answer runner.** All of that survives
+  untouched.
+
+---
+
+## Open, and honestly so
+
+- **Money In / Money Out** — whether Money splits. Decide on first contact with the shelf.
+- **The age-out window** for unconfirmed findings. N is unset.
+- **`/insights`** (323 lines) — unread, so unjudged.
+- The seven rendering defects found on the current screens on 2026-08-16 (duplicate React key on the
+  map, `break-all` shredding titles, "1 objects moved", the triplicated refusal paragraph, a leaked
+  `▸ none + finer framing` placeholder, `NEVER RUN · RUN #0` on a refusal). Slices 1–5 delete most of
+  the surfaces they live on. **Do not fix them first** — fix only what survives the rebuild.
+
+---
+
+## Measured facts behind this plan
+
+All queried 2026-08-16 against `tednluwflfhxyucgwigh`. Re-measure before trusting them again.
+
+| Fact | Value |
+|---|---|
+| Catalogued objects | 1,479 |
+| With `purpose` / `grain` / `join_keys` | 812 each (same set) |
+| With `caveat` | 728 |
+| Stubs (no purpose/grain/join_keys) | **667** |
+| With `verdict` | **0** |
+| `owner_app = 'neither'` | **1,479 of 1,479** |
+| `importance` tied at `0.0225` | **424** |
+| `act_business = true` | 306 — of which 132 `platform_ops_auth`, 91 unfiled |
+| `act_business_source` | `scope_table` 299, `name_rule` 7 |
+| Largest domain | `platform_ops_auth` 215 |
+| Objects carrying any domain | 812 of 1,479 |
+| `clarity_column` | 16,124 |
+| `clarity_edge` | 1,367 |
+| `clarity_code_ref` | 816 |
+| `clarity_answer` | 89 |
+| `clarity_gap_metric` / `_measurement` | 24 / 36 |
+| `clarity_event` | **10** |
+| Wiki markdown files | 1,090 (98 projects, 64 narrative, 58 decisions, 54 stories, 47 concepts, 34 synthesis, 23 people) |
+| Canonical project codes | 74, in 11 categories |
+| empathy-ledger-v2 consent migrations | 21, newest 2026-08-15 |
+| empathy-ledger-v2 Supabase project | `tednluwflfhxyucgwigh` — same as CivicGraph |
+| Current `/clarity` page height | 70,614px |


### PR DESCRIPTION
Rebuilds the `/clarity` front door. Plan and the full design rationale:
`thoughts/shared/plans/clarity-console.md` (added here).

## The diagnosis

`clarity_object` carries ~60 curated fields per object — purpose, caveat, grain, join_keys,
reference counts, link-graph degrees, access posture. There was nowhere to read any of it. All
1,479 objects rendered as three-line rows in one 1,222-row table, 70,614px tall, sorted by an
`importance` score that is tied at `0.0225` for 424 objects.

The content was an encyclopedia. The surface was a spreadsheet.

## Slice 1 — `/clarity/o/[key]`, a page for every object

Columns from the 16,124-row `clarity_column`, the link graph both directions with seam match
rates, what uses it, the questions built on it, shape, freshness, access posture, provenance. The
ledger's object names are now links; a click on `austender_contracts` previously went nowhere.

`justice_funding` now shows a caveat that was invisible before, including that CLAUDE.md's "71K"
is stale by 2.2x.

Three things the page deliberately refuses to say:

- `refs_app` / `refs_script` / `refs_migration` are 0 on **all 1,479 rows** — the scanner has
  never run. Rendering that as "nothing uses this" would call 1,151 objects orphans on the
  strength of an unrun probe. They read UNMEASURED. Same for `owner_app`, `'neither'` everywhere.
- An unmeasured seam match rate renders `?`, never 0.
- An object with no domain is UNFILED, never guessed. 667 of 1,479 are stubs and the page says so
  rather than showing empty panels that read like a bug.

Also renders the curated prose as markdown — 467 caveats and 84 purposes contain `**bold**` or
backticks and were showing their source. Two inline forms, no dependency, no
`dangerouslySetInnerHTML`.

## Slice 3 — the index becomes the front door

All 1,479 objects on one page, terse links, three columns, six real-world nouns. **15,052px, and
257 more objects than the old table showed.** The catalogue moves to `/clarity/catalogue`, where
its filters and segment tabs are the right tool.

Six nouns rather than the 17 domains: `domain` is a schema taxonomy in subject clothing, and its
largest member is `platform_ops_auth` at 215, so sorting by it puts auth tables above every dollar
in the country. Money / Organisations / People / Places / Evidence / The Machine, plumbing last.

Alphabetical by default; row-count and degree as one-click re-sorts via searchParams, so a sort is
shareable. Stable position beats optimal ranking on a page visited daily.

**747 of 1,479 are UNFILED, and that number is the point** — it is the progress bar for the next
slice. Two causes, kept visibly apart:

- 667 carry no domain at all
- ~80 are filed by SECTOR (`justice_youth_detention`, `social_services`, `child_protection`)

A sector is not a noun: `justice_funding` is money, youth-justice entity views are organisations,
detention statistics are evidence. Filing a sector under one noun would be a guess. The sector
cause renders as an inline chip rather than a tooltip — a tooltip is the same collapse in a
costume.

An unrecognised domain also falls to Unfiled rather than to The Machine, so a new domain can never
hide inside a real noun and make the progress bar read low.

## Plan correction found while building

The plan's orphan detector is **blocked, not ready**. It would have reported 1,151 orphans, every
one an artefact of the unrun code scanner rather than a fact about the corpus. A scanner slice is
now its prerequisite. Committed in `b67ce4c` along with the purpose statement that governs the
rest of the build.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run src/app/clarity` — 26 tests, 5 files (9 new in `nouns.test.ts`, locking the two
  failure modes: nothing guessed into a subject bucket, and the two unfiled causes never returning
  the same string)
- Rendered and eyeballed on 3013: the index, the index sorted three ways, `/clarity/o/justice_funding`,
  `/clarity/o/clarity_delta` (a stub), and `/clarity/catalogue`

**Not verified:** nothing in CI renders these pages. The Vercel preview is the first place to
click through them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
