### PR TITLE
Public docs surface: /dashboard/docs with allowlist-curated datasets

### DIFF
--- a/apps/web/src/app/dashboard/docs/page.tsx
+++ b/apps/web/src/app/dashboard/docs/page.tsx
@@ -1,0 +1,116 @@
+import Link from 'next/link';
+import { DATA_DOCS, liveCounts, approxCount } from '@/lib/data-docs';
+
+export const metadata = { title: 'The data — CivicGraph' };
+
+/** Counts are planner estimates and refresh hourly with the page. */
+export const revalidate = 3600;
+
+/**
+ * The public docs surface: what CivicGraph holds and how much to trust it.
+ * Content is the allowlist in lib/data-docs.ts — see the safety rule there before adding
+ * anything. Numbers on this page are live estimates, never typed in.
+ */
+export default async function DataDocsPage() {
+  const counts = await liveCounts();
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-5">
+      <header className="flex flex-col gap-1">
+        <h1 className="font-display text-[26px] font-extrabold">The data</h1>
+        <p className="text-sm" style={{ color: 'var(--shell-muted)' }}>
+          Every dataset behind this dashboard: where it came from, roughly how big it is, and
+          what it cannot tell you.
+        </p>
+      </header>
+
+      <section className="shell-card flex flex-col gap-3 px-6 py-5">
+        <h2 className="font-display text-[16px] font-bold">How it fits together</h2>
+        <p className="text-[13.5px] leading-relaxed">
+          Four kinds of data meet on one spine. <strong>Money</strong> — contracts, grants and
+          donations. <strong>Governance</strong> — who sits on which boards.{' '}
+          <strong>Place</strong> — where organisations and money actually are.{' '}
+          <strong>Evidence</strong> — what works. Each dataset below feeds one of those, and all
+          of them resolve to a shared entity graph, so a supplier in a contract, a recipient in a
+          grant register and a charity in the ACNC register can be recognised as the same
+          organisation.
+        </p>
+        <p className="text-[13.5px] leading-relaxed">
+          Every claim on this dashboard is graded: <strong>verified</strong> means computed from
+          these rows; anything derived or uncertain says so where it appears. Dollar figures pass
+          through the filters described in{' '}
+          <Link href="/dashboard/help" className="font-semibold" style={{ color: '#1040C0' }}>
+            Why our numbers differ
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section className="shell-card flex flex-col px-6 py-5">
+        <h2 className="font-display text-[16px] font-bold">The datasets</h2>
+        <div className="mt-2 flex flex-col">
+          {DATA_DOCS.map((d) => {
+            const n = counts.get(d.id);
+            return (
+              <div key={d.id} className="py-3.5" style={{ borderTop: '1px solid var(--shell-line)' }}>
+                <div className="flex items-baseline gap-3">
+                  <span className="text-[13.5px] font-bold">{d.name}</span>
+                  <div className="flex-1" />
+                  {n != null && (
+                    <span className="shrink-0 font-mono text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+                      {approxCount(n)} rows
+                    </span>
+                  )}
+                </div>
+                <p className="text-[13px]">{d.description}</p>
+                <p className="text-[12px]" style={{ color: 'var(--shell-muted)' }}>
+                  Source: {d.source}
+                </p>
+                {d.caveat && (
+                  <p className="mt-1 text-[12px] italic" style={{ color: 'var(--shell-muted)' }}>
+                    {d.caveat}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        <p className="mt-3 text-[12px]" style={{ color: 'var(--shell-muted)' }}>
+          Row counts are the database&rsquo;s own estimates, refreshed hourly — approximate on
+          purpose, so they can be live instead of stale.
+        </p>
+      </section>
+
+      <section className="shell-card flex flex-col gap-2 px-6 py-5">
+        <h2 className="font-display text-[16px] font-bold">Known limits</h2>
+        <ul className="flex list-disc flex-col gap-2 pl-5 text-[13.5px] leading-relaxed">
+          <li>
+            <strong>Funding figures are floors.</strong> They count what was published and could
+            be traced to a named organisation. Unpublished spending and departmental budget lines
+            are not here.
+          </li>
+          <li>
+            <strong>Money reaching remote communities is often credited to a regional hub.</strong>{' '}
+            Funding routed through land councils and regional intermediaries is recorded at the
+            intermediary&rsquo;s address, which can overstate cities and understate communities.
+          </li>
+          <li>
+            <strong>Financial-year labels are not uniform.</strong> Source registers write the
+            same year several ways, and some rows span multiple years. We show the labels as
+            recorded rather than merging them by guesswork.
+          </li>
+          <li>
+            <strong>Most political receipts cannot be attributed.</strong> Over half of declared
+            receipts carry no ABN and no reliable name match, so influence figures understate
+            rather than guess.
+          </li>
+          <li>
+            <strong>Evidence coverage is thin and honest about it.</strong> The Australian Living
+            Map of Alternatives (ALMA) register is small; the gap between money and recorded
+            evidence is itself one of our headline findings, not a defect to hide.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/shell/shell-menus.tsx
+++ b/apps/web/src/components/shell/shell-menus.tsx
@@ -106,6 +106,7 @@ export function ShellMenus({ events, userEmail, isAdmin }: ShellMenusProps) {
         <Popover title="Help">
           <MenuLink href="/dashboard/help" label="Why our numbers differ" />
           <MenuLink href="/dashboard/help#caveats" label="Caveats on every view" />
+          <MenuLink href="/dashboard/docs" label="The data we hold" />
           <MenuLink href="/clarity" label="The question registry" />
           <MenuLink href="/methodology" label="Methodology" />
         </Popover>

--- a/apps/web/src/lib/data-docs.ts
+++ b/apps/web/src/lib/data-docs.ts
@@ -1,0 +1,154 @@
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+/**
+ * The public-safe data documentation registry — what CivicGraph holds, where it came from,
+ * and what each dataset cannot tell you.
+ *
+ * SAFETY BY CONSTRUCTION. This module is hand-curated from the internal data map; it is NEVER
+ * generated from it. The internal map catalogues the whole shared database, roughly a third of
+ * which is A Curious Tractor's private business systems — none of that may appear on a public
+ * surface, so the rule is allowlist-only: a dataset exists here because someone typed it in,
+ * with its caveat, after deciding it is public. Do not add entries by copying from
+ * thoughts/shared/data-map/*.
+ *
+ * Row counts are fetched live via PostgREST's `estimated` count (the planner's statistics) —
+ * approximate by design, checked 2026-08-16 to track measured counts within a few percent,
+ * and — unlike a typed-in number — never years stale.
+ */
+
+export interface DataDoc {
+  id: string;
+  name: string;
+  /** The public origin of the data, in plain words. */
+  source: string;
+  /** Table the live count is read from. Allowlist — only civic tables belong here. */
+  table: string;
+  description: string;
+  /** What this dataset cannot tell you. Rendered with the dataset, always. */
+  caveat?: string;
+}
+
+export const DATA_DOCS: DataDoc[] = [
+  {
+    id: 'abr',
+    name: 'Australian Business Register',
+    source: 'ABR bulk extract (Commonwealth open data)',
+    table: 'abr_registry',
+    description: 'Every ABN ever issued — the base layer that lets a name in one dataset be matched to the same organisation in another.',
+  },
+  {
+    id: 'entities',
+    name: 'The entity graph',
+    source: 'Built by CivicGraph from all sources below',
+    table: 'gs_entities',
+    description: 'Organisations and people resolved across registers — one entity per real-world organisation, reached by ABN, name and place.',
+    caveat: 'Entity resolution is probabilistic below the ABN tier. Where a match is uncertain, records stay unlinked rather than guessed.',
+  },
+  {
+    id: 'contracts',
+    name: 'Commonwealth contracts',
+    source: 'AusTender (published contract notices)',
+    table: 'austender_contracts',
+    description: 'The full published history of Commonwealth contract notices — buyer, supplier, value, dates.',
+    caveat: 'Contract value is the published commitment, not money actually paid. A small number of outlier rows carry a large share of total value.',
+  },
+  {
+    id: 'grants-awarded',
+    name: 'Commonwealth grants',
+    source: 'GrantConnect (published grant awards)',
+    table: 'grantconnect_awards',
+    description: 'Awarded Commonwealth grants — recipient, program, amount.',
+  },
+  {
+    id: 'justice-funding',
+    name: 'Justice & community funding',
+    source: 'State budget papers, grant registers and FOI releases, compiled and tagged by service area',
+    table: 'justice_funding',
+    description: 'Grants in youth justice, child protection, family services, NDIS and related areas, tagged by topic so a theme can be summed.',
+    caveat: 'A floor, never a total: money that was never published, never tagged, or spent through a departmental budget line is not here. Budget aggregates and spreadsheet total rows are excluded from every figure — the exclusions are disclosed next to each number.',
+  },
+  {
+    id: 'donations',
+    name: 'Political donations',
+    source: 'AEC transparency register',
+    table: 'political_donations',
+    description: 'Declared receipts of registered political entities.',
+    caveat: 'Most declared receipts are not donations — our donation figures count only rows the AEC classifies as “donation received”. Under half of all receipts can be attributed to a specific organisation; the rest carry no ABN and no reliable name match.',
+  },
+  {
+    id: 'charities',
+    name: 'Charity register & financials',
+    source: 'ACNC register and Annual Information Statements',
+    table: 'acnc_charities',
+    description: 'Registered charities, their purposes and beneficiaries, and yearly financials from their Annual Information Statements.',
+  },
+  {
+    id: 'companies',
+    name: 'Company register',
+    source: 'ASIC company register',
+    table: 'asic_companies',
+    description: 'Registered companies, used to resolve suppliers and follow name changes.',
+  },
+  {
+    id: 'board-roles',
+    name: 'Board & director roles',
+    source: 'ACNC and ASIC filings',
+    table: 'person_roles',
+    description: 'Who holds which role at which organisation — the governance layer.',
+    caveat: 'People are counted, never priced: no dollar figure is ever attributed to an individual. Board counts are capped at 10 per person — above that sits the professional-nominee artefact, not a power signal.',
+  },
+  {
+    id: 'tax',
+    name: 'Corporate tax transparency',
+    source: 'ATO corporate tax transparency reports',
+    table: 'ato_tax_transparency',
+    description: 'Total income, taxable income and tax payable for large entities, by report year.',
+  },
+  {
+    id: 'foundations',
+    name: 'Philanthropic foundations',
+    source: 'ACNC data classified by CivicGraph',
+    table: 'foundations',
+    description: 'Grant-making foundations, their scale and thematic focus.',
+    caveat: 'Annual giving figures are estimates for many foundations; treat rankings as indicative.',
+  },
+  {
+    id: 'opportunities',
+    name: 'Grant opportunities',
+    source: 'GrantConnect and state grant portals',
+    table: 'grant_opportunities',
+    description: 'Open and historical grant rounds — amounts, deadlines, focus areas.',
+  },
+  {
+    id: 'alma',
+    name: 'Australian Living Map of Alternatives (ALMA)',
+    source: 'Curated evidence register, maintained with practitioners',
+    table: 'alma_interventions',
+    description: 'Interventions that work — programs, their evidence and recorded outcomes — so funding can be read against evidence.',
+    caveat: 'Small by design and growing. Absence of an evidence link means the register has not recorded one — it is not evidence that a program does not work.',
+  },
+];
+
+export async function liveCounts(): Promise<Map<string, number>> {
+  const supabase = getDirectServiceSupabase();
+  const out = new Map<string, number>();
+  await Promise.all(
+    DATA_DOCS.map(async (d) => {
+      try {
+        const { count, error } = await supabase
+          .from(d.table)
+          .select('*', { count: 'estimated', head: true });
+        if (!error && count != null && count > 0) out.set(d.id, count);
+      } catch {
+        // A missing count renders as absent, not zero — zero would be a claim.
+      }
+    }),
+  );
+  return out;
+}
+
+export function approxCount(n: number): string {
+  if (n >= 1e6) return `~${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `~${Math.round(n / 1e3).toLocaleString('en-AU')}K`;
+  return `~${n}`;
+}

--- a/thoughts/shared/handoffs/dashboard-shell/current.md
+++ b/thoughts/shared/handoffs/dashboard-shell/current.md
@@ -9,9 +9,9 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-16T07:20:00Z
+**Updated:** 2026-08-16T08:10:00Z
 **Goal:** Rebuild CivicGraph's console UX as a softened-Bauhaus dashboard shell (Ben's verdict on the deployed console: works but "hard to make sense of"; direction chosen: "soften Bauhaus toward the demo", shadcn dashboard reference). Every chrome element must have a real data source.
-**Branch:** `main` at `85c32ec`, clean, everything pushed. **Four PRs merged this session: #219 #220 #221 #222.**
+**Branch:** `main` at `5660801`, clean, everything pushed. **Six PRs merged this stream: #219–#222, then #223 (vocab dropdowns) + #224 (per-view pages).**
 **Test:** `cd apps/web && npx tsc --noEmit` · `npx vitest run` (711 pass) · smoke `curl localhost:3013/dashboard` (dev server 3013, `--turbopack`)
 
 ### Now
@@ -28,10 +28,12 @@ status: active
 - [x] Link integrity: /themes/* and /people NEVER existed (rail 404s); new `/reports/theme` index; People → /person; registry hrefs → real report pages (PR #222)
 - [x] `view-registry.ts` — typed saved-views registry, caveats carried on the view object
 
+- [x] Year/topic dropdowns fed by real vocabularies (PR #223): `v_vocab_financial_years` + `v_vocab_topics` (migration APPLIED by Ben 2026-08-16); `lib/vocab.ts` returns [] → dropdown absent, never invented; `themeMoney` gained `financialYear` opt; /dashboard `?topic=&fy=` validated against vocab; page revalidate → unstable_cache per loader (searchParams made it dynamic)
+- [x] Per-view pages (PR #224): `/dashboard/views/[id]` for all six registry views; `lib/view-data.ts` loaders never throw / never silently empty — every no-data outcome states WHY; registry hrefs → view pages, old targets kept as `deepHref`
+- FINDING: `justice_funding.financial_year` formats are MIXED — `2025-26` alongside `2026-2027` and multi-year `2026-2030` (32 distinct values). Dropdown shows actuals by design; normalising is a justice_funding cleaning task, not a dropdown bug.
+
 ### Next
-- [ ] Year/topic dropdowns fed by real vocabularies (`financial_year` actuals, hyphenated topic tags) — never hardcode year lists
 - [ ] Public-safe docs surface from the data map (NEEDS SAFETY PASS — the map names ACT private systems, plaintext-token tables etc.)
-- [ ] Per-view pages for remaining registry views; empty/error states that state WHY (sentinel text from the view map)
 - [ ] Possibly dark shell variant for /clarity, pending Ben's verdict
 - [ ] Older backlog still open: Slice 5 row viewer (transcripts have FIVE independent consent flags), person-influence lane (last SEVERE money-view fixes), mv_justice_proven_suppliers GRANT ALL posture question, benjamin@act.place password reset
 


### PR DESCRIPTION
Closes the dashboard-shell ledger item: public-safe docs surface from the data map.

- `/dashboard/docs`: four-spine framing, 13 civic datasets (source, description, caveat each), and a Known Limits section (floors not totals, intermediary crediting, mixed FY labels, donation attribution, ALMA coverage).
- Safety by construction: `lib/data-docs.ts` is a hand-typed allowlist, never generated from the internal data map (which names ACT private systems and token tables). Rule documented in the module header.
- Live counts that can't rot: PostgREST `estimated` counts (planner stats, verified within a few percent of measured), labeled approximate, refreshed hourly.
- Linked from the shell help menu. Also carries the ledger update for PRs #223/#224.

Gates: tsc clean · 711 vitest pass · page renders with counts on 3013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)