### PR TITLE
Project report enrichment: declaration gaps vs dormant projects

### DIFF
--- a/apps/web/src/app/clarity/projects/page.tsx
+++ b/apps/web/src/app/clarity/projects/page.tsx
@@ -16,7 +16,17 @@ interface CodeRow {
   tier: string | null;
   status: string | null;
   evidence_object_keys: string[];
+  summary: string | null;
+  repo: string | null;
+  repo_last_commit: string | null;
   synced_at: string;
+}
+
+/** A repo commit in the last ~6 months means the project is alive in code even if the data
+ *  cannot speak about it — that is a DECLARATION gap, not a dormant project. */
+function repoActive(r: CodeRow): boolean {
+  if (!r.repo_last_commit) return false;
+  return Date.now() - new Date(r.repo_last_commit).getTime() < 183 * 24 * 60 * 60 * 1000;
 }
 
 async function load(): Promise<CodeRow[]> {
@@ -50,6 +60,8 @@ export default async function ProjectsPage() {
   const withEvidence = rows.filter((r) => r.evidence_object_keys.length > 0);
   const zero = rows.filter((r) => r.evidence_object_keys.length === 0);
   const zeroActive = zero.filter((r) => r.status === 'active');
+  const gapAlive = zero.filter(repoActive);
+  const zeroRest = zero.filter((r) => !repoActive(r));
   const syncedAt = rows[0]?.synced_at ?? null;
 
   return (
@@ -64,7 +76,9 @@ export default async function ProjectsPage() {
               Of <strong>{rows.length}</strong> project codes,{' '}
               <strong className="text-bauhaus-red">{zero.length}</strong> have zero declared
               evidence — the data cannot currently speak about them at all.{' '}
-              <strong>{zeroActive.length}</strong> of those are active projects.
+              <strong>{zeroActive.length}</strong> of those are active projects, and{' '}
+              <strong>{gapAlive.length}</strong> have a codebase with commits in the last six
+              months — a declaration gap on a living project, not a dead one.
             </p>
             <p className="mt-2 max-w-[75ch] text-[13px] text-neutral-600">
               Declarations are made from the project side —{' '}
@@ -100,6 +114,9 @@ export default async function ProjectsPage() {
                     {r.tier ? ` · ${r.tier}` : ''}
                   </span>
                 </div>
+                {r.summary ? (
+                  <p className="mt-0.5 max-w-[85ch] text-[13px] text-neutral-600">{r.summary}</p>
+                ) : null}
                 <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
                   {r.evidence_object_keys.map((k) => (
                     <Link
@@ -117,16 +134,47 @@ export default async function ProjectsPage() {
         </section>
       ) : null}
 
-      {zero.length > 0 ? (
+      {gapAlive.length > 0 ? (
         <section className="mt-4 border-4 border-bauhaus-red bg-bauhaus-white">
           <h2 className="border-b-2 border-bauhaus-red px-4 py-2 font-mono text-[11px] font-black uppercase tracking-widest text-bauhaus-red">
-            Zero evidence · {zero.length}
+            Declaration gap — living codebase, no declared evidence · {gapAlive.length}
+          </h2>
+          <p className="border-b border-neutral-200 px-4 py-2 text-[13px] text-neutral-600">
+            Fix by declaring in{' '}
+            <code className="bg-bauhaus-canvas px-1 font-mono text-[0.92em]">
+              act-global-infrastructure/config/project-evidence.json
+            </code>{' '}
+            and re-running the sync.
+          </p>
+          <ul>
+            {gapAlive.map((r) => (
+              <li key={r.code} className="border-b border-neutral-200 px-4 py-2 last:border-b-0">
+                <span className="font-mono text-[12px] font-black">{r.code}</span>{' '}
+                <span className="text-[14px] font-semibold">{r.name}</span>
+                <span className="ml-2 font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+                  {r.repo} · last commit {r.repo_last_commit}
+                </span>
+                {r.summary ? (
+                  <p className="mt-0.5 max-w-[85ch] text-[13px] text-neutral-600">{r.summary}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {zeroRest.length > 0 ? (
+        <section className="mt-4 border-4 border-bauhaus-black bg-bauhaus-white">
+          <h2 className="border-b-2 border-bauhaus-black px-4 py-2 font-mono text-[11px] font-black uppercase tracking-widest">
+            Zero evidence · {zeroRest.length} · no recent codebase activity known
           </h2>
           <ul className="grid gap-x-6 gap-y-1 p-4 sm:grid-cols-2 lg:grid-cols-3">
-            {zero.map((r) => (
+            {zeroRest.map((r) => (
               <li key={r.code} className="font-mono text-[12px] leading-6">
                 <span className="font-black">{r.code}</span>{' '}
-                <span className="font-sans text-[13px]">{r.name}</span>
+                <span className="font-sans text-[13px]" title={r.summary ?? undefined}>
+                  {r.name}
+                </span>
                 <span
                   className={`ml-2 text-[10px] uppercase tracking-widest ${
                     r.status === 'active' ? 'text-bauhaus-red' : 'text-neutral-400'

--- a/migrations/2026-08-17-clarity-project-enrichment.sql
+++ b/migrations/2026-08-17-clarity-project-enrichment.sql
@@ -1,0 +1,10 @@
+-- Project-code enrichment: public summary (from the studio's generated wiki content) + linked
+-- repo with measured freshness. Lets the zero-evidence report distinguish "declaration gap on a
+-- living project" from "genuinely dormant".
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-clarity-project-enrichment.sql
+BEGIN;
+ALTER TABLE clarity_project_code
+  ADD COLUMN IF NOT EXISTS summary text,
+  ADD COLUMN IF NOT EXISTS repo text,
+  ADD COLUMN IF NOT EXISTS repo_last_commit date;
+COMMIT;

--- a/scripts/sync-project-evidence.mjs
+++ b/scripts/sync-project-evidence.mjs
@@ -6,7 +6,11 @@
  *   config/project-codes.json     — the 74 canonical codes
  *   config/project-evidence.json  — code -> [clarity_object object_keys]
  * Writes:
- *   clarity_project_code          — all 74 codes + metadata + evidence arrays
+ *   clarity_project_code          — all 74 codes + metadata + evidence arrays, PLUS enrichment:
+ *     summary          — public one-liner from the studio's generated wiki content
+ *                        (act-regenerative-studio/src/data/wiki-projects.generated.json)
+ *     repo             — the code's declared primary codebase (wiki-side 'repos' map)
+ *     repo_last_commit — MEASURED from git at sync time, never declared
  *   clarity_object.project_codes  — the same edge from the object end, for fast filtering
  *
  * VALIDATES AND REFUSES rather than skipping silently: an unknown code or an unknown object_key
@@ -62,6 +66,41 @@ async function main() {
   const badKeys = declaredKeys.filter((k) => !known.has(k));
   if (badKeys.length) throw new Error(`declared objects not in the catalogue: ${badKeys.join(', ')}`);
 
+  // Enrichment 1: public summaries from the studio's generated wiki content. Optional input —
+  // a missing studio checkout degrades to no summaries, loudly, rather than failing the sync.
+  const summaries = new Map();
+  const studioPath = join(
+    process.env.ACT_STUDIO_DIR ?? join(homedir(), 'Code', 'act-regenerative-studio'),
+    'src', 'data', 'wiki-projects.generated.json',
+  );
+  try {
+    const wikiProjects = JSON.parse(readFileSync(studioPath, 'utf8'));
+    const entries = Array.isArray(wikiProjects) ? wikiProjects : Object.values(wikiProjects.projects ?? wikiProjects);
+    for (const p of entries) {
+      const code = p.canonicalCode ?? p.code;
+      if (code && p.summary && !summaries.has(code)) summaries.set(code, String(p.summary));
+    }
+    console.log(`summaries: ${summaries.size} from studio wiki content`);
+  } catch {
+    console.log('WARNING: studio wiki-projects.generated.json unreadable — no summaries this sync.');
+  }
+
+  // Enrichment 2: declared repo + measured freshness. The declaration is wiki-side; the date is
+  // measured here and now. A declared repo that is not on disk is an error (same refuse-not-skip
+  // rule as object keys — a silent miss would render a living project dormant).
+  const repoInfo = new Map();
+  for (const [code, repoName] of Object.entries(evidence.repos ?? {})) {
+    if (!projects[code]) throw new Error(`repos map names unknown project code: ${code}`);
+    const repoDir = join(homedir(), 'Code', repoName);
+    let date;
+    try {
+      date = execFileSync('git', ['-C', repoDir, 'log', '-1', '--format=%cs'], { encoding: 'utf8' }).trim();
+    } catch {
+      throw new Error(`declared repo for ${code} not found or not a git repo: ${repoDir}`);
+    }
+    repoInfo.set(code, { repo: repoName, lastCommit: date });
+  }
+
   // object_key -> codes (the mirrored edge, from the object end)
   const byObject = new Map();
   for (const [code, keys] of Object.entries(declarations)) {
@@ -76,7 +115,9 @@ async function main() {
     'DELETE FROM clarity_project_code;',
     ...Object.entries(projects).map(([code, p]) => {
       const ev = declarations[code] ?? [];
-      return `INSERT INTO clarity_project_code (code, name, category, tier, status, evidence_object_keys) VALUES (${sqlLit(code)}, ${sqlLit(p.name)}, ${p.category ? sqlLit(p.category) : 'NULL'}, ${p.tier ? sqlLit(p.tier) : 'NULL'}, ${p.status ? sqlLit(p.status) : 'NULL'}, ${ev.length ? sqlArr(ev.sort()) : "'{}'::text[]"});`;
+      const s = summaries.get(code);
+      const r = repoInfo.get(code);
+      return `INSERT INTO clarity_project_code (code, name, category, tier, status, evidence_object_keys, summary, repo, repo_last_commit) VALUES (${sqlLit(code)}, ${sqlLit(p.name)}, ${p.category ? sqlLit(p.category) : 'NULL'}, ${p.tier ? sqlLit(p.tier) : 'NULL'}, ${p.status ? sqlLit(p.status) : 'NULL'}, ${ev.length ? sqlArr(ev.sort()) : "'{}'::text[]"}, ${s ? sqlLit(s) : 'NULL'}, ${r ? sqlLit(r.repo) : 'NULL'}, ${r ? sqlLit(r.lastCommit) : 'NULL'});`;
     }),
     'UPDATE clarity_object SET project_codes = NULL WHERE project_codes IS NOT NULL;',
     ...[...byObject.entries()].map(


### PR DESCRIPTION
## What

Follow-on to slice 9 (#232), built from Ben's pointer at the per-project repos and act-regenerative-studio as the fresher public-facing layer.

- **Wiki-side `repos` map** (act-global-infrastructure `df1d08a`): each code's primary codebase, 12 confident links only (ACT-EL corrected to `empathy-ledger-v2`; PICC and First Custodial Pathways left undeclared rather than guessed). Freshness is **measured at sync time, never declared**.
- **Sync enrichments** (`sync-project-evidence.mjs`): joins the studio's generated public summaries (`wiki-projects.generated.json`, 41 of 74 codes matched by canonical code — the studio registry itself is generated from the wiki's project-codes.json, so the join is same-vocabulary) and git-measured `repo_last_commit`. A declared repo missing from disk **aborts** the sync — same refuse-don't-skip rule as object keys.
- **`/clarity/projects`** splits the 70 zero-evidence codes: **6 have codebases with commits in the last six months** — declaration gaps on living projects, listed with repo, last-commit date, public summary, and the exact fix path — vs 64 with no recent codebase activity known. Evidenced codes gain their public one-liner.
- Migration `2026-08-17-clarity-project-enrichment.sql` (summary/repo/repo_last_commit columns) applied.

## Verification

tsc clean · vitest 726 pass · sync run (41 summaries, 12 repo dates, 6 gap-alive measured) · page smoked on 3013 with both sections rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)