### PR TITLE
Dashboard shell: softened-Bauhaus rail, live views, data-event chrome

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,11 +124,26 @@ A dark density variant scoped to `/clarity` only. Same fonts, same zero-radius, 
 **Do not extend this beyond `/clarity` without a new decision.** It is a reading instrument for
 one or two people, not a second brand.
 
+## Softened Shell Theme (.shell)
+Approved by Ben 2026-08-16 after reviewing the Pencil mock ("CG Dashboard Shell — Softened
+Bauhaus") against a shadcn-style dashboard reference. A density/warmth variant for the
+**dashboard shell surfaces** (rail + header + dashboard cards), scoped like `.ws`:
+
+- **Kept:** ink `#121212` rail and text, red/blue/yellow/green as rare signal colours,
+  display-weight condensed headings, JetBrains Mono for figures, restrained colour.
+- **Softened:** border-radius 6px (controls) / 10px (cards) — the first sanctioned break from
+  zero-radius; 1px hairline borders on `#E4E4E1`; warm-grey canvas `#F4F4F2`; white card
+  surfaces; **no hard offset shadows** inside the shell scope.
+- Scope class `.shell` on the shell layout wrapper; `bauhaus-*` utilities remap through CSS
+  variables inside it, same mechanism as `.ws` and `.clarity-dark`. Marketing/report pages
+  outside the shell keep full Bauhaus.
+
 ## Decisions Log
 | Date | Decision | Rationale |
 |------|----------|-----------|
 | 2026-03-26 | Initial design system created | Codified existing Bauhaus identity, upgraded typography from system fonts to Satoshi + DM Sans + JetBrains Mono. Research showed every competitor uses government blue + system fonts — CivicGraph's Bauhaus direction is the key differentiator. |
 | 2026-03-26 | ~~No dark mode~~ **superseded 2026-08-15 for `/clarity` only** | Bauhaus aesthetic requires light canvas for shadow system. Defer until user demand. |
 | 2026-08-15 | Dark theme for `/clarity`, and only `/clarity` | Ben compared the light Bauhaus board against a dark dense prototype side by side and chose dark: *"a way better way to showcase what we have and the best overall view I have seen so far."* The original "no dark mode" rationale still holds where it was aimed — the hard-offset shadow system needs a light canvas — but `/clarity` uses no shadows at all. It is a dense internal instrument, admin-gated, read for long stretches, showing every object we hold at once. The 2026-03-26 decision deferred dark "until user demand"; this is that demand, scoped rather than global. |
+| 2026-08-16 | Softened Shell theme (`.shell`) for dashboard surfaces | Ben reviewed the rebuilt console live and found it "hard to make sense of"; chose "soften Bauhaus toward the demo" from four options after seeing a shadcn dashboard reference. Radius 6/10px, hairline borders, warm-grey canvas — scoped to the shell, identity colours and type unchanged. Zero-radius stays everywhere outside the shell scope. |
 | 2026-03-26 | Zero border-radius enforced | Global `border-radius: 0 !important` — sharp corners are the identity, not a bug. |
 | 2026-03-26 | Satoshi over system fonts | System fonts (Avenir Next / Helvetica Neue) undermined the Bauhaus commitment. Satoshi's geometric letterforms complete the vision. |

--- a/apps/web/src/app/dashboard/help/page.tsx
+++ b/apps/web/src/app/dashboard/help/page.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { VIEW_REGISTRY } from '@/lib/view-registry';
+
+export const metadata = { title: 'Help — CivicGraph' };
+
+/**
+ * The help centre is provenance, not support tickets. The #1 question this product
+ * gets is "why is your number smaller than the press release" — so that answer
+ * comes first, in plain words, with the exclusions stated as features.
+ */
+export default function HelpPage() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-5">
+      <header className="flex flex-col gap-1">
+        <h1 className="font-display text-[26px] font-extrabold">Help</h1>
+        <p className="text-sm" style={{ color: 'var(--shell-muted)' }}>
+          How to read what this dashboard shows you — and why some numbers are smaller than
+          the ones in press releases.
+        </p>
+      </header>
+
+      <section className="shell-card flex flex-col gap-3 px-6 py-5">
+        <h2 className="font-display text-[16px] font-bold">Why our numbers differ</h2>
+        <p className="text-[13.5px] leading-relaxed">
+          Government funding data mixes three things that look the same in a spreadsheet:
+          real grants to real organisations, whole-of-state budget lines, and the
+          spreadsheet&rsquo;s own total rows. Summed naively, they overstate money to
+          organisations by billions. Every dollar figure on this dashboard applies three
+          filters before it reaches you:
+        </p>
+        <ol className="flex list-decimal flex-col gap-2 pl-5 text-[13.5px] leading-relaxed">
+          <li>
+            <strong>Grants only.</strong> State budget aggregates — money that was never paid
+            to any organisation — are excluded.
+          </li>
+          <li>
+            <strong>No total rows.</strong> Rows named &ldquo;Total&rdquo;,
+            &ldquo;Various&rdquo; or similar are spreadsheet artefacts, not recipients. On
+            youth justice alone these carried over $600M and would rank as the #1 recipient
+            in Australia if left in.
+          </li>
+          <li>
+            <strong>Excluded money is disclosed.</strong> Where a headline shows a total, the
+            dollars we removed are stated next to it, never silently dropped.
+          </li>
+        </ol>
+        <p className="text-[13.5px] leading-relaxed">
+          The result is a <strong>floor, not a total</strong>: money we can trace to a named
+          organisation. If a number here is smaller than one you have seen elsewhere, this is
+          usually why — and it is the more honest figure.
+        </p>
+      </section>
+
+      <section id="caveats" className="shell-card flex flex-col gap-3 px-6 py-5">
+        <h2 className="font-display text-[16px] font-bold">Caveats on every view</h2>
+        <p className="text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+          Each saved view carries its own caveat. They travel with the view — you will see
+          them on the cards too.
+        </p>
+        <div className="flex flex-col">
+          {VIEW_REGISTRY.map((v) => (
+            <div key={v.id} className="py-3" style={{ borderTop: '1px solid var(--shell-line)' }}>
+              <Link href={v.href} className="text-[13.5px] font-bold" style={{ color: '#1040C0' }}>
+                {v.name}
+              </Link>
+              <p className="text-[13px]">{v.question}</p>
+              {v.caveat && (
+                <p className="text-[12px] italic" style={{ color: 'var(--shell-muted)' }}>
+                  {v.caveat}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="shell-card flex flex-col gap-2 px-6 py-5">
+        <h2 className="font-display text-[16px] font-bold">People are counted, not priced</h2>
+        <p className="text-[13.5px] leading-relaxed">
+          Where the dashboard shows individuals — board members, directors — it shows how many
+          organisations they are connected to, never a personal dollar figure. Attributing
+          organisational money to a named person is misleading and unfair, so we do not do it.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { pinnedViews } from '@/lib/view-registry';
+import { ShellHeader } from './shell-header';
+import {
+  SquaresFour,
+  MagnifyingGlass,
+  Eye,
+  Tag,
+  Buildings,
+  Users,
+  MapPin,
+  FileText,
+  Database,
+} from '@phosphor-icons/react/dist/ssr';
+
+const NAV = [
+  { href: '/dashboard', label: 'Dashboard', icon: SquaresFour, active: true },
+  { href: '/search', label: 'Search', icon: MagnifyingGlass },
+  { href: '/clarity', label: 'Clarity', icon: Eye },
+  { href: '/themes', label: 'Themes', icon: Tag },
+  { href: '/entities', label: 'Entities', icon: Buildings },
+  { href: '/people', label: 'People', icon: Users },
+  { href: '/atlas', label: 'Places', icon: MapPin },
+  { href: '/reports', label: 'Reports', icon: FileText },
+];
+
+const VIEW_DOT: Record<string, string> = {
+  red: '#D02020',
+  blue: '#1040C0',
+  yellow: '#F0C020',
+  green: '#059669',
+  ink: '#6E6E6E',
+};
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="shell flex min-h-screen font-sans">
+      <aside
+        className="flex w-[236px] shrink-0 flex-col gap-1 px-4 py-5"
+        style={{ background: 'var(--shell-rail)' }}
+      >
+        <Link href="/" className="flex items-center gap-2.5 px-1">
+          <span
+            className="inline-block h-[22px] w-[22px]"
+            style={{ background: '#D02020', borderRadius: 'var(--shell-r-sm)' }}
+          />
+          <span className="font-display text-[15px] font-extrabold tracking-[0.15em] text-white">
+            CIVICGRAPH
+          </span>
+        </Link>
+        <div className="h-5" />
+        {NAV.map(({ href, label, icon: Icon, active }) => (
+          <Link
+            key={href}
+            href={href}
+            className="flex items-center gap-2.5 px-2.5 py-2 text-sm"
+            style={{
+              borderRadius: 'var(--shell-r-sm)',
+              background: active ? 'var(--shell-rail-hover)' : undefined,
+              color: active ? '#FFFFFF' : 'var(--shell-rail-text)',
+              fontWeight: active ? 600 : 500,
+            }}
+          >
+            <Icon size={16} weight="bold" />
+            {label}
+            {active && (
+              <span
+                className="ml-auto inline-block h-1.5 w-1.5"
+                style={{ background: '#D02020', borderRadius: 3 }}
+              />
+            )}
+          </Link>
+        ))}
+        <div className="h-6" />
+        <div className="px-2.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[#7A7A7A]">
+          Saved views
+        </div>
+        {pinnedViews().map((v) => (
+          <Link
+            key={v.id}
+            href={v.href}
+            title={v.question}
+            className="flex items-center gap-2.5 px-2.5 py-1.5 text-[13px]"
+            style={{ borderRadius: 'var(--shell-r-sm)', color: 'var(--shell-rail-text)' }}
+          >
+            <span
+              className="inline-block h-2 w-2 shrink-0"
+              style={{ background: VIEW_DOT[v.colour], borderRadius: 2 }}
+            />
+            {v.name}
+          </Link>
+        ))}
+        <div className="flex-1" />
+        <Link
+          href="/clarity"
+          className="flex items-center gap-2.5 px-2.5 py-2"
+          style={{
+            borderRadius: 'var(--shell-r-sm)',
+            background: '#1D1D1D',
+            color: 'var(--shell-rail-text)',
+          }}
+        >
+          <Database size={15} weight="bold" />
+          <span className="font-mono text-[11.5px]">52.3M rows on the graph</span>
+        </Link>
+      </aside>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <ShellHeader />
+        <main className="flex-1 px-7 py-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,7 +1,11 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { pinnedViews } from '@/lib/view-registry';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import { createSupabaseServer, hasSupabaseServerEnv } from '@/lib/supabase-server';
+import { isAdminEmail } from '@/lib/admin';
 import { ShellHeader } from './shell-header';
+import type { DataEvent } from './shell-menus';
 import {
   SquaresFour,
   MagnifyingGlass,
@@ -33,7 +37,54 @@ const VIEW_DOT: Record<string, string> = {
   ink: '#6E6E6E',
 };
 
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+async function recentDataEvents(): Promise<DataEvent[]> {
+  try {
+    const supabase = getDirectServiceSupabase();
+    const { data, error } = await supabase
+      .from('agent_runs')
+      .select('id,agent_name,status,items_new,started_at')
+      .order('started_at', { ascending: false })
+      .limit(6);
+    if (error) return [];
+    return ((data ?? []) as {
+      id: string;
+      agent_name: string | null;
+      status: string | null;
+      items_new: number | null;
+      started_at: string | null;
+    }[]).map((r) => ({
+      id: r.id,
+      title: r.agent_name ?? 'agent run',
+      detail:
+        r.status === 'success' || r.status === 'completed'
+          ? `${(r.items_new ?? 0).toLocaleString()} new items`
+          : (r.status ?? 'unknown status'),
+      at: r.started_at
+        ? new Date(r.started_at).toLocaleDateString('en-AU', { day: 'numeric', month: 'short' })
+        : '',
+      failed: r.status !== 'success' && r.status !== 'completed' && r.status !== 'running',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function currentUser(): Promise<{ email: string | null; isAdmin: boolean }> {
+  if (!hasSupabaseServerEnv()) return { email: null, isAdmin: false };
+  try {
+    const supabase = await createSupabaseServer();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const email = user?.email ?? null;
+    return { email, isAdmin: email ? isAdminEmail(email) : false };
+  } catch {
+    return { email: null, isAdmin: false };
+  }
+}
+
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const [events, user] = await Promise.all([recentDataEvents(), currentUser()]);
   return (
     <div className="shell flex min-h-screen font-sans">
       <aside
@@ -106,7 +157,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
         </Link>
       </aside>
       <div className="flex min-w-0 flex-1 flex-col">
-        <ShellHeader />
+        <ShellHeader events={events} userEmail={user.email} isAdmin={user.isAdmin} />
         <main className="flex-1 px-7 py-6">{children}</main>
       </div>
     </div>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,236 @@
+import Link from 'next/link';
+import { Money, Buildings, LinkSimple, Files } from '@phosphor-icons/react/dist/ssr';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import { themeMoney, money, type ThemeMoney } from '@/lib/justice-money';
+import { VIEW_REGISTRY } from '@/lib/view-registry';
+
+/** Hourly is fresh enough for counts that change nightly; themeMoney is built for this cadence. */
+export const revalidate = 3600;
+
+interface RemotenessBucket {
+  label: string;
+  dollars: number;
+  entities: number;
+}
+
+/** Canonical ABS remoteness order; raw values are matched by substring, unmatched rows are counted and disclosed. */
+const REMOTENESS_ORDER: [string, string][] = [
+  ['major cities', 'Major cities'],
+  ['inner regional', 'Inner regional'],
+  ['outer regional', 'Outer regional'],
+  ['very remote', 'Very remote'],
+  ['remote', 'Remote'],
+];
+
+async function fundingByRemoteness(): Promise<{ buckets: RemotenessBucket[]; unmapped: number }> {
+  const supabase = getDirectServiceSupabase();
+  const PAGE = 1000;
+  const byLabel = new Map<string, RemotenessBucket>();
+  let unmapped = 0;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('mv_funding_by_postcode')
+      .select('remoteness,entity_count,total_funding')
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`remoteness query failed: ${error.message}`);
+    const page = (data ?? []) as { remoteness: string | null; entity_count: number | null; total_funding: number | null }[];
+    for (const row of page) {
+      const raw = (row.remoteness ?? '').toLowerCase();
+      // 'remote' is a substring of 'very remote' — REMOTENESS_ORDER lists the longer match first.
+      const hit = REMOTENESS_ORDER.find(([needle]) => raw.includes(needle));
+      if (!hit) {
+        unmapped += 1;
+        continue;
+      }
+      const bucket = byLabel.get(hit[1]) ?? { label: hit[1], dollars: 0, entities: 0 };
+      bucket.dollars += row.total_funding ?? 0;
+      bucket.entities += row.entity_count ?? 0;
+      byLabel.set(hit[1], bucket);
+    }
+    if (page.length < PAGE) break;
+  }
+  const display = ['Major cities', 'Inner regional', 'Outer regional', 'Remote', 'Very remote'];
+  return { buckets: display.map((l) => byLabel.get(l)).filter((b): b is RemotenessBucket => Boolean(b)), unmapped };
+}
+
+async function count(table: string): Promise<number | null> {
+  const supabase = getDirectServiceSupabase();
+  const { count: n, error } = await supabase.from(table).select('*', { count: 'exact', head: true });
+  return error ? null : n;
+}
+
+export default async function DashboardPage() {
+  const [yj, remoteness, entityCount, contractCount] = await Promise.all([
+    themeMoney(['youth-justice']),
+    fundingByRemoteness(),
+    count('gs_entities'),
+    count('austender_contracts'),
+  ]);
+
+  const tiles = buildTiles(yj, entityCount, contractCount);
+  const maxDollars = Math.max(...remoteness.buckets.map((b) => b.dollars), 1);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
+        {tiles.map((t) => (
+          <div key={t.label} className="shell-card flex flex-col gap-2 px-4.5 py-4">
+            <div className="flex items-center gap-2">
+              <span
+                className="flex h-6 w-6 items-center justify-center"
+                style={{ background: t.colour, borderRadius: 'var(--shell-r-sm)' }}
+              >
+                <t.icon size={14} weight="bold" color="#FFFFFF" />
+              </span>
+              <span className="text-[12.5px] font-semibold" style={{ color: 'var(--shell-muted)' }}>
+                {t.label}
+              </span>
+            </div>
+            <div className="font-display text-[30px] font-extrabold leading-none">{t.value}</div>
+            <div className="text-xs" style={{ color: 'var(--shell-muted)' }}>
+              {t.sub}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-4 xl:flex-row">
+        <section className="shell-card flex min-w-0 flex-1 flex-col gap-4 px-5 py-4">
+          <div className="flex items-center gap-3">
+            <h2 className="font-display text-[15px] font-bold">Where the money sits — by remoteness</h2>
+            <div className="flex-1" />
+            <span className="text-xs" style={{ color: 'var(--shell-muted)' }}>
+              All funding on the graph, grouped by postcode remoteness
+            </span>
+          </div>
+          <div className="flex h-64 items-end gap-6 px-2">
+            {remoteness.buckets.map((b) => (
+              <div key={b.label} className="flex h-full flex-1 flex-col items-center justify-end gap-2">
+                <span className="font-mono text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+                  {money(b.dollars)}
+                </span>
+                <div
+                  className="w-full"
+                  style={{
+                    height: `${Math.max((b.dollars / maxDollars) * 100, 2)}%`,
+                    background: 'var(--shell-ink)',
+                    borderRadius: '4px 4px 0 0',
+                  }}
+                />
+                <span className="text-xs font-medium" style={{ color: 'var(--shell-muted)' }}>
+                  {b.label}
+                </span>
+              </div>
+            ))}
+          </div>
+          {remoteness.unmapped > 0 && (
+            <p className="text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+              {remoteness.unmapped.toLocaleString()} postcode rows had no remoteness classification and are not shown.
+            </p>
+          )}
+        </section>
+
+        <section className="shell-card flex w-full flex-col px-5 py-4 xl:w-[420px]">
+          <div className="flex items-center gap-2">
+            <h2 className="font-display text-[15px] font-bold">Top recipients — youth justice</h2>
+            <div className="flex-1" />
+            <Link href="/themes/youth-justice" className="text-[12.5px] font-semibold" style={{ color: '#1040C0' }}>
+              See all →
+            </Link>
+          </div>
+          <div className="mt-2 flex flex-col">
+            {(yj?.top ?? []).slice(0, 6).map((r) => (
+              <div
+                key={r.name}
+                className="flex items-center gap-2.5 py-2.5"
+                style={{ borderBottom: '1px solid var(--shell-line)' }}
+              >
+                <span
+                  className="shell-control flex h-[30px] w-[30px] shrink-0 items-center justify-center font-display text-[13px] font-bold"
+                  style={{ background: 'var(--shell-canvas)' }}
+                >
+                  {r.name.slice(0, 1)}
+                </span>
+                <div className="min-w-0 flex-1">
+                  {r.gsId ? (
+                    <Link href={`/entity/${r.gsId}`} className="block truncate text-[13.5px] font-semibold">
+                      {r.name}
+                    </Link>
+                  ) : (
+                    <span className="block truncate text-[13.5px] font-semibold">{r.name}</span>
+                  )}
+                  <span className="text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+                    {r.grants.toLocaleString()} grants
+                  </span>
+                </div>
+                <span className="font-mono text-[13px]">{money(r.dollars)}</span>
+              </div>
+            ))}
+            {!yj && (
+              <p className="py-4 text-sm" style={{ color: 'var(--shell-muted)' }}>
+                Youth justice money is unavailable right now.
+              </p>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {VIEW_REGISTRY.map((v) => (
+          <Link key={v.id} href={v.href} className="shell-card flex flex-col gap-1.5 px-4.5 py-4">
+            <span className="text-[13.5px] font-bold">{v.name}</span>
+            <span className="text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+              {v.question}
+            </span>
+            {v.caveat && (
+              <span className="text-[11px] italic" style={{ color: 'var(--shell-muted)' }}>
+                {v.caveat}
+              </span>
+            )}
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function buildTiles(yj: ThemeMoney | null, entityCount: number | null, contractCount: number | null) {
+  return [
+    {
+      label: 'Youth justice grants',
+      value: yj ? money(yj.total) : '—',
+      sub: yj
+        ? `${yj.firstYear ?? '?'}–${yj.lastYear ?? '?'} · ${money(yj.excludedDollars)} of aggregates excluded`
+        : 'unavailable',
+      colour: '#D02020',
+      icon: Money,
+    },
+    {
+      label: 'Organisations funded',
+      value: yj ? yj.organisationCount.toLocaleString() : '—',
+      sub: 'distinct youth justice recipients',
+      colour: '#F0C020',
+      icon: Buildings,
+    },
+    {
+      label: 'Entities on the graph',
+      value: entityCount != null ? compact(entityCount) : '—',
+      sub: 'organisations and people, cross-linked',
+      colour: '#1040C0',
+      icon: LinkSimple,
+    },
+    {
+      label: 'Contracts tracked',
+      value: contractCount != null ? compact(contractCount) : '—',
+      sub: 'AusTender, full published history',
+      colour: '#059669',
+      icon: Files,
+    },
+  ];
+}
+
+function compact(n: number): string {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
+  if (n >= 1e3) return `${Math.round(n / 1e3)}K`;
+  return String(n);
+}

--- a/apps/web/src/app/dashboard/shell-header.tsx
+++ b/apps/web/src/app/dashboard/shell-header.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr';
+import { GlobalSearch } from '@/app/components/global-search';
+
+/**
+ * Shell header: page title, always-present search affordance, data-freshness pill.
+ * The shell drops the global NavBar (chromeless layout), so the ⌘K listener that
+ * normally lives in NavBar is re-registered here.
+ */
+export function ShellHeader() {
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <header
+      className="flex items-center gap-4 px-7 py-3.5"
+      style={{ background: 'var(--shell-surface)', borderBottom: '1px solid var(--shell-line)' }}
+    >
+      <h1 className="font-display text-[19px] font-bold">Dashboard</h1>
+      <div className="flex-1" />
+      <button
+        type="button"
+        onClick={() => setSearchOpen(true)}
+        className="shell-control flex w-[380px] items-center gap-2 px-3 py-2 text-left"
+        style={{ background: 'var(--shell-canvas)' }}
+      >
+        <MagnifyingGlass size={15} weight="bold" style={{ color: 'var(--shell-muted)' }} />
+        <span className="flex-1 truncate text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+          Search entities, people, places, themes…
+        </span>
+        <kbd
+          className="shell-control px-1.5 py-0.5 font-mono text-[11px]"
+          style={{ background: 'var(--shell-surface)', color: 'var(--shell-muted)' }}
+        >
+          ⌘K
+        </kbd>
+      </button>
+      <div
+        className="shell-control flex items-center gap-1.5 px-3 py-1.5"
+        style={{ background: 'var(--shell-surface)' }}
+      >
+        <span className="inline-block h-[7px] w-[7px] rounded-full" style={{ background: '#059669' }} />
+        <span className="text-[12.5px] font-medium">Data: nightly refresh</span>
+      </div>
+      <GlobalSearch open={searchOpen} onClose={() => setSearchOpen(false)} />
+    </header>
+  );
+}

--- a/apps/web/src/app/dashboard/shell-header.tsx
+++ b/apps/web/src/app/dashboard/shell-header.tsx
@@ -3,13 +3,20 @@
 import { useEffect, useState } from 'react';
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr';
 import { GlobalSearch } from '@/app/components/global-search';
+import { ShellMenus, type DataEvent } from './shell-menus';
 
 /**
  * Shell header: page title, always-present search affordance, data-freshness pill.
  * The shell drops the global NavBar (chromeless layout), so the ⌘K listener that
  * normally lives in NavBar is re-registered here.
  */
-export function ShellHeader() {
+interface ShellHeaderProps {
+  events: DataEvent[];
+  userEmail: string | null;
+  isAdmin: boolean;
+}
+
+export function ShellHeader({ events, userEmail, isAdmin }: ShellHeaderProps) {
   const [searchOpen, setSearchOpen] = useState(false);
 
   useEffect(() => {
@@ -54,6 +61,7 @@ export function ShellHeader() {
         <span className="inline-block h-[7px] w-[7px] rounded-full" style={{ background: '#059669' }} />
         <span className="text-[12.5px] font-medium">Data: nightly refresh</span>
       </div>
+      <ShellMenus events={events} userEmail={userEmail} isAdmin={isAdmin} />
       <GlobalSearch open={searchOpen} onClose={() => setSearchOpen(false)} />
     </header>
   );

--- a/apps/web/src/app/dashboard/shell-menus.tsx
+++ b/apps/web/src/app/dashboard/shell-menus.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { Bell, Question, SignOut, User, Wrench } from '@phosphor-icons/react/dist/ssr';
+
+export interface DataEvent {
+  id: string;
+  title: string;
+  detail: string;
+  at: string; // preformatted, server-side — avoids TZ drift between server and client render
+  failed: boolean;
+}
+
+interface ShellMenusProps {
+  events: DataEvent[];
+  userEmail: string | null;
+  isAdmin: boolean;
+}
+
+/**
+ * Notifications here are DATA events (pipeline runs, refresh failures), not social noise —
+ * see thoughts/shared/plans/dashboard-shell-buildout.md. The dot is red only when
+ * something actually failed.
+ */
+export function ShellMenus({ events, userEmail, isAdmin }: ShellMenusProps) {
+  const [open, setOpen] = useState<'bell' | 'help' | 'profile' | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(null);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, []);
+
+  const hasFailure = events.some((e) => e.failed);
+  const toggle = (m: 'bell' | 'help' | 'profile') => setOpen((cur) => (cur === m ? null : m));
+
+  return (
+    <div ref={rootRef} className="relative flex items-center gap-1.5">
+      <button
+        type="button"
+        onClick={() => toggle('bell')}
+        aria-label="Data events"
+        className="shell-control relative flex h-9 w-9 items-center justify-center"
+        style={{ background: 'var(--shell-surface)' }}
+      >
+        <Bell size={16} weight="bold" />
+        {hasFailure && (
+          <span
+            className="absolute right-2 top-2 h-2 w-2 rounded-full"
+            style={{ background: '#D02020' }}
+          />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={() => toggle('help')}
+        aria-label="Help"
+        className="shell-control flex h-9 w-9 items-center justify-center"
+        style={{ background: 'var(--shell-surface)' }}
+      >
+        <Question size={16} weight="bold" />
+      </button>
+      <button
+        type="button"
+        onClick={() => toggle('profile')}
+        aria-label="Profile"
+        className="shell-control flex h-9 w-9 items-center justify-center"
+        style={{ background: 'var(--shell-ink)', color: '#FFFFFF' }}
+      >
+        <User size={16} weight="bold" />
+      </button>
+
+      {open === 'bell' && (
+        <Popover title="Data events">
+          {events.length === 0 && (
+            <p className="px-3 py-3 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+              No pipeline activity recorded.
+            </p>
+          )}
+          {events.map((e) => (
+            <div
+              key={e.id}
+              className="flex gap-2.5 px-3 py-2.5"
+              style={{ borderTop: '1px solid var(--shell-line)' }}
+            >
+              <span
+                className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                style={{ background: e.failed ? '#D02020' : '#059669' }}
+              />
+              <div className="min-w-0">
+                <div className="truncate text-[13px] font-semibold">{e.title}</div>
+                <div className="text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+                  {e.detail} · {e.at}
+                </div>
+              </div>
+            </div>
+          ))}
+        </Popover>
+      )}
+
+      {open === 'help' && (
+        <Popover title="Help">
+          <MenuLink href="/dashboard/help" label="Why our numbers differ" />
+          <MenuLink href="/dashboard/help#caveats" label="Caveats on every view" />
+          <MenuLink href="/clarity" label="The question registry" />
+          <MenuLink href="/methodology" label="Methodology" />
+        </Popover>
+      )}
+
+      {open === 'profile' && (
+        <Popover title={userEmail ?? 'Not signed in'}>
+          {userEmail ? (
+            <>
+              <MenuLink href="/account" label="Account" icon={<User size={14} weight="bold" />} />
+              {isAdmin && (
+                <MenuLink href="/admin" label="Admin" icon={<Wrench size={14} weight="bold" />} />
+              )}
+              <MenuLink
+                href="/auth/signout"
+                label="Sign out"
+                icon={<SignOut size={14} weight="bold" />}
+              />
+            </>
+          ) : (
+            <MenuLink href="/login" label="Sign in" />
+          )}
+        </Popover>
+      )}
+    </div>
+  );
+}
+
+function Popover({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div
+      className="shell-card absolute right-0 top-11 z-50 w-[320px] overflow-hidden py-1"
+      style={{ boxShadow: '0 8px 24px rgba(18,18,18,0.10)' }}
+    >
+      <div className="px-3 py-2 text-[11px] font-bold uppercase tracking-[0.12em]" style={{ color: 'var(--shell-muted)' }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function MenuLink({ href, label, icon }: { href: string; label: string; icon?: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium hover:bg-[var(--shell-canvas)]"
+    >
+      {icon}
+      {label}
+    </Link>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -108,8 +108,35 @@ h1, h2, h3, h4 {
 }
 
 /* Override all border-radius globally (Bauhaus pages) */
-*:not(.ws *) {
+*:not(.ws *):not(.shell *) {
   border-radius: 0 !important;
+}
+
+/* ── Softened Shell theme (dashboard shell surfaces) — DESIGN.md 2026-08-16 ──
+   Identity colours and type unchanged; radius/borders/canvas softened.
+   Scope class on the shell layout wrapper, like .ws / .clarity-dark. */
+.shell {
+  --shell-canvas: #F4F4F2;
+  --shell-surface: #FFFFFF;
+  --shell-line: #E4E4E1;
+  --shell-ink: #121212;
+  --shell-muted: #6E6E6E;
+  --shell-rail: #121212;
+  --shell-rail-text: #C9C9C9;
+  --shell-rail-hover: #2A2A2A;
+  --shell-r-sm: 6px;
+  --shell-r-md: 10px;
+  background: var(--shell-canvas);
+  color: var(--shell-ink);
+}
+.shell .shell-card {
+  background: var(--shell-surface);
+  border: 1px solid var(--shell-line);
+  border-radius: var(--shell-r-md);
+}
+.shell .shell-control {
+  border: 1px solid var(--shell-line);
+  border-radius: var(--shell-r-sm);
 }
 
 /* ── Workspace theme (editorial style for operational tools) ── */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -90,7 +90,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     || pathname.startsWith('/org/a-curious-tractor/')
     || pathname === '/org/curious-tractor'
     || pathname.startsWith('/org/curious-tractor/');
-  const isChromeless = pathname.startsWith('/embed')
+  const isChromeless = pathname.startsWith('/dashboard')
+    || pathname.startsWith('/embed')
     || pathname.startsWith('/share')
     || pathname.startsWith('/discover')
     || pathname.startsWith('/feedback')

--- a/apps/web/src/lib/view-registry.ts
+++ b/apps/web/src/lib/view-registry.ts
@@ -1,0 +1,84 @@
+/**
+ * The saved-views registry: the typed list of named views pinned to the shell rail.
+ *
+ * A view = a named, scoped query the dashboard can render and the rail can pin.
+ * Registry-in-code first (like the Atlas layer registry); user-created persistence can
+ * come later without changing consumers.
+ *
+ * Grounding: thoughts/shared/data-map/DASHBOARD-VIEW-MAP.md — only views verified
+ * runnable in the 2026-08-14 opportunity map belong here. Every money view MUST go
+ * through justice-money.ts helpers; person views are count-only (no dollar rollups).
+ */
+
+export type ViewColour = 'red' | 'blue' | 'yellow' | 'green' | 'ink';
+
+export interface RegisteredView {
+  id: string;
+  /** Short rail/card label, plain words. */
+  name: string;
+  /** One-sentence answer this view gives. */
+  question: string;
+  /** Where clicking through lands. */
+  href: string;
+  colour: ViewColour;
+  /** Caveat that must ship with the number, verbatim from the data map. Never render the view without it. */
+  caveat?: string;
+  /** Pinned to the rail by default. */
+  pinned?: boolean;
+}
+
+export const VIEW_REGISTRY: RegisteredView[] = [
+  {
+    id: 'youth-justice-money',
+    name: 'Youth justice money',
+    question: 'Where youth justice grant money went, filtered clean ($915.7M FY2018–24).',
+    href: '/themes/youth-justice',
+    colour: 'yellow',
+    caveat: 'Grants only: excludes state budget aggregates and source-spreadsheet total rows.',
+    pinned: true,
+  },
+  {
+    id: 'acco-share',
+    name: 'ACCO share',
+    question: 'How much of youth justice money reaches community-controlled organisations (11.5%).',
+    href: '/themes/youth-justice?lens=acco',
+    colour: 'blue',
+    pinned: true,
+  },
+  {
+    id: 'money-without-evidence',
+    name: 'Money vs evidence',
+    question: 'Funding to organisations with no recorded evidence of what works, by topic.',
+    href: '/clarity?q=evidence-gap',
+    colour: 'green',
+    caveat: 'Evidence link = ALMA register presence; absence of evidence is not evidence of absence.',
+    pinned: true,
+  },
+  {
+    id: 'power-concentration',
+    name: 'Power: top 1%',
+    question: 'Cross-system power concentration — the top 1% of entities hold 86.9% of $1.287T.',
+    href: '/power',
+    colour: 'red',
+    caveat: 'Entity-level only. Person-level influence is shown as counts, never dollars.',
+    pinned: true,
+  },
+  {
+    id: 'funding-deserts',
+    name: 'Funding deserts',
+    question: 'High-disadvantage LGAs receiving the least funding.',
+    href: '/reports/funding-deserts',
+    colour: 'ink',
+    caveat: 'Desert grain is not unique per LGA — deduplicated by name and state.',
+  },
+  {
+    id: 'board-interlocks',
+    name: 'Interlocked boards',
+    question: 'Organisations governed by people who sit on multiple boards.',
+    href: '/people',
+    colour: 'ink',
+    caveat: 'Banded by board count, capped at 10 — above that is the nominee-block artefact.',
+  },
+];
+
+export const pinnedViews = () => VIEW_REGISTRY.filter((v) => v.pinned);

--- a/thoughts/shared/data-map/DASHBOARD-VIEW-MAP.md
+++ b/thoughts/shared/data-map/DASHBOARD-VIEW-MAP.md
@@ -1,0 +1,80 @@
+# Dashboard View Map — data model → surfaces
+
+**Written 2026-08-16**, for the softened-Bauhaus dashboard shell rebuild (Pencil mock:
+"CG Dashboard Shell — Softened Bauhaus"). Distils `CANONICAL-DATA-MAP.md` + `OPPORTUNITY-MAP.md`
+into the thing the shell needs: which rail destination shows which data, backed by which objects,
+with which mandatory guardrails. Every number below is VERIFIED in the census docs unless marked.
+
+## The data model in one screen
+
+Four spines meet on one key (`gs_entities`, 609,448 rows, reached by uuid stamp → ABN →
+normalised name → place code). Nobody else in Australia joins any two of them.
+
+| Spine | What it holds | Anchor objects | Health |
+|---|---|---|---|
+| **Money** | contracts + grants + donations + philanthropy | `austender_contracts` 824K · `justice_funding` 157K · `grantconnect_awards` 291K · `political_donations` 2.55M · `foundations` 11K | Rich but booby-trapped: three mandatory filters (below) |
+| **Governance / people** | who sits on which boards | `person_roles` 340K · `mv_board_interlocks` 39.8K · `person_identities` 230K | Count-only rule for people; MAX_PLAUSIBLE_BOARDS cap stays |
+| **Place** | where entities and money actually are | `postcode_geo` 12K · `mv_funding_by_lga` · LGA stamps reason-coded (`lga_source`) | 40.5K placements added Aug-09; ~28.5K unplaced-with-postcode, every row reason-coded |
+| **Evidence** | what works | `alma_interventions` 2.1K · `alma_evidence` 631 · `alma_outcomes` 2.9K | Small but unique; 85% of yj-funded orgs have NO evidence link — that gap IS a view |
+
+Weak fifth spine: **story/media** — 77 objects, 4,501 rows total. Do not design views that
+depend on it carrying weight.
+
+Not civic data at all: **29% of objects (237)** are ACT's private business systems (Xero, GHL,
+email). The shell must never mix these into civic surfaces — separation at line one, not a filter.
+
+## Rail destination → data backing
+
+| Rail item | Backed by | State |
+|---|---|---|
+| **Dashboard** | stat tiles + 2–3 headline views from the list below | new — this build |
+| **Search** | `/api/global-search` 9 lanes (slice D, shipped) | live |
+| **Clarity** | 26-question registry, 17/19 answers running | live |
+| **Themes** | `topics @>` GIN over justice_funding (hyphenated tags) | live pages |
+| **Entities** | `gs_entities` + `entity_xref` (91.9% crosswalk) | live pages |
+| **People** | `mv_board_interlocks` / `mv_person_influence` — **counts only, no $ rollups** | partial; person trio fixes pending |
+| **Places** | Atlas steps 1–4 (layer registry w/ consent tiers) | live |
+| **Reports** | `report-service.ts` snapshot-backed pages | live |
+| **Saved views** | new object: named query + scope + filters, per user | new — this build |
+
+## The view inventory (verified runnable, from OPPORTUNITY-MAP)
+
+Ship-now views, each verified by an actually-run query. These are the candidates for dashboard
+cards and the seed set for "saved views":
+
+1. **Watchhouse tonight** — QLD watchhouse children, facility-level, ~daily. Self-contained.
+   Caveat ships with it: person-observations, not distinct children; coverage starts 2026-04-28.
+2. **Money vs evidence gap** — $ to orgs with no recorded evidence, by topic. The 85% headline.
+3. **Interlocked boards** — orgs governed by multi-board people + public money held. Band by
+   board_count, cap at 10 (nominee-block artefact above that).
+4. **Charity contract survivability** — `mv_justice_charity_financial_health` (5.9K).
+5. **ACCO share by theme/place** — the 11.5% headline, `is_community_controlled` × topic × LGA.
+6. **Funding deserts** — `mv_funding_deserts` (grain is NOT unique per LGA — dedupe by name|state).
+7. **Donor-contractors** — `mv_gs_donor_contractors`; donations filtered to `receipt_type='donation received'`.
+8. **Remoteness allocation** — mv_funding_by_lga × SEIFA × remoteness (the mock's chart).
+9. **Power concentration** — `mv_entity_power_index` top 1% hold 86.9% of $1.287T (entity-level
+   only; person-level stays count-only).
+
+## Guardrails that bind every view (non-negotiable)
+
+- `justice_funding`: `measure_kind='grant'` AND `is_aggregate IS NOT TRUE` AND the
+  aggregate-name blocklist — use `isRealRecipient()`/`themeMoney()` from
+  `apps/web/src/lib/justice-money.ts`, never re-derive. Omission = 26% overstatement.
+- `political_donations`: `receipt_type='donation received'` (89% of rows are not donations).
+- Topic tags are hyphenated; tag-by-tag concatenation double-counts — dedupe by id.
+- `NULLS LAST` on every amount ordering.
+- Sentinels ship with cross-sections or the cross-section doesn't ship (the $121bn law-firm
+  contract row exists; 29.4% of contract value sits in 13 rows).
+- Drill-through from graph edges to `justice_funding` source rows is **100% broken**
+  (`source_record_id` dead namespace) — views must query source tables, not `gs_relationships`,
+  until the edge rebuild lands.
+- Matview trust: `mv_funding_by_disadvantage` (1 row) and `mv_indigenous_funding_by_disadvantage`
+  (0 rows) refresh garbage nightly; `mv_person_identity_influence_v2` (the corrected one) is NOT
+  scheduled while superseded v1 is. Check before wiring any matview into a card.
+
+## What "saved views" are (the new model object)
+
+A saved view = `{name, destination, query params, colour}` pinned to the rail. The four in the
+mock (Youth justice money · ACCO suppliers · Alice Springs · Power: top 1%) map to views 5, 5-by-
+supplier, a place scope, and 9 above. Start as a typed registry in code (like the Atlas layer
+registry) — user-created persistence can come later; the registry alone gets the UX.

--- a/thoughts/shared/plans/dashboard-shell-buildout.md
+++ b/thoughts/shared/plans/dashboard-shell-buildout.md
@@ -1,0 +1,35 @@
+# Dashboard shell build-out — chrome elements → real data
+
+**2026-08-16.** Ben's direction after the first shell slice: take the full chrome vocabulary of a
+mature dashboard (shadcn demo reference) — notifications, profile, dropdowns, help centre, docs —
+and wire each one to data we actually hold. Rule: **no chrome without a data source.** A
+notification bell with fake dots is worse than no bell.
+
+## Element → data backing
+
+| Chrome element | Backed by (verified objects) | Notes |
+|---|---|---|
+| **Notifications** | `agent_runs` (status/failures), `mv_refresh_log` (stale/garbage MVs), watchhouse snapshot arrivals | "Data events", not social noise. Failure of a nightly refresh IS the user's business here. |
+| **Profile menu** | Supabase auth user + `org_profiles` (tier), impersonation cookie | Sign out, account, admin links when admin. |
+| **Help centre** | The 26-question clarity registry + view caveats from `view-registry.ts` + the three money filters | Our docs ARE the provenance. "Why is this number smaller than the press release?" is the #1 help topic. |
+| **Documentation** | `thoughts/shared/data-map/` distilled to public-safe pages | Phase 2 — needs a public-safety pass first (the map names private ACT systems). |
+| **Dropdowns/selects** | Year ranges from `financial_year` actuals, states, topics from the tag vocabulary | Never hardcode a year list that rots. |
+| **Command menu (⌘K)** | Existing GlobalSearch — extend with "jump to view" from the registry | Registry entries become searchable actions. |
+| **Empty/error states** | The caveat + sentinel text from DASHBOARD-VIEW-MAP | An empty chart states *why* (e.g. "matview refreshed 0 rows") — we already log this. |
+
+## Build order
+
+1. **Shell menus (this slice):** notifications popover (agent_runs + refresh log), profile
+   dropdown, help menu. One client component, data from the server layout.
+2. **Shell adoption:** wrap /search and /clarity in the shell so nav stops teleporting between
+   layouts.
+3. **Help centre page** (`/dashboard/help`): the money filters explained in plain words, the
+   view caveats, the question registry index.
+4. **ACCO tile + per-view pages:** each registry view gets a real page target.
+5. **Docs surface** (public-safe subset of the data map). Needs its own pass.
+
+## Component discipline
+
+Shell components live in `src/app/dashboard/` while the shell owns one route; promote to
+`src/components/shell/` when /search adopts it (step 2). Tokens only from `.shell` vars — no
+new hex values in components.


### PR DESCRIPTION
## What

The first slices of the dashboard shell rebuild, direction chosen by Ben 2026-08-16 ("soften Bauhaus toward the demo") after reviewing the deployed console.

- **`.shell` scoped theme** — radius 6/10px, 1px hairline borders on `#E4E4E1`, warm-grey canvas. First sanctioned break from zero-radius, scoped like `.ws`; Bauhaus untouched outside the scope. Recorded in DESIGN.md + the brand alignment map.
- **`/dashboard`** (chromeless route): dark rail (8 destinations + pinned saved views + data pill), header with GlobalSearch + re-registered ⌘K, four stat tiles, funding-by-remoteness chart, top youth-justice recipients — all live queries through the `justice-money.ts` guardrails; excluded aggregate dollars disclosed on the tile.
- **`view-registry.ts`** — typed saved-views registry seeded from `thoughts/shared/data-map/DASHBOARD-VIEW-MAP.md`; caveats live on the view object and render wherever the view appears.
- **Shell chrome** — notifications bell fed by `agent_runs` (red dot only on real failures), profile menu (auth + admin), help menu.
- **`/dashboard/help`** — the three money filters in plain words, per-view caveats, the count-only people rule.

## Design decisions
- No chrome without a data source (buildout map: `thoughts/shared/plans/dashboard-shell-buildout.md`)
- Grounding: `thoughts/shared/data-map/DASHBOARD-VIEW-MAP.md`
- Pencil mock: "CG Dashboard Shell — Softened Bauhaus"

## Test
- `tsc --noEmit` clean · vitest 711 pass · smoke-tested `/dashboard` + `/dashboard/help` on 3013 with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)