### PR TITLE
S1: ops + admin into the shell, /ops/health repair, Views index

### DIFF
--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -4,7 +4,7 @@ import { Shell } from '@/components/shell/shell';
 
 export const dynamic = 'force-dynamic';
 
-export default async function OpsLayout({ children }: { children: ReactNode }) {
-  await requireAdminPage('/ops');
-  return <Shell title="Ops">{children}</Shell>;
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  await requireAdminPage('/admin');
+  return <Shell title="Admin">{children}</Shell>;
 }

--- a/apps/web/src/app/api/ops/health/route.ts
+++ b/apps/web/src/app/api/ops/health/route.ts
@@ -61,9 +61,24 @@ export async function GET() {
       donorContractorStats,
       entityCoverageResult,
     ] = await Promise.all([
-      // Fast RPCs (fetch estimated counts dynamically as get_table_counts has visibility issues)
+      // Estimated counts for exactly the tables this page reads. The unfiltered pg_class scan
+      // silently lost most app tables to PostgREST's 1,000-row cap (pg_class holds ~4K relations),
+      // which zeroed every count on /ops/health.
       safe(db.rpc('exec_sql', {
-        query: `SELECT relname, coalesce(reltuples, 0) as count FROM pg_class`
+        query: `
+          SELECT c.relname, greatest(coalesce(c.reltuples, 0), 0) AS count
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relkind IN ('r', 'p', 'm')
+            AND c.relname IN (
+              'grant_opportunities','foundations','foundation_programs','acnc_charities',
+              'community_orgs','social_enterprises','oric_corporations','austender_contracts',
+              'political_donations','gs_entities','gs_relationships','asic_companies',
+              'ato_tax_transparency','rogs_justice_spending','asx_companies','money_flows',
+              'seifa_2021','justice_funding','alma_interventions','alma_outcomes','alma_evidence'
+            )
+        `
       }), 8000),
       safe(db.rpc('get_table_freshness'), 12000),
       // Filtered counts — each wrapped in safe() so pool saturation doesn't block response

--- a/apps/web/src/app/dashboard/views/page.tsx
+++ b/apps/web/src/app/dashboard/views/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { VIEW_REGISTRY } from '@/lib/view-registry';
+
+export const metadata: Metadata = { title: 'Views — CivicGraph' };
+
+const VIEW_DOT: Record<string, string> = {
+  red: '#D02020',
+  blue: '#1040C0',
+  yellow: '#F0C020',
+  green: '#059669',
+  ink: '#6E6E6E',
+};
+
+/**
+ * The complete views index. The rail pins a curated few; this page lists every registered view,
+ * so nothing in the registry is reachable only by knowing its URL.
+ */
+export default function ViewsIndexPage() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Views</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        Every saved view on the graph. Pinned views also sit in the rail; the rest live only here.
+      </p>
+      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+        {VIEW_REGISTRY.map((v) => (
+          <Link
+            key={v.id}
+            href={v.href}
+            className="block bg-white p-4"
+            style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+          >
+            <div className="flex items-center gap-2.5">
+              <span
+                className="inline-block h-2 w-2 shrink-0"
+                style={{ background: VIEW_DOT[v.colour], borderRadius: 2 }}
+              />
+              <span className="font-display text-[15px] font-bold">{v.name}</span>
+              {v.pinned && (
+                <span
+                  className="ml-auto font-mono text-[10px] uppercase tracking-widest"
+                  style={{ color: 'var(--shell-muted)' }}
+                >
+                  pinned
+                </span>
+              )}
+            </div>
+            <p className="mt-1.5 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+              {v.question}
+            </p>
+            {v.caveat && (
+              <p className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+                {v.caveat}
+              </p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/ops/health/layout.tsx
+++ b/apps/web/src/app/ops/health/layout.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
-import { Shell } from '@/components/shell/shell';
 
-/** Operator tool inside the app shell (phase-2 ruling 2026-08-17). The page's own Bauhaus
- *  content sits contained inside the soft shell — the accepted /clarity pattern. */
+/** The shell wrap moved up to /ops/layout.tsx when the whole ops group entered the shell —
+ *  wrapping here again would nest a shell inside a shell. */
 export default function Layout({ children }: { children: ReactNode }) {
-  return <Shell title="Data health">{children}</Shell>;
+  return children;
 }

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -151,6 +151,37 @@ export async function Shell({ title, children }: ShellProps) {
             {v.name}
           </Link>
         ))}
+        <Link
+          href="/dashboard/views"
+          className="flex items-center px-2.5 py-1.5 text-[12px]"
+          style={{ borderRadius: 'var(--shell-r-sm)', color: '#7A7A7A' }}
+        >
+          All views
+        </Link>
+        {user.isAdmin && (
+          <>
+            <div className="h-4" />
+            <div className="px-2.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[#7A7A7A]">
+              Ops
+            </div>
+            {[
+              ['/ops', 'Overview'],
+              ['/ops/health', 'Data health'],
+              ['/ops/claims', 'Claims'],
+              ['/ops/grant-recommendations', 'Grant recommendations'],
+              ['/admin/api-usage', 'API usage'],
+            ].map(([href, label]) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex items-center px-2.5 py-1.5 text-[13px]"
+                style={{ borderRadius: 'var(--shell-r-sm)', color: 'var(--shell-rail-text)' }}
+              >
+                {label}
+              </Link>
+            ))}
+          </>
+        )}
         <div className="flex-1" />
         <Link
           href="/clarity"

--- a/thoughts/shared/plans/one-shell-all-data.md
+++ b/thoughts/shared/plans/one-shell-all-data.md
@@ -1,0 +1,37 @@
+# One shell, all data — phase spec
+
+**Date:** 2026-08-17 · **Status:** agreed with Ben (grill session, this doc is the record)
+**Goal:** extend the dashboard shell and the proven Browse pattern until every populated kind of data has a rich, honest surface, and nothing renders off-system.
+
+## Scope
+
+- **Surface existing data, not ingest.** The grantee-ingest queue (Telethon, Stan Perron, RCH, Peter Mac) stays a parallel day-shift lane, Ben-in-loop.
+- **No chrome without a data source.** New capability only where a populated table/MV already backs it.
+- **Pattern:** Browse = list → filters/sorts → drawer → links. One kind per slice. Typed `view-registry.ts`. Transaction kinds (grants/contracts/donations) browse as **entity-shaped rollups** (top recipients / suppliers / donors) with the transaction list inside the drawer — never paginated raw-row UIs.
+
+## Safety rails (apply to every slice)
+
+1. **All rollups computed in SQL.** Browse RPCs are DB-side aggregates with LIMIT+OFFSET and `NULLS LAST`. Required year-or-search predicate where the base table is >500K rows.
+2. **Mandatory money filters baked into the RPC**, not the app: `justice_funding` → `measure_kind='grant' AND is_aggregate IS NOT TRUE AND` the `isRealRecipient()` name-blocklist (port to SQL); `political_donations` → `receipt_type='donation received'`. Reference: `apps/web/src/lib/justice-money.ts`.
+3. **GRANTs in every migration** — SELECT to anon/authenticated/service_role. Missing GRANT = PostgREST silently empty (5 prior instances).
+4. **Explicit error-vs-empty states.** Replace the try/catch-to-empty-list pattern in Browse pages: an RPC failure renders an error card, an empty result renders "0 with why". Verify per slice by breaking the RPC name once.
+5. **Honesty in the UI, not silent capping:** nominee cap (board_count ≤ 10) stays with an in-UI "why some people are excluded" note; person money uses the de-collided `_v2` method; places show `lga_source` provenance.
+
+## Slices
+
+Slice 1 first; 2–7 independent after it, land in any order.
+
+- **S0 — power-dynamics-live: DONE.** Already in main (byte-identical); ledger note was stale.
+- **S1 — Shell sweep + ops fold-in.** Wrap `/ops/*` and `/admin/api-usage` in the dashboard shell (keep URLs, rail "Ops" group). Repair `/ops/health` queries (zeros / score 26). Add a **Views index** page in the rail listing all registry views (pinning stays curated ~4). Sweep every route for softened-shell language drift.
+- **S2 — People browser.** List from `mv_person_influence`/`mv_board_interlocks`, sortable by boards / financial footprint. Drawer: boards held (linking to org drawers), de-collided money footprint, exclusion note.
+- **S3 — Places browser.** LGA primary grain (dedupe `mv_funding_deserts` grain in the RPC), postcode as drawer breakdown. Drawer: funding totals, entity count, SEIFA/remoteness, desert score, "how placed" `lga_source` provenance line.
+- **S4 — Grants browser.** Top recipients rollup of `justice_funding` (filters per rail 2), transactions in drawer.
+- **S5 — Contracts browser.** Top suppliers rollup of `austender_contracts`, transactions in drawer.
+- **S6 — Government buyers browser.** Buyer-side rollup of contracts (serves the buyer-wedge strategy).
+- **S7 — Donations browser.** Top donors rollup of `political_donations` (`receipt_type='donation received'`), transactions in drawer.
+- **S8 — Entities → search/jump-off.** `/dashboard/entities` becomes search + links into the kind browsers (not a browser itself). Error-state hardening anywhere still missing.
+
+## Definition of done
+
+**Per slice:** migration applied with GRANTs · `tsc --noEmit` + `vitest run` green · smoke on 3013 with real data visible · break-the-RPC error-state check · view registered in `view-registry.ts` · PR merged on green (ship-per-slice).
+**Phase exit:** Vercel prod eyeball of the entire shell (localhost-verified is not done).


### PR DESCRIPTION
Closes #244. First slice of the "One shell, all data" phase (`thoughts/shared/plans/one-shell-all-data.md`).

- `/ops/*` and `/admin/api-usage` render inside the dashboard shell; admin-only **Ops** rail group; de-nested the `/ops/health` shell wrap.
- **/ops/health zeros fixed**: the unfiltered `pg_class` count query silently lost most app tables to PostgREST's 1,000-row cap (~4K relations). Now a targeted 21-table query — API verified returning real counts (grants 25,906, foundations 11,159).
- `/dashboard/views` index lists every registry view (funding-deserts and board-interlocks were URL-only before), linked from the rail.

Gates: tsc clean · 726 tests pass · smoke on 3013 (`/dashboard`, `/dashboard/views`, `/ops`, `/ops/health`, `/admin/api-usage` all 200, single shell, live health payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)