### PR TITLE
Clarity slice 2: inline edit — and two shipped bugs its HTTP verification caught

### DIFF
--- a/apps/web/src/app/api/clarity/nouns/route.ts
+++ b/apps/web/src/app/api/clarity/nouns/route.ts
@@ -42,7 +42,11 @@ export async function POST(request: Request) {
     .update({
       noun,
       noun_source: noun === null ? null : 'human',
-      verdict: 'confirmed',
+      // clarity_object.verdict is the enum {keep, suspect, cruft} — lifecycle adjudication, not
+      // a confirmation vocabulary (found by slice 2's HTTP verification; 'confirmed' 500s).
+      // Filing a noun IS a human looking at the object and keeping it, so it records 'keep',
+      // and the noun action itself lives in verdict_reason.
+      verdict: 'keep',
       verdict_by: auth.user.email ?? 'admin',
       verdict_at: new Date().toISOString(),
       verdict_reason: reason ?? (noun === null ? 'unfiled by human' : `filed as ${noun}`),

--- a/apps/web/src/app/api/clarity/object/route.ts
+++ b/apps/web/src/app/api/clarity/object/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/admin-auth';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import { isCuratedField, normaliseCuratedValue } from '@/app/clarity/curated-fields';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * PATCH /api/clarity/object — inline edit of ONE curated field.
+ *
+ * { object_key, field: purpose|caveat|grain|join_keys, value: string|null }
+ *
+ * Field-allowlisted so documentation can never overwrite measurement, one field per call so a
+ * lost request loses one paragraph, provenance stamped (curated_by/curated_at) because "who wrote
+ * this and how stale is it" is the reader's first question of any doc.
+ */
+export async function PATCH(request: Request) {
+  const auth = await requireAdminApi();
+  if (auth.error) return auth.error;
+
+  let body: { object_key?: unknown; field?: unknown; value?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body.object_key !== 'string' || !body.object_key) {
+    return NextResponse.json({ error: 'object_key required' }, { status: 400 });
+  }
+  if (!isCuratedField(body.field)) {
+    return NextResponse.json(
+      { error: 'field must be one of purpose, caveat, grain, join_keys' },
+      { status: 400 },
+    );
+  }
+  const norm = normaliseCuratedValue(body.value);
+  if (!norm.ok) return NextResponse.json({ error: norm.error }, { status: 400 });
+
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase
+    .from('clarity_object')
+    .update({
+      [body.field]: norm.value,
+      curated_by: auth.user.email ?? 'admin',
+      curated_at: new Date().toISOString(),
+    })
+    .eq('object_key', body.object_key)
+    .select('object_key')
+    .limit(1);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data?.length) return NextResponse.json({ error: 'no such object' }, { status: 404 });
+  return NextResponse.json({ ok: true, value: norm.value });
+}

--- a/apps/web/src/app/clarity/curated-fields.test.ts
+++ b/apps/web/src/app/clarity/curated-fields.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { CURATED_MAX_LEN, isCuratedField, normaliseCuratedValue } from './curated-fields';
+
+describe('isCuratedField', () => {
+  it('accepts exactly the four prose fields', () => {
+    for (const f of ['purpose', 'caveat', 'grain', 'join_keys']) expect(isCuratedField(f)).toBe(true);
+  });
+  it('rejects measured columns — documentation must never overwrite measurement', () => {
+    for (const f of ['row_count', 'refs_app', 'noun', 'verdict', '', null, 7]) {
+      expect(isCuratedField(f)).toBe(false);
+    }
+  });
+});
+
+describe('normaliseCuratedValue', () => {
+  it('empty and whitespace become null — absence, not empty string', () => {
+    expect(normaliseCuratedValue('')).toEqual({ ok: true, value: null });
+    expect(normaliseCuratedValue('  \n ')).toEqual({ ok: true, value: null });
+    expect(normaliseCuratedValue(null)).toEqual({ ok: true, value: null });
+  });
+  it('trims, keeps content, rejects non-strings and over-length rather than truncating', () => {
+    expect(normaliseCuratedValue('  x  ')).toEqual({ ok: true, value: 'x' });
+    expect(normaliseCuratedValue(42).ok).toBe(false);
+    expect(normaliseCuratedValue('a'.repeat(CURATED_MAX_LEN + 1)).ok).toBe(false);
+    expect(normaliseCuratedValue('a'.repeat(CURATED_MAX_LEN)).ok).toBe(true);
+  });
+});

--- a/apps/web/src/app/clarity/curated-fields.ts
+++ b/apps/web/src/app/clarity/curated-fields.ts
@@ -1,0 +1,32 @@
+/**
+ * The curated fields inline edit can write, and nothing else. Everything measured (row counts,
+ * refs, freshness, access) is written by probes and scanners; letting the edit path near those
+ * would let documentation overwrite measurement. The four prose fields are the 667-stub gap the
+ * plan calls the write path's reason to exist.
+ */
+export const CURATED_FIELDS = ['purpose', 'caveat', 'grain', 'join_keys'] as const;
+export type CuratedField = (typeof CURATED_FIELDS)[number];
+
+export const CURATED_MAX_LEN = 8000;
+
+export function isCuratedField(v: unknown): v is CuratedField {
+  return typeof v === 'string' && (CURATED_FIELDS as readonly string[]).includes(v);
+}
+
+/**
+ * Normalise an incoming value: trim, empty becomes null (an empty purpose is the ABSENCE of a
+ * purpose, and the stub logic depends on null meaning that), reject over-length rather than
+ * silently truncating someone's writing.
+ */
+export function normaliseCuratedValue(
+  v: unknown,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (v === null) return { ok: true, value: null };
+  if (typeof v !== 'string') return { ok: false, error: 'value must be a string or null' };
+  const trimmed = v.trim();
+  if (trimmed === '') return { ok: true, value: null };
+  if (trimmed.length > CURATED_MAX_LEN) {
+    return { ok: false, error: `value exceeds ${CURATED_MAX_LEN} characters — not truncating your writing` };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/apps/web/src/app/clarity/o/[key]/EditableCurated.tsx
+++ b/apps/web/src/app/clarity/o/[key]/EditableCurated.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import type { CuratedField } from '../../curated-fields';
+import { Prose } from './prose';
+
+/**
+ * Inline edit for one curated field. The write path is the admin-gated PATCH
+ * /api/clarity/object; this component is a convenience over it, never a gate. Saved values
+ * render immediately; a failure restores the previous text and says so. Empty saves as null on
+ * purpose — the stub logic depends on null meaning "absent", not "wrote nothing".
+ */
+export default function EditableCurated({
+  objectKey,
+  field,
+  initial,
+  variant,
+  className,
+}: {
+  objectKey: string;
+  field: CuratedField;
+  initial: string | null;
+  variant: 'prose' | 'mono';
+  className?: string;
+}) {
+  const [value, setValue] = useState(initial);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/clarity/object', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ object_key: objectKey, field, value: draft }),
+      });
+      const body = (await res.json()) as { value?: string | null; error?: string };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setValue(body.value ?? null);
+      setEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className={className}>
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={variant === 'prose' ? 4 : 2}
+          autoFocus
+          className="w-full border-2 border-bauhaus-black p-2 font-mono text-[13px]"
+        />
+        <div className="mt-1.5 flex items-center gap-2">
+          <button
+            onClick={save}
+            disabled={busy}
+            className="border-2 border-bauhaus-black px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest hover:bg-bauhaus-black hover:text-bauhaus-canvas disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            onClick={() => setEditing(false)}
+            disabled={busy}
+            className="border-2 border-neutral-300 px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest text-neutral-500 hover:border-bauhaus-black hover:text-bauhaus-black disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          {error ? <span className="font-mono text-[11px] text-bauhaus-red">{error}</span> : null}
+        </div>
+      </div>
+    );
+  }
+
+  const editButton = (
+    <button
+      onClick={() => {
+        setDraft(value ?? '');
+        setEditing(true);
+      }}
+      className="font-mono text-[10px] font-black uppercase tracking-widest text-neutral-400 hover:text-bauhaus-blue"
+      aria-label={`edit ${field}`}
+    >
+      {value ? 'edit' : `add ${field.replace('_', ' ')}`}
+    </button>
+  );
+
+  if (!value) {
+    return <span className={className}>{editButton}</span>;
+  }
+  if (variant === 'mono') {
+    return (
+      <span className={className}>
+        {value} {editButton}
+      </span>
+    );
+  }
+  return (
+    <div className={className}>
+      <Prose text={value} />
+      <div className="mt-0.5">{editButton}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/clarity/o/[key]/page.tsx
+++ b/apps/web/src/app/clarity/o/[key]/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation';
 import { getDirectServiceSupabase } from '@/lib/supabase';
 import { VISIBILITY_MEANING, canRender, type Surface } from '@/lib/visibility';
 import { floorFor, floorReason } from '../../visibility-floor';
+import EditableCurated from './EditableCurated';
+import { Prose } from './prose';
 import {
   formatBytes,
   formatCount,
@@ -125,33 +127,6 @@ function Panel({
   );
 }
 
-/**
- * The curated prose is written in markdown — 467 caveats and 84 purposes contain `**bold**` or
- * backtick code. Rendered as plain text it reads as broken formatting, which is how it looked the
- * first time this page was opened. Only two inline forms are supported on purpose: no dependency,
- * no `dangerouslySetInnerHTML`, and nothing here can inject markup.
- */
-function Prose({ text, className }: { text: string; className?: string }) {
-  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
-  return (
-    <p className={className}>
-      {parts.map((part, i) => {
-        if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
-          return <strong key={i}>{part.slice(2, -2)}</strong>;
-        }
-        if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
-          return (
-            <code key={i} className="bg-bauhaus-canvas px-1 font-mono text-[0.92em]">
-              {part.slice(1, -1)}
-            </code>
-          );
-        }
-        return <span key={i}>{part}</span>;
-      })}
-    </p>
-  );
-}
-
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="border-b border-neutral-200 py-2 last:border-b-0">
@@ -269,24 +244,25 @@ export default async function ObjectPage({ params }: { params: Promise<{ key: st
 
         {stub ? (
           <p className="mt-4 border-l-4 border-neutral-400 pl-3 text-[14px] text-neutral-600">
-            This object has no purpose, grain or join keys recorded. It is one of{' '}
-            <strong>667 stubs</strong> in a catalogue of 1,479 — described objects carry all three
-            fields, so nothing here is half-written. Everything below is measured rather than
-            curated.
+            This object has no purpose, grain or join keys recorded — one of the{' '}
+            <strong>667 stubs</strong> the inline editor below exists to whittle down. Everything
+            further down is measured rather than curated.
           </p>
-        ) : (
-          <>
-            {o.purpose ? (
-              <Prose text={o.purpose} className="mt-4 text-[15px] leading-relaxed" />
-            ) : null}
-            {o.caveat ? (
-              <Prose
-                text={o.caveat}
-                className="mt-3 border-l-4 border-bauhaus-red pl-3 text-[14px] leading-relaxed"
-              />
-            ) : null}
-          </>
-        )}
+        ) : null}
+        <EditableCurated
+          objectKey={key}
+          field="purpose"
+          initial={o.purpose}
+          variant="prose"
+          className="mt-4 text-[15px] leading-relaxed"
+        />
+        <EditableCurated
+          objectKey={key}
+          field="caveat"
+          initial={o.caveat}
+          variant="prose"
+          className="mt-3 border-l-4 border-bauhaus-red pl-3 text-[14px] leading-relaxed"
+        />
       </header>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
@@ -466,9 +442,16 @@ export default async function ObjectPage({ params }: { params: Promise<{ key: st
                   <span className="text-neutral-500"> · {o.nullable_columns} nullable</span>
                 ) : null}
               </Field>
-              <Field label="Grain">{o.grain ?? <span className="text-neutral-400">—</span>}</Field>
+              <Field label="Grain">
+                <EditableCurated objectKey={key} field="grain" initial={o.grain} variant="mono" />
+              </Field>
               <Field label="Join keys">
-                {o.join_keys ?? <span className="text-neutral-400">—</span>}
+                <EditableCurated
+                  objectKey={key}
+                  field="join_keys"
+                  initial={o.join_keys}
+                  variant="mono"
+                />
               </Field>
               <Field label="Degree">
                 {o.degree ?? '—'}
@@ -596,6 +579,16 @@ export default async function ObjectPage({ params }: { params: Promise<{ key: st
               </Field>
               <Field label="State">{o.state ?? '—'}</Field>
               <Field label="Catalogue refreshed">{o.refreshed_at?.slice(0, 10) ?? '—'}</Field>
+              <Field label="Curated">
+                {o.curated_at ? (
+                  <>
+                    {o.curated_at.slice(0, 10)}
+                    {o.curated_by ? <span className="text-neutral-500"> · {o.curated_by}</span> : null}
+                  </>
+                ) : (
+                  <span className="text-neutral-500">never edited inline</span>
+                )}
+              </Field>
             </dl>
           </Panel>
         </div>

--- a/apps/web/src/app/clarity/o/[key]/prose.tsx
+++ b/apps/web/src/app/clarity/o/[key]/prose.tsx
@@ -1,0 +1,26 @@
+/**
+ * The curated prose is written in markdown — 467 caveats and 84 purposes contain `**bold**` or
+ * backtick code. Rendered as plain text it reads as broken formatting. Only two inline forms are
+ * supported on purpose: no dependency, no `dangerouslySetInnerHTML`, and nothing here can inject
+ * markup. Shared by the server page and the inline editor (pure, no directive needed).
+ */
+export function Prose({ text, className }: { text: string; className?: string }) {
+  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
+  return (
+    <p className={className}>
+      {parts.map((part, i) => {
+        if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+          return <strong key={i}>{part.slice(2, -2)}</strong>;
+        }
+        if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
+          return (
+            <code key={i} className="bg-bauhaus-canvas px-1 font-mono text-[0.92em]">
+              {part.slice(1, -1)}
+            </code>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
+    </p>
+  );
+}

--- a/apps/web/src/app/clarity/o/[key]/types.ts
+++ b/apps/web/src/app/clarity/o/[key]/types.ts
@@ -93,6 +93,8 @@ export interface ObjectRow {
   verdict_at: string | null;
   first_seen_at: string | null;
   refreshed_at: string | null;
+  curated_at: string | null;
+  curated_by: string | null;
   missing_since: string | null;
 }
 

--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -23,6 +23,13 @@ export async function requireAdminApi(): Promise<AdminApiResult> {
     data: { user },
   } = await supabase.auth.getUser();
 
+  // Same rule as requireAdminPage: the bypass covers ONLY the no-session case in local dev
+  // (never production, never Vercel), so the admin write paths are HTTP-testable on 3013 —
+  // slice 2's requirement — while a real signed-in non-admin still gets 403 below.
+  if (!user && isLocalDevBypass()) {
+    return { user: localDevAdminUser() };
+  }
+
   if (!user) {
     return {
       error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),

--- a/migrations/2026-08-16-clarity-curated-provenance.sql
+++ b/migrations/2026-08-16-clarity-curated-provenance.sql
@@ -1,0 +1,22 @@
+-- Slice 2: curated-field edit provenance.
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-16-clarity-curated-provenance.sql
+--
+-- clarity_object_history is a METRICS snapshot table (row_count, bytes, degree), not an edit
+-- audit, and clarity_object has no triggers — so the write path stamps who last curated the
+-- prose fields (purpose, caveat, grain, join_keys) and when. One stamp, not a log: the curated
+-- fields are documentation, and "who wrote this and how stale is it" is the question a reader
+-- actually asks of documentation.
+BEGIN;
+ALTER TABLE clarity_object
+  ADD COLUMN IF NOT EXISTS curated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS curated_by text;
+
+-- service_role held SELECT-only on clarity_object, found by slice 2's HTTP verification — which
+-- means the slice 4 nouns route shipped broken too (its UPDATE would 500). The grant is
+-- COLUMN-SCOPED on purpose: the app's write path can touch exactly the adjudication and curation
+-- columns, and the measured columns (row_count, refs_*, freshness, access) stay un-writable at
+-- the database even if a route bug tried. Documentation must never overwrite measurement.
+GRANT UPDATE (purpose, caveat, grain, join_keys, curated_at, curated_by,
+              noun, noun_source, verdict, verdict_by, verdict_at, verdict_reason)
+  ON clarity_object TO service_role;
+COMMIT;


### PR DESCRIPTION
## What

Slice 2 of the clarity console plan — the write path for the 667 stubs.

- **Inline edit** of the four curated fields (purpose, caveat, grain, join_keys) on `/clarity/o/[key]`: view/add/edit/save, markdown-lite rendering preserved (`Prose` extracted to a shared module), empty saves as **null** so stub logic stays honest, over-length rejected rather than truncated.
- **`PATCH /api/clarity/object`** — admin-gated, field-allowlisted, one field per call, stamps `curated_by`/`curated_at` (migration applied). "Curated" provenance row added to the object page.
- **Column-scoped `GRANT UPDATE`** on clarity_object to service_role, covering exactly the adjudication + curation columns — the DB itself now enforces that documentation can never overwrite measurement (row_count, refs_*, freshness stay un-writable even through a route bug).

## The two shipped bugs HTTP verification caught (the plan demanded "real HTTP verification, not a typecheck" — it paid twice)

1. **service_role held SELECT-only on clarity_object** — slice 4's nouns route (#229, merged) 500'd on every write. It had never served a real request.
2. **`clarity_object.verdict` is enum `{keep, suspect, cruft}`** — `'confirmed'` was never a member. Filing a noun now records `keep` (a human looked and kept it) with the noun action in `verdict_reason`.

To make write paths testable at all, `requireAdminApi` now honors the same local-dev bypass as `requireAdminPage` (no-session **local dev only** — never production, never Vercel; a real signed-in non-admin still gets 403).

## Verification

- tsc clean · vitest 726 pass (4 new allowlist/normalise tests).
- Over real HTTP on 3013: field-allowlist rejection, unknown-object 404, object-edit write-then-revert with provenance stamped, and a genuine filing (`agent_runs → machine`, noun_source=human, verdict=keep, recorded to the admin email) exercising the repaired slice-4 route end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)