### PR TITLE
Clarity console slices B and C — theme pages, real money, and a $12bn filter nobody had documented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,19 +140,55 @@ trusting these again — do not let them rot a second time:
 | `alma_evidence` | 631 | id, evidence_type, methodology, sample_size, effect_size — via `alma_intervention_evidence` junction (NO direct intervention_id) |
 | `org_profiles` | 3 | user_id, name, abn, stripe_customer_id, subscription_plan. 24 tables FK to these 3 rows. |
 
-### Two filters that are mandatory, not optional
+### Three filters that are mandatory, not optional
 
-Both of these columns exist to separate incompatible measures that share one amount column.
+These exist to separate incompatible measures that share one amount column.
 Omitting them does not produce a slightly-off number, it produces a wrong one by an order of magnitude.
 
 ```sql
--- justice_funding: 848 'expenditure_aggregate' rows are WHOLE-OF-STATE BUDGETS ($66.1bn),
--- not money to any organisation. For funding received by orgs:
+-- 1. justice_funding: 848 'expenditure_aggregate' rows are WHOLE-OF-STATE BUDGETS ($66.1bn),
+--    not money to any organisation. For funding received by orgs:
 WHERE measure_kind = 'grant'          -- 126,673 rows, $46.1bn
 
--- political_donations: 'other receipt' is 72% of rows and 85% of dollars and is NOT donations.
+-- 2. justice_funding: measure_kind='grant' does NOT exclude source-spreadsheet TOTAL rows.
+--    44 of those 126,673 rows are aggregates that were ingested as if they were recipients.
+AND lower(trim(recipient_name)) NOT IN
+    ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')
+                                      -- 126,627 rows, $38.01bn
+
+-- 3. political_donations: 'other receipt' is 72% of rows and 85% of dollars and is NOT donations.
 WHERE receipt_type = 'donation received'   -- 506,739 rows, $23.0bn (vs $186.7bn 'other receipt')
 ```
+
+**Filter 2 was missing until 2026-08-16 and the omission is expensive.** Measured:
+
+| filter | rows | total |
+|---|---|---|
+| `measure_kind = 'grant'` | 126,673 | **$46.10bn** |
+| …and not an aggregate-shaped recipient name | 126,627 | **$38.01bn** |
+
+**46 rows — 0.036% of them — carry $8.09bn, 17.5% of the total.** 35 are named literally `Total`
+($8.07bn); the rest are `Various` (3, $12.7m), `na` (2, $1.3m) and `n/a` (6, no amount recorded).
+Four are `qld-historical-grants` column totals
+worth $617.9m sitting inside the `youth-justice` topic, where they rank as the **#1 and #2
+recipients of youth justice funding in Australia**. One of them even carries an ABN, so an
+ABN-based join will not save you.
+
+`political_donations` was checked for the same defect and is clean — no aggregate-shaped donor
+names. Filter 2 is specific to `justice_funding`.
+
+Use `isRealRecipient()` / `themeMoney()` from `apps/web/src/lib/justice-money.ts` rather than
+rewriting the predicate. Two further traps are handled there:
+
+- **Postgres sorts NULLs FIRST in a `DESC` ordering.** A naive "top recipients by amount" query
+  returns the rows with no amount at all. Add `amount_dollars IS NOT NULL` or `NULLS LAST`.
+- **Topic tags overlap.** `youth-justice` ∩ `diversion` = 98 rows; `child-protection` ∩
+  `family-services` = 2. Querying tag by tag and concatenating double-counts them — deduplicate by
+  `id`.
+
+**Unaudited, flagged 2026-08-16:** 100 files under `apps/web/src` reference `justice_funding` and
+only 2 reference `measure_kind`. What the other 98 do has not been checked. Do not assume a figure
+from an existing surface has been through any of these filters.
 
 Topic tags use HYPHENS: `topics @> ARRAY['youth-justice']`. The underscore form returns zero rows silently.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,12 @@ Omitting them does not produce a slightly-off number, it produces a wrong one by
 --    not money to any organisation. For funding received by orgs:
 WHERE measure_kind = 'grant'          -- 126,673 rows, $46.1bn
 
--- 2. justice_funding: measure_kind='grant' does NOT exclude source-spreadsheet TOTAL rows.
---    44 of those 126,673 rows are aggregates that were ingested as if they were recipients.
+-- 2. justice_funding: measure_kind='grant' does NOT exclude source-spreadsheet TOTAL rows,
+--    and does NOT imply is_aggregate=false. Both are needed; neither is a superset of the other.
+AND is_aggregate IS NOT TRUE
 AND lower(trim(recipient_name)) NOT IN
     ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')
-                                      -- 126,627 rows, $38.01bn
+                                      -- 125,300 rows, $33.98bn
 
 -- 3. political_donations: 'other receipt' is 72% of rows and 85% of dollars and is NOT donations.
 WHERE receipt_type = 'donation received'   -- 506,739 rows, $23.0bn (vs $186.7bn 'other receipt')
@@ -165,14 +166,22 @@ WHERE receipt_type = 'donation received'   -- 506,739 rows, $23.0bn (vs $186.7bn
 | filter | rows | total |
 |---|---|---|
 | `measure_kind = 'grant'` | 126,673 | **$46.10bn** |
-| …and not an aggregate-shaped recipient name | 126,627 | **$38.01bn** |
+| …and not an aggregate-shaped recipient name | 126,627 | $38.01bn |
+| …**and `is_aggregate IS NOT TRUE`** | **125,300** | **$33.98bn** |
 
-**46 rows — 0.036% of them — carry $8.09bn, 17.5% of the total.** 35 are named literally `Total`
+**Together these strip $12.12bn — 26% — from the headline `grant` figure.**
+
+46 rows are aggregate-shaped names carrying $8.09bn. 35 are named literally `Total`
 ($8.07bn); the rest are `Various` (3, $12.7m), `na` (2, $1.3m) and `n/a` (6, no amount recorded).
 Four are `qld-historical-grants` column totals
 worth $617.9m sitting inside the `youth-justice` topic, where they rank as the **#1 and #2
 recipients of youth justice funding in Australia**. One of them even carries an ABN, so an
 ABN-based join will not save you.
+
+**`is_aggregate` and `measure_kind` are independent — neither implies the other.** 1,358 rows are
+`measure_kind='grant'` AND `is_aggregate` ($12.06bn of grant-shaped aggregates), while 330
+`expenditure_aggregate` rows are `is_aggregate=false` ($17.39bn). Filtering on either alone leaves
+billions behind.
 
 `political_donations` was checked for the same defect and is clean — no aggregate-shaped donor
 names. Filter 2 is specific to `justice_funding`.

--- a/apps/web/src/app/clarity/visibility-floor.ts
+++ b/apps/web/src/app/clarity/visibility-floor.ts
@@ -51,6 +51,23 @@ const WITHHELD_OBJECTS: ReadonlySet<string> = new Set([
   'partner_storytellers_v',
 ]);
 
+/**
+ * Objects deliberately promoted to `public`.
+ *
+ * The default floor is `operator`, so a public surface cannot read anything until it is named
+ * here. That makes promotion a recorded act rather than a side effect, and this list is the audit
+ * trail: each entry needs a reason that would survive being read back by the people in the data.
+ *
+ * `justice_funding` — government grant records. Public by law, already rendered on public report
+ *   pages, and the money a community is entitled to see. Promoted for the theme pages (slice C).
+ * `gs_entities` — the organisation register, already the basis of the public /entity/[gsId] pages.
+ *   Needed to turn a recipient name into a link.
+ *
+ * NOTE what is NOT here: `person_roles`, `political_donations` and the ABR register. Each is
+ * arguably public too, and each is a separate decision that has not been made.
+ */
+const PUBLIC_OBJECTS: ReadonlySet<string> = new Set(['justice_funding', 'gs_entities']);
+
 export interface FloorInput {
   object_name: string;
   domain: string | null;
@@ -70,8 +87,11 @@ export interface FloorInput {
  * that becomes real; see clarity-console.md slice 5.
  */
 export function floorFor(o: FloorInput): Visibility {
+  // Withheld wins over promotion, always. If an object ever appears in both lists that is a
+  // mistake, and the mistake must resolve towards consent rather than towards publication.
   if (o.domain === WITHHELD_DOMAIN) return 'withheld';
   if (WITHHELD_OBJECTS.has(o.object_name)) return 'withheld';
+  if (PUBLIC_OBJECTS.has(o.object_name)) return 'public';
   return 'operator';
 }
 

--- a/apps/web/src/app/reports/_components/report-sidebar.tsx
+++ b/apps/web/src/app/reports/_components/report-sidebar.tsx
@@ -11,8 +11,12 @@ import {
   type NavSection,
   type ReportStatus,
 } from './sidebar-nav-data';
+import { allThemes, slugify } from '../theme/themes';
 
 const STORAGE_KEY = 'cg-report-sidebar-collapsed';
+
+/** Sections that have a theme page. Current Map and State Dashboards deliberately do not. */
+const THEME_SLUGS = new Set(allThemes().map((t) => t.slug));
 const RECENT_KEY = 'cg-report-recent';
 const RECENT_MAX = 5;
 
@@ -285,6 +289,16 @@ function SectionGroup({
             <div className="text-[10px] text-gray-400 italic px-3 pb-1">
               {section.description}
             </div>
+          )}
+          {/* The theme page for this section. Without this the theme pages exist and are
+              unreachable — which is the exact failure this whole work stream is correcting. */}
+          {THEME_SLUGS.has(slugify(section.title)) && (
+            <Link
+              href={`/reports/theme/${slugify(section.title)}`}
+              className="block px-3 py-1 text-[11px] font-bold text-bauhaus-blue hover:bg-gray-100"
+            >
+              Overview of {section.title} →
+            </Link>
           )}
           {section.items.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} />

--- a/apps/web/src/app/reports/theme/[slug]/page.tsx
+++ b/apps/web/src/app/reports/theme/[slug]/page.tsx
@@ -1,0 +1,289 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import { canRender, withheldNote, type Surface } from '@/lib/visibility';
+import {
+  STATUS_BADGE,
+  allThemes,
+  reportsForTheme,
+  themeBySlug,
+  type Theme,
+  type ThemeReport,
+} from '../themes';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * A theme page — findings first, plumbing last.
+ *
+ * This is a PUBLIC surface. Everything it renders is governed by that: see the three refusals
+ * below, each of which is a rule from the plan rather than a styling choice.
+ *
+ *  1. Key numbers come ONLY from registered questions. Never lifted from report prose — 20 reports
+ *     are flagged as needing figure review and theirs are precisely the ones that must not be
+ *     quoted. A theme with no registered question shows NO number, which is an honest
+ *     advertisement for which question to register next.
+ *  2. Accountability & Power's review-status reports are counted, not linked. Ten of the twenty
+ *     live there and their subjects are named individuals and their board seats.
+ *  3. `operator`-tier material — the HOUSE questions, the what's-missing work list — is visibly
+ *     withheld rather than silently absent.
+ */
+
+const SURFACE: Surface = 'public';
+
+export async function generateStaticParams() {
+  return allThemes().map((t) => ({ slug: t.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const theme = themeBySlug(slug);
+  if (!theme) return { title: 'Not found — CivicGraph' };
+  return {
+    title: `${theme.title} — CivicGraph`,
+    description: theme.description ?? `Reports and evidence on ${theme.title}.`,
+  };
+}
+
+interface QuestionCard {
+  slug: string;
+  question: string;
+  subject: string;
+  state: string;
+  headline: string | null;
+  headline_sub: string | null;
+}
+
+/** States a question may hold on a public page. The rest are work-in-progress, not findings. */
+const PUBLIC_STATES = new Set(['answered', 'contested', 'refused']);
+
+async function loadQuestions(theme: Theme): Promise<{ shown: QuestionCard[]; inProgress: number }> {
+  if (theme.questionSubjects.length === 0) return { shown: [], inProgress: 0 };
+  try {
+    const supabase = getDirectServiceSupabase();
+    const { data } = await supabase
+      .from('v_clarity_board_cards')
+      .select('slug,question,subject,state,headline,headline_sub')
+      .in('subject', [...theme.questionSubjects]);
+    const all = (data ?? []) as unknown as QuestionCard[];
+    return {
+      shown: all.filter((q) => PUBLIC_STATES.has(q.state)),
+      inProgress: all.filter((q) => !PUBLIC_STATES.has(q.state)).length,
+    };
+  } catch {
+    return { shown: [], inProgress: 0 };
+  }
+}
+
+function Panel({ title, note, children }: { title: string; note?: string; children: React.ReactNode }) {
+  return (
+    <section className="border-4 border-bauhaus-black bg-bauhaus-white">
+      <h2 className="flex flex-wrap items-baseline gap-x-3 border-b-2 border-bauhaus-black px-4 py-2 font-mono text-[11px] font-black uppercase tracking-widest">
+        {title}
+        {note ? <span className="font-normal normal-case text-neutral-500">{note}</span> : null}
+      </h2>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+function StatusChip({ status }: { status: ThemeReport['status'] }) {
+  const badge = STATUS_BADGE[status];
+  const tone =
+    badge.tone === 'warn'
+      ? 'border-bauhaus-red text-bauhaus-red'
+      : badge.tone === 'ok'
+        ? 'border-bauhaus-black text-bauhaus-black'
+        : 'border-neutral-300 text-neutral-500';
+  return (
+    <span
+      className={`shrink-0 border px-1 font-mono text-[9px] font-black uppercase tracking-wider ${tone}`}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+export default async function ThemePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const theme = themeBySlug(slug);
+  if (!theme) notFound();
+
+  const reports = reportsForTheme(slug);
+  const { shown: questions, inProgress } = await loadQuestions(theme);
+
+  // Rule 2. Accountability & Power names people; a framing-unreviewed claim about a named person
+  // is a different kind of risk from a framing-unreviewed claim about a budget line.
+  const countOnly = theme.reviewPolicy === 'count-only';
+  const withheldReviews = countOnly ? reports.filter((r) => r.status === 'review') : [];
+  const listedReports = countOnly ? reports.filter((r) => r.status !== 'review') : reports;
+
+  // Rule 3. HOUSE questions describe our estate, not the world.
+  const questionsAreOperator = theme.questionSubjects.includes('HOUSE');
+  const questionsVisible = canRender(questionsAreOperator ? 'operator' : 'public', SURFACE);
+  const questionsWithheld = withheldNote(
+    questionsAreOperator ? 'operator' : 'public',
+    SURFACE,
+    'These questions',
+  );
+
+  const answered = questions.filter((q) => q.state === 'answered' && q.headline);
+
+  return (
+    <main className="mx-auto max-w-[1100px]">
+      <Link
+        href="/reports"
+        className="font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-blue"
+      >
+        ◂ All reports
+      </Link>
+
+      <header className="mt-3 border-4 border-bauhaus-black bg-bauhaus-white p-6">
+        <h1 className="font-display text-4xl font-black uppercase tracking-tight">{theme.title}</h1>
+        {theme.description ? (
+          <p className="mt-2 max-w-[65ch] text-[15px] text-neutral-700">{theme.description}</p>
+        ) : null}
+        <p className="mt-3 font-mono text-[11px] uppercase tracking-widest text-neutral-500">
+          {reports.length} report{reports.length === 1 ? '' : 's'}
+          {questionsVisible && questions.length > 0
+            ? ` · ${questions.length} registered question${questions.length === 1 ? '' : 's'}`
+            : ''}
+        </p>
+      </header>
+
+      <div className="mt-4 grid gap-4">
+        {/* 1. FINDINGS FIRST. The key numbers, and only from registered questions. */}
+        {questionsVisible && answered.length > 0 ? (
+          <Panel title="What we can say" note="from registered questions only">
+            <ul className="grid gap-4 sm:grid-cols-2">
+              {answered.map((q) => (
+                <li key={q.slug} className="border-l-4 border-bauhaus-blue pl-3">
+                  <Link href={`/clarity/q/${q.slug}`} className="block">
+                    <div className="font-display text-3xl font-black">{q.headline}</div>
+                    {q.headline_sub ? (
+                      <div className="mt-0.5 font-mono text-[11px] text-neutral-500">
+                        {q.headline_sub}
+                      </div>
+                    ) : null}
+                    <div className="mt-1 text-[13px] text-neutral-700 underline decoration-neutral-300">
+                      {q.question}
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </Panel>
+        ) : questionsVisible ? (
+          <Panel title="What we can say">
+            {/* An empty slot is a work queue, not a gap to paper over with a borrowed figure. */}
+            <p className="text-[14px] text-neutral-700">
+              <strong>No registered question answers anything on this theme yet.</strong> Figures in
+              the reports below have not been through the question registry, so none is quoted here
+              — a number on this page would carry a sentinel, a coverage figure and an exclusions
+              note, or it does not appear.
+            </p>
+          </Panel>
+        ) : (
+          <Panel title="What we can say">
+            <p className="text-[14px] text-neutral-700">{questionsWithheld}</p>
+          </Panel>
+        )}
+
+        {/* Contested and refused questions are findings too — often the most important ones. */}
+        {questionsVisible && questions.some((q) => q.state !== 'answered') ? (
+          <Panel title="Contested and refused">
+            <ul className="grid gap-2">
+              {questions
+                .filter((q) => q.state !== 'answered')
+                .map((q) => (
+                  <li key={q.slug} className="flex flex-wrap items-baseline gap-2">
+                    <span
+                      className={`shrink-0 border px-1 font-mono text-[9px] font-black uppercase tracking-wider ${
+                        q.state === 'refused'
+                          ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                          : 'border-bauhaus-black'
+                      }`}
+                    >
+                      {q.state}
+                    </span>
+                    <Link
+                      href={`/clarity/q/${q.slug}`}
+                      className="text-[14px] underline decoration-neutral-300"
+                    >
+                      {q.question}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </Panel>
+        ) : null}
+
+        <Panel title="Reports" note={`${listedReports.length} shown`}>
+          <ul className="grid gap-1.5">
+            {listedReports.map((r) => (
+              <li
+                key={r.href}
+                className="flex flex-wrap items-baseline gap-2"
+                style={{ paddingLeft: `${r.depth * 16}px` }}
+              >
+                <Link href={r.href} className="text-[14px] underline decoration-neutral-300">
+                  {r.label}
+                </Link>
+                <StatusChip status={r.status} />
+              </li>
+            ))}
+          </ul>
+
+          {/* Absence is stated, never silent — including when the absence is our own caution. */}
+          {withheldReviews.length > 0 ? (
+            <p className="mt-4 border-l-4 border-bauhaus-red pl-3 text-[13px] text-neutral-700">
+              <strong>
+                {withheldReviews.length} further report
+                {withheldReviews.length === 1 ? '' : 's'} on this theme {withheldReviews.length === 1 ? 'is' : 'are'} not
+                listed.
+              </strong>{' '}
+              They are marked as needing source-date, figure and framing review before being quoted
+              externally, and this theme names individuals and the boards they sit on. They stay
+              unpublished until reviewed rather than published with a warning.
+            </p>
+          ) : null}
+        </Panel>
+
+        {/* The ACT line. One sentence — the substance lives behind the workspace login. */}
+        {theme.actProjectCodes.length > 0 ? (
+          <Panel title="Who runs this atlas">
+            <p className="text-[14px] text-neutral-700">
+              A Curious Tractor works in this area, through{' '}
+              <span className="font-mono">{theme.actProjectCodes.join(', ')}</span>. We publish this
+              atlas and we also operate in the field, which you are entitled to know when reading
+              it.
+            </p>
+          </Panel>
+        ) : null}
+
+        {/* 4. PLUMBING LAST — and the work list is operator-tier, so it is named and withheld. */}
+        <Panel title="What is missing">
+          <p className="text-[14px] text-neutral-700">
+            {inProgress > 0 ? (
+              <>
+                <strong>
+                  {inProgress} question{inProgress === 1 ? '' : 's'} on this theme{' '}
+                  {inProgress === 1 ? 'is' : 'are'} registered but unanswerable or in draft.
+                </strong>{' '}
+              </>
+            ) : null}
+            {withheldNote('operator', SURFACE, 'The full work list')} It records which reports need
+            review, which questions the data cannot yet answer, and where our own projects have no
+            evidence behind them. It is our to-do list rather than a finding, so it is not published
+            — but it exists, and this says so.
+          </p>
+        </Panel>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/reports/theme/[slug]/page.tsx
+++ b/apps/web/src/app/reports/theme/[slug]/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getDirectServiceSupabase } from '@/lib/supabase';
 import { canRender, withheldNote, type Surface } from '@/lib/visibility';
+import { money, themeMoney, type ThemeMoney } from '@/lib/justice-money';
+import { floorFor } from '@/app/clarity/visibility-floor';
 import {
   STATUS_BADGE,
   allThemes,
@@ -12,7 +14,10 @@ import {
   type ThemeReport,
 } from '../themes';
 
-export const dynamic = 'force-dynamic';
+// Not force-dynamic: this page takes no per-request input and reads a nightly snapshot. The money
+// aggregate scans up to 16,418 rows for child-protection, and doing that per anonymous hit is the
+// exact service-role burst pattern that saturated the shared pool in August.
+export const revalidate = 3600;
 
 /**
  * A theme page — findings first, plumbing last.
@@ -117,6 +122,21 @@ export default async function ThemePage({ params }: { params: Promise<{ slug: st
   const reports = reportsForTheme(slug);
   const { shown: questions, inProgress } = await loadQuestions(theme);
 
+  // The money. Gated on the visibility floor rather than assumed: `justice_funding` is promoted to
+  // `public` explicitly in visibility-floor.ts, and if that promotion is ever revoked this panel
+  // disappears rather than leaking.
+  const moneyAllowed =
+    canRender(floorFor({ object_name: 'justice_funding', domain: 'justice_youth_detention' }), SURFACE) &&
+    theme.topicTags.length > 0;
+  let themeMoneyData: ThemeMoney | null = null;
+  if (moneyAllowed) {
+    try {
+      themeMoneyData = await themeMoney(theme.topicTags);
+    } catch {
+      themeMoneyData = null; // A failed aggregate costs a panel, not the page.
+    }
+  }
+
   // Rule 2. Accountability & Power names people; a framing-unreviewed claim about a named person
   // is a different kind of risk from a framing-unreviewed claim about a budget line.
   const countOnly = theme.reviewPolicy === 'count-only';
@@ -220,6 +240,99 @@ export default async function ThemePage({ params }: { params: Promise<{ slug: st
                   </li>
                 ))}
             </ul>
+          </Panel>
+        ) : null}
+
+        {/* THE MONEY. Real dollars, real organisations, each linking to the entity page that
+            already resolves them across seven registers. */}
+        {themeMoneyData && themeMoneyData.top.length > 0 ? (
+          <Panel
+            title="Where the money went"
+            note={`${themeMoneyData.firstYear} to ${themeMoneyData.lastYear}`}
+          >
+            <div className="flex flex-wrap items-baseline gap-x-8 gap-y-2 border-b-2 border-bauhaus-black pb-3">
+              <div>
+                <div className="font-display text-4xl font-black">
+                  {money(themeMoneyData.total)}
+                </div>
+                <div className="font-mono text-[11px] uppercase tracking-widest text-neutral-500">
+                  recorded, across {themeMoneyData.grantCount.toLocaleString('en-AU')} grants
+                </div>
+              </div>
+              <div>
+                <div className="font-display text-4xl font-black">
+                  {themeMoneyData.organisationCount.toLocaleString('en-AU')}
+                </div>
+                <div className="font-mono text-[11px] uppercase tracking-widest text-neutral-500">
+                  organisations
+                </div>
+              </div>
+            </div>
+
+            <ol className="mt-3 grid gap-1">
+              {themeMoneyData.top.map((r, i) => (
+                <li key={`${r.name}-${i}`} className="flex flex-wrap items-baseline gap-2">
+                  <span className="w-6 shrink-0 text-right font-mono text-[11px] text-neutral-400">
+                    {i + 1}
+                  </span>
+                  {r.gsId ? (
+                    <Link
+                      href={`/entity/${r.gsId}`}
+                      className="text-[14px] underline decoration-neutral-300"
+                    >
+                      {r.name}
+                    </Link>
+                  ) : (
+                    // No graph entity: the name is shown but not linked, rather than linking
+                    // somewhere plausible-looking that resolves to the wrong organisation.
+                    <span className="text-[14px] text-neutral-700">{r.name}</span>
+                  )}
+                  <span className="ml-auto shrink-0 font-mono text-[13px] font-bold">
+                    {money(r.dollars)}
+                  </span>
+                  <span className="w-16 shrink-0 text-right font-mono text-[11px] text-neutral-400">
+                    {r.grants} grant{r.grants === 1 ? '' : 's'}
+                  </span>
+                </li>
+              ))}
+            </ol>
+
+            {/* Every qualification this number carries, on the same screen as the number. */}
+            <div className="mt-4 border-t border-neutral-200 pt-3 text-[12px] leading-relaxed text-neutral-600">
+              <p>
+                <strong>This is a floor, not a total.</strong> It counts grants recorded in
+                CivicGraph and tagged to this theme. Money that was never published, never tagged,
+                or spent through a departmental budget line rather than a grant is not here.
+                Whole-of-state budget rows are excluded on purpose — they are not money to any
+                organisation.
+              </p>
+              {themeMoneyData.excludedRows > 0 ? (
+                <p className="mt-2">
+                  <strong>
+                    {themeMoneyData.excludedRows} row
+                    {themeMoneyData.excludedRows === 1 ? '' : 's'} worth{' '}
+                    {money(themeMoneyData.excludedDollars)} excluded
+                  </strong>{' '}
+                  as source-spreadsheet totals rather than recipients — rows whose recipient is
+                  literally named &ldquo;Total&rdquo; or &ldquo;Various&rdquo;. Left in, they would
+                  rank at the top of this list.
+                </p>
+              ) : null}
+              <p className="mt-2">
+                {themeMoneyData.linkedPct}% of these grants resolve to an organisation in the
+                graph. The rest are named but not linked — a name without a matched entity is shown
+                as text rather than pointed at a plausible-looking wrong organisation.
+              </p>
+            </div>
+          </Panel>
+        ) : theme.topicTags.length === 0 ? (
+          <Panel title="Where the money went">
+            <p className="text-[14px] text-neutral-700">
+              <strong>No money figure for this theme.</strong> The funding records CivicGraph holds
+              are tagged by service area — youth justice, child protection, NDIS, family services —
+              and nothing in this theme has a tag. Publishing a figure here would mean inventing a
+              boundary the data does not draw.
+            </p>
           </Panel>
         ) : null}
 

--- a/apps/web/src/app/reports/theme/themes.test.ts
+++ b/apps/web/src/app/reports/theme/themes.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { allThemes, reportsForTheme, slugify, themeBySlug } from './themes';
+
+describe('slugify', () => {
+  it('handles the ampersand titles without leaving a stray dash', () => {
+    expect(slugify('Accountability & Power')).toBe('accountability-power');
+    expect(slugify('Philanthropy & Corporate')).toBe('philanthropy-corporate');
+    expect(slugify('Cross-System')).toBe('cross-system');
+  });
+});
+
+describe('allThemes', () => {
+  it('excludes the curated shortcut sections', () => {
+    // Current Map and State Dashboards are lists of pointers, not subjects. A theme page for
+    // "Current Map" would be a page about a menu.
+    const slugs = allThemes().map((t) => t.slug);
+    expect(slugs).not.toContain('current-map');
+    expect(slugs).not.toContain('state-dashboards');
+  });
+
+  it('covers the subject sections', () => {
+    const slugs = allThemes().map((t) => t.slug);
+    for (const s of ['youth-justice', 'child-protection', 'accountability-power', 'data-system']) {
+      expect(slugs).toContain(s);
+    }
+  });
+
+  it('never collides with an existing report route', () => {
+    // /reports/youth-justice etc. are real pages — the section's own Overview. This is why theme
+    // pages live at /reports/theme/[slug] and not /reports/[slug].
+    for (const t of allThemes()) {
+      expect(t.slug).not.toMatch(/^\//);
+    }
+  });
+});
+
+describe('reportsForTheme', () => {
+  it('flattens the nav tree and de-duplicates by href', () => {
+    // A section can list the same page twice — an Overview that is also the parent of its own
+    // children. Rendering it twice reads as a bug.
+    const reports = reportsForTheme('youth-justice');
+    const hrefs = reports.map((r) => r.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+    expect(reports.length).toBeGreaterThan(10);
+  });
+
+  it('gives a child with no status its parent status rather than a default', () => {
+    // QLD is `current` and its children carry no status of their own. Defaulting them to
+    // `reference` would understate them; defaulting to `current` would overstate every other
+    // section's children. Inheritance is the only honest option.
+    const reports = reportsForTheme('youth-justice');
+    const watchhouse = reports.find((r) => r.href === '/reports/youth-justice/qld/watchhouse-data');
+    expect(watchhouse?.status).toBe('current');
+  });
+
+  it('returns nothing for an unknown slug', () => {
+    expect(reportsForTheme('not-a-theme')).toEqual([]);
+  });
+});
+
+describe('the review-status policy', () => {
+  it('makes Accountability & Power count-only', () => {
+    // 10 of the 20 review-status reports live here, and its subjects are named individuals and
+    // the boards they sit on. A framing-unreviewed claim about a person is a different risk from
+    // a framing-unreviewed claim about a budget line.
+    expect(themeBySlug('accountability-power')?.reviewPolicy).toBe('count-only');
+  });
+
+  it('leaves the sector themes able to link with a warning', () => {
+    for (const s of ['youth-justice', 'child-protection', 'disability']) {
+      expect(themeBySlug(s)?.reviewPolicy).toBe('link-with-warning');
+    }
+  });
+
+  it('still holds review-status reports to count — the restriction is real, not theoretical', () => {
+    const withheld = reportsForTheme('accountability-power').filter((r) => r.status === 'review');
+    expect(withheld.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe('HOUSE questions', () => {
+  it('are the only subject routed to a theme, and they are operator-tier', () => {
+    // data-system maps to HOUSE. HOUSE questions describe our own estate, not the world, so the
+    // page must withhold them from a public surface rather than publishing our to-do list as
+    // findings. The page asserts this via canRender(); this test pins the mapping it depends on.
+    expect(themeBySlug('data-system')?.questionSubjects).toContain('HOUSE');
+    for (const t of allThemes()) {
+      if (t.slug === 'data-system') continue;
+      expect(t.questionSubjects).not.toContain('HOUSE');
+    }
+  });
+});
+
+describe('themes with no registered question', () => {
+  it('declare it rather than borrowing a subject', () => {
+    // Child Protection has 10 reports and no registered question. The page must show no number at
+    // all rather than lifting a figure from report prose — 20 reports are flagged as needing
+    // figure review and theirs are exactly the ones that must not be quoted.
+    expect(themeBySlug('child-protection')?.questionSubjects).toEqual([]);
+    expect(reportsForTheme('child-protection').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/reports/theme/themes.ts
+++ b/apps/web/src/app/reports/theme/themes.ts
@@ -1,0 +1,201 @@
+import { reportSections, type NavItem, type ReportStatus } from '../_components/sidebar-nav-data';
+
+/**
+ * Theme pages — the 13 report sections, made into real pages.
+ *
+ * WHY THESE AND NOT SOMETHING NEW
+ *
+ * Three taxonomies exist in this system: 13 report sections, 11 ACT project categories, and 17
+ * database domains. The sections win because they are the only one written in the language a human
+ * uses about the world ("Youth Justice", "Child Protection") and they already file 74 nav items.
+ * The ACT categories are what a theme ALIGNS to, not what it navigates by. The DB domains were
+ * rejected in part 1 as a schema taxonomy in subject clothing.
+ *
+ * A fourth taxonomy to unify the three is how you end up with five.
+ *
+ * WHY /reports/theme/[slug] AND NOT /reports/[slug]
+ *
+ * The plan said `/reports/[section]`. It cannot be: every section slug is already a real report
+ * page — `/reports/youth-justice`, `/reports/child-protection`, `/reports/disability`,
+ * `/reports/education`, `/reports/social-enterprise`, `/reports/philanthropy` all exist and are
+ * the section's own Overview. One extra path segment, same neighbourhood.
+ *
+ * See `thoughts/shared/plans/clarity-console-part-2.md`, slice B.
+ */
+
+export interface Theme {
+  slug: string;
+  title: string;
+  description: string | null;
+  /**
+   * Question subjects from `v_clarity_board_cards`. Several themes map to none, and that is the
+   * honest state, not a gap to be filled with a borrowed number — an empty key-numbers slot is an
+   * advertisement for which question to register next.
+   */
+  questionSubjects: readonly string[];
+  /**
+   * Topic tags on `justice_funding.topics`. Present only for the sector themes; the power themes
+   * genuinely have none, and their pages must say why rather than showing a figure. Unused until
+   * slice C.
+   */
+  topicTags: readonly string[];
+  /** ACT project codes that work in this area. A judgement about our work, hand-declared. */
+  actProjectCodes: readonly string[];
+  /**
+   * Whether review-status reports may be LINKED here, or only counted.
+   *
+   * Accountability & Power holds 10 of the 20 review-status reports and its subjects are named
+   * individuals and their board seats. A framing-unreviewed report about disability funding is a
+   * quality problem; a framing-unreviewed report naming people is a defamation problem — the same
+   * reasoning that refused the ministerial-diaries question outright.
+   */
+  reviewPolicy: 'link-with-warning' | 'count-only';
+}
+
+/**
+ * Hand-written, deliberately. A theme's question subjects and project codes are judgements, and a
+ * rule that derived them would be wrong quietly. Themes absent from this map render their reports
+ * and nothing else.
+ */
+const THEME_META: Record<
+  string,
+  Pick<Theme, 'questionSubjects' | 'topicTags' | 'actProjectCodes' | 'reviewPolicy'>
+> = {
+  'youth-justice': {
+    questionSubjects: ['JUSTICE'],
+    topicTags: ['youth-justice', 'diversion'],
+    actProjectCodes: ['ACT-JH'],
+    reviewPolicy: 'link-with-warning',
+  },
+  'child-protection': {
+    questionSubjects: [],
+    topicTags: ['child-protection', 'family-services'],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  disability: {
+    questionSubjects: [],
+    topicTags: ['ndis'],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  education: {
+    questionSubjects: [],
+    topicTags: [],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  'cross-system': {
+    questionSubjects: ['EVIDENCE'],
+    topicTags: ['prevention', 'community-led'],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  'accountability-power': {
+    questionSubjects: ['POWER'],
+    topicTags: [],
+    actProjectCodes: [],
+    reviewPolicy: 'count-only',
+  },
+  'funding-equity': {
+    questionSubjects: ['MONEY', 'PLACE'],
+    topicTags: [],
+    actProjectCodes: ['ACT-CORE'],
+    reviewPolicy: 'link-with-warning',
+  },
+  'social-sector': {
+    questionSubjects: ['CHARITY'],
+    topicTags: ['legal-services'],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  'philanthropy-corporate': {
+    questionSubjects: ['MONEY'],
+    topicTags: [],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  'research-procurement': {
+    questionSubjects: [],
+    topicTags: [],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+  'data-system': {
+    // HOUSE questions are about our own estate, not about the world. They are `operator` tier and
+    // must not render publicly — see lib/visibility.ts.
+    questionSubjects: ['HOUSE'],
+    topicTags: [],
+    actProjectCodes: [],
+    reviewPolicy: 'link-with-warning',
+  },
+};
+
+/** Sections that are curated shortcuts rather than subjects. They get no theme page. */
+const NOT_A_THEME = new Set(['Current Map', 'State Dashboards']);
+
+export function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/&/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export interface ThemeReport {
+  label: string;
+  href: string;
+  status: ReportStatus;
+  /** Depth in the nav tree — top-level items lead, children indent. */
+  depth: number;
+}
+
+/** Flattens the nav tree. A child with no status inherits its parent's. */
+function flatten(items: readonly NavItem[], depth = 0, inherited: ReportStatus = 'reference'): ThemeReport[] {
+  const out: ThemeReport[] = [];
+  for (const item of items) {
+    const status = item.status ?? inherited;
+    out.push({ label: item.label, href: item.href, status, depth });
+    if (item.children?.length) out.push(...flatten(item.children, depth + 1, status));
+  }
+  return out;
+}
+
+export function allThemes(): Theme[] {
+  return reportSections
+    .filter((s) => !NOT_A_THEME.has(s.title))
+    .map((s) => {
+      const slug = slugify(s.title);
+      const meta = THEME_META[slug] ?? {
+        questionSubjects: [],
+        topicTags: [],
+        actProjectCodes: [],
+        reviewPolicy: 'link-with-warning' as const,
+      };
+      return { slug, title: s.title, description: s.description ?? null, ...meta };
+    });
+}
+
+export function themeBySlug(slug: string): Theme | null {
+  return allThemes().find((t) => t.slug === slug) ?? null;
+}
+
+export function reportsForTheme(slug: string): ThemeReport[] {
+  const section = reportSections.find((s) => slugify(s.title) === slug);
+  if (!section) return [];
+  // De-duplicate by href: a section can list the same page twice (an Overview that is also the
+  // parent of its own children). Keep the first, which carries the shallower depth.
+  const seen = new Set<string>();
+  return flatten(section.items).filter((r) => {
+    if (seen.has(r.href)) return false;
+    seen.add(r.href);
+    return true;
+  });
+}
+
+export const STATUS_BADGE: Record<ReportStatus, { label: string; tone: 'ok' | 'muted' | 'warn' }> = {
+  current: { label: 'Current', tone: 'ok' },
+  reference: { label: 'Reference', tone: 'muted' },
+  review: { label: 'Needs review', tone: 'warn' },
+  archive: { label: 'Archive', tone: 'muted' },
+};

--- a/apps/web/src/lib/justice-money.test.ts
+++ b/apps/web/src/lib/justice-money.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { NON_RECIPIENT_NAMES, isRealRecipient, money } from './justice-money';
+
+describe('isRealRecipient — the filter CLAUDE.md does not document', () => {
+  it('rejects source-spreadsheet total rows', () => {
+    // Found 2026-08-16. `measure_kind='grant'` does NOT exclude these: 44 rows out of 126,673
+    // carry aggregate-shaped names and hold $8.09bn — 17.5% of the documented $46.1bn.
+    for (const n of ['Total', 'total', ' TOTAL ', 'Totals', 'Grand Total', 'Subtotal']) {
+      expect(isRealRecipient(n)).toBe(false);
+    }
+  });
+
+  it('rejects placeholder recipients', () => {
+    for (const n of ['Various', 'n/a', 'N/A', 'Unknown', 'TBC', 'Other']) {
+      expect(isRealRecipient(n)).toBe(false);
+    }
+  });
+
+  it('accepts real organisations, including ones containing a rejected word', () => {
+    // Why this is an explicit set and not a /total/ pattern: excluding a real recipient
+    // understates them on a public page.
+    expect(isRealRecipient('Lifeline Community Care')).toBe(true);
+    expect(isRealRecipient('Mission Australia')).toBe(true);
+    expect(isRealRecipient('Total Care Youth Services Inc')).toBe(true);
+    expect(isRealRecipient('Various Voices Aboriginal Corporation')).toBe(true);
+  });
+
+  it('rejects an absent name rather than counting it', () => {
+    expect(isRealRecipient(null)).toBe(false);
+    expect(isRealRecipient(undefined)).toBe(false);
+    expect(isRealRecipient('')).toBe(false);
+    expect(isRealRecipient('   ')).toBe(false);
+  });
+
+  it('holds the exclusion list lower-cased, or the trim/lower comparison silently fails', () => {
+    for (const n of NON_RECIPIENT_NAMES) {
+      expect(n).toBe(n.toLowerCase().trim());
+    }
+  });
+});
+
+describe('money', () => {
+  it('formats at the scale a reader can hold', () => {
+    expect(money(1_040_000_000)).toBe('$1.04bn');
+    expect(money(30_100_000)).toBe('$30.1m');
+    expect(money(8_700)).toBe('$9k');
+    expect(money(412)).toBe('$412');
+  });
+
+  it('does not round a real figure up into a bigger unit', () => {
+    expect(money(999_999)).toBe('$1000k');
+    expect(money(1_000_000)).toBe('$1.0m');
+  });
+});

--- a/apps/web/src/lib/justice-money.ts
+++ b/apps/web/src/lib/justice-money.ts
@@ -116,6 +116,12 @@ export async function themeMoney(topics: readonly string[], topN = 15): Promise<
         .from('justice_funding')
         .select('id,recipient_name,amount_dollars,financial_year,gs_entity_id')
         .eq('measure_kind', 'grant')
+        // `is_aggregate` is NOT implied by measure_kind and cuts both ways: 1,358 rows are
+        // measure_kind='grant' AND is_aggregate — $12.06bn of grant-shaped aggregates — while 330
+        // expenditure_aggregate rows are is_aggregate=false. Neither column is a superset of the
+        // other, so both are required. Nationally this is the difference between $38.01bn and
+        // $33.98bn; on the youth-justice theme it moves $1,044.8m to $1,044.2m.
+        .not('is_aggregate', 'is', true)
         .contains('topics', [topic])
         .range(from, from + PAGE - 1);
       if (error) throw new Error(`justice money query failed: ${error.message}`);

--- a/apps/web/src/lib/justice-money.ts
+++ b/apps/web/src/lib/justice-money.ts
@@ -1,0 +1,206 @@
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Money from `justice_funding`, filtered honestly.
+ *
+ * THREE FILTERS, NOT ONE. All three are mandatory and omitting any of them does not produce a
+ * slightly-off number — it produces a wrong one by billions.
+ *
+ * 1. `measure_kind = 'grant'`
+ *    Documented in CLAUDE.md. 848 `expenditure_aggregate` rows are WHOLE-OF-STATE BUDGETS
+ *    ($66.1bn), not money to any organisation.
+ *
+ * 2. Aggregate-shaped recipient names — NOT previously documented anywhere, found 2026-08-16.
+ *    `measure_kind = 'grant'` does NOT exclude spreadsheet total rows. 44 rows out of 126,673
+ *    carry recipient names like `Total`, `Various` and `n/a`, and between them they hold
+ *    **$8.09bn — 17.5% of the $46.1bn that CLAUDE.md documents as the grant figure.**
+ *    Four of them are `qld-historical-grants` column totals worth $617.9M, sitting in the
+ *    youth-justice topic, where they rank as the #1 and #2 recipients of youth justice funding
+ *    in Australia. One of them even carries an ABN.
+ *
+ *      measure_kind='grant'                  126,673 rows   $46.10bn
+ *      ...minus aggregate-shaped names       126,629 rows   $38.01bn
+ *
+ * 3. `amount_dollars IS NOT NULL` for any ORDER BY on money. Postgres sorts NULLs FIRST in a
+ *    DESC ordering, so a naive "top recipients" query returns the rows with no amount at all.
+ *
+ * Topic tags use HYPHENS. `topics @> ARRAY['youth_justice']` returns zero rows silently.
+ */
+
+/**
+ * Recipient names that are not organisations. Compared lower-cased and trimmed.
+ *
+ * Kept as an explicit list rather than a pattern: a pattern matching /total/ would also catch a
+ * real organisation with "Total" in its name, and the cost of wrongly excluding a real recipient
+ * is understating them on a public page.
+ */
+export const NON_RECIPIENT_NAMES: ReadonlySet<string> = new Set([
+  'total',
+  'totals',
+  'grand total',
+  'subtotal',
+  'sub-total',
+  'various',
+  'n/a',
+  'na',
+  'unknown',
+  'tbc',
+  'other',
+]);
+
+export function isRealRecipient(name: string | null | undefined): boolean {
+  if (!name) return false;
+  // Trim BEFORE the emptiness check: `'   '` is truthy, and without this a whitespace-only
+  // recipient renders as a blank row carrying real dollars.
+  const normalised = name.trim().toLowerCase();
+  if (normalised === '') return false;
+  return !NON_RECIPIENT_NAMES.has(normalised);
+}
+
+export interface ThemeMoney {
+  /** Dollars, after all three filters. A FLOOR, never a total — see coverage below. */
+  total: number;
+  grantCount: number;
+  organisationCount: number;
+  firstYear: string | null;
+  lastYear: string | null;
+  /** Rows excluded as aggregate-shaped, and what they were worth. Stated, never silently dropped. */
+  excludedRows: number;
+  excludedDollars: number;
+  /** Share of included rows that resolve to a graph entity, so the links can be honest. */
+  linkedPct: number;
+  top: RecipientRow[];
+}
+
+export interface RecipientRow {
+  name: string;
+  gsId: string | null;
+  dollars: number;
+  grants: number;
+}
+
+interface RawRow {
+  /** Selected solely to deduplicate across tags. See the overlap note in themeMoney(). */
+  id: string;
+  recipient_name: string | null;
+  amount_dollars: number | null;
+  financial_year: string | null;
+  gs_entity_id: string | null;
+}
+
+/**
+ * Aggregates in memory rather than in SQL.
+ *
+ * PostgREST cannot GROUP BY, and adding a database function for this would be a migration on a
+ * shared production database for a read that runs once an hour behind `revalidate`. The largest
+ * topic is `child-protection` at 16,418 rows; at four columns that is a few hundred KB, fetched
+ * hourly per theme. If a theme ever needs sub-second freshness this becomes a matview.
+ */
+export async function themeMoney(topics: readonly string[], topN = 15): Promise<ThemeMoney | null> {
+  if (topics.length === 0) return null;
+
+  const supabase = getDirectServiceSupabase();
+  const PAGE = 1000;
+
+  // DEDUPLICATED BY id, because a theme's tags DO overlap. Measured 2026-08-16:
+  //   youth-justice ∩ diversion            98 rows
+  //   child-protection ∩ family-services    2 rows
+  //   prevention ∩ community-led            0 rows
+  // Querying tag by tag and concatenating would count those 98 grants twice and overstate youth
+  // justice funding. The `id` column exists in the select for no other reason.
+  const byId = new Map<string, RawRow>();
+
+  for (const topic of topics) {
+    for (let from = 0; ; from += PAGE) {
+      const { data, error } = await supabase
+        .from('justice_funding')
+        .select('id,recipient_name,amount_dollars,financial_year,gs_entity_id')
+        .eq('measure_kind', 'grant')
+        .contains('topics', [topic])
+        .range(from, from + PAGE - 1);
+      if (error) throw new Error(`justice money query failed: ${error.message}`);
+      const page = (data ?? []) as unknown as RawRow[];
+      for (const r of page) byId.set(r.id, r);
+      if (page.length < PAGE) break;
+    }
+  }
+
+  const rows = [...byId.values()];
+  if (rows.length === 0) return null;
+
+  const excluded = rows.filter((r) => !isRealRecipient(r.recipient_name));
+  const kept = rows.filter((r) => isRealRecipient(r.recipient_name));
+
+  const byName = new Map<string, { dollars: number; grants: number; gsEntityId: string | null }>();
+  let total = 0;
+  let linked = 0;
+  let firstYear: string | null = null;
+  let lastYear: string | null = null;
+
+  for (const r of kept) {
+    const amount = r.amount_dollars ?? 0;
+    total += amount;
+    if (r.gs_entity_id) linked += 1;
+    if (r.financial_year) {
+      if (!firstYear || r.financial_year < firstYear) firstYear = r.financial_year;
+      if (!lastYear || r.financial_year > lastYear) lastYear = r.financial_year;
+    }
+    const name = (r.recipient_name ?? '').trim();
+    const prev = byName.get(name) ?? { dollars: 0, grants: 0, gsEntityId: null };
+    byName.set(name, {
+      dollars: prev.dollars + amount,
+      grants: prev.grants + 1,
+      gsEntityId: prev.gsEntityId ?? r.gs_entity_id,
+    });
+  }
+
+  const entityIds = [
+    ...new Set(
+      [...byName.values()].map((v) => v.gsEntityId).filter((v): v is string => Boolean(v)),
+    ),
+  ];
+  const gsIdByEntityId = new Map<string, string>();
+  // Resolve internal ids to the public `gs_id` used by /entity/[gsId]. Chunked: a 1,274-org theme
+  // would otherwise build a URL longer than PostgREST accepts.
+  for (let i = 0; i < entityIds.length; i += 200) {
+    const chunk = entityIds.slice(i, i + 200);
+    try {
+      const { data } = await supabase.from('gs_entities').select('id,gs_id').in('id', chunk);
+      for (const e of (data ?? []) as { id: string; gs_id: string }[]) {
+        gsIdByEntityId.set(e.id, e.gs_id);
+      }
+    } catch {
+      // A failed chunk costs links, not numbers. The names still render.
+    }
+  }
+
+  const top = [...byName.entries()]
+    .map(([name, v]) => ({
+      name,
+      gsId: v.gsEntityId ? (gsIdByEntityId.get(v.gsEntityId) ?? null) : null,
+      dollars: v.dollars,
+      grants: v.grants,
+    }))
+    .filter((r) => r.dollars > 0)
+    .sort((a, b) => b.dollars - a.dollars)
+    .slice(0, topN);
+
+  return {
+    total,
+    grantCount: kept.length,
+    organisationCount: byName.size,
+    firstYear,
+    lastYear,
+    excludedRows: excluded.length,
+    excludedDollars: excluded.reduce((s, r) => s + (r.amount_dollars ?? 0), 0),
+    linkedPct: kept.length === 0 ? 0 : Math.round((linked / kept.length) * 1000) / 10,
+    top,
+  };
+}
+
+export function money(n: number): string {
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  if (n >= 1e3) return `$${Math.round(n / 1e3)}k`;
+  return `$${Math.round(n)}`;
+}

--- a/supabase/migrations/20260816020000_justice_funding_clean_expose_measure_columns.sql
+++ b/supabase/migrations/20260816020000_justice_funding_clean_expose_measure_columns.sql
@@ -1,0 +1,84 @@
+-- justice_funding_clean: expose the columns that make filtering possible.
+--
+-- APPLY WITH:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260816020000_justice_funding_clean_expose_measure_columns.sql
+--
+-- WHY
+--
+-- `justice_funding_clean` is named for a promise it does not keep. Its entire filter is
+-- `sector IS DISTINCT FROM 'procurement'`, and it reports $117.47bn across 151,866 rows against an
+-- honest $33.98bn across 125,300 — 3.1x, roughly $83bn of money that is not money received by an
+-- organisation.
+--
+-- The deeper problem is that no caller can fix it: the view does not select `measure_kind` or
+-- `is_aggregate`, so anything reading it is structurally unable to exclude whole-of-state budget
+-- rows even when it knows it should. 47 views read `justice_funding` and 4 reference
+-- `measure_kind`; 100 app files reference the table and 2 reference the column. Some of that is
+-- callers not knowing. Some of it is callers not being able to.
+--
+-- Full audit: thoughts/shared/data-map/justice-funding-filter-audit.md
+--
+-- WHAT THIS CHANGES
+--
+-- Nothing, today. It only ADDS columns. Every existing consumer selects named columns or `*`;
+-- adding two at the end changes no current result, no row count and no total. It is the
+-- prerequisite for the fixes, not a fix in itself.
+--
+-- Deliberately NOT done here: adding the filters to the view. Doing so would silently change every
+-- downstream number in one step, including views where the current behaviour is CORRECT — a view
+-- answering "total state expenditure on justice" should include the budget rows. Which views are
+-- wrong is a per-view judgement, and each should change with its own migration and its own note.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.justice_funding_clean AS
+SELECT
+  id,
+  source,
+  source_url,
+  source_statement_id,
+  recipient_name,
+  recipient_abn,
+  program_name,
+  program_round,
+  amount_dollars,
+  state,
+  location,
+  funding_type,
+  sector,
+  project_description,
+  announcement_date,
+  financial_year,
+  alma_intervention_id,
+  alma_organization_id,
+  created_at,
+  updated_at,
+  gs_entity_id,
+  topics,
+  -- Appended, in this order, so CREATE OR REPLACE accepts the change. Reordering or renaming any
+  -- column above requires a DROP, which would cascade to the 35 dependent views.
+  measure_kind,
+  is_aggregate
+FROM public.justice_funding
+WHERE sector IS DISTINCT FROM 'procurement'::text;
+
+COMMENT ON VIEW public.justice_funding_clean IS
+  'justice_funding minus procurement-sector rows. NOT a filtered money view: it includes '
+  'expenditure_aggregate whole-of-state budget rows and reports ~$117bn against ~$34bn of money '
+  'actually received by organisations. For money received, filter measure_kind = ''grant'' AND '
+  'is_aggregate IS NOT TRUE AND a non-aggregate recipient_name, and scope by topics — this table '
+  'is not all justice (it holds transport service contracts). '
+  'See thoughts/shared/data-map/justice-funding-filter-audit.md';
+
+COMMIT;
+
+-- VERIFY (should return 24 and both new columns present):
+--   SELECT count(*) FROM information_schema.columns WHERE table_name = 'justice_funding_clean';
+--   SELECT column_name FROM information_schema.columns
+--    WHERE table_name = 'justice_funding_clean' AND column_name IN ('measure_kind','is_aggregate');
+--
+-- VERIFY no number moved (should be 151866 rows / 117.47bn, exactly as before):
+--   SELECT count(*), round(sum(amount_dollars)/1e9, 2) FROM justice_funding_clean;

--- a/supabase/migrations/20260816030000_clarity_register_justice_money_to_orgs.sql
+++ b/supabase/migrations/20260816030000_clarity_register_justice_money_to_orgs.sql
@@ -1,0 +1,163 @@
+-- Register the honest justice_funding total, and a sentinel so it cannot regress a third time.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260816030000_clarity_register_justice_money_to_orgs.sql
+--
+-- WHY THIS EXISTS
+--
+-- On 2026-08-16 the same figure was corrected twice in two hours:
+--
+--   CLAUDE.md, as written           measure_kind='grant'                    $46.10bn
+--   first correction                ...minus aggregate-shaped names         $38.01bn
+--   second correction               ...and is_aggregate IS NOT TRUE         $33.98bn
+--
+-- Both errors were caught by hand, both by accident, and either could have shipped. A registered
+-- question with a sentinel is the mechanism this project already built for exactly that, and it
+-- had never been pointed at its own most-quoted number.
+--
+-- 71.81% of the dollars in justice_funding — $86.58bn of $120.56bn — are not money received by an
+-- organisation for justice work. Full audit:
+--   thoughts/shared/data-map/justice-funding-filter-audit.md
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- The sentinel — permanently tripped, and that is the design
+-- ---------------------------------------------------------------------------
+-- Modelled on receipt_type_contamination, which does the same job for political_donations. It is
+-- not an alarm that fires when something breaks; it is a standing condition of the table. Any
+-- question touching justice_funding must either apply the filters or write a clarity_sentinel
+-- exemption explaining why not. Silence is not an option the schema allows.
+INSERT INTO clarity_sentinel (key, label, description, probe_sql, severity, guards_objects)
+VALUES (
+  'measure_kind_contamination',
+  'justice_funding is not all money to organisations',
+  'Three independent classes of row in justice_funding are not money received by an organisation '
+  || 'for justice work, and none of them is excluded by the others: 848 expenditure_aggregate '
+  || 'whole-of-state budget rows; 1,900 rows flagged is_aggregate (1,358 of which are ALSO '
+  || 'measure_kind=''grant''); and 46 rows whose recipient is a source-spreadsheet total named '
+  || '"Total", "Various" or "n/a". A fourth trap is not a row class at all: the table holds '
+  || 'transport service contracts and rail concessions, so measure_kind alone never scopes it to '
+  || 'justice — topic filtering does. Raise this to warn only when a filtered view exists that '
+  || 'callers can safely default to.',
+  $probe$
+  SELECT (1 - sum(amount_dollars) FILTER (
+            WHERE measure_kind = 'grant'
+              AND is_aggregate IS NOT TRUE
+              AND lower(trim(recipient_name)) NOT IN
+                  ('total','totals','grand total','subtotal','sub-total',
+                   'various','n/a','na','unknown','tbc','other'))
+          / nullif(sum(amount_dollars), 0)) > 0.5 AS tripped,
+         count(*) FILTER (WHERE measure_kind <> 'grant' OR is_aggregate) AS n,
+         round((1 - sum(amount_dollars) FILTER (
+            WHERE measure_kind = 'grant'
+              AND is_aggregate IS NOT TRUE
+              AND lower(trim(recipient_name)) NOT IN
+                  ('total','totals','grand total','subtotal','sub-total',
+                   'various','n/a','na','unknown','tbc','other'))
+          / nullif(sum(amount_dollars), 0))::numeric, 4) AS share,
+         jsonb_build_object(
+           'note', 'filter measure_kind = ''grant'' AND is_aggregate IS NOT TRUE AND a '
+                || 'non-aggregate recipient_name, and scope by topics — this table is not all justice',
+           'audit', 'thoughts/shared/data-map/justice-funding-filter-audit.md') AS detail
+    FROM justice_funding
+  $probe$,
+  'block',
+  ARRAY['public.justice_funding']
+) ON CONFLICT (key) DO UPDATE
+  SET description = EXCLUDED.description,
+      probe_sql = EXCLUDED.probe_sql,
+      guards_objects = EXCLUDED.guards_objects;
+
+-- ---------------------------------------------------------------------------
+-- The question
+-- ---------------------------------------------------------------------------
+INSERT INTO clarity_question (
+  slug, stub, question, subject, state, form, honest_at, publishable,
+  defamation_sensitive, caveat, exclusions, claim_phrasing, forbidden_phrasing,
+  answer_sql, coverage_sql, live_rerun_ok, uniqueness, uniqueness_basis, surface
+) VALUES (
+  'justice-money-to-orgs',
+  'MONEY THAT REACHED ORGANISATIONS',
+  'How much of the justice-related funding we hold actually reached an organisation, rather than '
+  || 'being a budget line or a spreadsheet total?',
+  'MONEY', 'answered', 'scalar', 'national', 'public',
+  false,
+  'This is a floor and it is a record of what was PUBLISHED, not of what was spent. It counts '
+  || 'rows in justice_funding that are grants, are not flagged as aggregates, and name a real '
+  || 'recipient. It excludes whole-of-state budget lines, because a budget is not money to any '
+  || 'organisation. It does not scope to justice by topic, so it is the honest ceiling for '
+  || '"money to organisations in this table", not a justice total — the table also holds '
+  || 'transport service contracts.',
+  'Excluded and why: 848 expenditure_aggregate rows (whole-of-state budgets); 1,900 rows flagged '
+  || 'is_aggregate, of which 1,358 are also labelled grants; 46 rows whose recipient is a '
+  || 'spreadsheet total named "Total", "Various" or "n/a". Together $86.58bn of $120.56bn.',
+  'CivicGraph holds $33.98bn of published grants to named organisations in its justice funding '
+  || 'records. That is what was published and recorded, not what governments spent.',
+  ARRAY[
+    'Australia spends $34bn on justice',
+    'governments spent $33.98bn',
+    'total justice funding is $33.98bn',
+    '$46.1bn in justice grants'
+  ],
+  $answer$
+  WITH f AS (
+    SELECT amount_dollars, recipient_name
+      FROM justice_funding
+     WHERE measure_kind = 'grant'
+       AND is_aggregate IS NOT TRUE
+       AND lower(trim(recipient_name)) NOT IN
+           ('total','totals','grand total','subtotal','sub-total',
+            'various','n/a','na','unknown','tbc','other')
+  )
+  SELECT '$' || round((sum(amount_dollars) / 1e9)::numeric, 2)::text || 'bn' AS headline,
+         count(*)::text || ' grants to '
+           || count(DISTINCT recipient_name)::text
+           || ' named organisations, after excluding budget lines and spreadsheet totals'
+           AS headline_sub,
+         round((sum(amount_dollars) / 1e9)::numeric, 2) AS headline_num
+    FROM f
+  $answer$,
+  $coverage$
+  SELECT round(sum(amount_dollars) FILTER (
+            WHERE measure_kind = 'grant'
+              AND is_aggregate IS NOT TRUE
+              AND lower(trim(recipient_name)) NOT IN
+                  ('total','totals','grand total','subtotal','sub-total',
+                   'various','n/a','na','unknown','tbc','other'))
+          / nullif(sum(amount_dollars), 0), 4) AS coverage
+    FROM justice_funding
+  $coverage$,
+  true,
+  0.95,
+  'Nothing else in either repo states this number with its exclusions attached. Every other '
+  || 'surface reading justice_funding states a larger one, usually without knowing it.',
+  '/clarity/q/justice-money-to-orgs'
+) ON CONFLICT (slug) DO UPDATE
+  SET caveat = EXCLUDED.caveat,
+      exclusions = EXCLUDED.exclusions,
+      claim_phrasing = EXCLUDED.claim_phrasing,
+      forbidden_phrasing = EXCLUDED.forbidden_phrasing,
+      answer_sql = EXCLUDED.answer_sql,
+      coverage_sql = EXCLUDED.coverage_sql;
+
+-- The `public.` prefix is mandatory here and CHECK-constrained: this column is compared against
+-- clarity_sentinel.guards_objects. An unprefixed row detaches the sentinel and the answer runs
+-- green with a block sentinel silently tripped.
+INSERT INTO clarity_question_ingredient (question_slug, object_key, join_key, role, is_binding)
+VALUES ('justice-money-to-orgs', 'public.justice_funding', 'id', 'spine', true)
+ON CONFLICT DO NOTHING;
+
+COMMIT;
+
+-- VERIFY:
+--   SELECT tripped, share FROM ... (run the sentinel probe) -- expect tripped = true, share ~0.7181
+--   SELECT slug, state FROM clarity_question WHERE slug = 'justice-money-to-orgs';
+--   SELECT * FROM clarity_question_ingredient WHERE question_slug = 'justice-money-to-orgs';
+-- Then run the answer:
+--   node --env-file=.env scripts/run-clarity-answers.mjs --dry-run
+-- Expect headline $33.98bn and the sentinel to BLOCK until an exemption is written — that is the
+-- correct outcome, not a failure. The question's own filters satisfy the sentinel's intent, and
+-- the exemption should say exactly that.

--- a/supabase/migrations/20260816040000_clarity_justice_money_sentinel_exemption.sql
+++ b/supabase/migrations/20260816040000_clarity_justice_money_sentinel_exemption.sql
@@ -1,0 +1,38 @@
+-- justice-money-to-orgs: exempt from measure_kind_contamination, in writing.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260816040000_clarity_justice_money_sentinel_exemption.sql
+--
+-- The sentinel is permanently tripped by design: 71.81% of the dollars in justice_funding are not
+-- money received by an organisation. It blocks every question on the table, including the one
+-- written specifically to state the filtered figure. That is the mechanism working, not failing —
+-- a sentinel is never silently detached, it is exempted with a reason on the record.
+
+BEGIN;
+
+INSERT INTO clarity_sentinel_exemption (sentinel_key, question_slug, reason)
+VALUES (
+  'measure_kind_contamination',
+  'justice-money-to-orgs',
+  'This question IS the filter the sentinel demands. Its answer_sql applies all three row-level '
+  || 'exclusions the sentinel exists to enforce — measure_kind = ''grant'', is_aggregate IS NOT '
+  || 'TRUE, and a recipient_name that is not a spreadsheet total — and its exclusions field states '
+  || 'the $86.58bn of $120.56bn it removes and why. Blocking it would leave the contaminated '
+  || 'figure as the only one anybody could quote, which is the exact failure that produced two '
+  || 'corrections to CLAUDE.md in two hours on 2026-08-16. '
+  || 'SCOPE, stated so this exemption cannot be read as broader than it is: it covers the row '
+  || 'classes only. It does NOT cover the fourth trap, which is not a row class — justice_funding '
+  || 'holds transport service contracts and rail concessions, so no measure_kind filter scopes it '
+  || 'to justice. This question does not claim to be a justice total and its claim_phrasing and '
+  || 'forbidden_phrasing both say so. Any question that DOES claim a justice figure must scope by '
+  || 'topics and needs its own exemption, not this one.'
+) ON CONFLICT (sentinel_key, question_slug) DO UPDATE SET reason = EXCLUDED.reason;
+
+COMMIT;
+
+-- VERIFY:
+--   node --env-file=.env scripts/run-clarity-answers.mjs --dry-run
+-- Expect justice-money-to-orgs to answer $33.98bn, with the sentinel still TRIPPED (it should
+-- never stop being tripped) and the exemption rendered on the card.

--- a/supabase/migrations/20260816050000_clarity_add_is_aggregate_to_three_questions.sql
+++ b/supabase/migrations/20260816050000_clarity_add_is_aggregate_to_three_questions.sql
@@ -1,0 +1,148 @@
+-- Add is_aggregate to the three money questions the new sentinel caught, and exempt the fourth.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f supabase/migrations/20260816050000_clarity_add_is_aggregate_to_three_questions.sql
+--
+-- Within minutes of measure_kind_contamination being applied, it blocked four registered
+-- questions. Three were missing a filter that nobody knew about until 2026-08-16:
+--
+--   youth-justice-total     measure_kind YES  topics YES  is_aggregate NO   $1,534.2m -> $915.7m
+--   evidence-gap            measure_kind YES  topics YES  is_aggregate NO   778 -> 777 orgs
+--   every-dollar-one-abn    measure_kind YES  topics NO   is_aggregate NO   no change
+--   grant-behind-this-edge  not a money question at all                     exempt
+--
+-- youth-justice-total was overstated by 40%. 21 rows carry $618.5m, and they are the
+-- qld-historical-grants column totals — the same rows that rank as the #1 and #2 recipients of
+-- youth justice funding in Australia if you do not exclude them.
+--
+-- Audit: thoughts/shared/data-map/justice-funding-filter-audit.md
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- youth-justice-total — the 40% correction
+-- ---------------------------------------------------------------------------
+-- This question exists to teach the measure_kind trap: its headline_sub reports how much too high
+-- the naive sum would be. It now teaches BOTH traps, because the second one lives inside the
+-- answer to the first — 21 rows that pass `measure_kind = 'grant'` and are still aggregates.
+UPDATE clarity_question SET
+  answer_sql = $answer$
+  WITH k AS (
+    SELECT measure_kind, count(*) AS rows, sum(amount_dollars) AS dollars
+      FROM justice_funding
+     WHERE topics @> ARRAY['youth-justice']
+     GROUP BY 1
+  ),
+  gk AS (
+    SELECT sum(amount_dollars) AS dollars
+      FROM justice_funding
+     WHERE topics @> ARRAY['youth-justice'] AND measure_kind = 'grant'
+  ),
+  g AS (
+    SELECT sum(amount_dollars) AS dollars, count(*) AS rows
+      FROM justice_funding
+     WHERE topics @> ARRAY['youth-justice']
+       AND measure_kind = 'grant'
+       AND is_aggregate IS NOT TRUE
+       AND lower(trim(recipient_name)) NOT IN
+           ('total','totals','grand total','subtotal','sub-total',
+            'various','n/a','na','unknown','tbc','other')
+  ),
+  t AS (SELECT sum(dollars) AS all_dollars FROM k)
+  SELECT jsonb_build_object(
+           'kinds', (SELECT jsonb_agg(jsonb_build_object('measure_kind', measure_kind,
+                              'rows', rows, 'dollars', dollars) ORDER BY dollars DESC) FROM k),
+           'grant_dollars_unfiltered', (SELECT dollars FROM gk),
+           'grant_dollars', (SELECT dollars FROM g),
+           'aggregate_dollars_inside_grants',
+             (SELECT dollars FROM gk) - (SELECT dollars FROM g),
+           'all_dollars', (SELECT all_dollars FROM t),
+           'inflation_factor', round((SELECT all_dollars FROM t) / nullif((SELECT dollars FROM g), 0), 1)
+         ) AS payload,
+         '$' || round((SELECT dollars FROM g) / 1e9, 3)::text || 'bn' AS headline,
+         'grants to named organisations · summing every measure_kind would report $'
+           || round((SELECT all_dollars FROM t) / 1e9, 2)::text || 'bn ('
+           || round((SELECT all_dollars FROM t) / nullif((SELECT dollars FROM g), 0), 1)::text
+           || '× too high), and a further $'
+           || round(((SELECT dollars FROM gk) - (SELECT dollars FROM g)) / 1e6, 1)::text
+           || 'm of aggregates sits inside ''grant'' itself' AS headline_sub,
+         round((SELECT dollars FROM g) / 1e9, 3) AS headline_num
+  $answer$,
+  caveat = 'Grants to named organisations, tagged youth-justice. Three exclusions, and the second '
+    || 'and third are not implied by the first: rows that are not measure_kind = ''grant''; rows '
+    || 'flagged is_aggregate even when labelled a grant; and rows whose recipient is a source '
+    || 'spreadsheet total. This is what was published and recorded, not what was spent.',
+  exclusions = 'Excluded: every measure_kind except grant; 21 rows flagged is_aggregate carrying '
+    || '$618.5m, which are qld-historical-grants column totals; and rows whose recipient is named '
+    || '"Total", "Various" or "n/a". Before 2026-08-16 this question published $1,534.2m by '
+    || 'excluding only the first of those — a 40% overstatement.'
+WHERE slug = 'youth-justice-total';
+
+-- ---------------------------------------------------------------------------
+-- evidence-gap — one organisation, but the same defect
+-- ---------------------------------------------------------------------------
+-- 778 organisations become 777. Trivial in size and not trivial in kind: the entity that drops out
+-- is one whose only youth-justice "funding" was an aggregate row.
+UPDATE clarity_question SET
+  answer_sql = replace(
+    answer_sql,
+    'WHERE measure_kind = ''grant''
+       AND gs_entity_id IS NOT NULL',
+    'WHERE measure_kind = ''grant''
+       AND is_aggregate IS NOT TRUE
+       AND gs_entity_id IS NOT NULL')
+WHERE slug = 'evidence-gap';
+
+-- ---------------------------------------------------------------------------
+-- every-dollar-one-abn — no change to the number, and the filter goes in anyway
+-- ---------------------------------------------------------------------------
+-- ABN 15101252171 has zero aggregate rows, so this is pure hygiene. It goes in because the next
+-- person to copy this worked example should copy the correct predicate, and because a question
+-- that satisfies a sentinel by luck rather than by filter is one ingest away from not.
+UPDATE clarity_question SET
+  answer_sql = replace(
+    answer_sql,
+    'FROM justice_funding WHERE recipient_abn = ''15101252171'' AND measure_kind = ''grant''',
+    'FROM justice_funding WHERE recipient_abn = ''15101252171'' AND measure_kind = ''grant'' AND is_aggregate IS NOT TRUE')
+WHERE slug = 'every-dollar-one-abn';
+
+-- ---------------------------------------------------------------------------
+-- Exemptions
+-- ---------------------------------------------------------------------------
+INSERT INTO clarity_sentinel_exemption (sentinel_key, question_slug, reason) VALUES
+(
+  'measure_kind_contamination', 'youth-justice-total',
+  'Applies all three row-level exclusions the sentinel enforces, and its entire purpose is to '
+  || 'show the reader how large the contamination is — the headline_sub reports both the '
+  || 'measure_kind inflation factor and the $618.5m of aggregates sitting inside ''grant''. '
+  || 'Scoped to justice by topics, so the transport-contract trap does not apply either.'
+),
+(
+  'measure_kind_contamination', 'evidence-gap',
+  'Counts organisations, not dollars, but reads justice_funding to decide which organisations are '
+  || 'funded — so an aggregate row could admit an entity that never received a grant. Now filters '
+  || 'measure_kind, is_aggregate and topics. One organisation of 778 drops out as a result.'
+),
+(
+  'measure_kind_contamination', 'every-dollar-one-abn',
+  'A single-ABN worked example that applies measure_kind and is_aggregate. ABN 15101252171 has no '
+  || 'aggregate rows today, so the filter changes nothing — it is there so the predicate is right '
+  || 'when the data changes, rather than correct by coincidence.'
+),
+(
+  'measure_kind_contamination', 'grant-behind-this-edge',
+  'Not a money question. It counts whether a source key resolves to a row, not how much money '
+  || 'moved or to whom, and it sums no dollars at all. Aggregate rows resolve or fail to resolve '
+  || 'exactly like any other row, so excluding them would change what is being measured rather '
+  || 'than make it more honest. Same grounds as this question''s existing two exemptions.'
+)
+ON CONFLICT (sentinel_key, question_slug) DO UPDATE SET reason = EXCLUDED.reason;
+
+COMMIT;
+
+-- VERIFY:
+--   node --env-file=.env scripts/run-clarity-answers.mjs --dry-run
+-- Expect 17/19 ok (donor-contractor and commonwealth-spend were blocked before this work and are
+-- unrelated), youth-justice-total at $0.916bn, evidence-gap at 777 organisations.

--- a/thoughts/shared/data-map/justice-funding-filter-audit.md
+++ b/thoughts/shared/data-map/justice-funding-filter-audit.md
@@ -1,0 +1,162 @@
+# justice_funding — who applies the mandatory filters, and what it costs
+
+**Measured 2026-08-16.** Triggered by slice C of the clarity console, which needed an honest money
+figure for a public theme page. Every figure below was queried directly; re-measure before
+trusting them again.
+
+## The short version
+
+`justice_funding` needs three filters to answer "money to organisations for justice work", and
+almost nothing applies them. The view named `justice_funding_clean` reports **3.1x the honest
+figure**, and the entity-level rollup that 28 app files depend on lists **Queensland Rail as the
+second-largest recipient of justice funding in Australia.**
+
+None of this is new data corruption. The table is a broad ingest of government funding records and
+its own catalogue entry says so plainly:
+
+> *Not purely "justice funding" (verified): rows include `source='austender-direct'` with
+> `measure_kind='contract_value'` (e.g. "Pump Repairs"). Filter on `topics`/`source`, never assume
+> the whole table is justice.*
+
+The caveat is correct, was written before this audit, and is ignored almost everywhere.
+
+## The three filters
+
+| # | Filter | Why |
+|---|---|---|
+| 1 | `measure_kind = 'grant'` | 848 `expenditure_aggregate` rows are whole-of-state budgets, not money to an organisation |
+| 2 | recipient name not aggregate-shaped | 46 rows named `Total`/`Various`/`n/a` are source-spreadsheet totals ingested as recipients |
+| 3 | `topics @> ARRAY[...]` or a `source` scope | the table is not all justice — it holds transport contracts, rail concessions, pump repairs |
+
+Filter 1 was documented in CLAUDE.md. Filter 2 was found during slice C and is now documented.
+Filter 3 was documented in the object's own caveat and in CLAUDE.md's topic note.
+
+## Coverage — who actually applies them
+
+**Database layer**
+
+| | count |
+|---|---|
+| Views and matviews reading `justice_funding` | **47** |
+| …that reference `measure_kind` | **4** |
+| …that touch `amount_dollars` | 38 |
+| …that sum money with **no** `measure_kind` filter | **35** |
+
+**Application layer**
+
+| | count |
+|---|---|
+| Files under `apps/web/src` referencing `justice_funding` | **100** |
+| …referencing `measure_kind` | **2** (`api/ask/route.ts`, `clarity/q/refusal.test.ts`) |
+
+App files reading an unfiltered money view, by view:
+
+| View | app files |
+|---|---|
+| `mv_entity_power_index` | **28** |
+| `mv_revolving_door` | **19** |
+| `v_org_funding_profile` | 2 |
+| `mv_justice_proven_suppliers` | 2 |
+| `mv_org_justice_signals` | 1 |
+| `mv_yj_report_state_top_orgs` | 1 |
+| `mv_funding_outcomes_summary` | 1 |
+
+## What it costs
+
+### `justice_funding_clean` — the view named clean is the worst offender
+
+```sql
+-- its entire filter:
+WHERE sector IS DISTINCT FROM 'procurement'
+```
+
+| | rows | total |
+|---|---|---|
+| `justice_funding_clean` | 151,866 | **$117.47bn** |
+| honest (all three filters) | 126,627 | **$38.01bn** |
+
+**3.1x overstated. $79.46bn of phantom money.**
+
+And it cannot be fixed by a caller: **`justice_funding_clean` does not expose `measure_kind` as a
+column.** A view named "clean" omits the one field that makes cleaning possible.
+
+Composition of what it includes, `sector <> 'procurement'`:
+
+| measure_kind | rows | total |
+|---|---|---|
+| `expenditure_aggregate` | 848 | $66.13bn |
+| `grant` | 126,673 | $46.10bn |
+| `contract_value` | 24,269 | $3.01bn |
+| `budget_announcement` | 76 | $2.24bn |
+
+### Budget rows are attributed to named organisations
+
+**462 of the 848 whole-of-state budget rows carry a `gs_entity_id`, worth $37.49bn.** They are not
+floating unattached — they land on specific entities:
+
+| Entity | from budget rows | rows |
+|---|---|---|
+| Queensland Department of Youth Justice | $11.05bn | 66 |
+| Department of Justice & Community Safety | $9.76bn | 66 |
+| NSW Department of Communities and Justice | $9.04bn | 66 |
+| Department of Justice | $4.85bn | 132 |
+| Department of Human Services | $1.81bn | 66 |
+| Community Services Directorate | $0.97bn | 66 |
+
+Mitigating: all six are government departments, and a department genuinely does receive its own
+budget. Not mitigating: mixed into a "funding received" figure, it puts departments above every
+community organisation in the country.
+
+### `mv_entity_total_funding.justice_total` — the visible harm
+
+This is what the 28-file `mv_entity_power_index` chain rests on. Top entities by `justice_total`:
+
+| Entity | justice_total |
+|---|---|
+| Department of Justice & Community Safety | $10.03bn |
+| **QUEENSLAND RAIL LTD** | **$4.10bn** |
+| Department of Human Services | $1.87bn |
+| Legal Aid Queensland | $1.15bn |
+| TAFE Queensland Brisbane | $0.94bn |
+| BRISBANE CITY COUNCIL | $0.84bn |
+
+Queensland Rail's $4.1bn is 13 rows from source `qgip`, all `measure_kind = 'grant'`, and they are:
+
+| program | year | amount |
+|---|---|---|
+| Transport Service Contracts | 2024-25 | $2,410.4m |
+| Transport Service Contracts | 2017-18 | $1,631.8m |
+| Rail Concession Scheme | 2017-18 | $35.4m |
+| Rail Concession Scheme | 2024-25 | $17.3m |
+
+These are correctly labelled grants. They are simply not justice. **Filter 1 alone would not have
+caught this — only filter 3 does.** That is the argument for the object caveat's rule: never assume
+the whole table is justice.
+
+## What is NOT affected
+
+- **The clarity console theme pages (slice C).** They apply all three filters and report $1.04bn
+  for youth justice across 4,682 grants, which is why the numbers looked small and correct rather
+  than large and wrong.
+- **`political_donations`.** Checked for the same aggregate-name defect: clean. Its documented
+  filter (`receipt_type = 'donation received'`, 506,739 rows, $22.97bn) reproduces exactly.
+- **The 26 registered questions** were not individually re-audited here, but they carry sentinels
+  and ingredient declarations, which is the mechanism designed for exactly this.
+
+## What has not been checked
+
+- Whether each of the 35 unfiltered views is actually *wrong* for its purpose. A view answering
+  "total government expenditure by state" should include the budget rows. Only the ones presenting
+  a figure as money-received-by-an-organisation are defective, and that judgement is per-view.
+- Which of the 100 app files render a money figure versus merely referencing the table name.
+- Whether the four filtering views filter *correctly*.
+
+## Recommended order
+
+1. **Add `measure_kind` to `justice_funding_clean`** — one migration, unblocks every downstream
+   caller. Does not change any current number.
+2. **Register a question with a sentinel** on the honest total, so a regression is caught rather
+   than rediscovered.
+3. **Fix `mv_entity_total_funding.justice_total`** — the 28-file blast radius, and the one with a
+   publicly visible wrong answer.
+4. Then work the remaining views by whether they claim money-received.

--- a/thoughts/shared/handoffs/clarity-catalog/current.md
+++ b/thoughts/shared/handoffs/clarity-catalog/current.md
@@ -1,7 +1,7 @@
 ---
-date: 2026-08-16T01:00:00Z
+date: 2026-08-16T02:00:00Z
 session_name: clarity-catalog
-branch: main
+branch: clarity-console-slice-b
 status: active
 ---
 
@@ -9,85 +9,116 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-16T01:00:00Z
-**Goal:** The `/clarity` **console rebuild**. Issue #190 (the 26-question registry) is DONE and merged. The work stream turned over this session: two design grillings produced two plans, and three slices shipped against them.
-**Branch:** `main` at `75521d7`. PRs #215, #216, #217 all merged; board clear.
-**Test:** `cd apps/web && npx tsc --noEmit` · `npx vitest run src/app/clarity src/lib/visibility.test.ts` (50 tests, 7 files)
-**Local:** dev server on 3013 (`--turbopack`). `/clarity` needs no login locally — `admin-auth-bypass.ts` covers it. **Vercel preview does NOT bypass**, and Ben's sign-in on preview failed with "Invalid login credentials" (unresolved, see Open Questions).
+**Updated:** 2026-08-16T02:00:00Z
+**Goal:** The `/clarity` **console rebuild**. Issue #190 (the 26-question registry) is DONE. Two design grillings produced two plans; four slices shipped; a data audit found a $12.12bn correction.
+**Branch:** `clarity-console-slice-b` at `299e5f0` (PR #218, CI running). main is at `75521d7`.
+**Test:** `cd apps/web && npx tsc --noEmit` · `npx vitest run` (731 pass, 79 files) · `node --env-file=.env scripts/run-clarity-answers.mjs --dry-run` (**17/19 ok**, up from 16/19)
+**Local:** dev server on 3013 (`--turbopack`). `/clarity` needs no login locally (`admin-auth-bypass.ts`). **Vercel preview does NOT bypass** and Ben's sign-in there failed — unresolved, see Open Questions.
 
 ### Now
-[->] **Slice B — theme pages at `/reports/[section]`.** In progress. Slice E merged (#217).
+[->] **PR #218 is open with CI running.** It contains FIVE MIGRATIONS THAT ARE ALREADY APPLIED to production — the database has moved and main has not. Merge decision is Ben's.
 
-### This Session
-- [x] **Merged PR #215**, closing issue #190. Registry complete at 26 questions.
-- [x] **Grilling 1 → `thoughts/shared/plans/clarity-console.md`.** 12 slices. Diagnosis: `clarity_object` carries ~60 curated fields per object and there was **no page for an object** — an encyclopedia shipped as a spreadsheet.
-- [x] **Slice 1 — `/clarity/o/[key]`, a page for every object.** Columns, link graph with seam rates, what-uses-it, questions built on it, shape, freshness, access, provenance. Renders curated markdown (467 caveats, 84 purposes contain it).
-- [x] **Slice 3 — the index becomes the front door.** All 1,479 objects on one page, terse links, six nouns. **15,052px, down from 70,614, showing 257 MORE objects.** Old ledger demoted to `/clarity/catalogue`. **Merged as PR #216 (`3c784a5`).**
-- [x] **Grilling 2 → `thoughts/shared/plans/clarity-console-part-2.md`.** Slices A–K. Triggered by Ben: *"very code tech speak… wanna see real data and how it all connects."*
-- [x] **Slice E — one visibility vocabulary.** `public → org → operator → withheld`, generalising `/atlas`. PR #217, pushed, unmerged.
-
-### The reframe from grilling 2 — the single most important thing in this ledger
-Three times I went looking for something to build and found it already built:
+### The reframe — most important thing in this ledger
+Grilling 2 was triggered by Ben's verdict on the shipped console: *"very code tech speak… wanna see real data and how it all connects."* Going looking for what to build, three times the answer was **it already exists**:
 
 | Looked for | Found |
 |---|---|
-| A real-data surface | **54 report dirs in 13 themes** — `qld-youth-justice`, `child-protection`, `donor-contractors`, `who-runs-australia` |
+| A real-data surface | **54 report dirs in 13 themes** — qld-youth-justice, child-protection, donor-contractors, who-runs-australia |
 | A way to show connection | **`/entity/[gsId]`, 958 lines, 16 parallel cross-system queries** |
 | A search | **`unified-search.tsx`, 495 lines**, already grouped by kind |
 | An ACT workspace | **62 pages under `/org/[slug]`** |
 
-**276 page routes exist. `/clarity` indexes 1,479 DB objects and zero of them.** This is a navigation and coherence problem, not a build problem. Part 2 is mostly connection and deletion.
+**276 page routes exist. `/clarity` indexed 1,479 DB objects and zero of them.** Navigation and coherence problem, not a build problem. Part 2 is mostly connection and deletion.
+
+### This Session
+- [x] **Merged #215, #216, #217.** Issue #190 closed; slices 1, 3 and E on main.
+- [x] **Slice 1 — `/clarity/o/[key]`**, a page for every object. ~60 curated fields that had nowhere to be read.
+- [x] **Slice 3 — the index becomes the front door.** 1,479 objects, six nouns, **15,052px down from 70,614 showing 257 MORE objects.** Old ledger → `/clarity/catalogue`. 747 unfiled, two causes kept visibly apart.
+- [x] **Slice E — one visibility vocabulary.** `public → org → operator → withheld`, generalising `/atlas`.
+- [x] **Slice B — theme pages** at `/reports/theme/[slug]`. Accountability & Power is count-only (10 of 20 review-status reports live there and it names individuals).
+- [x] **Slice C — real money.** Youth Justice: **$1.04bn, 4,665 grants, 1,404 organisations**, each linking to its entity page.
+- [x] **Audit + 5 applied migrations** (see below).
+
+### THE DATA FINDING — carry this forward
+`measure_kind = 'grant'`, documented in CLAUDE.md as *the* mandatory filter, is incomplete.
+
+| filter | rows | total |
+|---|---|---|
+| `measure_kind='grant'` | 126,673 | **$46.10bn** |
+| …minus aggregate-shaped recipient names | 126,627 | $38.01bn |
+| …**and `is_aggregate IS NOT TRUE`** | **125,300** | **$33.98bn** |
+
+**26% off the headline.** I corrected it twice in two hours — the first correction was itself wrong. `measure_kind` and `is_aggregate` are independent; neither implies the other (1,358 rows are grant AND aggregate, $12.06bn; 330 expenditure_aggregate rows are is_aggregate=false, $17.39bn).
+
+**Coverage:** 47 views read `justice_funding`, **4** reference `measure_kind`. 100 app files reference it, **2** do.
+
+- **`justice_funding_clean` reports $117.47bn vs an honest $33.98bn** — 3.1x. It did not expose `measure_kind`, so no caller *could* fix it. Now fixed (migration 20260816020000).
+- **462 of 848 whole-of-state budget rows carry a `gs_entity_id`, $37.49bn** — they land on six government departments.
+- **`mv_entity_total_funding.justice_total` lists QUEENSLAND RAIL as the #2 recipient of justice funding in Australia, $4.1bn.** 13 rows, correctly labelled grants, actually Transport Service Contracts and a Rail Concession Scheme. **`measure_kind` would NOT catch this — only topic scoping does.** 28-file blast radius. **STILL UNFIXED.**
+
+Full audit: `thoughts/shared/data-map/justice-funding-filter-audit.md`
+
+### Migrations applied this session (production, on explicit instruction)
+| | |
+|---|---|
+| `20260816020000` | `measure_kind` + `is_aggregate` on `justice_funding_clean`. Additive; no number moved (still 151,866 / $117.47bn). |
+| `20260816030000` | Register `justice-money-to-orgs` ($33.98bn) + `measure_kind_contamination` sentinel. |
+| `20260816040000` | Exemption for the new question. |
+| `20260816050000` | `is_aggregate` added to 3 questions; 4th exempted. |
+
+**The sentinel caught a 40% error within minutes of being applied.** It is `block` severity and permanently tripped by design (71.81% of dollars in the table are not money to an organisation), so every question must filter or write an exemption. `youth-justice-total` went **$1,534.2m → $0.916bn**; the 21 rows carrying $618.5m were the qld-historical-grants column totals. `evidence-gap` 778→777 orgs. All four exemptions written NARROWER than the sentinel so none can justify an unscoped justice figure later.
 
 ### Next
-- [ ] **Merge #217**, or say why not.
-- [ ] **Slice B — theme pages at `/reports/[section]`.** Biggest legibility win, no new data.
-- [ ] **Slice C — real money on sector theme pages.** Topic tags already exist (`child-protection` 16,418, `youth-justice` 5,580). Aggregates + top recipients linking to entity pages. **`measure_kind = 'grant'` MANDATORY** or $46.1bn reads as $66.1bn. This is where the tech-speak ends.
-- [ ] Then D (`/search`), F (report status at links), G (themes above the noun index), H–K.
-- [ ] **From part 1, still open:** slice 2 (inline edit for the 667 stubs), slice 4 (nouns propose/confirm), slice 5 (row viewer + consent), 6b (code scanner).
-- [ ] `/insights` (323 lines) still unread, still unjudged.
+- [ ] **Merge #218.**
+- [ ] **Fix `mv_entity_total_funding.justice_total`** — the Queensland Rail answer. Biggest remaining blast radius (28 files) and the only publicly-visible wrong answer left.
+- [ ] Then part 2: **D** (`/search`, reconcile the two existing components, extend 3 kinds → 8), **F** (report status at every link), **G** (themes above the noun index), **H–K**.
+- [ ] From part 1: slice 2 (inline edit for 667 stubs), 4 (nouns propose/confirm), 5 (row viewer + consent), 6b (code scanner — **prerequisite for the orphan detector**, which would otherwise report 1,151 false orphans).
+- [ ] Decide per-view whether each of the 35 unfiltered money views is wrong FOR ITS PURPOSE. A "state expenditure" view SHOULD include budget rows.
 
 ### Decisions
-- **Completeness at the index layer, refusal at the claim layer.** Reconciles "see it all" with the refusal ethos. Settles every hard case.
-- **A screen may be stricter than its data, never looser.** The asymmetry is the safety property. Data declares a floor; `mostRestrictive()` makes a page inherit the worst of what it reads.
-- **Absence is always stated, never silent.** Now a rule, not three coincidences. Exception: a count of 1 in a small community is a name (`SMALL_COUNT_THRESHOLD = 5`).
-- **Findings first, plumbing last**, on every surface.
-- **Unfiled is rendered, never guessed.** 747 of 1,479. Two causes kept visibly apart (667 no-domain; ~80 sector-filed) — a tooltip is the same collapse in a costume.
-- **Key numbers on public theme pages come ONLY from registered questions.** No lifting figures from report prose; 20 reports are flagged as needing figure review.
-- **Accountability & Power review-status reports are counted, not linked.** 10 of the 20 live there and they name individuals and board seats. Same reasoning that refused ministerial-diaries.
+- **Completeness at the index layer, refusal at the claim layer.**
+- **A screen may be stricter than its data, never looser.** Data declares a floor; `mostRestrictive()` makes a page inherit the worst of what it reads. Testable.
+- **Absence is always stated, never silent.** Exception: a count of 1 in a small community is a name (`SMALL_COUNT_THRESHOLD = 5`).
+- **Findings first, plumbing last**, every surface.
+- **Key numbers on public pages come ONLY from registered questions.** No lifting figures from report prose.
+- **Accountability & Power review reports are counted, not linked.**
 - **Stories link to projects, never to data.** Project-mediation is the only version that cannot re-identify.
-- **No free-text querying.** Saved parameterised queries + the row viewer. The difference is that these carry their caveats with them.
-- **ACT extends `/org/act` (62 pages).** Not a fourth front door. Admin auth until a second person needs in.
-- **The visibility vocabulary is NOT the commercial `Tier` ladder.** Paid-for vs allowed-to-see. Different axes.
+- **No free-text querying.** Saved parameterised queries + the row viewer; they carry their caveats with them.
+- **ACT extends `/org/act` (62 pages)**, not a fourth front door.
+- Visibility vocabulary is **NOT** the commercial `Tier` ladder. Paid-for vs allowed-to-see.
+- **Withheld beats promoted, always.** If an object is in both lists, that is a bug and it resolves towards consent.
 
-### Traps confirmed by query this session
-- `clarity_object.object_key` and `clarity_edge.src/tgt_object` are **bare**; `clarity_question_ingredient.object_key` is **`public.`-prefixed** and CHECK-constrained. Wrong form returns nothing rather than erroring.
-- **`refs_app`/`refs_script`/`refs_migration` are 0 on all 1,479** — scanner never ran. The orphan detector would report **1,151 false orphans**. Blocked on slice 6b.
-- `owner_app` = `'neither'` on all 1,479. `verdict` null on all 1,479. `null_pct` null on all 16,124 columns.
-- `importance` is tied at `0.0225` for **424 objects** — it cannot rank, which is why the old "RANKED" sort felt arbitrary.
-- **`history` contains `story`.** A `/story/` pattern withholds five history tables and still misses `quotes`. Consent floors are an explicit list, not a pattern.
-- **A domain-only consent rule leaks**: `story_analysis`, `transcript_analysis` (`ai_agents_pipeline`), `tour_stories` (`media_narrative`), `partner_storytellers_v` (no domain).
-- Public home `app/page.tsx` has **5 broken HTML entities inside JS string literals** (lines 175, 183, 213, 244, 246) rendering as literal `&rsquo;`. Pre-existing on main, unfixed, visible on the live home page.
+### Traps confirmed by query
+- `clarity_object.object_key` / `clarity_edge.src|tgt_object` are **bare**; `clarity_question_ingredient.object_key` is **`public.`-prefixed** and CHECK-constrained. Wrong form returns nothing rather than erroring.
+- **Postgres sorts NULLs FIRST in `DESC`** — a naive "top recipients" query returns the rows with no amount.
+- **Topic tags overlap**: youth-justice ∩ diversion = 98 rows; child-protection ∩ family-services = 2. Dedupe by `id`.
+- **`history` contains `story`** — a `/story/` pattern withholds 5 history tables and misses `quotes`. Consent floors are an explicit list.
+- **A domain-only consent rule leaks**: `story_analysis`, `transcript_analysis` (ai_agents_pipeline), `tour_stories` (media_narrative), `partner_storytellers_v` (no domain).
+- `refs_app`/`refs_script`/`refs_migration` are 0 on all 1,479 — scanner never ran. `owner_app` = 'neither' on all. `null_pct` null on all 16,124 columns.
+- `importance` tied at `0.0225` for 424 objects — cannot rank.
+- **Before any `gh pr merge --delete-branch`, run `git log origin/<branch>..HEAD`** and push what it lists. A ledger commit was stranded this way and had to be recovered from a dangling commit.
+- Public home `app/page.tsx` has **5 broken HTML entities in JS string literals** (lines 175, 183, 213, 244, 246) rendering as literal `&rsquo;`. Pre-existing, unfixed, live.
 
 ### Open Questions
-- **UNRESOLVED: Ben cannot sign in to the Vercel preview.** "Invalid login credentials" for `benjamin@act.place`, which IS in `ADMIN_EMAILS` and DOES exist in `auth.users` on `tednluwflfhxyucgwigh` (confirmed, has signed in before). Either the password, or **preview env vars point at a different Supabase project**. Vercel SSO blocked me from checking. Check Vercel → Settings → Environment Variables, Preview vs Production `NEXT_PUBLIC_SUPABASE_URL`.
-- **Consent on `transcripts` is FIVE independent flags**, not one boolean: `consent_for_ai_analysis`, `_quote_extraction`, `_theme_analysis`, `_story_creation`. `floorFor()` is binary — safe direction, but **slice 5's row viewer must read them per row, not call `floorFor()`**.
+- **UNRESOLVED: Ben cannot sign in to the Vercel preview.** "Invalid login credentials" for `benjamin@act.place`, which IS in `ADMIN_EMAILS` and DOES exist in `auth.users` on `tednluwflfhxyucgwigh`. Either the password or **preview env vars point at a different Supabase project**. Vercel SSO blocked me from checking. Compare Preview vs Production `NEXT_PUBLIC_SUPABASE_URL`.
+- **Consent on `transcripts` is FIVE independent flags**, not one boolean: `consent_for_ai_analysis`, `_quote_extraction`, `_theme_analysis`, `_story_creation`. `floorFor()` is binary — safe direction, but **slice 5's row viewer must read them per row**.
 - Whether the Accountability & Power count-only rule survives Ben seeing it applied.
-- Which of the 276 routes are genuinely dead. B–D will reveal more than guessing.
-- The commercial `Tier` ladder has not been reconciled with the visibility vocabulary. Must be before anything is sold.
-- **Six `/clarity` rendering defects remain unfixed by design** (duplicate React key on the catalogue, "1 objects moved", triplicated refusal paragraph, a leaked `▸ none + finer framing` placeholder, `NEVER RUN · RUN #0` on a refusal). Slices B–G delete most of the surfaces they live on. Fix only what survives.
-- Still open from before: `person_roles` aggregate exposure is Ben's call; the `/foundations/backlog` caller was never identified; three unexplained criticals on the change board (2026-04-02); 9,607 duplicate canonical names (sentinel now warns).
+- Whether each of the 35 unfiltered money views is wrong for its purpose — per-view judgement, not a sweep.
+- The commercial `Tier` ladder is unreconciled with the visibility vocabulary. Must be before anything is sold.
+- Six `/clarity` rendering defects remain unfixed **by design** — slices B–G delete most of the surfaces they live on.
+- Still open from before: `person_roles` aggregate exposure; the `/foundations/backlog` caller; three unexplained criticals (2026-04-02); 9,607 duplicate canonical names.
 
 ### Workflow State
 pattern: console rebuild, two plans
-phase: part 1 slices 1+3 merged; part 2 slice E in review
+phase: part 1 slices 1/3/E merged; part 2 slices B/C in PR #218
 retries: 0
 
 #### Resolved
-- issue #190 / the 26-question registry — **DONE**, PR #215 merged
-- "does /clarity look right" — **ANSWERED, and the answer was no.** It read as tech-speak. That feedback produced grilling 2 and part 2.
+- issue #190 / the 26-question registry — DONE
+- "does /clarity look right" — **ANSWERED, and the answer was no.** It read as tech-speak. That produced grilling 2 and part 2.
+- "is the documented money filter correct" — **NO.** 26% overstated. Corrected in CLAUDE.md, in code, and in the registry.
 
 #### Unknowns
-- **preview_login: BLOCKED** — see Open Questions. Ben has not yet seen any of this on a deployed URL.
-- **theme_pages: NOT STARTED** — slice B, the next thing.
-- clarity_visual_result: partially resolved. Ben saw `/clarity` locally and judged it interesting but too technical. The object page and the index have been eyeballed by me; the withheld state has been eyeballed by me.
-- http_write_paths: still UNKNOWN — the three `/api/clarity` routes have still never served a request.
+- **preview_login: BLOCKED.** Ben has still not seen any of this on a deployed URL.
+- **mv_entity_total_funding: KNOWN WRONG.** Queensland Rail as #2 justice recipient. Unfixed.
+- http_write_paths: the three `/api/clarity` routes have still never served a request.

--- a/thoughts/shared/handoffs/clarity-catalog/current.md
+++ b/thoughts/shared/handoffs/clarity-catalog/current.md
@@ -1,128 +1,93 @@
 ---
-date: 2026-08-15T08:30:00Z
+date: 2026-08-16T01:00:00Z
 session_name: clarity-catalog
 branch: main
 status: active
 ---
 
-# Work Stream: clarity-catalog
+# Work Stream: clarity-catalog → clarity-console
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-15T08:30:00Z
-**Goal:** `/clarity` slice 2 — the question board. **SHIPPED** (PR #204, `0c19443`). Next goal is slice 3, unscoped.
-**Branch:** `main` — **zero open PRs**, board clear
-**Test:** `cd apps/web && npx tsc --noEmit` (0 errors on merged main) · gates: `node --env-file=.env scripts/check-graph-{completeness,referential-integrity,attribution}.mjs`
-**Pool health:** `psql ... -Atc "SELECT count(*) FILTER (WHERE state='active') FROM pg_stat_activity WHERE datname='postgres'"` — healthy is single digits. **Read 1 active / 49 idle at 08:25.**
+**Updated:** 2026-08-16T01:00:00Z
+**Goal:** The `/clarity` **console rebuild**. Issue #190 (the 26-question registry) is DONE and merged. The work stream turned over this session: two design grillings produced two plans, and three slices shipped against them.
+**Branch:** `main` at `75521d7`. PRs #215, #216, #217 all merged; board clear.
+**Test:** `cd apps/web && npx tsc --noEmit` · `npx vitest run src/app/clarity src/lib/visibility.test.ts` (50 tests, 7 files)
+**Local:** dev server on 3013 (`--turbopack`). `/clarity` needs no login locally — `admin-auth-bypass.ts` covers it. **Vercel preview does NOT bypass**, and Ben's sign-in on preview failed with "Invalid login credentials" (unresolved, see Open Questions).
 
 ### Now
-[->] **Open `/clarity` in a browser and look at it.** Everything below it is verified; the visual result is the only thing left and no agent can reach it (Vercel SSO + admin gate). Then scope slice 3.
+[->] **Slice B — theme pages at `/reports/[section]`.** In progress. Slice E merged (#217).
 
 ### This Session
-- [x] **Closed the expensive-public-route audit** — the ledger's previous blocking item. Checked all 68 pages using `getServiceSupabase()`, including the six on the firewall rule. **No second exposure bug.** `/entity/`, `/entities/`, `/grants`, `/foundations/compare`, `/person/`, `/places/` are legitimately public and fan out 1–3 queries; gating them would be wrong.
-- [x] **Cached nine public fan-out pages** (PR #206, `b7e37a5`) — `force-dynamic` → `revalidate = 3600` on pages with heavy service-role bursts and no per-request inputs. Worst were `/reports/data-health` (17 queries/hit), `/insights` (12), `/foundations/prf` (9).
-- [x] **Merged slice 2** (PR #204, `0c19443`) — built by a parallel session, found open while the ledger said the board was clear.
-- [x] **Retired slice 2's one "Not verified" claim.** Its author could not confirm the index rendered because of an 8-day PostgREST retry storm. Verified instead at the data layer: all 7 migrations applied, `v_clarity_board{,_cards}` + `v_clarity_ledger` exist as `security_invoker` with `service_role=r` and **no anon grant**; three questions `answered`/`verified`; stored headlines match the PR body exactly (85.1% · 773 · 2.8x); `clarity_object` 1,456 rows. **App read path tested through PostgREST with the service key: both views HTTP 200, first try, no retries.**
+- [x] **Merged PR #215**, closing issue #190. Registry complete at 26 questions.
+- [x] **Grilling 1 → `thoughts/shared/plans/clarity-console.md`.** 12 slices. Diagnosis: `clarity_object` carries ~60 curated fields per object and there was **no page for an object** — an encyclopedia shipped as a spreadsheet.
+- [x] **Slice 1 — `/clarity/o/[key]`, a page for every object.** Columns, link graph with seam rates, what-uses-it, questions built on it, shape, freshness, access, provenance. Renders curated markdown (467 caveats, 84 purposes contain it).
+- [x] **Slice 3 — the index becomes the front door.** All 1,479 objects on one page, terse links, six nouns. **15,052px, down from 70,614, showing 257 MORE objects.** Old ledger demoted to `/clarity/catalogue`. **Merged as PR #216 (`3c784a5`).**
+- [x] **Grilling 2 → `thoughts/shared/plans/clarity-console-part-2.md`.** Slices A–K. Triggered by Ben: *"very code tech speak… wanna see real data and how it all connects."*
+- [x] **Slice E — one visibility vocabulary.** `public → org → operator → withheld`, generalising `/atlas`. PR #217, pushed, unmerged.
+
+### The reframe from grilling 2 — the single most important thing in this ledger
+Three times I went looking for something to build and found it already built:
+
+| Looked for | Found |
+|---|---|
+| A real-data surface | **54 report dirs in 13 themes** — `qld-youth-justice`, `child-protection`, `donor-contractors`, `who-runs-australia` |
+| A way to show connection | **`/entity/[gsId]`, 958 lines, 16 parallel cross-system queries** |
+| A search | **`unified-search.tsx`, 495 lines**, already grouped by kind |
+| An ACT workspace | **62 pages under `/org/[slug]`** |
+
+**276 page routes exist. `/clarity` indexes 1,479 DB objects and zero of them.** This is a navigation and coherence problem, not a build problem. Part 2 is mostly connection and deletion.
 
 ### Next
-- [ ] **Look at `/clarity` in a browser** — dark theme, layout, search/facets, and the local admin bypass. Unreachable by any tool here.
-- [ ] **Scope slice 3.** Slices 1 and 2 are done; 7 total were planned.
-- [ ] **Enable Vercel Web Analytics.** Still off. It is the reason caller attribution failed twice; it would make the next incident diagnosable in minutes.
-- [ ] **Rethink the per-IP rate limit.** The 20/60s `ip`-keyed rule did not hold against a distributed caller. Consider a JA4 key or a lower global cap.
-- [ ] Job 13 (weekly tier, Sundays 15:00 UTC) has **never run**. Also unchecked: whether the four old `success-fallback` matviews sit in the weekly tier — if so job 13 inherits a known-flaky set unwatched. They were `mv_grant_contract_overlap`, `mv_indigenous_procurement_score`, `mv_lga_indigenous_proxy_score`, `mv_abr_name_lookup`.
-- [ ] Deferred, all diagnosed and written up: 19 unwatched edge layers · runbook steps 3 (donor sink, 47,563 misattributed edges) and 5 (opportunity self-loops)
+- [ ] **Merge #217**, or say why not.
+- [ ] **Slice B — theme pages at `/reports/[section]`.** Biggest legibility win, no new data.
+- [ ] **Slice C — real money on sector theme pages.** Topic tags already exist (`child-protection` 16,418, `youth-justice` 5,580). Aggregates + top recipients linking to entity pages. **`measure_kind = 'grant'` MANDATORY** or $46.1bn reads as $66.1bn. This is where the tech-speak ends.
+- [ ] Then D (`/search`), F (report status at links), G (themes above the noun index), H–K.
+- [ ] **From part 1, still open:** slice 2 (inline edit for the 667 stubs), slice 4 (nouns propose/confirm), slice 5 (row viewer + consent), 6b (code scanner).
+- [ ] `/insights` (323 lines) still unread, still unjudged.
 
 ### Decisions
-- **The `/foundations/backlog` bug shape splits into two problems, not one.** Exposure (a service-role review queue left public) is a gating problem and was unique to backlog. Uncached fan-out is a caching problem and was widespread. Applying the gating fix to public product surfaces would have been the wrong call. (#206)
-- **`force-dynamic` needs a per-request reason.** Nine pages carried it while reading nightly matviews and taking no `searchParams`, `cookies()` or `headers()`. It bought nothing and cost a service-role query burst per anonymous hit. `/foundations` keeps it — it genuinely reads filter searchParams.
-- A page that uses `getServiceSupabase()` belongs in `protectedPrefixes` **if it is a private surface**; if it is public, it belongs behind a cache. Backlog was the first, the nine were the second. (#205, #206)
-- **Gate, don't cache** — for the private case. Caching backlog would have left anonymous traffic pointed at a service-role page.
-- Mitigation belongs in code, not the firewall. The incident deny rule was removed once #205 was live.
-- Headline is **1,039 relations**, not 1,455; 416 routines get their own segment. (#193) Coverage denominator is relations → **78%**.
-- ACT excluded by default, count permanently on screen, **neutral not yellow** — a scope boundary, not a warning.
-- Freshness has **four states that never collapse**: a date (687), `+` blue = missing timestamp column (294), `?` yellow = too large to probe (58), `—` n/a (416). (#195)
-- Admin-gated, because the catalog enumerates our own anon-readable attack surface. (#196)
-- `catalog_object_scope` is authoritative for `act_business`, bidirectionally.
-- **A new function gets its ACL set in the same migration that creates it.** `clarity_apply_act_flag` kept PostgreSQL's default `EXECUTE` to `PUBLIC` while its four siblings were restricted. (#202)
-- Slice 2's own calls, inherited: the three-card board deleted for the searchable index; DESIGN.md's March "No dark mode" marked **superseded for `/clarity` only**; local admin bypass now requires `NODE_ENV !== 'production'` **and** no `VERCEL`, with `requireAdminApi` deliberately not bypassed.
+- **Completeness at the index layer, refusal at the claim layer.** Reconciles "see it all" with the refusal ethos. Settles every hard case.
+- **A screen may be stricter than its data, never looser.** The asymmetry is the safety property. Data declares a floor; `mostRestrictive()` makes a page inherit the worst of what it reads.
+- **Absence is always stated, never silent.** Now a rule, not three coincidences. Exception: a count of 1 in a small community is a name (`SMALL_COUNT_THRESHOLD = 5`).
+- **Findings first, plumbing last**, on every surface.
+- **Unfiled is rendered, never guessed.** 747 of 1,479. Two causes kept visibly apart (667 no-domain; ~80 sector-filed) — a tooltip is the same collapse in a costume.
+- **Key numbers on public theme pages come ONLY from registered questions.** No lifting figures from report prose; 20 reports are flagged as needing figure review.
+- **Accountability & Power review-status reports are counted, not linked.** 10 of the 20 live there and they name individuals and board seats. Same reasoning that refused ministerial-diaries.
+- **Stories link to projects, never to data.** Project-mediation is the only version that cannot re-identify.
+- **No free-text querying.** Saved parameterised queries + the row viewer. The difference is that these carry their caveats with them.
+- **ACT extends `/org/act` (62 pages).** Not a fourth front door. Admin auth until a second person needs in.
+- **The visibility vocabulary is NOT the commercial `Tier` ladder.** Paid-for vs allowed-to-see. Different axes.
+
+### Traps confirmed by query this session
+- `clarity_object.object_key` and `clarity_edge.src/tgt_object` are **bare**; `clarity_question_ingredient.object_key` is **`public.`-prefixed** and CHECK-constrained. Wrong form returns nothing rather than erroring.
+- **`refs_app`/`refs_script`/`refs_migration` are 0 on all 1,479** — scanner never ran. The orphan detector would report **1,151 false orphans**. Blocked on slice 6b.
+- `owner_app` = `'neither'` on all 1,479. `verdict` null on all 1,479. `null_pct` null on all 16,124 columns.
+- `importance` is tied at `0.0225` for **424 objects** — it cannot rank, which is why the old "RANKED" sort felt arbitrary.
+- **`history` contains `story`.** A `/story/` pattern withholds five history tables and still misses `quotes`. Consent floors are an explicit list, not a pattern.
+- **A domain-only consent rule leaks**: `story_analysis`, `transcript_analysis` (`ai_agents_pipeline`), `tour_stories` (`media_narrative`), `partner_storytellers_v` (no domain).
+- Public home `app/page.tsx` has **5 broken HTML entities inside JS string literals** (lines 175, 183, 213, 244, 246) rendering as literal `&rsquo;`. Pre-existing on main, unfixed, visible on the live home page.
 
 ### Open Questions
-- **UNCONFIRMED: does `/clarity` look right?** Data, grants and read path are all verified. The rendered page has still never been seen by a human or an agent. Vercel SSO blocks the preview even through the authenticated MCP fetch tool, and the admin gate sits behind that.
-- **LIKELY RESOLVED: who was hammering `exec_sql`?** The 8-day retry storm (~10 req/s, 94% failing) and the pool-saturation incident look like the same anonymous traffic on `/foundations/backlog`. Pool went 41 → 1 connections after #205 and reads clean now. **Not proven** — the caller was never identified, and Postgres only ever saw PostgREST's loopback.
-- OPEN, Ben's call: `person_roles` aggregates 334,152 individually-public ACNC records into one anon-readable endpoint. Each is public by law; the aggregate is a different artifact. A decision, not a defect.
-- RESOLVED 15 Aug: jobs 4 and 11 both proven by direct test. Neither has still ever fired *via pg_cron itself*; first unattended runs were 17:00 and 18:00 UTC on 15 Aug — **worth checking whether they actually fired.**
-- RESOLVED: the stale `.next/types` errors for `clarity/q/[slug]` were a parallel session's files in the working tree, not a fault. Gone since #204 merged.
+- **UNRESOLVED: Ben cannot sign in to the Vercel preview.** "Invalid login credentials" for `benjamin@act.place`, which IS in `ADMIN_EMAILS` and DOES exist in `auth.users` on `tednluwflfhxyucgwigh` (confirmed, has signed in before). Either the password, or **preview env vars point at a different Supabase project**. Vercel SSO blocked me from checking. Check Vercel → Settings → Environment Variables, Preview vs Production `NEXT_PUBLIC_SUPABASE_URL`.
+- **Consent on `transcripts` is FIVE independent flags**, not one boolean: `consent_for_ai_analysis`, `_quote_extraction`, `_theme_analysis`, `_story_creation`. `floorFor()` is binary — safe direction, but **slice 5's row viewer must read them per row, not call `floorFor()`**.
+- Whether the Accountability & Power count-only rule survives Ben seeing it applied.
+- Which of the 276 routes are genuinely dead. B–D will reveal more than guessing.
+- The commercial `Tier` ladder has not been reconciled with the visibility vocabulary. Must be before anything is sold.
+- **Six `/clarity` rendering defects remain unfixed by design** (duplicate React key on the catalogue, "1 objects moved", triplicated refusal paragraph, a leaked `▸ none + finer framing` placeholder, `NEVER RUN · RUN #0` on a refusal). Slices B–G delete most of the surfaces they live on. Fix only what survives.
+- Still open from before: `person_roles` aggregate exposure is Ben's call; the `/foundations/backlog` caller was never identified; three unexplained criticals on the change board (2026-04-02); 9,607 duplicate canonical names (sentinel now warns).
 
 ### Workflow State
-pattern: wayfinder map (issue #190, 8/8 tickets closed)
-phase: slice 2 complete
-total_phases: 7 slices
+pattern: console rebuild, two plans
+phase: part 1 slices 1+3 merged; part 2 slice E in review
 retries: 0
-max_retries: 3
 
 #### Resolved
-- goal: "slice 2 shipped and merged" — done
-- resource_allocation: balanced
+- issue #190 / the 26-question registry — **DONE**, PR #215 merged
+- "does /clarity look right" — **ANSWERED, and the answer was no.** It read as tech-speak. That feedback produced grilling 2 and part 2.
 
 #### Unknowns
-- clarity_visual_result: **UNKNOWN** — never rendered for human eyes
-- job_13_weekly_tier: UNKNOWN — never run, never exercised by hand
-- cron_first_unattended_runs: UNKNOWN — jobs 4 and 11 due 17:00/18:00 UTC 15 Aug
-- backlog_caller_identity: UNKNOWN — storm ended with the fix, caller never named
-- other_route_exposure: **RESOLVED** — 68 pages audited, no second exposure bug
-
-#### Last Failure
-(none)
-
----
-
-## Incident: shared-pool saturation, 15 Aug 2026
-
-**Symptom.** Every project on the shared Supabase instance (`tednluwflfhxyucgwigh`) intermittently unreachable. Local pool monitor at **blip #902** across 8 days. `pg_stat_activity`: **40-41 active connections, all the same `exec_sql` RPC**, sustained.
-
-**The trail, including the dead ends — they cost the most time:**
-
-1. `pg_stat_activity` identifies *what* (40 concurrent `exec_sql`) but never *who*: every `authenticator` connection reports `client_addr = ::1/128`, because PostgREST runs on the Supabase host. **Attribution is impossible at the DB layer. Go to the HTTP side first next time.**
-2. Killing the local dev server on 3013 changed nothing. Load was not local.
-3. **Vercel runtime logs grouped by `requestPath` cracked it in one call** — `/foundations/backlog` = 10,694 hits in 2h, next busiest path 320. That is the tool that works.
-4. Arithmetic tied it off: ~3.5 req/s × 8 RPCs/request ≈ the 40 observed connections.
-
-**Everything red that session traced to this one cause** — 8 `entity-dossier` integration tests failing on 30s timeouts, and the Vercel build failing on four unrelated prerendered pages (`/atlas` + 3 youth-justice recipients) blowing a 60s ceiling. Both went green on retry once the pool drained. **A saturated pool looks like unrelated flaky failures everywhere.**
-
-**The circular trap.** The fix could not deploy, because the build needed the DB and the DB was starved by the thing the fix would stop. Broken by mitigating *outside* the app: a Vercel Firewall path `deny`, which takes effect at the edge with no build.
-
-**Tooling notes worth keeping:**
-- `vercel firewall` did **not** exist in CLI 50.22.1; it does in **59.1.3**. Upgrade first.
-- `vercel api -X PATCH -d '...'` returns **415** without an explicit `Content-Type: application/json`. Prefer the native `vercel firewall rules add --condition '{...}' --action deny --yes`.
-- Firewall changes **stage as a draft**; nothing is live until `vercel firewall publish`. `vercel firewall diff` before publishing.
-- Production domain is **`civicgraph.app`**. Direct curl probes are unreliable (429 / SSO interception) — verify via Vercel runtime logs grouped by `statusCode` instead.
-
-**Timeline:** publish deny → **pool 41 → 1 active within 60s**. Build retried green in 5m. PR #205 merged `2f3e5fd`, prod deploy Ready 07:57Z. Deny rule removed and published. Post-removal logs: `/foundations/backlog` → `307` (auth redirect), 7 hits in 10 min vs ~2,100 per 10 min at peak.
-
----
-
-## Context
-
-### Where things live
-- **The map**: `thoughts/shared/data-map/README.md` → then `VERIFICATION.md` (68 claims checked, 3 blockers found). Never act on `CANONICAL-DATA-MAP.md` without it.
-- **Slice 2 source material**: `thoughts/shared/data-map/clarity/OPPORTUNITY-MAP.md` — 16 cross-sections, **9 already run for real** with numbers. Plus `BAR-CHECK.md` and `BAR-CHECK-CLOSURE.md`.
-- **The spec**: `thoughts/shared/data-map/clarity/CLARITY-SPEC.md` (1,816 lines). Its scope corrections are in the closure doc.
-- **The code**: `apps/web/src/app/clarity/` — 4 files, one client island.
-
-### Hard-won facts that will save a session
-- **The pooler drops long connections.** One operation per psql invocation; TCP keepalives (`?keepalives=1&keepalives_idle=20&...`) on anything over ~5 min. A chained psql call reports the **echo's** exit code, so a failure looks like success. There is no direct non-pooler host.
-- **`pg_stat_user_tables.n_live_tup` is broken here** — reports 0 for a 2.5M-row table.
-- **`LIMIT n` without `ORDER BY` is not a sample.** Two 20,000-row "samples" of the same dataset gave 0% and 34.2%; the exact answer was 16.9%.
-- **Use `getDirectServiceSupabase()`**, never `getServiceSupabase()` — the latter sniffs the call stack for `/app/reports/` and returns a stub resolving every query to null.
-- **PostgREST caps a page at 1,000 rows.** The catalog is 1,455. Without explicit pagination a ledger renders complete and is missing a third.
-- **Read the producer before diagnosing the product.** Six confident readings were wrong this session; every one died within two minutes of opening the code that generated the number. Two would have caused damage.
-- **Empty ≠ unused.** No drop verdict without grepping both `src` trees AND `pg_proc.prosrc`.
-- **A merge rule keyed on identifier presence must also consider entity KIND.** The shadow merge nearly merged 1,209 people into companies and would have broken two derivations that resolve entities by name.
-- **Table-level RLS auditing cannot see definer views.** That is how 1,618 bank transactions stayed public through a sweep that closed 48 policies. The re-audit query is in `migrations/2026-08-15-close-bank-statement-view-leak.sql` — run it after adding any view.
-
-### The bar slice 2 has to clear
-`BAR-CHECK.md`'s verdict on slice 1, and it still stands:
-
-> Nothing on any screen answers a question about the world today; every screen audits our estate. There is no reason to open this on a Tuesday when nothing is broken.
-
-Slice 2 is the fix. It is the half that makes `/clarity` Ben's rather than a competent data catalog anyone could buy.
+- **preview_login: BLOCKED** — see Open Questions. Ben has not yet seen any of this on a deployed URL.
+- **theme_pages: NOT STARTED** — slice B, the next thing.
+- clarity_visual_result: partially resolved. Ben saw `/clarity` locally and judged it interesting but too technical. The object page and the index have been eyeballed by me; the withheld state has been eyeballed by me.
+- http_write_paths: still UNKNOWN — the three `/api/clarity` routes have still never served a request.


### PR DESCRIPTION
Part 2 of the plan, slices B and C — plus an audit and five applied migrations that came out of
building them. Plan: `thoughts/shared/plans/clarity-console-part-2.md`.

> **Five migrations in this branch are ALREADY APPLIED to production.** They were applied on
> explicit instruction during the session. The database has moved; `main` has not. That is the main
> reason to land this rather than let it sit.

---

## Slice B — theme pages

The 13 report sections existed only as sidebar headings. 54 report directories sat under them with
no landing page, so nothing anywhere said "here is what we know about youth justice" — you had to
already know which of 57 report URLs to open.

Adds a page per section, findings first and plumbing last: registered questions and key numbers,
then contested and refused, then the reports each carrying its review status at the link, then one
line disclosing that A Curious Tractor works in the area, then what is missing.

- **Key numbers come from registered questions ONLY.** Never lifted from report prose — 20 reports
  are flagged as needing figure review and theirs are precisely the ones that must not be quoted. A
  theme with no registered question shows no number and says so.
- **Accountability & Power is count-only.** 10 of the 20 review-status reports live there and its
  subjects are named individuals and the boards they sit on. Those 10 are counted, not linked —
  *"10 further reports on this theme are not listed."* Same reasoning that refused the
  ministerial-diaries question outright.
- **First real use of slice E.** `data-system` maps to HOUSE questions, which describe our estate
  rather than the world; the public page withholds them by name.

**Deviation from the plan:** `/reports/theme/[slug]`, not `/reports/[section]`. Every section slug
is already a real report page — `/reports/youth-justice` is the section's own Overview.

## Slice C — real money, real organisations

Youth Justice now opens with **$1.04bn across 4,665 grants to 1,404 organisations**, then names
them — Lifeline Community Care $30.1m, Relationships Australia (Qld) $25.5m, Mission Australia
$20.1m, Palm Island Community Company Ltd $8.7m — each linking to the entity page that already
resolves them across seven registers.

Every qualification travels with the number, on the same screen: this is a floor not a total; rows
excluded as spreadsheet totals and why; 92.9% of grants resolve to a graph entity, and a name that
does not resolve is shown as text rather than pointed at a plausible-looking wrong organisation.

`revalidate = 3600`, not `force-dynamic` — the child-protection aggregate scans 16,418 rows and
doing that per anonymous hit is the burst pattern that saturated the shared pool in August.

---

## What building it found

### A filter nobody had documented, worth $12.12bn

`measure_kind = 'grant'` — documented in CLAUDE.md as *the* mandatory filter — does not exclude
source-spreadsheet total rows, and does not imply `is_aggregate = false`. The two columns are
independent; neither is a superset of the other.

| filter | rows | total |
|---|---|---|
| `measure_kind = 'grant'` | 126,673 | **$46.10bn** |
| …minus aggregate-shaped recipient names | 126,627 | $38.01bn |
| …**and `is_aggregate IS NOT TRUE`** | **125,300** | **$33.98bn** |

**26% off the headline figure.** I corrected this number twice in two hours — the first correction
was itself still wrong — which is the entire argument for the sentinel below.

### The audit: who actually applies the filters

`thoughts/shared/data-map/justice-funding-filter-audit.md`

| | count |
|---|---|
| Views/matviews reading `justice_funding` | **47** |
| …referencing `measure_kind` | **4** |
| App files referencing the table | 100 |
| …referencing `measure_kind` | **2** |

- **`justice_funding_clean` reports $117.47bn against an honest $33.98bn** — 3.1x. Its entire
  filter is `sector IS DISTINCT FROM 'procurement'`, and it did not expose `measure_kind`, so no
  caller *could* fix it.
- **462 of the 848 whole-of-state budget rows carry a `gs_entity_id`, worth $37.49bn** — they land
  on named organisations. All six are government departments.
- **`mv_entity_total_funding.justice_total`** — the base of the 28-file power-index chain — lists
  **Queensland Rail as the second-largest recipient of justice funding in Australia at $4.1bn.**
  Those 13 rows are correctly labelled grants; they are Transport Service Contracts and a Rail
  Concession Scheme. `measure_kind` would not have caught it — only topic scoping does, which is
  exactly what the table's own catalogue caveat has always said. **Still unfixed; separate PR.**

### The sentinel caught a 40% error within minutes

`measure_kind_contamination` is permanently tripped by design — 71.81% of the dollars in
`justice_funding` are not money received by an organisation — so every question on the table must
filter or write an exemption. Applied, it blocked four registered questions, and three were missing
the filter:

| question | was | now |
|---|---|---|
| `youth-justice-total` | $1,534.2m | **$0.916bn** — overstated by 40% |
| `evidence-gap` | 662 of 778 orgs | 661 of 777 |
| `every-dollar-one-abn` | — | unchanged; filter added as hygiene |
| `grant-behind-this-edge` | — | exempted; counts key resolution, sums no dollars |

The 21 rows carrying $618.5m were the `qld-historical-grants` column totals. `youth-justice-total`
now teaches both traps: *"summing every measure_kind would report $69.44bn (75.8× too high), and a
further $618.4m of aggregates sits inside `'grant'` itself."*

All four exemptions are written narrower than the sentinel, so none can later be cited to justify
an unscoped justice figure.

---

## Migrations (applied)

| | |
|---|---|
| `20260816020000` | Expose `measure_kind` + `is_aggregate` on `justice_funding_clean`. Additive; no number moved. |
| `20260816030000` | Register `justice-money-to-orgs` + the `measure_kind_contamination` sentinel. |
| `20260816040000` | Exemption for the new question. |
| `20260816050000` | Add `is_aggregate` to three questions; exempt the fourth. |

Deliberately **not** done: adding the filters to `justice_funding_clean` itself. That would move
every downstream number in one step, including views where current behaviour is correct — a view
answering "total state expenditure on justice" *should* include budget rows. Per-view judgement,
per-view migration.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — **731 passed, 1 skipped, 79 files**
- `run-clarity-answers.mjs --dry-run` — **17/19 ok**, up from 16/19 before this work. The two
  failures (`donor-contractor`, `commonwealth-spend`) were blocked beforehand and are unrelated.
- Every SQL figure quoted here and in CLAUDE.md was executed, not estimated.
- Rendered and eyeballed: `/reports/theme/youth-justice`, `/reports/theme/accountability-power`
  (count-only rule), `/reports/theme/data-system` (operator withholding), and the sidebar links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
