### PR TITLE
Dashboard topic/year dropdowns fed by DB vocabularies

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,11 +1,16 @@
 import Link from 'next/link';
+import { unstable_cache } from 'next/cache';
 import { Money, Buildings, LinkSimple, Files } from '@phosphor-icons/react/dist/ssr';
 import { getDirectServiceSupabase } from '@/lib/supabase';
 import { themeMoney, money, type ThemeMoney } from '@/lib/justice-money';
 import { VIEW_REGISTRY } from '@/lib/view-registry';
+import { financialYearVocab, topicVocab, topicLabel } from '@/lib/vocab';
+import { ShellFilters } from '@/components/shell/shell-filters';
+import { allThemes } from '@/app/reports/theme/themes';
 
-/** Hourly is fresh enough for counts that change nightly; themeMoney is built for this cadence. */
-export const revalidate = 3600;
+// Reading searchParams makes this page dynamic, so the hourly cadence moves from page-level
+// `revalidate` to unstable_cache around each data loader — one DB scan per (topic, year)
+// combination per hour, never one per hit (the August pooler-saturation pattern).
 
 interface RemotenessBucket {
   label: string;
@@ -59,19 +64,57 @@ async function count(table: string): Promise<number | null> {
   return error ? null : n;
 }
 
-export default async function DashboardPage() {
-  const [yj, remoteness, entityCount, contractCount] = await Promise.all([
-    themeMoney(['youth-justice']),
-    fundingByRemoteness(),
-    count('gs_entities'),
-    count('austender_contracts'),
+const cachedRemoteness = unstable_cache(fundingByRemoteness, ['dash-remoteness'], {
+  revalidate: 3600,
+});
+const cachedCount = unstable_cache(count, ['dash-count'], { revalidate: 3600 });
+const cachedTopicVocab = unstable_cache(topicVocab, ['dash-topic-vocab'], { revalidate: 3600 });
+const cachedYearVocab = unstable_cache(financialYearVocab, ['dash-year-vocab'], {
+  revalidate: 3600,
+});
+const cachedThemeMoney = unstable_cache(
+  (topic: string, fy: string) =>
+    themeMoney([topic], 15, { financialYear: fy === '' ? undefined : fy }),
+  ['dash-theme-money'],
+  { revalidate: 3600 },
+);
+
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ topic?: string; fy?: string }>;
+}) {
+  const params = await searchParams;
+  const [topics, years] = await Promise.all([cachedTopicVocab(), cachedYearVocab()]);
+
+  // Params are only honoured when they exist in the DB vocabulary — an unknown value falls back
+  // rather than feeding themeMoney a filter that silently matches nothing.
+  const topic =
+    params.topic && topics.some((t) => t.value === params.topic) ? params.topic : 'youth-justice';
+  const fy = params.fy && years.some((y) => y.value === params.fy) ? params.fy : null;
+
+  const [selected, remoteness, entityCount, contractCount] = await Promise.all([
+    cachedThemeMoney(topic, fy ?? ''),
+    cachedRemoteness(),
+    cachedCount('gs_entities'),
+    cachedCount('austender_contracts'),
   ]);
 
-  const tiles = buildTiles(yj, entityCount, contractCount);
+  const topicName = topicLabel(topic);
+  const theme = allThemes().find((t) => t.topicTags.includes(topic));
+  const tiles = buildTiles(selected, entityCount, contractCount, topicName, fy);
   const maxDollars = Math.max(...remoteness.buckets.map((b) => b.dollars), 1);
 
   return (
     <div className="flex flex-col gap-5">
+      {(topics.length > 0 || years.length > 0) && (
+        <div className="flex items-center gap-3">
+          <ShellFilters topics={topics} years={years} activeTopic={topic} activeYear={fy} />
+          <span className="text-xs" style={{ color: 'var(--shell-muted)' }}>
+            Scopes the money tiles and top recipients. Options come from the data, not a list.
+          </span>
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
         {tiles.map((t) => (
           <div key={t.label} className="shell-card flex flex-col gap-2 px-4.5 py-4">
@@ -132,14 +175,21 @@ export default async function DashboardPage() {
 
         <section className="shell-card flex w-full flex-col px-5 py-4 xl:w-[420px]">
           <div className="flex items-center gap-2">
-            <h2 className="font-display text-[15px] font-bold">Top recipients — youth justice</h2>
+            <h2 className="font-display text-[15px] font-bold">
+              Top recipients — {topicName.toLowerCase()}
+              {fy ? ` · ${fy}` : ''}
+            </h2>
             <div className="flex-1" />
-            <Link href="/reports/theme/youth-justice" className="text-[12.5px] font-semibold" style={{ color: '#1040C0' }}>
+            <Link
+              href={theme ? `/reports/theme/${theme.slug}` : '/reports/theme'}
+              className="text-[12.5px] font-semibold"
+              style={{ color: '#1040C0' }}
+            >
               See all →
             </Link>
           </div>
           <div className="mt-2 flex flex-col">
-            {(yj?.top ?? []).slice(0, 6).map((r) => (
+            {(selected?.top ?? []).slice(0, 6).map((r) => (
               <div
                 key={r.name}
                 className="flex items-center gap-2.5 py-2.5"
@@ -166,9 +216,10 @@ export default async function DashboardPage() {
                 <span className="font-mono text-[13px]">{money(r.dollars)}</span>
               </div>
             ))}
-            {!yj && (
+            {!selected && (
               <p className="py-4 text-sm" style={{ color: 'var(--shell-muted)' }}>
-                Youth justice money is unavailable right now.
+                No {topicName.toLowerCase()} grants{fy ? ` in ${fy}` : ''}, or the query failed —
+                nothing is shown rather than a stale figure.
               </p>
             )}
           </div>
@@ -194,22 +245,28 @@ export default async function DashboardPage() {
   );
 }
 
-function buildTiles(yj: ThemeMoney | null, entityCount: number | null, contractCount: number | null) {
+function buildTiles(
+  selected: ThemeMoney | null,
+  entityCount: number | null,
+  contractCount: number | null,
+  topicName: string,
+  fy: string | null,
+) {
   return [
     {
-      label: 'Youth justice grants',
-      value: yj ? money(yj.total) : '—',
-      sub: yj
-        ? `${yj.firstYear ?? '?'}–${yj.lastYear ?? '?'} · ${money(yj.excludedDollars)} of aggregates excluded`
+      label: `${topicName} grants`,
+      value: selected ? money(selected.total) : '—',
+      sub: selected
+        ? `${fy ?? `${selected.firstYear ?? '?'}–${selected.lastYear ?? '?'}`} · ${money(selected.excludedDollars)} of aggregates excluded`
         : 'unavailable',
       colour: '#D02020',
       icon: Money,
     },
     {
       label: 'ACCO share',
-      value: yj ? `${yj.accoPctOfLinked}%` : '—',
-      sub: yj
-        ? `${money(yj.accoDollars)} of ${money(yj.linkedDollars)} linked youth justice money`
+      value: selected ? `${selected.accoPctOfLinked}%` : '—',
+      sub: selected
+        ? `${money(selected.accoDollars)} of ${money(selected.linkedDollars)} linked ${topicName.toLowerCase()} money`
         : 'unavailable',
       colour: '#F0C020',
       icon: Buildings,

--- a/apps/web/src/components/shell/shell-filters.tsx
+++ b/apps/web/src/components/shell/shell-filters.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { topicLabel, type VocabEntry } from '@/lib/vocab';
+
+/**
+ * Topic / year selects for shell pages. Options come exclusively from the DB vocabularies
+ * (lib/vocab.ts) — this component never invents a value, and a vocabulary that failed to load
+ * simply renders no control.
+ *
+ * Selection lives in the URL (?topic=…&fy=…) so a filtered view is shareable and the server
+ * component re-renders with validated params.
+ */
+export function ShellFilters({
+  topics,
+  years,
+  activeTopic,
+  activeYear,
+}: {
+  topics: VocabEntry[];
+  years: VocabEntry[];
+  activeTopic: string;
+  activeYear: string | null;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function setParam(key: 'topic' | 'fy', value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === '') params.delete(key);
+    else params.set(key, value);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }
+
+  const selectStyle = {
+    background: 'var(--shell-canvas)',
+    color: 'var(--shell-ink)',
+  } as const;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {topics.length > 0 && (
+        <select
+          aria-label="Topic"
+          value={activeTopic}
+          onChange={(e) => setParam('topic', e.target.value)}
+          className="shell-control px-2.5 py-1.5 text-[12.5px] font-semibold"
+          style={selectStyle}
+        >
+          {topics.map((t) => (
+            <option key={t.value} value={t.value}>
+              {topicLabel(t.value)}
+            </option>
+          ))}
+        </select>
+      )}
+      {years.length > 0 && (
+        <select
+          aria-label="Financial year"
+          value={activeYear ?? ''}
+          onChange={(e) => setParam('fy', e.target.value)}
+          className="shell-control px-2.5 py-1.5 text-[12.5px] font-semibold"
+          style={selectStyle}
+        >
+          <option value="">All years</option>
+          {years.map((y) => (
+            <option key={y.value} value={y.value}>
+              {y.value}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/justice-money.ts
+++ b/apps/web/src/lib/justice-money.ts
@@ -138,7 +138,11 @@ interface RawRow {
  * topic is `child-protection` at 16,418 rows; at four columns that is a few hundred KB, fetched
  * hourly per theme. If a theme ever needs sub-second freshness this becomes a matview.
  */
-export async function themeMoney(topics: readonly string[], topN = 15): Promise<ThemeMoney | null> {
+export async function themeMoney(
+  topics: readonly string[],
+  topN = 15,
+  opts: { financialYear?: string } = {},
+): Promise<ThemeMoney | null> {
   if (topics.length === 0) return null;
 
   const supabase = getDirectServiceSupabase();
@@ -154,7 +158,7 @@ export async function themeMoney(topics: readonly string[], topN = 15): Promise<
 
   for (const topic of topics) {
     for (let from = 0; ; from += PAGE) {
-      const { data, error } = await supabase
+      let query = supabase
         .from('justice_funding')
         .select('id,recipient_name,amount_dollars,financial_year,gs_entity_id')
         .eq('measure_kind', 'grant')
@@ -164,8 +168,11 @@ export async function themeMoney(topics: readonly string[], topN = 15): Promise<
         // other, so both are required. Nationally this is the difference between $38.01bn and
         // $33.98bn; on the youth-justice theme it moves $1,044.8m to $1,044.2m.
         .not('is_aggregate', 'is', true)
-        .contains('topics', [topic])
-        .range(from, from + PAGE - 1);
+        .contains('topics', [topic]);
+      // Only ever a value from the v_vocab_financial_years vocabulary — a free-text year here
+      // would silently return zero rows and render as "no money", so callers must validate first.
+      if (opts.financialYear) query = query.eq('financial_year', opts.financialYear);
+      const { data, error } = await query.range(from, from + PAGE - 1);
       if (error) throw new Error(`justice money query failed: ${error.message}`);
       const page = (data ?? []) as unknown as RawRow[];
       for (const r of page) byId.set(r.id, r);

--- a/apps/web/src/lib/vocab.ts
+++ b/apps/web/src/lib/vocab.ts
@@ -1,0 +1,48 @@
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Dropdown vocabularies, read from the database rather than typed into code.
+ *
+ * The rule (dashboard-shell-buildout.md): never hardcode a year list that rots. Both
+ * vocabularies come from `v_vocab_financial_years` / `v_vocab_topics`
+ * (migrations/2026-08-16-vocab-views.sql), which carry the same two DB-side grant filters as
+ * every money surface — so a year or topic appears here exactly when the money panels have
+ * rows for it.
+ *
+ * Until that migration is applied, both loaders return [] and callers hide the control —
+ * a missing dropdown, not an invented list.
+ */
+
+export interface VocabEntry {
+  /** The raw database value — hyphenated topic tag, or financial_year string like '2023-24'. */
+  value: string;
+  /** Grant rows behind the value, so a caller can show how much a choice narrows to. */
+  rows: number;
+}
+
+export async function financialYearVocab(): Promise<VocabEntry[]> {
+  return loadVocab('v_vocab_financial_years', 'financial_year');
+}
+
+export async function topicVocab(): Promise<VocabEntry[]> {
+  return loadVocab('v_vocab_topics', 'topic');
+}
+
+async function loadVocab(view: string, column: string): Promise<VocabEntry[]> {
+  try {
+    const supabase = getDirectServiceSupabase();
+    const { data, error } = await supabase.from(view).select(`${column},grant_rows`);
+    if (error) return [];
+    return ((data ?? []) as unknown as Record<string, string | number>[])
+      .map((r) => ({ value: String(r[column]), rows: Number(r.grant_rows ?? 0) }))
+      .filter((e) => e.value !== '');
+  } catch {
+    return [];
+  }
+}
+
+/** 'youth-justice' → 'Youth justice'. Display only — queries always use the raw tag. */
+export function topicLabel(tag: string): string {
+  const words = tag.split('-').join(' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/migrations/2026-08-16-vocab-views.sql
+++ b/migrations/2026-08-16-vocab-views.sql
@@ -1,0 +1,27 @@
+-- Vocab views for shell dropdowns — real vocabularies, never hardcoded lists.
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-16-vocab-views.sql
+--
+-- Both views carry the two DB-side grant filters (measure_kind + is_aggregate) so the
+-- vocabularies describe the same row population the money surfaces sum. The name-based
+-- third filter is app-side (see justice-money.ts) and does not change which years/topics exist.
+
+CREATE OR REPLACE VIEW v_vocab_financial_years AS
+SELECT financial_year, count(*) AS grant_rows
+FROM justice_funding
+WHERE measure_kind = 'grant'
+  AND is_aggregate IS NOT TRUE
+  AND financial_year IS NOT NULL
+GROUP BY financial_year
+ORDER BY financial_year;
+
+CREATE OR REPLACE VIEW v_vocab_topics AS
+SELECT topic, count(*) AS grant_rows
+FROM justice_funding
+CROSS JOIN LATERAL unnest(topics) AS topic
+WHERE measure_kind = 'grant'
+  AND is_aggregate IS NOT TRUE
+GROUP BY topic
+ORDER BY grant_rows DESC;
+
+-- Views default to owner-only; without these grants the dropdowns render empty (Goods chip lesson).
+GRANT SELECT ON v_vocab_financial_years, v_vocab_topics TO anon, authenticated, service_role;


### PR DESCRIPTION
Next item from the dashboard-shell stream: dropdowns fed by real vocabularies, never hardcoded year lists.

- `migrations/2026-08-16-vocab-views.sql`: `v_vocab_financial_years` + `v_vocab_topics` over `justice_funding` with the mandatory grant filters, granted to all roles. **Not yet applied** — apply command in the file header (Ben, Tier 3).
- `lib/vocab.ts`: loaders return `[]` until the views exist, so the controls are absent rather than invented.
- `themeMoney` gains an optional `financialYear` filter; only vocabulary-validated values reach it.
- `/dashboard` reads `?topic=&fy=`, validates against the vocab, and re-scopes the money tiles + top recipients. Page-level `revalidate` moved to `unstable_cache` per loader so the dynamic page still hits the DB once per (topic, year) per hour.

Gates: tsc clean · 711 vitest pass · smoke 200 on 3013 with and without params (graceful degrade confirmed while views are unapplied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)