### PR TITLE
Consent gate on the public place page's Community Voice

### DIFF
--- a/apps/web/src/app/places/[postcode]/page.tsx
+++ b/apps/web/src/app/places/[postcode]/page.tsx
@@ -337,6 +337,10 @@ export default async function PlaceDetailPage({ params }: { params: Promise<{ po
         .from('storytellers')
         .select('id, full_name, bio, profile_image_url, location_id')
         .not('full_name', 'is', null)
+        // Consent gate (2026-08-17): name + bio + photo on a public page needs consent_given,
+        // unexpired. 11 of 227 storyteller rows lack it and were previously renderable.
+        .eq('consent_given', true)
+        .or('consent_expiry.is.null,consent_expiry.gt.now()')
         .limit(200),
       [] as Array<Storyteller & { location_id: string | null }>,
     );

--- a/apps/web/src/lib/services/place-brief-service.ts
+++ b/apps/web/src/lib/services/place-brief-service.ts
@@ -55,16 +55,30 @@ export async function getPlaceBrief(
   // Fetch transcripts + ALMA interventions in parallel
   const patterns = locationPatterns(postcode, locality, state);
 
-  // Build transcript query — match by location ILIKE patterns
+  // Build transcript query — match by location ILIKE patterns.
+  //
+  // CONSENT GATE (2026-08-17, found via /clarity/surfaces): el_transcripts carries NO consent
+  // columns and its status vocabulary contains no 'published' — the old status filter matched
+  // nothing and a "try without status filter" fallback then rendered EVERY transcript's name +
+  // verbatim excerpt + place on a public page. The consent basis is the storyteller's:
+  // quote_sharing_consent (verbatim excerpts are quotes) AND consent_given, unexpired. A
+  // transcript with no storyteller_id has no consent basis and is never rendered.
   let transcripts: PlaceTranscript[] = [];
   if (patterns.length > 0) {
-    // Try each pattern until we get results
-    for (const pattern of patterns) {
+    const { data: consented } = await db
+      .from('storytellers')
+      .select('id')
+      .eq('consent_given', true)
+      .eq('quote_sharing_consent', true)
+      .or('consent_expiry.is.null,consent_expiry.gt.now()');
+    const consentedIds = (consented ?? []).map((s: { id: string }) => s.id);
+
+    for (const pattern of consentedIds.length > 0 ? patterns : []) {
       const { data } = await db
         .from('el_transcripts')
-        .select('id, title, content, storyteller_name, word_count, has_video, themes')
+        .select('id, title, content, storyteller_name, storyteller_id, word_count, has_video, themes')
         .ilike('location', pattern)
-        .eq('status', 'published')
+        .in('storyteller_id', consentedIds)
         .order('word_count', { ascending: false })
         .limit(20);
 
@@ -81,32 +95,8 @@ export async function getPlaceBrief(
         break;
       }
     }
-
-    // If no published transcripts found, try without status filter
-    if (transcripts.length === 0) {
-      for (const pattern of patterns) {
-        const { data } = await db
-          .from('el_transcripts')
-          .select('id, title, content, storyteller_name, word_count, has_video, themes')
-          .ilike('location', pattern)
-          .order('word_count', { ascending: false })
-          .limit(20);
-
-        if (data && data.length > 0) {
-          transcripts = data.map((t) => ({
-            id: t.id,
-            title: t.title || 'Untitled',
-            storyteller_name: t.storyteller_name || 'Anonymous',
-            word_count: t.word_count || 0,
-            has_video: t.has_video || false,
-            themes: t.themes,
-            excerpt: extractExcerpt(t.content, 200),
-          }));
-          break;
-        }
-      }
-    }
   }
+
 
   // Fetch ALMA interventions for this area
   // geography is text[] — cast to text for ILIKE

--- a/docs/dashboard-shell-ux-findings.md
+++ b/docs/dashboard-shell-ux-findings.md
@@ -67,3 +67,33 @@ the ledger reserves for Ben — this paragraph is input, not the verdict.
 - **F4 FIXED** — the cause was styling, not missing hrefs: linked rows were visually identical to
   plain text. Links now carry the accent colour + hover underline.
 - **F5 / F7 / dark-inside-light** — open, Ben's taste calls.
+
+
+## Surfaces walkthrough — consent review, pass 1 (2026-08-17)
+
+Chased all 27 consent-object references on public-family code (from /clarity/surfaces) to their
+actual lines.
+
+### SEVERE, FIXED (branch consent-gate-place-voice)
+`/places/[postcode]` RENDERED consent-governed content, and the gate was broken twice over:
+1. **The "Community Voice" transcript section's only filter was `status='published'` — a status
+   that does not exist in el_transcripts** (the vocabulary is 'completed' only), so the primary
+   query always matched nothing and a "try without status filter" fallback rendered EVERY
+   transcript's storyteller name + verbatim excerpt, anchored to the place. Place is a
+   quasi-identifier; this is the exact re-identification pattern the story↔project design forbids.
+   el_transcripts carries NO consent columns of its own.
+2. **Storyteller cards (name + bio + photo, up to 6) checked no consent flag** — 11 of 227
+   storyteller rows lack consent_given and were renderable.
+
+Fix: excerpts now require the storyteller's `quote_sharing_consent` AND `consent_given`,
+unexpired, via the storyteller_id join (41 of 52 transcripts qualify); a transcript with no
+storyteller_id has no consent basis and never renders. Storyteller cards gained the same
+consent_given + expiry gate. The API brief route and the PDF reuse the same service — fixed once.
+
+### Benign (verified, no action)
+- `/reports/yj/[state]/sector`: the word "transcripts" in Hansard-caveat prose.
+- `/snow-foundation`: external links to Empathy Ledger, no data rendered.
+- `stories`/`quotes` word-matches across 20 files: overwhelmingly the English words in copy, or
+  reads of the PUBLISHED-status stories table (its own gate). Spot-checked, none render
+  consent-governed rows.
+- `photos` on /goods-on-country: Goods' own photo assets, not storyteller photos.


### PR DESCRIPTION
## What

Found on /clarity/surfaces' first walkthrough (all 27 consent-object references on public-family code chased to their lines). The public `/places/[postcode]` page **rendered** consent-governed content with a doubly broken gate:

1. **The transcript section's only filter was `status='published'` — a status that does not exist in `el_transcripts`** (the vocabulary is `completed` only). The primary query always matched nothing, and a *"try without status filter"* fallback then rendered **every** transcript's storyteller name + verbatim excerpt, anchored to the place. Place is a quasi-identifier — this is the exact re-identification pattern the story↔project design forbids, live on the path that always fired. `el_transcripts` carries no consent columns of its own.
2. **Storyteller cards (name + bio + photo, up to 6) checked no consent flag** — 11 of 227 storyteller rows lack `consent_given` and were renderable.

## The fix (a real consent basis, not just a removal)

- Excerpts require the storyteller's **`quote_sharing_consent` AND `consent_given`, unexpired**, via the `storyteller_id` join (41 of 52 transcripts qualify). A transcript with no `storyteller_id` has no consent basis and never renders. The fallback is deleted.
- Storyteller cards gain the same `consent_given` + expiry gate.
- The API brief route and the place-brief PDF reuse `getPlaceBrief` — all three paths fixed at the service.

Everything else in the 27-ref review was verified benign (Hansard prose, external EL links, English-word matches, Goods' own photos) — recorded in `docs/dashboard-shell-ux-findings.md`.

## Verification

tsc clean · vitest 726 pass · /places/4870 renders 200 post-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)