### PR TITLE
Clarity slice 4: the noun column — rules propose, a human confirms

### DIFF
--- a/apps/web/src/app/api/clarity/nouns/route.ts
+++ b/apps/web/src/app/api/clarity/nouns/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+const NOUNS = ['money', 'organisations', 'people', 'places', 'evidence', 'machine'] as const;
+
+/**
+ * POST /api/clarity/nouns — a human files (or unfiles) an object.
+ *
+ * { object_key, noun: one of the six | null, reason? }
+ *
+ * The only writer of noun_source='human'. A rule's proposal never files an object; this route is
+ * the confirmation the plan requires, recorded through the verdict columns that existed unused
+ * since the catalogue was built ("first use of verdict in anger"). noun: null un-files — human
+ * judgement that the rule filing was wrong is also a verdict worth recording.
+ */
+export async function POST(request: Request) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  let body: { object_key?: unknown; noun?: unknown; reason?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body.object_key !== 'string' || !body.object_key) {
+    return NextResponse.json({ error: 'object_key required' }, { status: 400 });
+  }
+  const noun = body.noun === null ? null : (body.noun as string);
+  if (noun !== null && !NOUNS.includes(noun as (typeof NOUNS)[number])) {
+    return NextResponse.json({ error: `noun must be null or one of ${NOUNS.join(', ')}` }, { status: 400 });
+  }
+  const reason = typeof body.reason === 'string' && body.reason.trim() ? body.reason.trim() : null;
+
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase
+    .from('clarity_object')
+    .update({
+      noun,
+      noun_source: noun === null ? null : 'human',
+      verdict: 'confirmed',
+      verdict_by: auth.user.email ?? 'admin',
+      verdict_at: new Date().toISOString(),
+      verdict_reason: reason ?? (noun === null ? 'unfiled by human' : `filed as ${noun}`),
+    })
+    .eq('object_key', body.object_key)
+    .select('object_key')
+    .limit(1);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data?.length) return NextResponse.json({ error: 'no such object' }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/clarity/nouns.ts
+++ b/apps/web/src/app/clarity/nouns.ts
@@ -103,6 +103,14 @@ export const SECTOR_DOMAINS = new Set([
   'unknown',
 ]);
 
+/**
+ * SINCE SLICE 4 the `clarity_object.noun` COLUMN is authoritative and the index reads it, not
+ * this function. DOMAIN_TO_NOUN above was mirrored into the column by
+ * migrations/2026-08-16-clarity-noun.sql (noun_source='domain_rule'); humans file the rest via
+ * /clarity/unfiled → /api/clarity/nouns (noun_source='human'). This function remains as the
+ * documented rule and its tests keep the SQL mirror honest — if you edit the mapping, edit the
+ * migration's CASE too.
+ */
 export function nounFor(domain: string | null | undefined): Noun {
   if (!domain) return 'unfiled';
   return DOMAIN_TO_NOUN[domain] ?? 'unfiled';

--- a/apps/web/src/app/clarity/page.tsx
+++ b/apps/web/src/app/clarity/page.tsx
@@ -8,7 +8,6 @@ import {
   NOUN_ORDER,
   SORT_LABEL,
   UNFILED_NOTE,
-  nounFor,
   parseSort,
   unfiledReason,
   type IndexSort,
@@ -40,6 +39,7 @@ interface IndexObject {
   object_name: string;
   object_kind: string;
   domain: string | null;
+  noun: Noun | null;
   row_count: number | null;
   row_count_is_estimate: boolean | null;
   degree: number | null;
@@ -81,7 +81,7 @@ async function load(sort: IndexSort): Promise<Loaded> {
     const { data, error } = await supabase
       .from('clarity_object')
       .select(
-        'object_key,object_name,object_kind,domain,row_count,row_count_is_estimate,degree,purpose,refreshed_at',
+        'object_key,object_name,object_kind,domain,noun,row_count,row_count_is_estimate,degree,purpose,refreshed_at',
       )
       .order('object_name')
       .range(from, from + PAGE - 1);
@@ -93,7 +93,9 @@ async function load(sort: IndexSort): Promise<Loaded> {
 
   const byNoun = new Map<Noun, IndexObject[]>();
   for (const n of NOUN_ORDER) byNoun.set(n, []);
-  for (const o of all) byNoun.get(nounFor(o.domain))!.push(o);
+  // The COLUMN is authoritative since slice 4 — filing is data with provenance (domain_rule or
+  // human via /api/clarity/nouns), not a render-time function call. A proposal never files.
+  for (const o of all) byNoun.get(o.noun ?? 'unfiled')!.push(o);
 
   const cmp: Record<IndexSort, (a: IndexObject, b: IndexObject) => number> = {
     name: (a, b) => a.object_name.localeCompare(b.object_name),
@@ -286,7 +288,10 @@ export default async function ClarityIndexPage({
 
               {isUnfiled ? (
                 <p className="border-b border-bauhaus-black/15 bg-bauhaus-canvas px-4 py-2 text-[12px] text-bauhaus-black/70">
-                  {UNFILED_NOTE}
+                  {UNFILED_NOTE}{' '}
+                  <Link href="/clarity/unfiled" className="font-black text-bauhaus-blue underline">
+                    File them →
+                  </Link>
                 </p>
               ) : null}
 

--- a/apps/web/src/app/clarity/unfiled/UnfiledClient.tsx
+++ b/apps/web/src/app/clarity/unfiled/UnfiledClient.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { NOUN_LABEL, unfiledReason, type Noun } from '../nouns';
+
+export interface UnfiledRow {
+  object_key: string;
+  object_name: string;
+  object_kind: string;
+  domain: string | null;
+  row_count: number | null;
+  purpose: string | null;
+  noun_proposed: Exclude<Noun, 'unfiled'> | null;
+}
+
+const FILEABLE: Exclude<Noun, 'unfiled'>[] = [
+  'money',
+  'organisations',
+  'people',
+  'places',
+  'evidence',
+  'machine',
+];
+
+/**
+ * The adjudication surface for nouns. A proposal (from the name heuristics in the noun migration)
+ * is a HIGHLIGHTED BUTTON, never a filing — clicking is the confirmation, and the API records who
+ * and when through the verdict columns. Filed rows leave the list; the counter is the progress bar.
+ */
+export default function UnfiledClient({ initial, total }: { initial: UnfiledRow[]; total: number }) {
+  const [rows, setRows] = useState(initial);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const filedThisSession = initial.length - rows.length;
+
+  const proposedCount = useMemo(() => rows.filter((r) => r.noun_proposed).length, [rows]);
+
+  async function file(objectKey: string, noun: Exclude<Noun, 'unfiled'>) {
+    const before = rows;
+    setBusy(objectKey);
+    setRows((rs) => rs.filter((r) => r.object_key !== objectKey));
+    try {
+      const res = await fetch('/api/clarity/nouns', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ object_key: objectKey, noun }),
+      });
+      if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
+    } catch (e) {
+      setRows(before);
+      setNote(`Filing failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <>
+      <header className="border-4 border-bauhaus-black bg-bauhaus-white p-5">
+        <h1 className="font-mono text-2xl font-black">The unfiled</h1>
+        <p className="mt-2 max-w-[75ch] text-[14px] leading-relaxed text-neutral-700">
+          {rows.length.toLocaleString('en-AU')} of {total.toLocaleString('en-AU')} objects have no
+          confirmed noun. Rules propose ({proposedCount} carry a highlighted guess from the name
+          heuristics); clicking a noun is the confirmation, recorded with who and when. An object
+          filed wrongly is worse than an object left here — skip anything you are not sure of.
+        </p>
+        {filedThisSession > 0 ? (
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-widest text-neutral-500">
+            {filedThisSession} filed this session
+          </p>
+        ) : null}
+        {note ? (
+          <p className="mt-2 border-l-4 border-bauhaus-red pl-3 font-mono text-[12px]">{note}</p>
+        ) : null}
+      </header>
+
+      <section className="mt-4 border-4 border-bauhaus-black bg-bauhaus-white">
+        <ul>
+          {rows.map((r) => (
+            <li
+              key={r.object_key}
+              className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-neutral-200 px-4 py-2 last:border-b-0"
+            >
+              <Link
+                href={`/clarity/o/${encodeURIComponent(r.object_key)}`}
+                className="font-mono text-[12.5px] font-semibold text-bauhaus-blue underline"
+              >
+                {r.object_name}
+              </Link>
+              <span className="font-mono text-[10px] uppercase tracking-widest text-neutral-400">
+                {r.object_kind}
+                {r.row_count != null ? ` · ${r.row_count.toLocaleString('en-AU')} rows` : ''}
+              </span>
+              {unfiledReason(r.domain) ? (
+                <span className="font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+                  {unfiledReason(r.domain)}
+                </span>
+              ) : null}
+              <span className="ml-auto flex flex-wrap gap-1">
+                {FILEABLE.map((n) => (
+                  <button
+                    key={n}
+                    disabled={busy === r.object_key}
+                    onClick={() => file(r.object_key, n)}
+                    className={`border-2 px-1.5 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest disabled:opacity-40 ${
+                      r.noun_proposed === n
+                        ? 'border-bauhaus-blue bg-bauhaus-blue text-white hover:bg-bauhaus-black hover:border-bauhaus-black'
+                        : 'border-neutral-300 text-neutral-500 hover:border-bauhaus-black hover:text-bauhaus-black'
+                    }`}
+                    title={r.noun_proposed === n ? 'proposed by the name heuristic' : undefined}
+                  >
+                    {NOUN_LABEL[n]}
+                  </button>
+                ))}
+              </span>
+            </li>
+          ))}
+        </ul>
+        {rows.length === 0 ? (
+          <p className="p-4 font-mono text-[12px] text-neutral-500">
+            Nothing unfiled. The progress bar is full.
+          </p>
+        ) : null}
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/app/clarity/unfiled/page.tsx
+++ b/apps/web/src/app/clarity/unfiled/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import UnfiledClient, { type UnfiledRow } from './UnfiledClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'The unfiled · Clarity',
+  description: 'Every object without a confirmed noun. Rules propose; you confirm. The counter is the progress bar.',
+};
+
+async function load(): Promise<{ rows: UnfiledRow[]; total: number }> {
+  const supabase = getDirectServiceSupabase();
+  const PAGE = 1000;
+  const rows: UnfiledRow[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('clarity_object')
+      .select('object_key,object_name,object_kind,domain,row_count,purpose,noun_proposed')
+      .is('noun', null)
+      .order('noun_proposed', { ascending: true, nullsFirst: false })
+      .order('object_name')
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`unfiled query failed: ${error.message}`);
+    const page = (data ?? []) as unknown as UnfiledRow[];
+    rows.push(...page);
+    if (page.length < PAGE) break;
+  }
+  const { count } = await supabase
+    .from('clarity_object')
+    .select('object_key', { count: 'exact', head: true });
+  return { rows, total: count ?? 1479 };
+}
+
+export default async function UnfiledPage() {
+  let rows: UnfiledRow[] = [];
+  let total = 0;
+  let error: string | null = null;
+  try {
+    ({ rows, total } = await load());
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <main className="mx-auto max-w-[1180px] px-4 py-8">
+      {error ? (
+        <p className="border-4 border-bauhaus-red bg-bauhaus-white p-4 font-mono text-[13px]">
+          The unfiled failed to load: {error}
+        </p>
+      ) : (
+        <UnfiledClient initial={rows} total={total} />
+      )}
+    </main>
+  );
+}

--- a/migrations/2026-08-16-clarity-noun.sql
+++ b/migrations/2026-08-16-clarity-noun.sql
@@ -1,0 +1,72 @@
+-- Slice 4: the noun column — rules propose, a human confirms, unfiled is the progress bar.
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-16-clarity-noun.sql
+--
+-- Three columns, three different strengths of claim:
+--   noun           the FILED noun. Only two writers: this backfill (mirroring the hand-written
+--                  DOMAIN_TO_NOUN table in apps/web/src/app/clarity/nouns.ts, which shipped with
+--                  slice 3 as deliberate curation) and a human via /api/clarity/nouns.
+--   noun_source    which of those two wrote it ('domain_rule' | 'human').
+--   noun_proposed  a rule's guess for the unfiled, shown ONLY on the adjudication surface.
+--                  A proposal never files an object — the index renders noun IS NULL as
+--                  Unfiled regardless of what is proposed.
+--
+-- The index reads the COLUMN after this, not the domain mapping at render time: filing becomes
+-- data with provenance instead of a function call, and a human confirmation survives a domain
+-- re-catalogue.
+
+BEGIN;
+
+ALTER TABLE clarity_object
+  ADD COLUMN IF NOT EXISTS noun text
+    CHECK (noun IN ('money', 'organisations', 'people', 'places', 'evidence', 'machine')),
+  ADD COLUMN IF NOT EXISTS noun_source text
+    CHECK (noun_source IN ('domain_rule', 'human')),
+  ADD COLUMN IF NOT EXISTS noun_proposed text
+    CHECK (noun_proposed IN ('money', 'organisations', 'people', 'places', 'evidence', 'machine'));
+
+-- Backfill: the unambiguous half of the domain taxonomy, exactly nouns.ts DOMAIN_TO_NOUN.
+-- Sector domains (justice_youth_detention, social_services, child_protection, unknown) are
+-- deliberately absent — a sector spans several nouns, and filing it would be a guess.
+UPDATE clarity_object SET
+  noun = CASE domain
+    WHEN 'grants_funding' THEN 'money'
+    WHEN 'philanthropy_giving' THEN 'money'
+    WHEN 'government_spend_procurement' THEN 'money'
+    WHEN 'political_influence' THEN 'money'
+    WHEN 'charities_ngo' THEN 'organisations'
+    WHEN 'corporate_registry' THEN 'organisations'
+    WHEN 'people_directors_governance' THEN 'people'
+    WHEN 'geography_place' THEN 'places'
+    WHEN 'evidence_outcomes_alma' THEN 'evidence'
+    WHEN 'storytelling_consent' THEN 'evidence'
+    WHEN 'media_narrative' THEN 'evidence'
+    WHEN 'platform_ops_auth' THEN 'machine'
+    WHEN 'ai_agents_pipeline' THEN 'machine'
+  END,
+  noun_source = 'domain_rule'
+WHERE noun IS NULL
+  AND domain IN ('grants_funding', 'philanthropy_giving', 'government_spend_procurement',
+    'political_influence', 'charities_ngo', 'corporate_registry', 'people_directors_governance',
+    'geography_place', 'evidence_outcomes_alma', 'storytelling_consent', 'media_narrative',
+    'platform_ops_auth', 'ai_agents_pipeline');
+
+-- Proposals for the unfiled: first-match name heuristics. Machine patterns run FIRST — a table
+-- named agent_funding_queue is plumbing about money, not money — then money before the rest.
+-- These are guesses by construction and are labelled as such on the adjudication surface.
+UPDATE clarity_object SET noun_proposed = CASE
+  WHEN object_name ~ '(^|_)(agent|auth|user|session|log|logs|queue|job|jobs|cron|cache|staging|pipeline|config|settings|migration|webhook|api_key|token|sync|import|export|scrape|ingest)s?(_|$)'
+    THEN 'machine'
+  WHEN object_name ~ '(fund|grant|payment|donat|contract|tender|invoice|budget|money|spend|revenue|giving|procure)'
+    THEN 'money'
+  WHEN object_name ~ '(person|people|director|board|role|identit|member)'
+    THEN 'people'
+  WHEN object_name ~ '(postcode|lga|seifa|geo|place|region|suburb|locality|remoteness|electorate)'
+    THEN 'places'
+  WHEN object_name ~ '(entit|organi[sz]|charit|compan|abr|asic|acnc|foundation|supplier|abn)'
+    THEN 'organisations'
+  WHEN object_name ~ '(story|stories|transcript|outcome|evidence|intervention|alma|media|consent|narrative|quote)'
+    THEN 'evidence'
+  END
+WHERE noun IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## What

Slice 4 of the clarity console plan — filing becomes data with provenance, and the first use of the verdict columns in anger.

- **Three columns, three strengths of claim** (migration `2026-08-16-clarity-noun.sql`, applied): `noun` (the filed noun — written only by the domain-rule backfill or a human), `noun_source` (`domain_rule` | `human`), `noun_proposed` (a name-heuristic guess shown only on the adjudication surface — a proposal never files an object).
- **Backfill**: 732 objects filed by the hand-written DOMAIN_TO_NOUN map (the deliberate curation slice 3 shipped at render time, now recorded in data). **747 unfiled**, 282 with proposals; machine name patterns run before money so `agent_funding_queue` proposes as machine.
- **`/clarity/unfiled`**: rows show WHY unfiled (no domain vs sector), six noun buttons with the proposal highlighted; clicking confirms via admin-gated `/api/clarity/nouns`, recorded with who/when through `verdict`/`verdict_by`/`verdict_at`. Un-filing is supported and also recorded.
- **The index reads the column** now, not `nounFor()` at render time; nouns.ts documents that the mapping and the migration CASE must move together. Unfiled group links 'File them →'.

## Verification

tsc clean · vitest 722 pass · migration applied (732/747/282 measured) · index + /clarity/unfiled smoked on 3013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)