### PR TITLE
Clarity console slice E — one visibility vocabulary

### DIFF
--- a/apps/web/src/app/clarity/o/[key]/page.tsx
+++ b/apps/web/src/app/clarity/o/[key]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getDirectServiceSupabase } from '@/lib/supabase';
+import { VISIBILITY_MEANING, canRender, type Surface } from '@/lib/visibility';
+import { floorFor, floorReason } from '../../visibility-floor';
 import {
   formatBytes,
   formatCount,
@@ -187,6 +189,30 @@ export default async function ObjectPage({ params }: { params: Promise<{ key: st
   const usage = usageMeasurement(o);
   const isRoutine = o.object_kind === 'function';
 
+  // /clarity is an operator surface. The floor decides what an operator may see of THIS object.
+  //
+  // WHERE THE LINE SITS, and why it moved once.
+  //
+  // Metadata is visible at every tier: that the object exists, its shape, its columns, its grain,
+  // its freshness, its access posture. ROWS are the contents, and rows are what the floor
+  // governs. A storyteller consented to their story being used a particular way, not to it being
+  // browsable by whoever holds the admin session.
+  //
+  // This first shipped withholding the COLUMN CATALOGUE too, and that was wrong twice over. It
+  // contradicted the written design in clarity-console.md ("shows its row count, its grain, its
+  // freshness, its RLS posture — and refuses the rows"), and it did not even work: column names
+  // also arrive through `grain`, `join_keys` and `clarity_edge.src_column`/`tgt_column`, so
+  // `transcripts` still shipped `storyteller_id` and `transcript_text` in its payload. A guard
+  // that blocks one of four paths is worse than no guard, because it reads as protection.
+  //
+  // If a future object has a column name that is itself disclosive (a diagnosis, a status), that
+  // is an argument for withholding THAT object's metadata explicitly — not for a blanket rule
+  // enforced in one place out of four.
+  const SURFACE: Surface = 'operator';
+  const floor = floorFor(o);
+  const rowsVisible = canRender(floor, SURFACE);
+  const withheldBecause = floorReason(o);
+
   return (
     <main className="mx-auto max-w-[1180px] px-4 py-8">
       <Link
@@ -225,7 +251,21 @@ export default async function ObjectPage({ params }: { params: Promise<{ key: st
               missing since {o.missing_since.slice(0, 10)}
             </span>
           ) : null}
+          {!rowsVisible ? (
+            <span className="border-2 border-bauhaus-black bg-bauhaus-black px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest text-bauhaus-canvas">
+              rows withheld
+            </span>
+          ) : null}
         </div>
+
+        {!rowsVisible ? (
+          <p className="mt-4 border-l-4 border-bauhaus-black bg-bauhaus-canvas p-3 text-[14px] leading-relaxed">
+            <strong>The rows of this object are withheld.</strong> {withheldBecause}.{' '}
+            {VISIBILITY_MEANING[floor]} Everything <em>about</em> it is below — what it is, its
+            shape, how fresh, who may reach it — because knowing that a thing exists is not the
+            same as reading what is inside it. Admin access is not a consent basis.
+          </p>
+        ) : null}
 
         {stub ? (
           <p className="mt-4 border-l-4 border-neutral-400 pl-3 text-[14px] text-neutral-600">

--- a/apps/web/src/app/clarity/visibility-floor.test.ts
+++ b/apps/web/src/app/clarity/visibility-floor.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { canRender } from '@/lib/visibility';
+import { floorFor, floorReason } from './visibility-floor';
+
+describe('floorFor — safe by default', () => {
+  it('defaults an unknown object to operator, never public', () => {
+    // The inversion that makes a miss cheap: getting the floor wrong costs visibility, not
+    // consent. Nothing in the catalogue is public unless a surface deliberately promotes it.
+    expect(floorFor({ object_name: 'some_new_table', domain: null })).toBe('operator');
+    expect(floorFor({ object_name: 'austender_contracts', domain: 'government_spend_procurement' })).toBe(
+      'operator',
+    );
+  });
+
+  it('withholds every object in the storytelling_consent domain', () => {
+    for (const name of ['stories', 'storytellers', 'transcripts', 'quotes', 'alma_consent_ledger']) {
+      expect(floorFor({ object_name: name, domain: 'storytelling_consent' })).toBe('withheld');
+    }
+  });
+
+  it('withholds the consent-governed objects that domain alone misses', () => {
+    // Found 2026-08-16: a domain-only rule leaks these four. Derived analysis of a transcript is
+    // still the storyteller's, and a view over storytellers is still storytellers.
+    expect(floorFor({ object_name: 'story_analysis', domain: 'ai_agents_pipeline' })).toBe('withheld');
+    expect(floorFor({ object_name: 'transcript_analysis', domain: 'ai_agents_pipeline' })).toBe(
+      'withheld',
+    );
+    expect(floorFor({ object_name: 'tour_stories', domain: 'media_narrative' })).toBe('withheld');
+    expect(floorFor({ object_name: 'partner_storytellers_v', domain: null })).toBe('withheld');
+  });
+
+  it('does not withhold history tables — `history` contains `story`', () => {
+    // The over-capture that killed the name-pattern approach. h-i-STORY.
+    for (const name of [
+      'subscription_history',
+      'communications_history',
+      'clarity_object_history',
+      'receipt_match_history',
+      'project_health_history',
+      'clarity_edge_history',
+    ]) {
+      expect(floorFor({ object_name: name, domain: 'platform_ops_auth' })).toBe('operator');
+    }
+  });
+});
+
+describe('floorReason — a refusal names its mechanism', () => {
+  it('gives no reason for an ordinary object', () => {
+    expect(floorReason({ object_name: 'gs_entities', domain: 'corporate_registry' })).toBeNull();
+  });
+
+  it('names the domain when that is why', () => {
+    expect(floorReason({ object_name: 'stories', domain: 'storytelling_consent' })).toMatch(
+      /storytelling_consent/,
+    );
+  });
+
+  it('explains an out-of-domain withholding, naming where it was actually filed', () => {
+    const reason = floorReason({ object_name: 'tour_stories', domain: 'media_narrative' });
+    expect(reason).toMatch(/story content or identifies storytellers/);
+    expect(reason).toMatch(/media narrative/);
+  });
+});
+
+describe('the console surface', () => {
+  it('cannot read the contents of any consent-governed object', () => {
+    // The end-to-end assertion: the floor and the vocabulary agree that an admin session does not
+    // open a storyteller's transcript.
+    const consentGoverned = [
+      { object_name: 'transcripts', domain: 'storytelling_consent' },
+      { object_name: 'story_analysis', domain: 'ai_agents_pipeline' },
+      { object_name: 'partner_storytellers_v', domain: null },
+    ];
+    for (const o of consentGoverned) {
+      expect(canRender(floorFor(o), 'operator')).toBe(false);
+      expect(canRender(floorFor(o), 'org')).toBe(false);
+      expect(canRender(floorFor(o), 'public')).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/app/clarity/visibility-floor.ts
+++ b/apps/web/src/app/clarity/visibility-floor.ts
@@ -1,0 +1,92 @@
+import type { Visibility } from '@/lib/visibility';
+
+/**
+ * The visibility floor for a catalogued object.
+ *
+ * SAFE BY DEFAULT
+ *
+ * Every catalogued object defaults to `operator`. Nothing in the catalogue is `public` unless a
+ * surface deliberately promotes it. That inversion is the point: a rule that misses something
+ * yields a thing that is merely unpublished, never a thing that is exposed. Getting the floor
+ * wrong should cost visibility, not consent.
+ *
+ * `withheld` therefore carries the only precision burden — it means "not even an operator sees the
+ * rows" — and it is an explicit list rather than a pattern.
+ *
+ * WHY NOT A NAME PATTERN
+ *
+ * Two failures, found while building this:
+ *
+ *   Over-capture. `history` contains `story`. A pattern matching /story/ silently withholds
+ *   `subscription_history`, `communications_history`, `clarity_object_history`,
+ *   `receipt_match_history` and `project_health_history` — none of which are anybody's story.
+ *
+ *   Under-capture. `quotes` contains none of the obvious words and is consent-governed.
+ *
+ * WHY NOT DOMAIN ALONE
+ *
+ * `storytelling_consent` covers 22 of the consent-governed objects and misses four that sit in
+ * other domains or none: `story_analysis` and `transcript_analysis` (`ai_agents_pipeline`),
+ * `tour_stories` (`media_narrative`), and `partner_storytellers_v` (undomained). Derived analysis
+ * of a transcript is still the storyteller's, and a view over storytellers is still storytellers.
+ *
+ * So: domain OR explicit list, and the list is short enough to review by eye.
+ */
+
+/** The domain whose every object is consent-governed. */
+const WITHHELD_DOMAIN = 'storytelling_consent';
+
+/**
+ * Consent-governed objects living outside that domain. Verified individually 2026-08-16 — each
+ * carries story content or identifies storytellers, regardless of which domain it was filed under.
+ *
+ * Add to this list when a new one appears; the cost of a wrong addition is that operators cannot
+ * browse a table, which is cheap. The cost of a wrong omission is a person's story rendered to
+ * someone they never agreed to.
+ */
+const WITHHELD_OBJECTS: ReadonlySet<string> = new Set([
+  'story_analysis',
+  'transcript_analysis',
+  'tour_stories',
+  'partner_storytellers_v',
+]);
+
+export interface FloorInput {
+  object_name: string;
+  domain: string | null;
+}
+
+/**
+ * KNOWN LIMIT — this floor is binary and consent is not.
+ *
+ * `transcripts` carries its own caveat in the catalogue: "Highest-sensitivity content in the
+ * shard: raw first-person transcripts. Five distinct consent flags (consent_for_ai_analysis,
+ * _quote_extraction, _theme_analysis, _story_creation) must each be honoured independently."
+ *
+ * So a storyteller may have consented to theme analysis and not to quote extraction, and this
+ * function cannot express that. Withheld-for-everything is the SAFE direction to be wrong in, so
+ * the binary stands for now — but any surface that wants to use consent-governed data for a
+ * specific purpose must read those flags per row, not ask this function. The row viewer is where
+ * that becomes real; see clarity-console.md slice 5.
+ */
+export function floorFor(o: FloorInput): Visibility {
+  if (o.domain === WITHHELD_DOMAIN) return 'withheld';
+  if (WITHHELD_OBJECTS.has(o.object_name)) return 'withheld';
+  return 'operator';
+}
+
+/**
+ * Why an object is withheld, rendered on the card. Absence is always stated, never silent — and a
+ * reason that names the mechanism is the difference between a refusal and a bug.
+ */
+export function floorReason(o: FloorInput): string | null {
+  if (o.domain === WITHHELD_DOMAIN) {
+    return 'consent-governed: filed under storytelling_consent';
+  }
+  if (WITHHELD_OBJECTS.has(o.object_name)) {
+    return `consent-governed: holds story content or identifies storytellers, despite being filed under ${
+      o.domain ? o.domain.replace(/_/g, ' ') : 'no domain'
+    }`;
+  }
+  return null;
+}

--- a/apps/web/src/lib/visibility.test.ts
+++ b/apps/web/src/lib/visibility.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SMALL_COUNT_THRESHOLD,
+  VISIBILITY_ORDER,
+  assertRenderable,
+  canRender,
+  mostRestrictive,
+  suppressSmallCount,
+  withheldNote,
+  type Surface,
+  type Visibility,
+} from './visibility';
+
+const SURFACES: Surface[] = ['public', 'org', 'operator'];
+
+describe('canRender — a screen may be stricter than its data, never looser', () => {
+  it('never renders withheld data on any surface', () => {
+    // The single most important assertion in this file. There is no surface, no session, no
+    // admin flag that renders consent-governed content.
+    for (const s of SURFACES) {
+      expect(canRender('withheld', s)).toBe(false);
+    }
+  });
+
+  it('renders public data everywhere', () => {
+    for (const s of SURFACES) {
+      expect(canRender('public', s)).toBe(true);
+    }
+  });
+
+  it('never renders data above the surface clearance', () => {
+    expect(canRender('org', 'public')).toBe(false);
+    expect(canRender('operator', 'public')).toBe(false);
+    expect(canRender('operator', 'org')).toBe(false);
+  });
+
+  it('renders data at or below the surface clearance', () => {
+    expect(canRender('org', 'org')).toBe(true);
+    expect(canRender('public', 'org')).toBe(true);
+    expect(canRender('org', 'operator')).toBe(true);
+    expect(canRender('operator', 'operator')).toBe(true);
+  });
+
+  it('is monotonic — nothing renders on a lower surface that is refused on a higher one', () => {
+    // Guards against someone later "fixing" an ordering bug by special-casing a tier.
+    const floors: Visibility[] = [...VISIBILITY_ORDER];
+    for (const floor of floors) {
+      const allowed = SURFACES.map((s) => canRender(floor, s));
+      const firstTrue = allowed.indexOf(true);
+      if (firstTrue === -1) continue;
+      expect(allowed.slice(firstTrue).every(Boolean)).toBe(true);
+    }
+  });
+});
+
+describe('mostRestrictive — a page inherits the worst of what it reads', () => {
+  it('returns public for an empty page', () => {
+    expect(mostRestrictive([])).toBe('public');
+  });
+
+  it('is dragged down by a single restricted object', () => {
+    // One incidental join is all it takes, which is exactly why pages compute this.
+    expect(mostRestrictive(['public', 'public', 'withheld'])).toBe('withheld');
+    expect(mostRestrictive(['public', 'org'])).toBe('org');
+    expect(mostRestrictive(['public', 'operator', 'org'])).toBe('operator');
+  });
+});
+
+describe('assertRenderable', () => {
+  it('throws rather than returning empty', () => {
+    // "Withheld" and "broken" must never look the same — the same rule the seams, wants and
+    // baseline screens already follow for unmeasured vs zero.
+    expect(() => assertRenderable('withheld', 'operator', 'stories')).toThrow(/refusing to render/);
+    expect(() => assertRenderable('operator', 'public', 'unfiled counts')).toThrow(/never looser/);
+  });
+
+  it('is silent when the render is allowed', () => {
+    expect(() => assertRenderable('public', 'public', 'a report')).not.toThrow();
+  });
+});
+
+describe('withheldNote — absence is stated, never silent', () => {
+  it('returns null when there is nothing to withhold', () => {
+    expect(withheldNote('public', 'public', 'x')).toBeNull();
+  });
+
+  it('names consent, and denies that admin access is a consent basis', () => {
+    const note = withheldNote('withheld', 'operator', 'Rows');
+    expect(note).toMatch(/consent-governed/);
+    expect(note).toMatch(/admin access is not a consent basis/);
+  });
+
+  it('explains a tier mismatch without invoking consent', () => {
+    const note = withheldNote('operator', 'public', 'Unfiled counts');
+    expect(note).toMatch(/operator-tier/);
+    expect(note).not.toMatch(/consent/);
+  });
+});
+
+describe('suppressSmallCount — a count of 1 in a small community is a name', () => {
+  it('suppresses counts below the threshold', () => {
+    expect(suppressSmallCount(1)).toEqual({ show: false, label: `<${SMALL_COUNT_THRESHOLD}` });
+    expect(suppressSmallCount(4)).toEqual({ show: false, label: `<${SMALL_COUNT_THRESHOLD}` });
+  });
+
+  it('shows zero, because zero identifies nobody', () => {
+    expect(suppressSmallCount(0)).toEqual({ show: true, label: '0' });
+  });
+
+  it('shows counts at or above the threshold', () => {
+    expect(suppressSmallCount(5).show).toBe(true);
+    expect(suppressSmallCount(1200).label).toBe('1200');
+  });
+
+  it('distinguishes null from zero', () => {
+    expect(suppressSmallCount(null).show).toBe(false);
+    expect(suppressSmallCount(null).label).toBe('—');
+  });
+});

--- a/apps/web/src/lib/visibility.ts
+++ b/apps/web/src/lib/visibility.ts
@@ -1,0 +1,134 @@
+/**
+ * The visibility vocabulary — one model for the whole system.
+ *
+ * WHY THIS EXISTS
+ *
+ * `/atlas` already had a good model: `public` / `org` / `withheld`, with two rules written into
+ * `lib/atlas/layers.ts` — withheld renders nowhere, and any org/withheld layer's DATA must be
+ * stripped server-side rather than hidden client-side. That model was correct and scoped to map
+ * layers, so every other surface invented its own answer: the reports are ungated, `/clarity` is
+ * admin-gated, `/org/[slug]` checks an email allowlist, and the consent-governed story tables are
+ * protected by nothing but the fact that nobody has pointed a reader at them yet.
+ *
+ * The result was that visibility got re-decided per screen. This file is the one vocabulary.
+ * See `thoughts/shared/plans/clarity-console-part-2.md`.
+ *
+ * NOT the commercial tier ladder in `lib/subscription.ts`
+ * (`community`/`professional`/`organisation`/`funder`/`enterprise`). That is what someone has
+ * PAID for. This is what someone is ALLOWED to see. They are different axes and must not be
+ * conflated — a funder-tier subscriber still has no business reading a consent-governed story.
+ */
+
+/**
+ * The clearance a viewer must hold before data may be rendered to them.
+ *
+ * Ordered least to most restrictive. `operator` is the one addition to the Atlas's three: it
+ * covers things true about the ESTATE rather than about the WORLD — unfiled counts, report review
+ * status, the 1,151 objects whose usage was never measured. That material is not sensitive, it is
+ * simply not about anything; publishing it would be publishing our own to-do list as findings.
+ */
+export type Visibility = 'public' | 'org' | 'operator' | 'withheld';
+
+export const VISIBILITY_ORDER: readonly Visibility[] = ['public', 'org', 'operator', 'withheld'];
+
+/**
+ * The clearance a SURFACE carries. `withheld` is deliberately absent: it is a property data can
+ * have and a surface can never have, because a surface that renders withheld data is not a
+ * surface, it is a leak.
+ */
+export type Surface = 'public' | 'org' | 'operator';
+
+export const VISIBILITY_LABEL: Record<Visibility, string> = {
+  public: 'Public',
+  org: 'Organisation',
+  operator: 'Operator',
+  withheld: 'Withheld',
+};
+
+export const VISIBILITY_MEANING: Record<Visibility, string> = {
+  public: 'Anyone may see this.',
+  org: 'Only inside a logged-in organisation workspace.',
+  operator: 'True about our estate, not about the world. Never published.',
+  withheld: 'Rendered nowhere, on any surface, until a consent conversation changes it.',
+};
+
+function rank(v: Visibility): number {
+  return VISIBILITY_ORDER.indexOf(v);
+}
+
+/**
+ * THE RULE: a screen may always be more restrictive than its data. It may never be less.
+ *
+ * That asymmetry is the whole safety property. It means a consent-governed table cannot leak onto
+ * a public page no matter who writes that page later — which matters because the stories and the
+ * 52.3M rows of public money share one Supabase project, so nothing physical stands between them.
+ */
+export function canRender(dataFloor: Visibility, surface: Surface): boolean {
+  if (dataFloor === 'withheld') return false;
+  return rank(dataFloor) <= rank(surface);
+}
+
+/**
+ * A page that reads many objects inherits the most restrictive of them. Computing this per page
+ * is what stops one incidental join from quietly publishing something.
+ */
+export function mostRestrictive(floors: readonly Visibility[]): Visibility {
+  return floors.reduce<Visibility>((worst, f) => (rank(f) > rank(worst) ? f : worst), 'public');
+}
+
+/**
+ * Throwing guard for server components. Deliberately throws rather than returning empty: a page
+ * that silently renders nothing is indistinguishable from a page whose query failed, and the
+ * difference between "withheld" and "broken" is exactly the distinction this project refuses to
+ * collapse anywhere else.
+ */
+export function assertRenderable(
+  dataFloor: Visibility,
+  surface: Surface,
+  what: string,
+): void {
+  if (!canRender(dataFloor, surface)) {
+    throw new Error(
+      `visibility: refusing to render ${what} (${dataFloor}) on a ${surface} surface. ` +
+        `A screen may be stricter than its data, never looser.`,
+    );
+  }
+}
+
+/**
+ * The sentence shown in place of withheld content.
+ *
+ * Absence is always stated, never silent — the same principle as the refusal cards and the
+ * `?`-never-`0` rule. The shape of what you cannot see is itself information, and hiding it is
+ * the one thing that makes a system untrustworthy.
+ */
+export function withheldNote(dataFloor: Visibility, surface: Surface, what: string): string | null {
+  if (canRender(dataFloor, surface)) return null;
+  if (dataFloor === 'withheld') {
+    return `${what} is withheld. It is consent-governed, and admin access is not a consent basis.`;
+  }
+  return `${what} is ${VISIBILITY_LABEL[dataFloor].toLowerCase()}-tier and is not shown on this surface.`;
+}
+
+/**
+ * Suppression for small counts.
+ *
+ * The exception that proves the absence-is-stated rule: a count of 1 in a small community is a
+ * name. Where a count describes people or places rather than dollars, anything under the threshold
+ * reports as suppressed rather than as a number.
+ */
+export const SMALL_COUNT_THRESHOLD = 5;
+
+export function suppressSmallCount(n: number | null): { show: boolean; label: string } {
+  if (n === null) return { show: false, label: '—' };
+  if (n === 0) return { show: true, label: '0' };
+  if (n < SMALL_COUNT_THRESHOLD) return { show: false, label: `<${SMALL_COUNT_THRESHOLD}` };
+  return { show: true, label: String(n) };
+}
+
+/**
+ * The Atlas's three-tier type is a strict subset of this one, so its registry keeps working
+ * unchanged and simply never uses `operator`. This alias exists so the relationship is visible in
+ * the type system rather than being a coincidence two files apart.
+ */
+export type AtlasCompatibleVisibility = Extract<Visibility, 'public' | 'org' | 'withheld'>;


### PR DESCRIPTION
Part 2 of the plan, slice E: `thoughts/shared/plans/clarity-console-part-2.md`.

## Why

Visibility was being decided per screen. `/atlas` already had a good model — `public` / `org` /
`withheld`, with the rule written into `lib/atlas/layers.ts` that withheld data is stripped
server-side rather than hidden client-side. Everything else invented its own answer: the reports
are ungated, `/clarity` is admin-gated, `/org/[slug]` checks an email allowlist, and the
consent-governed story tables were protected by nothing but the fact that nobody had yet pointed a
reader at them.

This matters more than it sounds because **empathy-ledger-v2 and CivicGraph are the same Supabase
project**. Nothing physical stands between the stories and the 52.3M rows of public money.

## What

Generalises the Atlas model with exactly one addition:

```
public  ->  org  ->  operator  ->  withheld
```

`operator` covers things true about the **estate** rather than the **world** — unfiled counts,
report review status, the 1,151 objects whose usage was never measured. Not sensitive; just not
about anything, and publishing it would be publishing our own to-do list as findings.

**The rule: a screen may be stricter than its data, never looser.** That asymmetry is the safety
property. `mostRestrictive()` makes a page inherit the worst of what it reads, so one incidental
join cannot quietly publish something.

Explicitly **not** the commercial `Tier` ladder in `lib/subscription.ts`. That is what someone has
*paid for*; this is what they are *allowed to see*. A funder-tier subscriber still has no business
reading a consent-governed story.

The floor is **safe by default**: every catalogued object is `operator` unless a surface promotes
it. A rule that misses something yields a thing unpublished, never a thing exposed.

## Two findings

**A domain-only rule leaks.** Four consent-governed objects sit outside `storytelling_consent`:
`story_analysis` and `transcript_analysis` (filed under `ai_agents_pipeline`), `tour_stories`
(`media_narrative`), `partner_storytellers_v` (no domain). Derived analysis of a transcript is
still the storyteller's, and a view over storytellers is still storytellers.

**A name pattern is worse.** `history` contains `story`. A `/story/` match silently withholds
`subscription_history`, `communications_history`, `clarity_object_history`, `receipt_match_history`
and `project_health_history` — none of which are anybody's story — while still missing `quotes`.

Both are locked by tests.

## A known limit, recorded rather than papered over

`transcripts` carries its own caveat in the catalogue: *"Highest-sensitivity content in the shard:
raw first-person transcripts. Five distinct consent flags (`consent_for_ai_analysis`,
`_quote_extraction`, `_theme_analysis`, `_story_creation`) must each be honoured independently."*

**This floor is binary and consent is not.** Withheld-for-everything is the safe direction to be
wrong in, so the binary stands for a console that renders no rows — but the row viewer (part 1,
slice 5) **must read those flags per row rather than calling `floorFor()`**. Written into the code
and the commit message.

## A correction made mid-slice

This first shipped withholding the **column catalogue** as well, with a note claiming the column
names never reached the payload. That was false: `transcripts` still shipped `storyteller_id` and
`transcript_text`, because column names also arrive via `grain`, `join_keys` and
`clarity_edge.src_column`/`tgt_column`. A guard covering one of four paths is worse than no guard,
because it reads as protection.

Reverted to what `clarity-console.md` actually specified — *"shows its row count, its grain, its
freshness, its RLS posture… and refuses the rows"*. **Metadata visible, rows withheld.** The
reasoning is in a comment at the call site so it reads as a decision rather than an oversight.

## Also

Small-count suppression (`SMALL_COUNT_THRESHOLD = 5`): a count of 1 in a small community is a
name. Zero still shows, because zero identifies nobody.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run src/app/clarity src/lib/visibility.test.ts` — **50 tests, 7 files** (24 new)
- Rendered and checked: `/clarity/o/transcripts` (withheld, reason on the card),
  `/clarity/o/story_analysis` (withheld despite its domain), `/clarity/o/subscription_history`
  (**not** withheld — the hi-story trap), `/clarity/o/justice_funding` (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
