### PR TITLE
Shell-native noun pages: the rail never exits the shell

### DIFF
--- a/apps/web/src/app/dashboard/entities/page.tsx
+++ b/apps/web/src/app/dashboard/entities/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const metadata: Metadata = { title: 'Entities — CivicGraph' };
+
+function money(n: number): string {
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+const load = unstable_cache(
+  async () => {
+    const supabase = getDirectServiceSupabase();
+    const [{ count }, { data: top, error }] = await Promise.all([
+      supabase.from('gs_entities').select('id', { count: 'estimated', head: true }),
+      supabase
+        .from('mv_entity_power_index')
+        .select('gs_id,canonical_name,entity_type,system_count,total_dollar_flow,power_score')
+        .order('power_score', { ascending: false })
+        .limit(15),
+    ]);
+    if (error) throw new Error(error.message);
+    return { count: count ?? null, top: top ?? [] };
+  },
+  ['dash-entities'],
+  { revalidate: 3600 },
+);
+
+/** Shell-native Entities index. Entity detail pages remain the public atlas for now. */
+export default async function EntitiesPage() {
+  let data: Awaited<ReturnType<typeof load>> | null = null;
+  let why: string | null = null;
+  try {
+    data = await load();
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Entities</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        {data?.count ? `~${data.count.toLocaleString('en-AU')} organisations and people on the graph. ` : ''}
+        Search with ⌘K, or start from the most cross-system-present entities below. Entity pages
+        open on the public atlas.
+      </p>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>
+          The power index could not be read: {why}
+        </p>
+      ) : (
+        <div
+          className="mt-5 bg-white p-4"
+          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+        >
+          <h2 className="font-display text-[14px] font-bold">
+            Most present across systems
+            <span className="ml-2 font-mono text-[10px] font-normal uppercase" style={{ color: 'var(--shell-muted)' }}>
+              power index · grants filtered clean
+            </span>
+          </h2>
+          {(data?.top ?? []).map((e, i) => (
+            <div
+              key={e.gs_id ?? i}
+              className="flex items-baseline gap-3 py-2"
+              style={{ borderTop: i === 0 ? undefined : '1px solid var(--shell-line)' }}
+            >
+              <Link
+                href={`/entity/${e.gs_id}`}
+                className="min-w-0 flex-1 truncate text-[13.5px] font-semibold hover:underline"
+                style={{ color: '#1040C0' }}
+              >
+                {e.canonical_name}
+              </Link>
+              <span className="shrink-0 text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {e.entity_type ?? '—'} · {e.system_count} systems
+              </span>
+              <span className="shrink-0 font-mono text-[13px]">{money(Number(e.total_dollar_flow ?? 0))}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/people/page.tsx
+++ b/apps/web/src/app/dashboard/people/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const metadata: Metadata = { title: 'People — CivicGraph' };
+
+const load = unstable_cache(
+  async () => {
+    const supabase = getDirectServiceSupabase();
+    // MAX_PLAUSIBLE_BOARDS: rows above 10 boards are professional-trustee/nominee blocks
+    // (the top unfiltered "person" sits on 745 estate trusts) — the person-disambiguation cap
+    // is a standing decision (2026-06-19, CAP STAYS), applied here as a read-side filter.
+    const { data, error } = await supabase
+      .from('mv_board_interlocks')
+      .select('person_name_display,board_count,organisations,interlock_score')
+      .lte('board_count', 10)
+      .order('interlock_score', { ascending: false })
+      .limit(15);
+    if (error) throw new Error(error.message);
+    return data ?? [];
+  },
+  ['dash-people'],
+  { revalidate: 3600 },
+);
+
+/**
+ * Shell-native People index off the board-interlocks matview. KNOWN LIMIT, stated on screen:
+ * names are string-normalised, so common names can collapse several real people into one row —
+ * the identity lane's job, not this page's.
+ */
+export default async function PeoplePage() {
+  let rows: Awaited<ReturnType<typeof load>> = [];
+  let why: string | null = null;
+  try {
+    rows = await load();
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">People</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        People on multiple boards (2–10; more than that is a professional trustee block, excluded), ranked by interlock. Names are matched by string — a common name
+        can be several real people; treat high board counts as a lead, not a fact. Person pages
+        open on the public atlas.
+      </p>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>
+          Board interlocks could not be read: {why}
+        </p>
+      ) : (
+        <div
+          className="mt-5 bg-white p-4"
+          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+        >
+          {rows.map((p, i) => (
+            <div
+              key={p.person_name_display ?? i}
+              className="flex items-baseline gap-3 py-2"
+              style={{ borderTop: i === 0 ? undefined : '1px solid var(--shell-line)' }}
+            >
+              <Link
+                href={`/person/${encodeURIComponent((p.person_name_display ?? '').replace(/\s+/g, '-'))}`}
+                className="min-w-0 flex-1 truncate text-[13.5px] font-semibold hover:underline"
+                style={{ color: '#1040C0' }}
+              >
+                {p.person_name_display}
+              </Link>
+              <span className="shrink-0 text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {p.board_count} boards
+              </span>
+              <span className="shrink-0 truncate font-mono text-[11px]" style={{ color: 'var(--shell-muted)', maxWidth: 340 }}>
+                {(p.organisations ?? []).slice(0, 3).join(' · ')}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/places/page.tsx
+++ b/apps/web/src/app/dashboard/places/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const metadata: Metadata = { title: 'Places — CivicGraph' };
+
+function money(n: number): string {
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+const load = unstable_cache(
+  async () => {
+    const supabase = getDirectServiceSupabase();
+    const { data, error } = await supabase
+      .from('mv_funding_by_postcode')
+      .select('postcode,state,remoteness,entity_count,total_funding')
+      .order('total_funding', { ascending: false })
+      .limit(15);
+    if (error) throw new Error(error.message);
+    return data ?? [];
+  },
+  ['dash-places'],
+  { revalidate: 3600 },
+);
+
+/** Shell-native Places index. The Atlas (public) stays the deep place experience. */
+export default async function PlacesIndexPage() {
+  let rows: Awaited<ReturnType<typeof load>> = [];
+  let why: string | null = null;
+  try {
+    rows = await load();
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Places</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        Where the money lands, by postcode. Place pages and the full Atlas open on the public site.
+      </p>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>
+          Funding by postcode could not be read: {why}
+        </p>
+      ) : (
+        <div
+          className="mt-5 bg-white p-4"
+          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+        >
+          <h2 className="font-display text-[14px] font-bold">
+            Highest-funded postcodes
+            <Link href="/atlas" className="ml-3 text-[12px] font-semibold hover:underline" style={{ color: '#1040C0' }}>
+              open the Atlas →
+            </Link>
+          </h2>
+          {rows.map((r, i) => (
+            <div
+              key={`${r.postcode}-${i}`}
+              className="flex items-baseline gap-3 py-2"
+              style={{ borderTop: i === 0 ? undefined : '1px solid var(--shell-line)' }}
+            >
+              <Link
+                href={`/places/${r.postcode}`}
+                className="shrink-0 font-mono text-[13.5px] font-semibold hover:underline"
+                style={{ color: '#1040C0' }}
+              >
+                {r.postcode}
+              </Link>
+              <span className="min-w-0 flex-1 truncate text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {r.state ?? '—'} · {r.remoteness ?? 'remoteness unknown'} · {r.entity_count ?? 0} organisations
+              </span>
+              <span className="shrink-0 font-mono text-[13px]">{money(Number(r.total_funding ?? 0))}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/reports/page.tsx
+++ b/apps/web/src/app/dashboard/reports/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  reportSections,
+  reportStatusMeta,
+  type NavItem,
+} from '../../reports/_components/sidebar-nav-data';
+
+export const metadata: Metadata = { title: 'Reports — CivicGraph' };
+
+function flatten(items: NavItem[]): NavItem[] {
+  return items.flatMap((i) => [i, ...(i.children ? flatten(i.children) : [])]);
+}
+
+/** Shell-native Reports index; report pages themselves are the public atlas by design. */
+export default function ReportsIndexPage() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Reports</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        Every published report, with its review status. Reports open on the public atlas.
+      </p>
+      {reportSections.map((section) => (
+        <section
+          key={section.title}
+          className="mt-5 bg-white p-4"
+          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+        >
+          <h2 className="font-display text-[14px] font-bold">{section.title}</h2>
+          <ul className="mt-2 grid gap-x-6 gap-y-1 sm:grid-cols-2">
+            {Array.from(new Map(flatten(section.items).map((r) => [r.href, r])).values()).map(
+              (r) => (
+                <li key={r.href} className="flex items-baseline gap-2 text-[13px]">
+                  <Link href={r.href} className="hover:underline" style={{ color: '#1040C0' }}>
+                    {r.label}
+                  </Link>
+                  {r.status ? (
+                    <span
+                      className="font-mono text-[10px] uppercase"
+                      style={{ color: r.status === 'review' ? '#D02020' : 'var(--shell-muted)' }}
+                    >
+                      {reportStatusMeta[r.status]?.label ?? r.status}
+                    </span>
+                  ) : null}
+                </li>
+              ),
+            )}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/themes/page.tsx
+++ b/apps/web/src/app/dashboard/themes/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { allThemes, reportsForTheme } from '../../reports/theme/themes';
+
+export const metadata: Metadata = { title: 'Themes — CivicGraph' };
+
+/**
+ * Shell-native Themes index (phase-2 ruling 2026-08-17: the rail must not exit the shell).
+ * Theme DETAIL still lives on the public atlas (/reports/theme/[slug]) — the card says so.
+ */
+export default function ThemesPage() {
+  const themes = allThemes().map((t) => ({
+    slug: t.slug,
+    title: t.title,
+    description: t.description,
+    reportCount: reportsForTheme(t.slug).length,
+  }));
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Themes</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        The world&rsquo;s language for what the data holds. Theme pages open on the public atlas.
+      </p>
+      <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {themes.map((t) => (
+          <Link
+            key={t.slug}
+            href={`/reports/theme/${t.slug}`}
+            className="block bg-white p-4"
+            style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+          >
+            <div className="font-display text-[15px] font-bold">{t.title}</div>
+            <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+              {t.description}
+            </p>
+            <div className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+              {t.reportCount} report{t.reportCount === 1 ? '' : 's'} · atlas →
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -228,7 +228,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                       <li><a href="/reports" className="text-bauhaus-muted hover:text-white transition-colors">All Reports</a></li>
                       <li><a href="/reports/big-philanthropy" className="text-bauhaus-muted hover:text-white transition-colors">Big Philanthropy</a></li>
                       <li><a href="/reports/power-dynamics" className="text-bauhaus-muted hover:text-white transition-colors">Power Dynamics</a></li>
-                      <li><a href="/ask" className="text-bauhaus-muted hover:text-white transition-colors">Ask CivicGraph</a></li>
                     </ul>
                   </div>
                   <div>

--- a/apps/web/src/components/shell/rail-nav.tsx
+++ b/apps/web/src/components/shell/rail-nav.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  SquaresFour,
+  MagnifyingGlass,
+  Eye,
+  Tag,
+  Buildings,
+  Users,
+  MapPin,
+  FileText,
+} from '@phosphor-icons/react';
+
+/**
+ * The rail's nav entries live HERE, in the client component — component references cannot cross
+ * the server->client boundary as props (the first cut tried and 500'd every shell page).
+ *
+ * Phase-2 ruling (2026-08-17): the rail never exits the shell. The five nouns point at
+ * shell-native index pages; DETAIL pages still open on the public atlas, stated on each page.
+ */
+const NAV = [
+  { href: '/dashboard', label: 'Dashboard', Icon: SquaresFour },
+  { href: '/search', label: 'Search', Icon: MagnifyingGlass },
+  { href: '/clarity', label: 'Clarity', Icon: Eye },
+  { href: '/dashboard/themes', label: 'Themes', Icon: Tag },
+  { href: '/dashboard/entities', label: 'Entities', Icon: Buildings },
+  { href: '/dashboard/people', label: 'People', Icon: Users },
+  { href: '/dashboard/places', label: 'Places', Icon: MapPin },
+  { href: '/dashboard/reports', label: 'Reports', Icon: FileText },
+];
+
+/**
+ * Pathname-aware active state: the LONGEST matching prefix wins, so /dashboard/people lights
+ * People (not Dashboard) and /clarity/o/x lights Clarity. Replaced the static activeHref prop,
+ * which could not know where the reader actually was.
+ */
+export function RailNav() {
+  const pathname = usePathname() ?? '';
+  const active = NAV
+    .filter((e) => pathname === e.href || pathname.startsWith(`${e.href}/`))
+    .sort((a, b) => b.href.length - a.href.length)[0]?.href;
+
+  return (
+    <>
+      {NAV.map(({ href, label, Icon }) => {
+        const isActive = href === active;
+        return (
+          <Link
+            key={href}
+            href={href}
+            className="flex items-center gap-2.5 px-2.5 py-2 text-sm"
+            style={{
+              borderRadius: 'var(--shell-r-sm)',
+              background: isActive ? 'var(--shell-rail-hover)' : undefined,
+              color: isActive ? '#FFFFFF' : 'var(--shell-rail-text)',
+              fontWeight: isActive ? 600 : 500,
+            }}
+          >
+            <Icon size={16} weight="bold" />
+            {label}
+            {isActive && (
+              <span
+                className="ml-auto inline-block h-1.5 w-1.5"
+                style={{ background: '#D02020', borderRadius: 3 }}
+              />
+            )}
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -5,29 +5,10 @@ import { getDirectServiceSupabase } from '@/lib/supabase';
 import { createSupabaseServer, hasSupabaseServerEnv } from '@/lib/supabase-server';
 import { isAdminEmail } from '@/lib/admin';
 import { ShellHeader } from './shell-header';
+import { RailNav } from './rail-nav';
 import type { DataEvent } from './shell-menus';
-import {
-  SquaresFour,
-  MagnifyingGlass,
-  Eye,
-  Tag,
-  Buildings,
-  Users,
-  MapPin,
-  FileText,
-  Database,
-} from '@phosphor-icons/react/dist/ssr';
+import { Database } from '@phosphor-icons/react/dist/ssr';
 
-const NAV = [
-  { href: '/dashboard', label: 'Dashboard', icon: SquaresFour },
-  { href: '/search', label: 'Search', icon: MagnifyingGlass },
-  { href: '/clarity', label: 'Clarity', icon: Eye },
-  { href: '/reports/theme', label: 'Themes', icon: Tag },
-  { href: '/entities', label: 'Entities', icon: Buildings },
-  { href: '/person', label: 'People', icon: Users },
-  { href: '/atlas', label: 'Places', icon: MapPin },
-  { href: '/reports', label: 'Reports', icon: FileText },
-];
 
 const VIEW_DOT: Record<string, string> = {
   red: '#D02020',
@@ -85,13 +66,14 @@ async function currentUser(): Promise<{ email: string | null; isAdmin: boolean }
 
 export interface ShellProps {
   title: string;
-  /** Which NAV entry renders as active; matches the entry's href. */
-  activeHref: string;
+  /** Deprecated (phase 2): the rail derives its own active entry from the pathname. Kept so
+   *  existing call sites keep compiling; the value is ignored. */
+  activeHref?: string;
   children: ReactNode;
 }
 
 /** The softened-Bauhaus app shell: dark rail + header. DESIGN.md `.shell` theme, 2026-08-16. */
-export async function Shell({ title, activeHref, children }: ShellProps) {
+export async function Shell({ title, children }: ShellProps) {
   const [events, user] = await Promise.all([recentDataEvents(), currentUser()]);
 
   return (
@@ -110,31 +92,7 @@ export async function Shell({ title, activeHref, children }: ShellProps) {
           </span>
         </Link>
         <div className="h-5" />
-        {NAV.map(({ href, label, icon: Icon }) => {
-          const active = href === activeHref;
-          return (
-            <Link
-              key={href}
-              href={href}
-              className="flex items-center gap-2.5 px-2.5 py-2 text-sm"
-              style={{
-                borderRadius: 'var(--shell-r-sm)',
-                background: active ? 'var(--shell-rail-hover)' : undefined,
-                color: active ? '#FFFFFF' : 'var(--shell-rail-text)',
-                fontWeight: active ? 600 : 500,
-              }}
-            >
-              <Icon size={16} weight="bold" />
-              {label}
-              {active && (
-                <span
-                  className="ml-auto inline-block h-1.5 w-1.5"
-                  style={{ background: '#D02020', borderRadius: 3 }}
-                />
-              )}
-            </Link>
-          );
-        })}
+        <RailNav />
         <div className="h-6" />
         <div className="px-2.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[#7A7A7A]">
           Saved views

--- a/thoughts/shared/handoffs/dashboard-shell/current.md
+++ b/thoughts/shared/handoffs/dashboard-shell/current.md
@@ -44,6 +44,19 @@ Work order: 1) chrome crawl from /dashboard (pattern-collapsed) → map every re
 visual family vs intent (root layout isChromeless list is the code's intent, layout.tsx:93) →
 convert stragglers to shell; 2) data→surface mapping via clarity (visibility floor + owner_app +
 nouns feeding a per-surface data contract).
+- [x] CRAWL DONE 2026-08-17: 47 screens, ZERO broken chrome — clean two-family split (shell:
+  dashboard+views+docs+search+18 clarity surfaces; public Bauhaus: everything else). One 404
+  (/ask footer link, removed). Ben's rulings: shell-native noun pages (rail never exits the
+  shell) + ops tools (/ops/health /alerts /tracker /foundations/tracker) move into the shell.
+- [x] Five shell-native noun pages BUILT (branch shell-native-noun-pages): /dashboard/{themes,
+  reports,entities,people,places} reusing themes registry / reportSections / mv_entity_power_index
+  / mv_board_interlocks (**MAX_PLAUSIBLE_BOARDS cap applied read-side — unfiltered top "person"
+  sits on 745 estate trusts**) / mv_funding_by_postcode. Detail pages still open the public atlas,
+  stated on every page. Rail is now pathname-aware (`rail-nav.tsx` client component, longest-prefix
+  active; TRAP: component refs can't cross the server→client boundary as props — NAV must live in
+  the client file). Shell.activeHref deprecated-ignored.
+- [ ] Ops tools into the shell (second PR of this stream).
+- [ ] Then: clarity-driven data→surface contract (visibility floor + owner + noun per surface).
 
 ### Next
 - [ ] Ben's taste verdicts: deployed shell overall + `/clarity` dark-inside-light framing (gates the dark shell variant); also eyeball /dashboard/views/* and /dashboard/docs

--- a/thoughts/shared/handoffs/dashboard-shell/current.md
+++ b/thoughts/shared/handoffs/dashboard-shell/current.md
@@ -35,6 +35,16 @@ status: active
 - [x] `justice_funding.financial_year` normalisation APPLIED (migration `migrations/2026-08-16-justice-fy-normalise.sql`): the mess was not formatting — 41 rows were multi-year spans / `YYYY-ongoing` / bare `2024`, incl. `2021-25` = a 2021→2025 PRF span that LOOKS canonical. New parsed cols `fy_start`/`fy_end`/`fy_open_ended` on all 157,116 rows (zero unparsed), maintained by trigger `trg_justice_funding_parse_fy`; raw strings kept as provenance except `2026-2027`→`2026-27` (2 rows, single-FY either way); `v_vocab_financial_years` now requires `fy_end = fy_start + 1` → dropdown is 19 clean FYs (2008-09…2026-27). Filter by `fy_*`, never by string shape.
 - Vocab views live: 9 topics (child-protection 7,481 rows → prevention 313), 19 financial years. Dropdowns appear as each surface's hourly vocab cache refreshes.
 
+### Phase 2 directive (Ben, 2026-08-17)
+"See any screen we've got on this new dashboard and make sure it aligns to the new design system;
+searchable queries; keep thinking about which parts of the data go where. Make sure the dashboard
+and all links go to the right style UX/UI, then make sure all the data is linked the right way, and
+use the clarity tool to understand what data goes into which user's experience."
+Work order: 1) chrome crawl from /dashboard (pattern-collapsed) → map every reachable screen's
+visual family vs intent (root layout isChromeless list is the code's intent, layout.tsx:93) →
+convert stragglers to shell; 2) data→surface mapping via clarity (visibility floor + owner_app +
+nouns feeding a per-surface data contract).
+
 ### Next
 - [ ] Ben's taste verdicts: deployed shell overall + `/clarity` dark-inside-light framing (gates the dark shell variant); also eyeball /dashboard/views/* and /dashboard/docs
 - [ ] Older backlog still open: Slice 5 row viewer (transcripts have FIVE independent consent flags), person-influence lane (last SEVERE money-view fixes), mv_justice_proven_suppliers GRANT ALL posture question, benjamin@act.place password reset


### PR DESCRIPTION
## What

Phase 2 of the dashboard-shell stream, per Ben's rulings after the chrome crawl (47 reachable screens, clean two-family split, zero broken chrome): the five rail nouns get **shell-native index pages** so app users never fall out of the shell into the public atlas mid-journey; detail pages still open on the atlas, stated on every page.

- **`/dashboard/themes`** — theme registry cards (reports count, atlas link).
- **`/dashboard/reports`** — report sections with review statuses from `sidebar-nav-data`.
- **`/dashboard/entities`** — ~609K estimated count + top 15 by cross-system power (`mv_entity_power_index`).
- **`/dashboard/people`** — board interlocks **with the MAX_PLAUSIBLE_BOARDS cap applied read-side**: the unfiltered top "person" sits on 745 estate trusts (professional trustee block). The page shows 2–10-board people and says why on screen.
- **`/dashboard/places`** — top-funded postcodes from `mv_funding_by_postcode`, Atlas link.
- **Pathname-aware rail** (`rail-nav.tsx`, client): longest-prefix active matching — People lights on /dashboard/people, Clarity on /clarity/o/x. `Shell.activeHref` deprecated-ignored. Trap documented: component refs can't cross the server→client boundary as props (first cut 500'd every shell page).
- Dead `/ask` footer link removed (the crawl's one 404).

All loaders `unstable_cache` 1h, degrade with a stated WHY, never silently empty.

## Verification

tsc clean · vitest 726 pass · all six shell routes 200 with live data on 3013 · People page visually verified (rail active state + capped rows) · post-cap payload shows 9–10 board rows, not 745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)