### PR TITLE
Shell polish fix-pass 1: F1–F4 from the audit

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -140,10 +140,10 @@ export default async function DashboardPage({
       <div className="flex flex-col gap-4 xl:flex-row">
         <section className="shell-card flex min-w-0 flex-1 flex-col gap-4 px-5 py-4">
           <div className="flex items-center gap-3">
-            <h2 className="font-display text-[15px] font-bold">Where the money sits — by remoteness</h2>
+            <h2 className="font-display text-[15px] font-bold">Where ALL money sits — by remoteness</h2>
             <div className="flex-1" />
             <span className="text-xs" style={{ color: 'var(--shell-muted)' }}>
-              All funding on the graph, grouped by postcode remoteness
+              Every dollar on the graph, all topics and years — the filters above do not scope this chart
             </span>
           </div>
           <div className="flex h-64 items-end gap-6 px-2">
@@ -256,8 +256,14 @@ function buildTiles(
     {
       label: `${topicName} grants`,
       value: selected ? money(selected.total) : '—',
+      // Zero-valued filter notes are noise (polish F3): the exclusion clause appears only when
+      // the aggregate filter actually removed dollars for this scope.
       sub: selected
-        ? `${fy ?? `${selected.firstYear ?? '?'}–${selected.lastYear ?? '?'}`} · ${money(selected.excludedDollars)} of aggregates excluded`
+        ? `${fy ?? `${selected.firstYear ?? '?'}–${selected.lastYear ?? '?'}`}${
+            selected.excludedDollars > 0
+              ? ` · ${money(selected.excludedDollars)} of aggregates excluded`
+              : ''
+          }`
         : 'unavailable',
       colour: '#D02020',
       icon: Money,

--- a/apps/web/src/app/dashboard/views/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/views/[id]/page.tsx
@@ -89,7 +89,13 @@ export default async function ViewPage({ params }: { params: Promise<{ id: strin
                   style={{ borderTop: '1px solid var(--shell-line)' }}
                 >
                   {r.href ? (
-                    <Link href={r.href} className="min-w-0 flex-1 truncate text-[13.5px] font-semibold">
+                    // A link that looks like plain text is a dead end in disguise (polish F4):
+                    // linked rows carry the accent colour so the drill-in is visible.
+                    <Link
+                      href={r.href}
+                      className="min-w-0 flex-1 truncate text-[13.5px] font-semibold hover:underline"
+                      style={{ color: '#1040C0' }}
+                    >
                       {r.label}
                     </Link>
                   ) : (

--- a/apps/web/src/lib/view-data.ts
+++ b/apps/web/src/lib/view-data.ts
@@ -83,7 +83,13 @@ async function youthJusticeMoney(): Promise<ViewData> {
       value: money(r.dollars),
       meta: `${r.grants} grant${r.grants === 1 ? '' : 's'}`,
     })),
-    note: `${m.excludedRows} aggregate-shaped rows worth ${money(m.excludedDollars)} excluded (recipients literally named "Total" or "Various"). ${m.linkedPct}% of grants resolve to a graph entity; unlinked names are shown unlinked.`,
+    // A filter that removed nothing is not worth a sentence (polish F3) — the exclusion line
+    // appears only when it fired; the linkage line is a measurement and always shows.
+    note: `${
+      m.excludedRows > 0
+        ? `${m.excludedRows} aggregate-shaped rows worth ${money(m.excludedDollars)} excluded (recipients literally named "Total" or "Various"). `
+        : ''
+    }${m.linkedPct}% of grants resolve to a graph entity; unlinked names are shown unlinked.`,
   };
 }
 

--- a/apps/web/src/lib/view-registry.ts
+++ b/apps/web/src/lib/view-registry.ts
@@ -33,7 +33,7 @@ export const VIEW_REGISTRY: RegisteredView[] = [
   {
     id: 'youth-justice-money',
     name: 'Youth justice money',
-    question: 'Where youth justice grant money went, filtered clean ($915.7M FY2018–24).',
+    question: 'Where youth justice grant money went, filtered clean. The headline figure and span come from the live query, never this blurb.',
     href: '/dashboard/views/youth-justice-money',
     deepHref: '/reports/theme/youth-justice',
     colour: 'yellow',
@@ -43,7 +43,7 @@ export const VIEW_REGISTRY: RegisteredView[] = [
   {
     id: 'acco-share',
     name: 'ACCO share',
-    question: 'How much of youth justice money reaches community-controlled organisations (11.5%).',
+    question: 'How much of youth justice money reaches community-controlled organisations.',
     href: '/dashboard/views/acco-share',
     deepHref: '/reports/youth-justice',
     colour: 'blue',
@@ -62,7 +62,7 @@ export const VIEW_REGISTRY: RegisteredView[] = [
   {
     id: 'power-concentration',
     name: 'Power: top 1%',
-    question: 'Cross-system power concentration — the top 1% of entities hold 86.9% of $1.287T.',
+    question: 'Cross-system power concentration — how much the top 1% of entities hold.',
     href: '/dashboard/views/power-concentration',
     deepHref: '/power',
     colour: 'red',

--- a/docs/dashboard-shell-ux-findings.md
+++ b/docs/dashboard-shell-ux-findings.md
@@ -34,9 +34,10 @@ Major cities ($1004bn) vs Very remote ($11.5bn): four of five bars are slivers. 
 treatment (or excluding the dominant bucket with a stated reason) would actually show the
 distribution the chart exists to show.
 
-### F6 (S) — No active state for /dashboard/docs in the rail
-On `/dashboard/docs` the rail still highlights "Dashboard"; docs is reachable only through the help
-menu and has no you-are-here marker.
+### F6 (S) — RECLASSIFIED on fix-pass 1: section-level active is defensible
+The rail highlighting "Dashboard" on `/dashboard/docs` is section-level active state — a standard
+pattern. The residual question is IA, not styling: should "The data" be a rail entry rather than
+help-menu-only? That's Ben's call; no code change made.
 
 ### F7 (S, watch) — The /clarity chip row is nearing a label stack
 Now 10 chips (findings, owners, projects, stories added this week), wrapping to two lines above the
@@ -56,3 +57,13 @@ reads as a deliberate Bauhaus object contained by the soft shell, not a clash; t
 under it are light; the double-nav (shell rail + clarity chips) is acceptable as section sub-nav.
 Recommend: accept the framing, which un-gates the dark shell variant. But this is the taste verdict
 the ledger reserves for Ben — this paragraph is input, not the verdict.
+
+
+## Fix pass 1 (2026-08-17, branch shell-polish-fixes-1)
+- **F1 FIXED** — figures stripped from registry blurbs; the loader owns every number and span.
+- **F2 FIXED (labelling)** — chart retitled "Where ALL money sits" + caption states the filters do
+  not scope it. The full fix (a topic-scoped remoteness query) is real data work, left open.
+- **F3 FIXED** — zero-valued exclusion clauses suppressed on the tile and the view caveat.
+- **F4 FIXED** — the cause was styling, not missing hrefs: linked rows were visually identical to
+  plain text. Links now carry the accent colour + hover underline.
+- **F5 / F7 / dark-inside-light** — open, Ben's taste calls.


### PR DESCRIPTION
## What

The four mechanical fixes from the dashboard-shell polish audit (`docs/dashboard-shell-ux-findings.md`, pass 1):

- **F1 — blurbs no longer carry figures.** The view-registry blurb said "$915.7M FY2018–24" while the loader's headline said $1.04bn 2008-09–2024-25 on the same screen. Figures stripped from all three blurbs that had them; the live query owns every number and span, so copy can't rot against the loader again.
- **F2 (labelling) — the remoteness chart states it is unscoped.** Retitled "Where ALL money sits — by remoteness" with a caption saying the filters above do not scope it. The full fix (topic-scoped remoteness query) is real data work, left open in the findings doc.
- **F3 — zero-valued filter notes suppressed.** "$0 of aggregates excluded" / "0 aggregate-shaped rows worth $0 excluded" render only when the filter actually removed something.
- **F4 — linked rows look like links.** The hrefs were always there; the styling made them identical to plain text. Accent colour + hover underline.
- **F6 reclassified** — section-level rail active state is a standard pattern; whether "The data" earns its own rail entry is an IA call for Ben, no code change.

Open taste calls (not in this PR): F5 chart-as-shares, F7 clarity chip grouping, dark-inside-light verdict.

## Verification

tsc clean · vitest 726 pass · every fix re-verified over HTTP on 3013 (blurb text, chart title/caption, absence of the $0 clause, 24 accent-coloured links on the view page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)