### PR TITLE
⌘K jump-to-view actions + live ACCO-share tile

### DIFF
--- a/apps/web/src/app/components/global-search.tsx
+++ b/apps/web/src/app/components/global-search.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { VIEW_REGISTRY } from '@/lib/view-registry';
 
 interface EntityResult {
   type: 'entity';
@@ -87,12 +88,23 @@ export function GlobalSearch({ open, onClose }: GlobalSearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  // Flatten all results for keyboard navigation
+  // Registry views are jump actions: pinned ones surface on an empty query,
+  // and any view matches by name/question text. Pure client-side — the
+  // registry is a static typed list, no fetch involved.
+  const q = query.trim().toLowerCase();
+  const viewMatches =
+    q.length === 0
+      ? VIEW_REGISTRY.filter((v) => v.pinned)
+      : VIEW_REGISTRY.filter((v) => `${v.name} ${v.question}`.toLowerCase().includes(q));
+  const viewOffset = viewMatches.length;
+
+  // Flatten all results for keyboard navigation (views first)
   const allResults: SearchResult[] = [
     ...results.entities,
     ...results.foundations,
     ...results.grants,
   ];
+  const navHrefs: string[] = [...viewMatches.map((v) => v.href), ...allResults.map((r) => r.href)];
 
   // Escape to close
   useEffect(() => {
@@ -167,24 +179,24 @@ export function GlobalSearch({ open, onClose }: GlobalSearchProps) {
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setSelectedIndex(i => Math.min(i + 1, allResults.length - 1));
+      setSelectedIndex(i => Math.min(i + 1, navHrefs.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setSelectedIndex(i => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (allResults[selectedIndex]) {
-        navigate(allResults[selectedIndex].href);
+      if (navHrefs[selectedIndex]) {
+        navigate(navHrefs[selectedIndex]);
       } else if (query.trim().length >= 2) {
         // No typeahead hit — hand off to the full /search page (all 8 kinds).
         navigate(`/search?q=${encodeURIComponent(query.trim())}`);
       }
     }
-  }, [allResults, selectedIndex, navigate, query]);
+  }, [navHrefs, selectedIndex, navigate, query]);
 
   if (!open) return null;
 
-  const hasResults = allResults.length > 0;
+  const hasResults = allResults.length > 0 || viewMatches.length > 0;
 
   return (
     <div className="fixed inset-0 z-[100]" onClick={() => onClose()}>
@@ -218,6 +230,38 @@ export function GlobalSearch({ open, onClose }: GlobalSearchProps) {
           {/* Results */}
           {hasResults && (
             <div className="max-h-[60vh] overflow-y-auto">
+              {/* Views (registry jump actions) */}
+              {viewMatches.length > 0 && (
+                <div>
+                  <div className="px-4 pt-3 pb-1">
+                    <span className="text-[10px] font-black text-bauhaus-muted uppercase tracking-widest">
+                      Views
+                    </span>
+                  </div>
+                  {viewMatches.map((v, i) => (
+                    <button
+                      key={v.id}
+                      onClick={() => navigate(v.href)}
+                      className={`w-full text-left px-4 py-3 flex items-center gap-3 transition-colors cursor-pointer ${
+                        selectedIndex === i ? 'bg-bauhaus-canvas' : 'hover:bg-bauhaus-canvas/50'
+                      }`}
+                    >
+                      <span
+                        className="inline-block h-2 w-2 shrink-0"
+                        style={{
+                          background:
+                            { red: '#D02020', blue: '#1040C0', yellow: '#F0C020', green: '#059669', ink: '#6E6E6E' }[v.colour],
+                        }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="font-bold text-bauhaus-black truncate">{v.name}</div>
+                        <div className="text-[11px] text-bauhaus-muted font-medium truncate">{v.question}</div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+
               {/* Entities */}
               {results.entities.length > 0 && (
                 <div>
@@ -227,7 +271,7 @@ export function GlobalSearch({ open, onClose }: GlobalSearchProps) {
                     </span>
                   </div>
                   {results.entities.map((r, i) => {
-                    const flatIndex = i;
+                    const flatIndex = viewOffset + i;
                     return (
                       <button
                         key={r.id}
@@ -276,7 +320,7 @@ export function GlobalSearch({ open, onClose }: GlobalSearchProps) {
                     </span>
                   </div>
                   {results.foundations.map((r, i) => {
-                    const flatIndex = results.entities.length + i;
+                    const flatIndex = viewOffset + results.entities.length + i;
                     return (
                       <button
                         key={r.id}
@@ -315,7 +359,7 @@ export function GlobalSearch({ open, onClose }: GlobalSearchProps) {
                     </span>
                   </div>
                   {results.grants.map((r, i) => {
-                    const flatIndex = results.entities.length + results.foundations.length + i;
+                    const flatIndex = viewOffset + results.entities.length + results.foundations.length + i;
                     return (
                       <button
                         key={r.id}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -206,9 +206,11 @@ function buildTiles(yj: ThemeMoney | null, entityCount: number | null, contractC
       icon: Money,
     },
     {
-      label: 'Organisations funded',
-      value: yj ? yj.organisationCount.toLocaleString() : '—',
-      sub: 'distinct youth justice recipients',
+      label: 'ACCO share',
+      value: yj ? `${yj.accoPctOfLinked}%` : '—',
+      sub: yj
+        ? `${money(yj.accoDollars)} of ${money(yj.linkedDollars)} linked youth justice money`
+        : 'unavailable',
       colour: '#F0C020',
       icon: Buildings,
     },

--- a/apps/web/src/lib/justice-money.ts
+++ b/apps/web/src/lib/justice-money.ts
@@ -101,6 +101,16 @@ export interface ThemeMoney {
   excludedDollars: number;
   /** Share of included rows that resolve to a graph entity, so the links can be honest. */
   linkedPct: number;
+  /** Dollars held by recipients that resolve to a graph entity — the classifiable base. */
+  linkedDollars: number;
+  /** Dollars held by linked recipients flagged `is_community_controlled`. */
+  accoDollars: number;
+  /**
+   * ACCO share **of linked dollars**, one decimal. Unlinked money cannot be classified either
+   * way, so the honest denominator is linkedDollars, and the basis must be stated wherever
+   * this renders.
+   */
+  accoPctOfLinked: number;
   top: RecipientRow[];
 }
 
@@ -198,17 +208,38 @@ export async function themeMoney(topics: readonly string[], topN = 15): Promise<
     ),
   ];
   const gsIdByEntityId = new Map<string, string>();
-  // Resolve internal ids to the public `gs_id` used by /entity/[gsId]. Chunked: a 1,274-org theme
-  // would otherwise build a URL longer than PostgREST accepts.
+  const accoByEntityId = new Map<string, boolean>();
+  // Resolve internal ids to the public `gs_id` used by /entity/[gsId], and pick up the
+  // community-controlled flag in the same pass. Chunked: a 1,274-org theme would otherwise
+  // build a URL longer than PostgREST accepts.
   for (let i = 0; i < entityIds.length; i += 200) {
     const chunk = entityIds.slice(i, i + 200);
     try {
-      const { data } = await supabase.from('gs_entities').select('id,gs_id').in('id', chunk);
-      for (const e of (data ?? []) as { id: string; gs_id: string }[]) {
+      const { data } = await supabase
+        .from('gs_entities')
+        .select('id,gs_id,is_community_controlled')
+        .in('id', chunk);
+      for (const e of (data ?? []) as {
+        id: string;
+        gs_id: string;
+        is_community_controlled: boolean | null;
+      }[]) {
         gsIdByEntityId.set(e.id, e.gs_id);
+        accoByEntityId.set(e.id, e.is_community_controlled === true);
       }
     } catch {
       // A failed chunk costs links, not numbers. The names still render.
+    }
+  }
+
+  let linkedDollars = 0;
+  let accoDollars = 0;
+  for (const v of byName.values()) {
+    // Classify against the resolved chunk, not the raw stamp: an id whose lookup chunk failed
+    // is unclassifiable and must not inflate the denominator.
+    if (v.gsEntityId && gsIdByEntityId.has(v.gsEntityId)) {
+      linkedDollars += v.dollars;
+      if (accoByEntityId.get(v.gsEntityId)) accoDollars += v.dollars;
     }
   }
 
@@ -232,6 +263,9 @@ export async function themeMoney(topics: readonly string[], topN = 15): Promise<
     excludedRows: excluded.length,
     excludedDollars: excluded.reduce((s, r) => s + (r.amount_dollars ?? 0), 0),
     linkedPct: kept.length === 0 ? 0 : Math.round((linked / kept.length) * 1000) / 10,
+    linkedDollars,
+    accoDollars,
+    accoPctOfLinked: linkedDollars === 0 ? 0 : Math.round((accoDollars / linkedDollars) * 1000) / 10,
     top,
   };
 }


### PR DESCRIPTION
Follows #220.

- **GlobalSearch**: registry views surface as jump actions — pinned views on empty query, text-matched otherwise; keyboard nav spans views + results as one list
- **themeMoney**: classifies linked recipients via `is_community_controlled`, returns `accoDollars` / `linkedDollars` / `accoPctOfLinked`. Denominator is linked money only — unlinked grants can't be classified either way; the basis renders on the tile
- **Dashboard**: org-count tile becomes the ACCO-share tile (11.6% live, dollars shown)

Test: tsc clean · vitest 711 pass · tile + modal smoke-tested on 3013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)