### PR TITLE
Browse every kind: people, places, grants, contracts, buyers, donors + entities jump-off

### DIFF
--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -4,7 +4,7 @@ import { Shell } from '@/components/shell/shell';
 
 export const dynamic = 'force-dynamic';
 
-export default async function OpsLayout({ children }: { children: ReactNode }) {
-  await requireAdminPage('/ops');
-  return <Shell title="Ops">{children}</Shell>;
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  await requireAdminPage('/admin');
+  return <Shell title="Admin">{children}</Shell>;
 }

--- a/apps/web/src/app/api/browse/contract-buyer/route.ts
+++ b/apps/web/src/app/api/browse/contract-buyer/route.ts
@@ -12,6 +12,7 @@ export async function GET(req: NextRequest) {
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   if (!data) return NextResponse.json({ error: 'no record for that buyer' }, { status: 404 });
   const d = data as Record<string, unknown>;
+  if (!d.buyer_name) return NextResponse.json({ error: 'no record for that buyer' }, { status: 404 });
   return NextResponse.json({
     name: d.buyer_name,
     abn: null,

--- a/apps/web/src/app/api/browse/contract-buyer/route.ts
+++ b/apps/web/src/app/api/browse/contract-buyer/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const key = req.nextUrl.searchParams.get('key');
+  const from = parseInt(req.nextUrl.searchParams.get('from') ?? '2020', 10);
+  if (!key) return NextResponse.json({ error: 'key is required' }, { status: 400 });
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('contract_buyer_detail', { p_key: key, p_from_year: Number.isFinite(from) ? from : 2020 });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'no record for that buyer' }, { status: 404 });
+  const d = data as Record<string, unknown>;
+  return NextResponse.json({
+    name: d.buyer_name,
+    abn: null,
+    contract_count: d.contract_count,
+    total_value: d.total_value,
+    counterparties: ((d.suppliers ?? []) as { supplier: string; value: number | null; contracts: number }[]).map((s) => ({ name: s.supplier, value: s.value, contracts: s.contracts })),
+    contracts: ((d.contracts ?? []) as { title: string | null; supplier: string | null; value: number | null; start: string | null; end: string | null }[]).map((c) => ({ title: c.title, counterparty: c.supplier, value: c.value, start: c.start, end: c.end })),
+  });
+}

--- a/apps/web/src/app/api/browse/contract-supplier/route.ts
+++ b/apps/web/src/app/api/browse/contract-supplier/route.ts
@@ -12,6 +12,7 @@ export async function GET(req: NextRequest) {
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   if (!data) return NextResponse.json({ error: 'no record for that supplier' }, { status: 404 });
   const d = data as Record<string, unknown>;
+  if (!d.supplier_name) return NextResponse.json({ error: 'no record for that supplier' }, { status: 404 });
   return NextResponse.json({
     name: d.supplier_name,
     abn: d.supplier_abn,

--- a/apps/web/src/app/api/browse/contract-supplier/route.ts
+++ b/apps/web/src/app/api/browse/contract-supplier/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const key = req.nextUrl.searchParams.get('key');
+  const from = parseInt(req.nextUrl.searchParams.get('from') ?? '2020', 10);
+  if (!key) return NextResponse.json({ error: 'key is required' }, { status: 400 });
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('contract_supplier_detail', { p_key: key, p_from_year: Number.isFinite(from) ? from : 2020 });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'no record for that supplier' }, { status: 404 });
+  const d = data as Record<string, unknown>;
+  return NextResponse.json({
+    name: d.supplier_name,
+    abn: d.supplier_abn,
+    contract_count: d.contract_count,
+    total_value: d.total_value,
+    counterparties: ((d.buyers ?? []) as { buyer: string; value: number | null; contracts: number }[]).map((b) => ({ name: b.buyer, value: b.value, contracts: b.contracts })),
+    contracts: ((d.contracts ?? []) as { title: string | null; buyer: string | null; value: number | null; start: string | null; end: string | null }[]).map((c) => ({ title: c.title, counterparty: c.buyer, value: c.value, start: c.start, end: c.end })),
+  });
+}

--- a/apps/web/src/app/api/browse/donor/route.ts
+++ b/apps/web/src/app/api/browse/donor/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const key = req.nextUrl.searchParams.get('key');
+  const from = req.nextUrl.searchParams.get('from') || '2014-15';
+  if (!key) return NextResponse.json({ error: 'key is required' }, { status: 400 });
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('donation_donor_detail', { p_key: key, p_from_fy: from });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'no record for that donor' }, { status: 404 });
+  const d = data as Record<string, unknown>;
+  if (!d.donor_name) return NextResponse.json({ error: 'no record for that donor' }, { status: 404 });
+  return NextResponse.json({
+    name: d.donor_name,
+    abn: d.donor_abn,
+    contract_count: d.donation_count,
+    total_value: d.total_dollars,
+    counterparties: ((d.recipients ?? []) as { recipient: string; dollars: number | null; donations: number }[]).map((r) => ({ name: r.recipient, value: r.dollars, contracts: r.donations })),
+    contracts: ((d.donations ?? []) as { recipient: string | null; amount: number | null; year: string | null }[]).map((g) => ({ title: g.recipient, counterparty: g.year, value: g.amount, start: null, end: null })),
+  });
+}

--- a/apps/web/src/app/api/browse/grant-recipient/route.ts
+++ b/apps/web/src/app/api/browse/grant-recipient/route.ts
@@ -9,6 +9,8 @@ export async function GET(req: NextRequest) {
   const supabase = getDirectServiceSupabase();
   const { data, error } = await supabase.rpc('grant_recipient_detail', { p_key: key });
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!data) return NextResponse.json({ error: 'no record for that recipient' }, { status: 404 });
+  if (!data || !(data as Record<string, unknown>).recipient_name) {
+    return NextResponse.json({ error: 'no record for that recipient' }, { status: 404 });
+  }
   return NextResponse.json(data);
 }

--- a/apps/web/src/app/api/browse/grant-recipient/route.ts
+++ b/apps/web/src/app/api/browse/grant-recipient/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const key = req.nextUrl.searchParams.get('key');
+  if (!key) return NextResponse.json({ error: 'key is required' }, { status: 400 });
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('grant_recipient_detail', { p_key: key });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'no record for that recipient' }, { status: 404 });
+  return NextResponse.json(data);
+}

--- a/apps/web/src/app/api/browse/person/route.ts
+++ b/apps/web/src/app/api/browse/person/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const norm = req.nextUrl.searchParams.get('norm');
+  if (!norm) return NextResponse.json({ error: 'norm is required' }, { status: 400 });
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('person_detail', { p_norm: norm });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'no record for that person' }, { status: 404 });
+  return NextResponse.json(data);
+}

--- a/apps/web/src/app/api/browse/place/route.ts
+++ b/apps/web/src/app/api/browse/place/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const lga = req.nextUrl.searchParams.get('lga');
+  const state = req.nextUrl.searchParams.get('state');
+  if (!lga || !state) return NextResponse.json({ error: 'lga and state are required' }, { status: 400 });
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('place_detail', { p_lga: lga, p_state: state });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'no record for that place' }, { status: 404 });
+  return NextResponse.json(data);
+}

--- a/apps/web/src/app/api/ops/health/route.ts
+++ b/apps/web/src/app/api/ops/health/route.ts
@@ -61,9 +61,24 @@ export async function GET() {
       donorContractorStats,
       entityCoverageResult,
     ] = await Promise.all([
-      // Fast RPCs (fetch estimated counts dynamically as get_table_counts has visibility issues)
+      // Estimated counts for exactly the tables this page reads. The unfiltered pg_class scan
+      // silently lost most app tables to PostgREST's 1,000-row cap (pg_class holds ~4K relations),
+      // which zeroed every count on /ops/health.
       safe(db.rpc('exec_sql', {
-        query: `SELECT relname, coalesce(reltuples, 0) as count FROM pg_class`
+        query: `
+          SELECT c.relname, greatest(coalesce(c.reltuples, 0), 0) AS count
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relkind IN ('r', 'p', 'm')
+            AND c.relname IN (
+              'grant_opportunities','foundations','foundation_programs','acnc_charities',
+              'community_orgs','social_enterprises','oric_corporations','austender_contracts',
+              'political_donations','gs_entities','gs_relationships','asic_companies',
+              'ato_tax_transparency','rogs_justice_spending','asx_companies','money_flows',
+              'seifa_2021','justice_funding','alma_interventions','alma_outcomes','alma_evidence'
+            )
+        `
       }), 8000),
       safe(db.rpc('get_table_freshness'), 12000),
       // Filtered counts — each wrapped in safe() so pool saturation doesn't block response

--- a/apps/web/src/app/dashboard/browse/ContractSideBrowser.tsx
+++ b/apps/web/src/app/dashboard/browse/ContractSideBrowser.tsx
@@ -20,10 +20,14 @@ export interface SideRow {
 }
 
 export interface SideConfig {
-  side: 'supplier' | 'buyer';
+  side: 'supplier' | 'buyer' | 'donor';
   basePath: string;
-  counterpartyLabel: string; // 'Buyers' | 'Suppliers'
+  counterpartyLabel: string; // 'Buyers' | 'Suppliers' | 'Recipients'
   detailApi: string;
+  /** What one row in the drawer's list is: 'contract' (default) or 'donation'. */
+  itemLabel?: string;
+  /** Since-floor chips; calendar years for contracts, financial years for donations. */
+  yearOptions?: string[];
 }
 
 interface SideDetail {
@@ -47,7 +51,7 @@ const SORTS: [string, string][] = [
   ['contracts', 'Contracts'],
   ['name', 'A–Z'],
 ];
-const YEARS = ['2015', '2020', '2023'];
+const DEFAULT_YEARS = ['2015', '2020', '2023'];
 
 function L({ children }: { children: React.ReactNode }) {
   return (
@@ -115,8 +119,8 @@ export default function ContractSideBrowser({
       </form>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>since</span>
-        {YEARS.map((y) => (
-          <Link key={y} href={qs({ from: y })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(fromYear || '2020') === y ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+        {(cfg.yearOptions ?? DEFAULT_YEARS).map((y) => (
+          <Link key={y} href={qs({ from: y })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(fromYear || (cfg.yearOptions ?? DEFAULT_YEARS)[1]) === y ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
             {y}
           </Link>
         ))}
@@ -134,7 +138,7 @@ export default function ContractSideBrowser({
           <span className="flex-1">Name</span>
           <span className="w-[220px]">Top {cfg.counterpartyLabel.toLowerCase().replace(/s$/, '')}</span>
           <span className="w-[72px] text-right">{cfg.counterpartyLabel}</span>
-          <span className="w-[76px] text-right">Contracts</span>
+          <span className="w-[76px] text-right">{(cfg.itemLabel ?? 'contract') === 'donation' ? 'Donations' : 'Contracts'}</span>
           <span className="w-[92px] text-right">Total $</span>
         </div>
         {rows.map((r) => (
@@ -162,7 +166,7 @@ export default function ContractSideBrowser({
             <>
               <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
                 {detail.abn ? `ABN ${detail.abn} · ` : ''}
-                {detail.contract_count.toLocaleString('en-AU')} contracts since {fromYear || '2020'} · {money(detail.total_value)}
+                {detail.contract_count.toLocaleString('en-AU')} {(cfg.itemLabel ?? 'contract')}s since {fromYear || (cfg.yearOptions ?? DEFAULT_YEARS)[1]} · {money(detail.total_value)}
               </p>
 
               {detail.counterparties.length > 0 ? (
@@ -184,7 +188,7 @@ export default function ContractSideBrowser({
 
               {detail.contracts.length > 0 ? (
                 <>
-                  <L>Largest contracts</L>
+                  <L>Largest {(cfg.itemLabel ?? 'contract') + 's'}</L>
                   <div className="flex flex-col gap-1.5">
                     {detail.contracts.slice(0, 25).map((g, i) => (
                       <div key={i} className="text-[12px]" style={{ borderTop: i ? '1px solid var(--shell-line)' : undefined, paddingTop: i ? 6 : 0 }}>

--- a/apps/web/src/app/dashboard/browse/ContractSideBrowser.tsx
+++ b/apps/web/src/app/dashboard/browse/ContractSideBrowser.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * Shared browser for the two sides of AusTender: suppliers (who wins contracts) and buyers
+ * (which agencies let them). Rollups and the from-year floor are computed in the RPC — the
+ * 824K-row table is never paginated raw into the UI.
+ */
+
+export interface SideRow {
+  key: string;
+  name: string;
+  abn: string | null;
+  contracts: number;
+  value: number | null;
+  counterparties: number;
+  topCounterparty: string | null;
+}
+
+export interface SideConfig {
+  side: 'supplier' | 'buyer';
+  basePath: string;
+  counterpartyLabel: string; // 'Buyers' | 'Suppliers'
+  detailApi: string;
+}
+
+interface SideDetail {
+  name: string;
+  abn: string | null;
+  contract_count: number;
+  total_value: number | null;
+  counterparties: { name: string; value: number | null; contracts: number }[];
+  contracts: { title: string | null; counterparty: string | null; value: number | null; start: string | null; end: string | null }[];
+}
+
+function money(n: number | null | undefined): string {
+  if (!n || n <= 0) return '—';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+const SORTS: [string, string][] = [
+  ['total', 'Total $'],
+  ['contracts', 'Contracts'],
+  ['name', 'A–Z'],
+];
+const YEARS = ['2015', '2020', '2023'];
+
+function L({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
+      {children}
+    </div>
+  );
+}
+
+export default function ContractSideBrowser({
+  rows,
+  cfg,
+  q,
+  fromYear,
+  sort,
+  statsLine,
+  caveat,
+}: {
+  rows: SideRow[];
+  cfg: SideConfig;
+  q: string;
+  fromYear: string;
+  sort: string;
+  statsLine: string;
+  caveat: string;
+}) {
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SideDetail | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  function open(key: string) {
+    setOpenKey(key);
+    setDetail(null);
+    setErr(null);
+    fetch(`${cfg.detailApi}?key=${encodeURIComponent(key)}&from=${encodeURIComponent(fromYear || '2020')}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
+        return r.json() as Promise<SideDetail>;
+      })
+      .then(setDetail)
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }
+
+  const qs = (over: Record<string, string>) => {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries({ q, from: fromYear, sort, ...over })) if (v) p.set(k, v);
+    const s = p.toString();
+    return `${cfg.basePath}${s ? `?${s}` : ''}`;
+  };
+
+  return (
+    <>
+      <p className="mt-1 font-mono text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+        {statsLine}
+      </p>
+      <form className="mt-3" action={cfg.basePath}>
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Search by name…"
+          className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
+        />
+        {fromYear ? <input type="hidden" name="from" value={fromYear} /> : null}
+        {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+      </form>
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>since</span>
+        {YEARS.map((y) => (
+          <Link key={y} href={qs({ from: y })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(fromYear || '2020') === y ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {y}
+          </Link>
+        ))}
+        <span className="ml-auto flex items-center gap-1.5">
+          {SORTS.map(([v, label]) => (
+            <Link key={v} href={qs({ sort: v })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(sort || 'total') === v ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+              {label}
+            </Link>
+          ))}
+        </span>
+      </div>
+
+      <div className="mt-4 shell-card">
+        <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
+          <span className="flex-1">Name</span>
+          <span className="w-[220px]">Top {cfg.counterpartyLabel.toLowerCase().replace(/s$/, '')}</span>
+          <span className="w-[72px] text-right">{cfg.counterpartyLabel}</span>
+          <span className="w-[76px] text-right">Contracts</span>
+          <span className="w-[92px] text-right">Total $</span>
+        </div>
+        {rows.map((r) => (
+          <button key={r.key} onClick={() => open(r.key)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>
+            <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold" style={{ color: '#1040C0' }}>{r.name}</span>
+            <span className="w-[220px] shrink-0 truncate font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>{r.topCounterparty ?? '—'}</span>
+            <span className="w-[72px] shrink-0 text-right font-mono text-[12.5px]">{r.counterparties}</span>
+            <span className="w-[76px] shrink-0 text-right font-mono text-[12.5px]">{r.contracts.toLocaleString('en-AU')}</span>
+            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.value)}</span>
+          </button>
+        ))}
+      </div>
+      <p className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+        {caveat}
+      </p>
+
+      {openKey ? (
+        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="font-display text-[17px] font-extrabold">{detail?.name ?? 'loading…'}</h2>
+            <button onClick={() => setOpenKey(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
+          </div>
+          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+          {detail ? (
+            <>
+              <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {detail.abn ? `ABN ${detail.abn} · ` : ''}
+                {detail.contract_count.toLocaleString('en-AU')} contracts since {fromYear || '2020'} · {money(detail.total_value)}
+              </p>
+
+              {detail.counterparties.length > 0 ? (
+                <>
+                  <L>{cfg.counterpartyLabel}</L>
+                  <table className="w-full text-right font-mono text-[11.5px]">
+                    <tbody>
+                      {detail.counterparties.map((c, i) => (
+                        <tr key={i} style={{ borderTop: '1px solid var(--shell-line)' }}>
+                          <td className="max-w-[220px] truncate py-0.5 text-left">{c.name}</td>
+                          <td>{c.contracts}</td>
+                          <td>{money(c.value)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </>
+              ) : null}
+
+              {detail.contracts.length > 0 ? (
+                <>
+                  <L>Largest contracts</L>
+                  <div className="flex flex-col gap-1.5">
+                    {detail.contracts.slice(0, 25).map((g, i) => (
+                      <div key={i} className="text-[12px]" style={{ borderTop: i ? '1px solid var(--shell-line)' : undefined, paddingTop: i ? 6 : 0 }}>
+                        <div className="flex items-baseline justify-between gap-3">
+                          <span className="min-w-0 truncate font-semibold">{g.title ?? 'untitled contract'}</span>
+                          <span className="shrink-0 font-mono text-[11.5px]">{money(g.value)}</span>
+                        </div>
+                        <div className="font-mono text-[10.5px]" style={{ color: 'var(--shell-muted)' }}>
+                          {[g.counterparty, g.start?.slice(0, 10), g.end ? `to ${g.end.slice(0, 10)}` : null].filter(Boolean).join(' · ')}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/dashboard/browse/buyers/page.tsx
+++ b/apps/web/src/app/dashboard/browse/buyers/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import ContractSideBrowser, { type SideRow } from '../ContractSideBrowser';
+
+export const dynamic = 'force-dynamic';
+export const metadata: Metadata = { title: 'Government buyers — CivicGraph' };
+
+const load = unstable_cache(
+  async (q: string, from: number, sort: string) => {
+    const supabase = getDirectServiceSupabase();
+    const [browse, stats] = await Promise.all([
+      supabase.rpc('contract_buyer_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('contract_browse_stats', { p_from_year: from }),
+    ]);
+    if (browse.error) throw new Error(browse.error.message);
+    return { rows: browse.data ?? [], stats: stats.data ?? null };
+  },
+  ['contract-buyer-browse'],
+  { revalidate: 3600 },
+);
+
+/** Buyer side of AusTender: which agencies let the contracts. */
+export default async function BuyersBrowsePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+  const from = typeof sp.from === 'string' && /^\d{4}$/.test(sp.from) ? parseInt(sp.from, 10) : 2020;
+  const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+
+  let rows: SideRow[] = [];
+  let statsLine = '';
+  let why: string | null = null;
+  try {
+    const { rows: data, stats } = await load(q, from, sort);
+    rows = (data as {
+      buyer_key: string;
+      buyer_name: string;
+      contract_count: number;
+      total_value: number | null;
+      supplier_count: number;
+      top_supplier: string | null;
+    }[]).map((r) => ({
+      key: r.buyer_key,
+      name: r.buyer_name,
+      abn: null,
+      contracts: r.contract_count,
+      value: r.total_value,
+      counterparties: r.supplier_count,
+      topCounterparty: r.top_supplier,
+    }));
+    const s = stats as { contracts: number; total_value: number; suppliers: number; buyers: number } | null;
+    if (s) {
+      statsLine = `${s.buyers.toLocaleString('en-AU')} buying agencies · ${s.contracts.toLocaleString('en-AU')} contracts worth $${(s.total_value / 1e9).toFixed(0)}bn since ${from}`;
+    }
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1180px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Government buyers</h1>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
+      ) : (
+        <ContractSideBrowser
+          rows={rows}
+          cfg={{ side: 'buyer', basePath: '/dashboard/browse/buyers', counterpartyLabel: 'Suppliers', detailApi: '/api/browse/contract-buyer' }}
+          q={q}
+          fromYear={String(from)}
+          sort={sort}
+          statsLine={statsLine}
+          caveat="AusTender: Commonwealth agencies only. A buyer's supplier mix is the procurement story a supply-side pitch lands into. The since-year floor is applied in the query."
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/browse/contracts/page.tsx
+++ b/apps/web/src/app/dashboard/browse/contracts/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import ContractSideBrowser, { type SideRow } from '../ContractSideBrowser';
+
+export const dynamic = 'force-dynamic';
+export const metadata: Metadata = { title: 'Contract suppliers — CivicGraph' };
+
+// The rollup scans up to 767K rows (~3.5s): cache per (q, from, sort) for an hour.
+const load = unstable_cache(
+  async (q: string, from: number, sort: string) => {
+    const supabase = getDirectServiceSupabase();
+    const [browse, stats] = await Promise.all([
+      supabase.rpc('contract_supplier_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('contract_browse_stats', { p_from_year: from }),
+    ]);
+    if (browse.error) throw new Error(browse.error.message);
+    return { rows: browse.data ?? [], stats: stats.data ?? null };
+  },
+  ['contract-supplier-browse'],
+  { revalidate: 3600 },
+);
+
+/** Suppliers side of AusTender: who wins Commonwealth contracts. */
+export default async function ContractsBrowsePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+  const from = typeof sp.from === 'string' && /^\d{4}$/.test(sp.from) ? parseInt(sp.from, 10) : 2020;
+  const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+
+  let rows: SideRow[] = [];
+  let statsLine = '';
+  let why: string | null = null;
+  try {
+    const { rows: data, stats } = await load(q, from, sort);
+    rows = (data as {
+      supplier_key: string;
+      supplier_name: string;
+      supplier_abn: string | null;
+      contract_count: number;
+      total_value: number | null;
+      buyer_count: number;
+      top_buyer: string | null;
+    }[]).map((r) => ({
+      key: r.supplier_key,
+      name: r.supplier_name,
+      abn: r.supplier_abn,
+      contracts: r.contract_count,
+      value: r.total_value,
+      counterparties: r.buyer_count,
+      topCounterparty: r.top_buyer,
+    }));
+    const s = stats as { contracts: number; total_value: number; suppliers: number; buyers: number } | null;
+    if (s) {
+      statsLine = `${s.contracts.toLocaleString('en-AU')} contracts worth $${(s.total_value / 1e9).toFixed(0)}bn since ${from} · ${s.suppliers.toLocaleString('en-AU')} suppliers · ${s.buyers.toLocaleString('en-AU')} buying agencies`;
+    }
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1180px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Contract suppliers</h1>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
+      ) : (
+        <ContractSideBrowser
+          rows={rows}
+          cfg={{ side: 'supplier', basePath: '/dashboard/browse/contracts', counterpartyLabel: 'Buyers', detailApi: '/api/browse/contract-supplier' }}
+          q={q}
+          fromYear={String(from)}
+          sort={sort}
+          statsLine={statsLine}
+          caveat="AusTender: Commonwealth contracts only — state contracts live in their own registers. Suppliers are grouped by ABN where recorded, else by name. The since-year floor is applied in the query; contracts with junk start dates are excluded by it."
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/browse/donations/page.tsx
+++ b/apps/web/src/app/dashboard/browse/donations/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import ContractSideBrowser, { type SideRow } from '../ContractSideBrowser';
+
+export const dynamic = 'force-dynamic';
+export const metadata: Metadata = { title: 'Political donors — CivicGraph' };
+
+const FY_OPTIONS = ['1998-1999', '2014-15', '2019-20', '2022-23'];
+
+const load = unstable_cache(
+  async (q: string, from: string, sort: string) => {
+    const supabase = getDirectServiceSupabase();
+    const [browse, stats] = await Promise.all([
+      supabase.rpc('donation_donor_browse', { p_q: q || null, p_from_fy: from, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('donation_browse_stats', { p_from_fy: from }),
+    ]);
+    if (browse.error) throw new Error(browse.error.message);
+    return { rows: browse.data ?? [], stats: stats.data ?? null };
+  },
+  ['donation-donor-browse'],
+  { revalidate: 3600 },
+);
+
+/** Political donors browser: donations-received only, the 'other receipt' 85% is excluded in SQL. */
+export default async function DonationsBrowsePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+  const from = typeof sp.from === 'string' && FY_OPTIONS.includes(sp.from) ? sp.from : '2014-15';
+  const sortParam = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+  const rpcSort = sortParam === 'contracts' ? 'donations' : sortParam;
+
+  let rows: SideRow[] = [];
+  let statsLine = '';
+  let why: string | null = null;
+  try {
+    const { rows: data, stats } = await load(q, from, rpcSort);
+    rows = (data as {
+      donor_key: string;
+      donor_name: string;
+      donor_abn: string | null;
+      donation_count: number;
+      total_dollars: number | null;
+      recipient_count: number;
+      top_recipient: string | null;
+    }[]).map((r) => ({
+      key: r.donor_key,
+      name: r.donor_name,
+      abn: r.donor_abn,
+      contracts: r.donation_count,
+      value: r.total_dollars,
+      counterparties: r.recipient_count,
+      topCounterparty: r.top_recipient,
+    }));
+    const s = stats as { donations: number; total_dollars: number; other_receipt_dollars: number } | null;
+    if (s) {
+      statsLine = `${s.donations.toLocaleString('en-AU')} declared donations worth $${(s.total_dollars / 1e9).toFixed(1)}bn since ${from} · a further $${(s.other_receipt_dollars / 1e9).toFixed(0)}bn of 'other receipts' is excluded — it is not donations`;
+    }
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1180px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Political donors</h1>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
+      ) : (
+        <ContractSideBrowser
+          rows={rows}
+          cfg={{
+            side: 'donor',
+            basePath: '/dashboard/browse/donations',
+            counterpartyLabel: 'Recipients',
+            detailApi: '/api/browse/donor',
+            itemLabel: 'donation',
+            yearOptions: FY_OPTIONS,
+          }}
+          q={q}
+          fromYear={from}
+          sort={sortParam}
+          statsLine={statsLine}
+          caveat="AEC declared receipts, 'donation received' only — the far larger 'other receipt' category (investment returns, transfers between branches) is excluded in the query. Donors are grouped by ABN where declared, else by name; the same donor under two spellings appears twice. In the drawer's donation list the small line shows the financial year."
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/browse/grants/GrantBrowser.tsx
+++ b/apps/web/src/app/dashboard/browse/grants/GrantBrowser.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * Grants browser: recipients of justice_funding as entity-shaped rollups, the individual grants
+ * inside the drawer. The mandatory money filters live in the RPC SQL — this component never
+ * computes a total itself.
+ */
+
+export interface RecipientRow {
+  key: string;
+  name: string;
+  abn: string | null;
+  grants: number;
+  dollars: number | null;
+  states: string[] | null;
+  span: string;
+}
+
+interface RecipientDetail {
+  recipient_name: string;
+  recipient_abn: string | null;
+  grant_count: number;
+  total_dollars: number | null;
+  by_year: { year: string; dollars: number | null; grants: number }[];
+  grants: { program: string | null; year: string | null; amount: number | null; state: string | null; topics: string[] | null }[];
+}
+
+function money(n: number | null | undefined): string {
+  if (!n || n <= 0) return '—';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+const SORTS: [string, string][] = [
+  ['total', 'Total $'],
+  ['grants', 'Grant count'],
+  ['name', 'A–Z'],
+];
+const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT', 'FED'];
+const TOPICS = ['child-protection', 'family-services', 'youth-justice', 'indigenous', 'community-led', 'diversion'];
+
+function L({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
+      {children}
+    </div>
+  );
+}
+
+export default function GrantBrowser({
+  rows,
+  q,
+  state,
+  topic,
+  sort,
+  statsLine,
+  caveat,
+}: {
+  rows: RecipientRow[];
+  q: string;
+  state: string;
+  topic: string;
+  sort: string;
+  statsLine: string;
+  caveat: string;
+}) {
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<RecipientDetail | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  function open(key: string) {
+    setOpenKey(key);
+    setDetail(null);
+    setErr(null);
+    fetch(`/api/browse/grant-recipient?key=${encodeURIComponent(key)}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
+        return r.json() as Promise<RecipientDetail>;
+      })
+      .then(setDetail)
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }
+
+  const qs = (over: Record<string, string>) => {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries({ q, state, topic, sort, ...over })) if (v) p.set(k, v);
+    const s = p.toString();
+    return `/dashboard/browse/grants${s ? `?${s}` : ''}`;
+  };
+
+  return (
+    <>
+      <p className="mt-1 font-mono text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+        {statsLine}
+      </p>
+      <form className="mt-3" action="/dashboard/browse/grants">
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Search recipients…"
+          className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
+        />
+        {state ? <input type="hidden" name="state" value={state} /> : null}
+        {topic ? <input type="hidden" name="topic" value={topic} /> : null}
+        {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+      </form>
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <Link href={qs({ state: '' })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === '' ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+          All states
+        </Link>
+        {STATES.map((s) => (
+          <Link key={s} href={qs({ state: s })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === s ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {s}
+          </Link>
+        ))}
+      </div>
+      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+        {TOPICS.map((t) => (
+          <Link key={t} href={qs({ topic: topic === t ? '' : t })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={topic === t ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {t.replace(/-/g, ' ')}
+          </Link>
+        ))}
+        <span className="ml-auto flex items-center gap-1.5">
+          {SORTS.map(([v, label]) => (
+            <Link key={v} href={qs({ sort: v })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(sort || 'total') === v ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+              {label}
+            </Link>
+          ))}
+        </span>
+      </div>
+
+      <div className="mt-4 shell-card">
+        <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
+          <span className="flex-1">Recipient</span>
+          <span className="w-[110px]">States</span>
+          <span className="w-[120px]">Years</span>
+          <span className="w-[64px] text-right">Grants</span>
+          <span className="w-[92px] text-right">Total $</span>
+        </div>
+        {rows.map((r) => (
+          <button key={r.key} onClick={() => open(r.key)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>
+            <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold" style={{ color: '#1040C0' }}>{r.name}</span>
+            <span className="w-[110px] shrink-0 truncate font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>{(r.states ?? []).join(' ')}</span>
+            <span className="w-[120px] shrink-0 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>{r.span}</span>
+            <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.grants}</span>
+            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.dollars)}</span>
+          </button>
+        ))}
+      </div>
+      <p className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+        {caveat}
+      </p>
+
+      {openKey ? (
+        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="font-display text-[17px] font-extrabold">{detail?.recipient_name ?? 'loading…'}</h2>
+            <button onClick={() => setOpenKey(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
+          </div>
+          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+          {detail ? (
+            <>
+              <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {detail.recipient_abn ? `ABN ${detail.recipient_abn} · ` : ''}
+                {detail.grant_count} grants · {money(detail.total_dollars)}
+              </p>
+
+              {detail.by_year.length > 0 ? (
+                <>
+                  <L>By year</L>
+                  <table className="w-full text-right font-mono text-[11.5px]">
+                    <tbody>
+                      {detail.by_year.map((y) => (
+                        <tr key={y.year ?? 'unknown'} style={{ borderTop: '1px solid var(--shell-line)' }}>
+                          <td className="py-0.5 text-left">{y.year ?? 'year not recorded'}</td>
+                          <td>{y.grants} grants</td>
+                          <td>{money(y.dollars)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </>
+              ) : null}
+
+              {detail.grants.length > 0 ? (
+                <>
+                  <L>Grants{detail.grant_count > detail.grants.length ? ` · largest ${detail.grants.length} of ${detail.grant_count}` : ''}</L>
+                  <div className="flex flex-col gap-1.5">
+                    {detail.grants.map((g, i) => (
+                      <div key={i} className="text-[12px]" style={{ borderTop: i ? '1px solid var(--shell-line)' : undefined, paddingTop: i ? 6 : 0 }}>
+                        <div className="flex items-baseline justify-between gap-3">
+                          <span className="min-w-0 truncate font-semibold">{g.program ?? 'program not recorded'}</span>
+                          <span className="shrink-0 font-mono text-[11.5px]">{money(g.amount)}</span>
+                        </div>
+                        <div className="font-mono text-[10.5px]" style={{ color: 'var(--shell-muted)' }}>
+                          {[g.year, g.state, ...(g.topics ?? [])].filter(Boolean).join(' · ')}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/dashboard/browse/grants/page.tsx
+++ b/apps/web/src/app/dashboard/browse/grants/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import GrantBrowser, { type RecipientRow } from './GrantBrowser';
+
+export const dynamic = 'force-dynamic';
+export const metadata: Metadata = { title: 'Grant recipients — CivicGraph' };
+
+const stats = unstable_cache(
+  async () => {
+    const supabase = getDirectServiceSupabase();
+    const { data } = await supabase.rpc('grant_browse_stats');
+    return data as { kept_rows: number; kept_dollars: number; excluded_rows: number } | null;
+  },
+  ['grant-browse-stats'],
+  { revalidate: 3600 },
+);
+
+/** Grant recipients browser over justice_funding, mandatory filters baked into the RPC. */
+export default async function GrantsBrowsePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+  const state = typeof sp.state === 'string' ? sp.state : '';
+  const topic = typeof sp.topic === 'string' ? sp.topic : '';
+  const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+
+  const supabase = getDirectServiceSupabase();
+  let rows: RecipientRow[] = [];
+  let statsLine = '';
+  let why: string | null = null;
+  try {
+    const [{ data, error }, s] = await Promise.all([
+      supabase.rpc('grant_recipient_browse', {
+        p_q: q || null,
+        p_state: state || null,
+        p_topic: topic || null,
+        p_sort: sort,
+        p_limit: 200,
+      }),
+      stats(),
+    ]);
+    if (error) throw new Error(error.message);
+    rows = ((data ?? []) as {
+      recipient_key: string;
+      recipient_name: string;
+      recipient_abn: string | null;
+      grant_count: number;
+      total_dollars: number | null;
+      states: string[] | null;
+      first_year: string | null;
+      last_year: string | null;
+    }[]).map((r) => ({
+      key: r.recipient_key,
+      name: r.recipient_name,
+      abn: r.recipient_abn,
+      grants: r.grant_count,
+      dollars: r.total_dollars,
+      states: r.states,
+      span:
+        r.first_year && r.last_year
+          ? r.first_year === r.last_year
+            ? r.first_year
+            : `${r.first_year}–${r.last_year}`
+          : '—',
+    }));
+    if (s) {
+      statsLine = `${s.kept_rows.toLocaleString('en-AU')} grants worth $${(s.kept_dollars / 1e9).toFixed(1)}bn after the filters · ${s.excluded_rows.toLocaleString('en-AU')} rows excluded (budget aggregates, spreadsheet totals, non-organisation names)`;
+    }
+  } catch (e) {
+    why = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="mx-auto max-w-[1180px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Grant recipients</h1>
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
+      ) : (
+        <GrantBrowser
+          rows={rows}
+          q={q}
+          state={state}
+          topic={topic}
+          sort={sort}
+          statsLine={statsLine}
+          caveat="Grants only: state budget aggregates and source-spreadsheet total rows are excluded in the query itself. Recipients are grouped by name — the same organisation under two spellings appears twice."
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/entities/page.tsx
+++ b/apps/web/src/app/dashboard/entities/page.tsx
@@ -3,102 +3,124 @@ import Link from 'next/link';
 import { unstable_cache } from 'next/cache';
 import { getDirectServiceSupabase } from '@/lib/supabase';
 
+export const dynamic = 'force-dynamic';
 export const metadata: Metadata = { title: 'Entities — CivicGraph' };
 
-function money(n: number): string {
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}bn`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
-  return `$${Math.round(n / 1e3)}k`;
-}
+/**
+ * Entities is the union of the other kinds, so this page is a search and jump-off, not another
+ * browser: find any organisation on the graph, then land in the kind browser or atlas page
+ * that actually holds its story.
+ */
 
-const load = unstable_cache(
+const KINDS: { href: string; label: string; blurb: string }[] = [
+  { href: '/dashboard/browse/foundations', label: 'Foundations', blurb: 'who gives, and to whom' },
+  { href: '/dashboard/browse/social-enterprises', label: 'Social enterprises', blurb: 'the register and what we know' },
+  { href: '/dashboard/browse/charities', label: 'Charities', blurb: 'ACNC register with six years of returns' },
+  { href: '/dashboard/browse/grants', label: 'Grant recipients', blurb: 'who receives justice-system grants' },
+  { href: '/dashboard/browse/contracts', label: 'Contract suppliers', blurb: 'who wins Commonwealth contracts' },
+  { href: '/dashboard/browse/buyers', label: 'Government buyers', blurb: 'which agencies let them' },
+  { href: '/dashboard/browse/donations', label: 'Political donors', blurb: 'declared donations only' },
+  { href: '/dashboard/people', label: 'People', blurb: 'boards and the money past them' },
+  { href: '/dashboard/places', label: 'Places', blurb: 'council areas: money vs disadvantage' },
+];
+
+const countEntities = unstable_cache(
   async () => {
     const supabase = getDirectServiceSupabase();
-    const [{ count }, { data: top, error }] = await Promise.all([
-      supabase.from('gs_entities').select('id', { count: 'estimated', head: true }),
-      supabase
-        .from('mv_entity_power_index')
-        .select('gs_id,canonical_name,entity_type,system_count,total_dollar_flow,power_score')
-        .order('power_score', { ascending: false })
-        .limit(15),
-    ]);
-    if (error) throw new Error(error.message);
-    return { count: count ?? null, top: top ?? [] };
+    const { count } = await supabase.from('gs_entities').select('id', { count: 'estimated', head: true });
+    return count ?? null;
   },
-  ['dash-entities'],
-  { revalidate: 3600 },
+  ['dash-entities-count'],
+  { revalidate: 86400 },
 );
 
-/** Shell-native Entities index. Entity detail pages remain the public atlas for now. */
-export default async function EntitiesPage() {
-  let data: Awaited<ReturnType<typeof load>> | null = null;
+interface Hit {
+  gs_id: string;
+  canonical_name: string;
+  abn: string | null;
+  entity_type: string | null;
+  state: string | null;
+}
+
+export default async function EntitiesPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+
+  let hits: Hit[] = [];
   let why: string | null = null;
-  try {
-    data = await load();
-  } catch (e) {
-    why = e instanceof Error ? e.message : String(e);
+  const total = await countEntities().catch(() => null);
+  if (q.length >= 2) {
+    try {
+      const supabase = getDirectServiceSupabase();
+      const { data, error } = await supabase
+        .from('gs_entities')
+        .select('gs_id,canonical_name,abn,entity_type,state')
+        .ilike('canonical_name', `%${q}%`)
+        .limit(20);
+      if (error) throw new Error(error.message);
+      hits = (data ?? []) as Hit[];
+    } catch (e) {
+      why = e instanceof Error ? e.message : String(e);
+    }
   }
 
   return (
     <div className="mx-auto max-w-[1100px] px-6 py-6">
       <h1 className="font-display text-[22px] font-extrabold">Entities</h1>
-      <div className="mt-2 flex flex-wrap gap-2">
-        {[
-          ['/dashboard/browse/foundations', 'Foundations'],
-          ['/dashboard/browse/social-enterprises', 'Social enterprises'],
-          ['/dashboard/browse/charities', 'Charities'],
-        ].map(([href, label]) => (
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        {total ? `${total.toLocaleString('en-AU')} organisations on the graph. ` : ''}
+        Search anything, or start from a kind — each kind browser knows its own story.
+      </p>
+
+      <form className="mt-4" action="/dashboard/entities">
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Search any organisation…"
+          className="w-full max-w-[420px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
+        />
+      </form>
+
+      {why ? (
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The search could not run: {why}</p>
+      ) : q.length >= 2 ? (
+        hits.length === 0 ? (
+          <p className="mt-4 text-[13px]" style={{ color: 'var(--shell-muted)' }}>
+            Nothing on the graph matches &ldquo;{q}&rdquo; — try fewer words, or a different spelling.
+          </p>
+        ) : (
+          <div className="mt-4 shell-card">
+            {hits.map((h) => (
+              <div key={h.gs_id} className="flex items-baseline gap-3 px-4 py-2" style={{ borderBottom: '1px solid var(--shell-line)' }}>
+                <Link href={`/entity/${h.gs_id}`} className="min-w-0 flex-1 truncate text-[13.5px] font-semibold hover:underline" style={{ color: '#1040C0' }}>
+                  {h.canonical_name}
+                </Link>
+                <span className="shrink-0 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+                  {[h.entity_type, h.state, h.abn ? `ABN ${h.abn}` : null].filter(Boolean).join(' · ')}
+                </span>
+              </div>
+            ))}
+          </div>
+        )
+      ) : null}
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {KINDS.map((k) => (
           <Link
-            key={href}
-            href={href}
-            className="bg-white px-3 py-1.5 text-[13px] font-semibold shell-control hover:underline"
-            style={{ color: '#1040C0' }}
+            key={k.href}
+            href={k.href}
+            className="block bg-white p-4"
+            style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
           >
-            {label} →
+            <div className="font-display text-[15px] font-bold">{k.label}</div>
+            <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>{k.blurb}</p>
           </Link>
         ))}
       </div>
-      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
-        {data?.count ? `~${data.count.toLocaleString('en-AU')} organisations and people on the graph. ` : ''}
-        Search with ⌘K, or start from the most cross-system-present entities below. Entity pages
-        open on the public atlas.
-      </p>
-      {why ? (
-        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>
-          The power index could not be read: {why}
-        </p>
-      ) : (
-        <div
-          className="mt-5 bg-white p-4"
-          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
-        >
-          <h2 className="font-display text-[14px] font-bold">
-            Most present across systems
-            <span className="ml-2 font-mono text-[10px] font-normal uppercase" style={{ color: 'var(--shell-muted)' }}>
-              power index · grants filtered clean
-            </span>
-          </h2>
-          {(data?.top ?? []).map((e, i) => (
-            <div
-              key={e.gs_id ?? i}
-              className="flex items-baseline gap-3 py-2"
-              style={{ borderTop: i === 0 ? undefined : '1px solid var(--shell-line)' }}
-            >
-              <Link
-                href={`/entity/${e.gs_id}`}
-                className="min-w-0 flex-1 truncate text-[13.5px] font-semibold hover:underline"
-                style={{ color: '#1040C0' }}
-              >
-                {e.canonical_name}
-              </Link>
-              <span className="shrink-0 text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
-                {e.entity_type ?? '—'} · {e.system_count} systems
-              </span>
-              <span className="shrink-0 font-mono text-[13px]">{money(Number(e.total_dollar_flow ?? 0))}</span>
-            </div>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/people/PersonBrowser.tsx
+++ b/apps/web/src/app/dashboard/people/PersonBrowser.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * People browser: board interlocks + de-collided money footprint. The list excludes nominee
+ * blocks and >10-board identities BY DESIGN — the exclusion is stated under the list, never
+ * silent. Dollars are attributed_* figures (shared-board money split, not double-counted).
+ */
+
+export interface PersonRow {
+  key: string;
+  name: string;
+  norm: string;
+  boards: number;
+  accoBoards: number;
+  procurement: number | null;
+  justice: number | null;
+  donations: number | null;
+  systems: number | null;
+}
+
+interface PersonDetail {
+  person_name: string;
+  board_count: number;
+  organisations: string[] | null;
+  organisation_abns: (string | null)[] | null;
+  role_types: string[] | null;
+  connects_community_controlled: boolean | null;
+  attributed: {
+    procurement: number | null;
+    justice: number | null;
+    donations: number | null;
+    systems: number | null;
+  } | null;
+}
+
+function money(n: number | null | undefined): string {
+  if (!n || n <= 0) return '—';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+const SORTS: [string, string][] = [
+  ['influence', 'Influence'],
+  ['boards', 'Boards'],
+  ['procurement', 'Contracts $'],
+  ['justice', 'Grants $'],
+  ['donations', 'Donations $'],
+  ['name', 'A–Z'],
+];
+
+function L({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
+      {children}
+    </div>
+  );
+}
+
+export default function PersonBrowser({
+  rows,
+  q,
+  sort,
+  statsLine,
+  exclusionNote,
+}: {
+  rows: PersonRow[];
+  q: string;
+  sort: string;
+  statsLine: string;
+  exclusionNote: string;
+}) {
+  const [openNorm, setOpenNorm] = useState<string | null>(null);
+  const [detail, setDetail] = useState<PersonDetail | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  function open(norm: string) {
+    setOpenNorm(norm);
+    setDetail(null);
+    setErr(null);
+    fetch(`/api/browse/person?norm=${encodeURIComponent(norm)}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
+        return r.json() as Promise<PersonDetail>;
+      })
+      .then(setDetail)
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }
+
+  const qs = (over: Record<string, string>) => {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries({ q, sort, ...over })) if (v) p.set(k, v);
+    const s = p.toString();
+    return `/dashboard/people${s ? `?${s}` : ''}`;
+  };
+
+  return (
+    <>
+      <p className="mt-1 font-mono text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+        {statsLine}
+      </p>
+      <form className="mt-3" action="/dashboard/people">
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Search by name…"
+          className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
+        />
+        {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+      </form>
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <span className="ml-auto flex items-center gap-1.5">
+          {SORTS.map(([v, label]) => (
+            <Link key={v} href={qs({ sort: v })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(sort || 'influence') === v ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+              {label}
+            </Link>
+          ))}
+        </span>
+      </div>
+
+      <div className="mt-4 shell-card">
+        <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
+          <span className="flex-1">Name</span>
+          <span className="w-[64px] text-right">Boards</span>
+          <span className="w-[64px] text-right">Systems</span>
+          <span className="w-[92px] text-right">Contracts $</span>
+          <span className="w-[92px] text-right">Grants $</span>
+          <span className="w-[92px] text-right">Donations $</span>
+        </div>
+        {rows.map((r) => (
+          <button key={r.key} onClick={() => open(r.norm)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>
+            <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold" style={{ color: '#1040C0' }}>
+              {r.name}
+              {r.accoBoards > 0 ? (
+                <span className="ml-2 font-mono text-[10px] uppercase tracking-wider" style={{ color: '#059669' }} title="sits on at least one community-controlled board">
+                  acco
+                </span>
+              ) : null}
+            </span>
+            <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.boards}</span>
+            <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.systems ?? '—'}</span>
+            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.procurement)}</span>
+            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.justice)}</span>
+            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.donations)}</span>
+          </button>
+        ))}
+      </div>
+      <p className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+        {exclusionNote}
+      </p>
+
+      {openNorm ? (
+        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="font-display text-[17px] font-extrabold">{detail?.person_name ?? 'loading…'}</h2>
+            <button onClick={() => setOpenNorm(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
+          </div>
+          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+          {detail ? (
+            <>
+              <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {detail.board_count} boards on record
+                {detail.role_types?.length ? ` · ${detail.role_types.join(', ')}` : ''}
+                {detail.connects_community_controlled ? ' · connects community-controlled orgs' : ''}
+              </p>
+
+              {detail.attributed ? (
+                <>
+                  <L>Money moving past these boards</L>
+                  <p className="text-[13px]">
+                    contracts {money(detail.attributed.procurement)} · grants {money(detail.attributed.justice)} · donations {money(detail.attributed.donations)}
+                    {detail.attributed.systems ? ` · across ${detail.attributed.systems} systems` : ''}
+                  </p>
+                  <p className="font-mono text-[10.5px]" style={{ color: 'var(--shell-muted)' }}>
+                    attributed figures: money at shared boards is split between the people on them, not counted once each
+                  </p>
+                </>
+              ) : null}
+
+              {detail.organisations?.length ? (
+                <>
+                  <L>Boards held</L>
+                  <div className="flex flex-col gap-1">
+                    {detail.organisations.map((org, i) => {
+                      const abn = detail.organisation_abns?.[i] ?? null;
+                      return abn ? (
+                        <Link key={`${org}-${i}`} href={`/dashboard/browse/charities?q=${encodeURIComponent(org)}`} className="text-[12.5px]" style={{ color: '#1040C0' }}>
+                          {org}
+                        </Link>
+                      ) : (
+                        <span key={`${org}-${i}`} className="text-[12.5px]">{org}</span>
+                      );
+                    })}
+                  </div>
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/dashboard/people/page.tsx
+++ b/apps/web/src/app/dashboard/people/page.tsx
@@ -1,82 +1,82 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { unstable_cache } from 'next/cache';
 import { getDirectServiceSupabase } from '@/lib/supabase';
+import PersonBrowser, { type PersonRow } from './PersonBrowser';
 
+export const dynamic = 'force-dynamic';
 export const metadata: Metadata = { title: 'People — CivicGraph' };
 
-const load = unstable_cache(
+const stats = unstable_cache(
   async () => {
     const supabase = getDirectServiceSupabase();
-    // MAX_PLAUSIBLE_BOARDS: rows above 10 boards are professional-trustee/nominee blocks
-    // (the top unfiltered "person" sits on 745 estate trusts) — the person-disambiguation cap
-    // is a standing decision (2026-06-19, CAP STAYS), applied here as a read-side filter.
-    const { data, error } = await supabase
-      .from('mv_board_interlocks')
-      .select('person_name_display,board_count,organisations,interlock_score')
-      .lte('board_count', 10)
-      .order('interlock_score', { ascending: false })
-      .limit(15);
-    if (error) throw new Error(error.message);
-    return data ?? [];
+    const { data } = await supabase.rpc('person_browse_stats');
+    return data as { total: number; listable: number; nominee_blocked: number; over_cap: number } | null;
   },
-  ['dash-people'],
+  ['person-browse-stats'],
   { revalidate: 3600 },
 );
 
 /**
- * Shell-native People index off the board-interlocks matview. KNOWN LIMIT, stated on screen:
- * names are string-normalised, so common names can collapse several real people into one row —
- * the identity lane's job, not this page's.
+ * People browser off the de-collided identity matview. KNOWN LIMIT, stated on screen: names are
+ * string-normalised, so a common name can collapse several real people into one row — the
+ * identity lane's job, not this page's. The nominee/board-cap exclusions are stated, not silent.
  */
-export default async function PeoplePage() {
-  let rows: Awaited<ReturnType<typeof load>> = [];
+export default async function PeoplePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+  const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'influence';
+
+  const supabase = getDirectServiceSupabase();
+  let rows: PersonRow[] = [];
+  let statsLine = '';
+  let exclusionNote = '';
   let why: string | null = null;
   try {
-    rows = await load();
+    const [{ data, error }, s] = await Promise.all([
+      supabase.rpc('person_browse', { p_q: q || null, p_sort: sort, p_limit: 200 }),
+      stats(),
+    ]);
+    if (error) throw new Error(error.message);
+    rows = ((data ?? []) as {
+      identity_key: string;
+      person_name: string;
+      person_name_normalised: string;
+      board_count: number;
+      acco_boards: number;
+      attributed_procurement: number | null;
+      attributed_justice: number | null;
+      attributed_donations: number | null;
+      financial_system_count: number | null;
+    }[]).map((r) => ({
+      key: r.identity_key,
+      name: r.person_name,
+      norm: r.person_name_normalised,
+      boards: r.board_count,
+      accoBoards: r.acco_boards,
+      procurement: r.attributed_procurement,
+      justice: r.attributed_justice,
+      donations: r.attributed_donations,
+      systems: r.financial_system_count,
+    }));
+    if (s) {
+      statsLine = `${s.listable.toLocaleString('en-AU')} people on the graph · showing the top 200 for this search and sort`;
+      exclusionNote = `${(s.nominee_blocked + s.over_cap).toLocaleString('en-AU')} identities are excluded on purpose: ${s.nominee_blocked.toLocaleString('en-AU')} professional-trustee/nominee blocks and ${s.over_cap.toLocaleString('en-AU')} with more than 10 boards (the standing cap — above it, "one person" is usually a nominee service). Names are matched by string, so a common name can be several real people; treat rows as leads, not facts. Dollars are attributed: money at shared boards is split between the people on them.`;
+    }
   } catch (e) {
     why = e instanceof Error ? e.message : String(e);
   }
 
   return (
-    <div className="mx-auto max-w-[1100px] px-6 py-6">
+    <div className="mx-auto max-w-[1180px] px-6 py-6">
       <h1 className="font-display text-[22px] font-extrabold">People</h1>
-      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
-        People on multiple boards (2–10; more than that is a professional trustee block, excluded), ranked by interlock. Names are matched by string — a common name
-        can be several real people; treat high board counts as a lead, not a fact. Person pages
-        open on the public atlas.
-      </p>
       {why ? (
-        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>
-          Board interlocks could not be read: {why}
-        </p>
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
       ) : (
-        <div
-          className="mt-5 bg-white p-4"
-          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
-        >
-          {rows.map((p, i) => (
-            <div
-              key={p.person_name_display ?? i}
-              className="flex items-baseline gap-3 py-2"
-              style={{ borderTop: i === 0 ? undefined : '1px solid var(--shell-line)' }}
-            >
-              <Link
-                href={`/person/${encodeURIComponent((p.person_name_display ?? '').replace(/\s+/g, '-'))}`}
-                className="min-w-0 flex-1 truncate text-[13.5px] font-semibold hover:underline"
-                style={{ color: '#1040C0' }}
-              >
-                {p.person_name_display}
-              </Link>
-              <span className="shrink-0 text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
-                {p.board_count} boards
-              </span>
-              <span className="shrink-0 truncate font-mono text-[11px]" style={{ color: 'var(--shell-muted)', maxWidth: 340 }}>
-                {(p.organisations ?? []).slice(0, 3).join(' · ')}
-              </span>
-            </div>
-          ))}
-        </div>
+        <PersonBrowser rows={rows} q={q} sort={sort} statsLine={statsLine} exclusionNote={exclusionNote} />
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
+++ b/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * Places browser at LGA grain. The drawer's provenance block shows HOW each entity was placed
+ * (lga_source stamps from the attribution rebuild) — a null LGA elsewhere is deliberate
+ * unplacement with a reason code, not missing data.
+ */
+
+export interface PlaceRow {
+  key: string;
+  lga: string;
+  state: string;
+  entities: number;
+  acco: number;
+  funding: number | null;
+  seifa: number | null;
+  remoteness: string | null;
+  desert: number | null;
+}
+
+interface PlaceDetail {
+  lga_name: string;
+  state: string;
+  funding: {
+    entity_count: number | null;
+    community_controlled_count: number | null;
+    total_funding: number | null;
+    avg_seifa_decile: number | null;
+  } | null;
+  desert: { desert_score: number | null; remoteness: string | null } | null;
+  postcodes: { postcode: string; entity_count: number | null; total_funding: number | null; remoteness: string | null }[];
+  placement: Record<string, number>;
+}
+
+function money(n: number | null | undefined): string {
+  if (!n || n <= 0) return '—';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+const SORTS: [string, string][] = [
+  ['funding', 'Funding $'],
+  ['desert', 'Desert score'],
+  ['entities', 'Entities'],
+  ['disadvantage', 'Most disadvantaged'],
+  ['name', 'A–Z'],
+];
+
+const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'];
+
+/** Plain-word labels for lga_source stamps; unknown stamps fall through as-is. */
+const PLACEMENT_LABEL: Record<string, string> = {
+  registry_address: 'registered address',
+  single_lga_postcode: 'postcode sits in one council area',
+  poa_ratio_dominant: 'postcode is ≥90% in this council area',
+  poa_ratio_nolocality: 'postcode is ≥90% in this council area (no suburb on file — less sure)',
+  straddler_ratio_dominant: 'straddling postcode, dominant council area',
+  'acnc_town_city+abs_asgs': 'charity register town',
+  'own_name_town+abs_asgs': 'the organisation is named after its town',
+  'oric_register_address+abs_asgs': 'ORIC register address',
+  'community_name+abs_asgs': 'community name',
+  'acnc_street_line+sal_ratio_dominant': 'charity register street address',
+};
+
+function L({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
+      {children}
+    </div>
+  );
+}
+
+export default function PlaceBrowser({
+  rows,
+  q,
+  state,
+  sort,
+  statsLine,
+  caveat,
+}: {
+  rows: PlaceRow[];
+  q: string;
+  state: string;
+  sort: string;
+  statsLine: string;
+  caveat: string;
+}) {
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<PlaceDetail | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  function open(row: PlaceRow) {
+    setOpenKey(row.key);
+    setDetail(null);
+    setErr(null);
+    fetch(`/api/browse/place?lga=${encodeURIComponent(row.lga)}&state=${encodeURIComponent(row.state)}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
+        return r.json() as Promise<PlaceDetail>;
+      })
+      .then(setDetail)
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }
+
+  const qs = (over: Record<string, string>) => {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries({ q, state, sort, ...over })) if (v) p.set(k, v);
+    const s = p.toString();
+    return `/dashboard/places${s ? `?${s}` : ''}`;
+  };
+
+  return (
+    <>
+      <p className="mt-1 font-mono text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>
+        {statsLine}
+      </p>
+      <form className="mt-3" action="/dashboard/places">
+        <input
+          name="q"
+          defaultValue={q}
+          placeholder="Search by council area…"
+          className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
+        />
+        {state ? <input type="hidden" name="state" value={state} /> : null}
+        {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+      </form>
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <Link href={qs({ state: '' })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === '' ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+          All states
+        </Link>
+        {STATES.map((s) => (
+          <Link key={s} href={qs({ state: s })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === s ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {s}
+          </Link>
+        ))}
+        <span className="ml-auto flex items-center gap-1.5">
+          {SORTS.map(([v, label]) => (
+            <Link key={v} href={qs({ sort: v })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={(sort || 'funding') === v ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+              {label}
+            </Link>
+          ))}
+        </span>
+      </div>
+
+      <div className="mt-4 shell-card">
+        <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
+          <span className="flex-1">Council area</span>
+          <span className="w-[52px]">State</span>
+          <span className="w-[72px] text-right">Entities</span>
+          <span className="w-[64px] text-right" title="community-controlled organisations">ACCO</span>
+          <span className="w-[92px] text-right">Funding $</span>
+          <span className="w-[56px] text-right" title="average SEIFA disadvantage decile, 1 = most disadvantaged">SEIFA</span>
+          <span className="w-[64px] text-right" title="funding-desert score: disadvantage vs money reaching the area">Desert</span>
+        </div>
+        {rows.map((r) => (
+          <button key={r.key} onClick={() => open(r)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>
+            <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold" style={{ color: '#1040C0' }}>{r.lga}</span>
+            <span className="w-[52px] shrink-0 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>{r.state}</span>
+            <span className="w-[72px] shrink-0 text-right font-mono text-[12.5px]">{r.entities.toLocaleString('en-AU')}</span>
+            <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.acco || '—'}</span>
+            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.funding)}</span>
+            <span className="w-[56px] shrink-0 text-right font-mono text-[12.5px]">{r.seifa ?? '—'}</span>
+            <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.desert ?? '—'}</span>
+          </button>
+        ))}
+      </div>
+      <p className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+        {caveat}
+      </p>
+
+      {openKey ? (
+        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="font-display text-[17px] font-extrabold">{detail ? `${detail.lga_name} (${detail.state})` : 'loading…'}</h2>
+            <button onClick={() => setOpenKey(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
+          </div>
+          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+          {detail ? (
+            <>
+              <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+                {detail.desert?.remoteness ?? ''}
+                {detail.desert?.desert_score != null ? ` · desert score ${detail.desert.desert_score}` : ''}
+              </p>
+
+              {detail.funding ? (
+                <>
+                  <L>What the record holds here</L>
+                  <p className="text-[13px]">
+                    {(detail.funding.entity_count ?? 0).toLocaleString('en-AU')} organisations
+                    {detail.funding.community_controlled_count ? ` · ${detail.funding.community_controlled_count} community-controlled` : ''}
+                    {' · '}funding visible {money(detail.funding.total_funding)}
+                    {detail.funding.avg_seifa_decile != null ? ` · SEIFA decile ${detail.funding.avg_seifa_decile}` : ''}
+                  </p>
+                  <p className="font-mono text-[10.5px]" style={{ color: 'var(--shell-muted)' }}>
+                    money attaches to an organisation&rsquo;s address — head-office areas collect their branches&rsquo; figures
+                  </p>
+                </>
+              ) : null}
+
+              {detail.postcodes.length > 0 ? (
+                <>
+                  <L>By postcode</L>
+                  <table className="w-full text-right font-mono text-[11.5px]">
+                    <thead>
+                      <tr style={{ color: 'var(--shell-muted)' }}>
+                        <th className="py-0.5 text-left font-normal">postcode</th>
+                        <th className="font-normal">orgs</th>
+                        <th className="font-normal">funding</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {detail.postcodes.slice(0, 12).map((p) => (
+                        <tr key={p.postcode} style={{ borderTop: '1px solid var(--shell-line)' }}>
+                          <td className="py-0.5 text-left">{p.postcode}</td>
+                          <td>{p.entity_count ?? '—'}</td>
+                          <td>{money(p.total_funding)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </>
+              ) : null}
+
+              {Object.keys(detail.placement).length > 0 ? (
+                <>
+                  <L>How organisations were placed here</L>
+                  <div className="flex flex-col gap-0.5">
+                    {Object.entries(detail.placement)
+                      .sort(([, a], [, b]) => b - a)
+                      .map(([src, n]) => (
+                        <div key={src} className="flex items-baseline justify-between gap-3 text-[12px]">
+                          <span>{PLACEMENT_LABEL[src] ?? src}</span>
+                          <span className="font-mono text-[11.5px]" style={{ color: 'var(--shell-muted)' }}>{n.toLocaleString('en-AU')}</span>
+                        </div>
+                      ))}
+                  </div>
+                  <p className="mt-1 font-mono text-[10.5px]" style={{ color: 'var(--shell-muted)' }}>
+                    every placement carries its method; organisations we could not place confidently are left unplaced with a reason, not guessed
+                  </p>
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/dashboard/places/page.tsx
+++ b/apps/web/src/app/dashboard/places/page.tsx
@@ -1,82 +1,83 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { unstable_cache } from 'next/cache';
 import { getDirectServiceSupabase } from '@/lib/supabase';
+import PlaceBrowser, { type PlaceRow } from './PlaceBrowser';
 
+export const dynamic = 'force-dynamic';
 export const metadata: Metadata = { title: 'Places — CivicGraph' };
 
-function money(n: number): string {
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}bn`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
-  return `$${Math.round(n / 1e3)}k`;
-}
-
-const load = unstable_cache(
+const stats = unstable_cache(
   async () => {
     const supabase = getDirectServiceSupabase();
-    const { data, error } = await supabase
-      .from('mv_funding_by_postcode')
-      .select('postcode,state,remoteness,entity_count,total_funding')
-      .order('total_funding', { ascending: false })
-      .limit(15);
-    if (error) throw new Error(error.message);
-    return data ?? [];
+    const { data } = await supabase.rpc('place_browse_stats');
+    return data as { lgas: number; entities_placed: number; unplaced_with_postcode: number; no_postcode: number } | null;
   },
-  ['dash-places'],
+  ['place-browse-stats'],
   { revalidate: 3600 },
 );
 
-/** Shell-native Places index. The Atlas (public) stays the deep place experience. */
-export default async function PlacesIndexPage() {
-  let rows: Awaited<ReturnType<typeof load>> = [];
+/** Places browser at LGA (council area) grain, with placement provenance in the drawer. */
+export default async function PlacesPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === 'string' ? sp.q.trim() : '';
+  const state = typeof sp.state === 'string' ? sp.state : '';
+  const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'funding';
+
+  const supabase = getDirectServiceSupabase();
+  let rows: PlaceRow[] = [];
+  let statsLine = '';
   let why: string | null = null;
   try {
-    rows = await load();
+    const [{ data, error }, s] = await Promise.all([
+      supabase.rpc('place_browse', { p_q: q || null, p_state: state || null, p_sort: sort, p_limit: 200 }),
+      stats(),
+    ]);
+    if (error) throw new Error(error.message);
+    rows = ((data ?? []) as {
+      lga_name: string;
+      state: string;
+      entity_count: number;
+      community_controlled_count: number;
+      total_funding: number | null;
+      avg_seifa_decile: number | null;
+      remoteness: string | null;
+      desert_score: number | null;
+    }[]).map((r) => ({
+      key: `${r.lga_name}|${r.state}`,
+      lga: r.lga_name,
+      state: r.state,
+      entities: r.entity_count,
+      acco: r.community_controlled_count,
+      funding: r.total_funding,
+      seifa: r.avg_seifa_decile,
+      remoteness: r.remoteness,
+      desert: r.desert_score,
+    }));
+    if (s) {
+      statsLine = `${s.lgas.toLocaleString('en-AU')} council areas · ${s.entities_placed.toLocaleString('en-AU')} organisations placed · ${s.unplaced_with_postcode.toLocaleString('en-AU')} deliberately unplaced with a reason code · ${s.no_postcode.toLocaleString('en-AU')} with no postcode on record`;
+    }
   } catch (e) {
     why = e instanceof Error ? e.message : String(e);
   }
 
   return (
-    <div className="mx-auto max-w-[1100px] px-6 py-6">
+    <div className="mx-auto max-w-[1180px] px-6 py-6">
       <h1 className="font-display text-[22px] font-extrabold">Places</h1>
-      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
-        Where the money lands, by postcode. Place pages and the full Atlas open on the public site.
-      </p>
       {why ? (
-        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>
-          Funding by postcode could not be read: {why}
-        </p>
+        <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
       ) : (
-        <div
-          className="mt-5 bg-white p-4"
-          style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
-        >
-          <h2 className="font-display text-[14px] font-bold">
-            Highest-funded postcodes
-            <Link href="/atlas" className="ml-3 text-[12px] font-semibold hover:underline" style={{ color: '#1040C0' }}>
-              open the Atlas →
-            </Link>
-          </h2>
-          {rows.map((r, i) => (
-            <div
-              key={`${r.postcode}-${i}`}
-              className="flex items-baseline gap-3 py-2"
-              style={{ borderTop: i === 0 ? undefined : '1px solid var(--shell-line)' }}
-            >
-              <Link
-                href={`/places/${r.postcode}`}
-                className="shrink-0 font-mono text-[13.5px] font-semibold hover:underline"
-                style={{ color: '#1040C0' }}
-              >
-                {r.postcode}
-              </Link>
-              <span className="min-w-0 flex-1 truncate text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
-                {r.state ?? '—'} · {r.remoteness ?? 'remoteness unknown'} · {r.entity_count ?? 0} organisations
-              </span>
-              <span className="shrink-0 font-mono text-[13px]">{money(Number(r.total_funding ?? 0))}</span>
-            </div>
-          ))}
-        </div>
+        <PlaceBrowser
+          rows={rows}
+          q={q}
+          state={state}
+          sort={sort}
+          statsLine={statsLine}
+          caveat="Funding attaches to an organisation's address, so head-office council areas collect their branches' figures. SEIFA decile 1 = most disadvantaged. Desert score compares disadvantage with money reaching the area."
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/views/page.tsx
+++ b/apps/web/src/app/dashboard/views/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { VIEW_REGISTRY } from '@/lib/view-registry';
+
+export const metadata: Metadata = { title: 'Views — CivicGraph' };
+
+const VIEW_DOT: Record<string, string> = {
+  red: '#D02020',
+  blue: '#1040C0',
+  yellow: '#F0C020',
+  green: '#059669',
+  ink: '#6E6E6E',
+};
+
+/**
+ * The complete views index. The rail pins a curated few; this page lists every registered view,
+ * so nothing in the registry is reachable only by knowing its URL.
+ */
+export default function ViewsIndexPage() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-6 py-6">
+      <h1 className="font-display text-[22px] font-extrabold">Views</h1>
+      <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
+        Every saved view on the graph. Pinned views also sit in the rail; the rest live only here.
+      </p>
+      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+        {VIEW_REGISTRY.map((v) => (
+          <Link
+            key={v.id}
+            href={v.href}
+            className="block bg-white p-4"
+            style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+          >
+            <div className="flex items-center gap-2.5">
+              <span
+                className="inline-block h-2 w-2 shrink-0"
+                style={{ background: VIEW_DOT[v.colour], borderRadius: 2 }}
+              />
+              <span className="font-display text-[15px] font-bold">{v.name}</span>
+              {v.pinned && (
+                <span
+                  className="ml-auto font-mono text-[10px] uppercase tracking-widest"
+                  style={{ color: 'var(--shell-muted)' }}
+                >
+                  pinned
+                </span>
+              )}
+            </div>
+            <p className="mt-1.5 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
+              {v.question}
+            </p>
+            {v.caveat && (
+              <p className="mt-2 font-mono text-[11px]" style={{ color: 'var(--shell-muted)' }}>
+                {v.caveat}
+              </p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/ops/health/layout.tsx
+++ b/apps/web/src/app/ops/health/layout.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
-import { Shell } from '@/components/shell/shell';
 
-/** Operator tool inside the app shell (phase-2 ruling 2026-08-17). The page's own Bauhaus
- *  content sits contained inside the soft shell — the accepted /clarity pattern. */
+/** The shell wrap moved up to /ops/layout.tsx when the whole ops group entered the shell —
+ *  wrapping here again would nest a shell inside a shell. */
 export default function Layout({ children }: { children: ReactNode }) {
-  return <Shell title="Data health">{children}</Shell>;
+  return children;
 }

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -151,6 +151,37 @@ export async function Shell({ title, children }: ShellProps) {
             {v.name}
           </Link>
         ))}
+        <Link
+          href="/dashboard/views"
+          className="flex items-center px-2.5 py-1.5 text-[12px]"
+          style={{ borderRadius: 'var(--shell-r-sm)', color: '#7A7A7A' }}
+        >
+          All views
+        </Link>
+        {user.isAdmin && (
+          <>
+            <div className="h-4" />
+            <div className="px-2.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[#7A7A7A]">
+              Ops
+            </div>
+            {[
+              ['/ops', 'Overview'],
+              ['/ops/health', 'Data health'],
+              ['/ops/claims', 'Claims'],
+              ['/ops/grant-recommendations', 'Grant recommendations'],
+              ['/admin/api-usage', 'API usage'],
+            ].map(([href, label]) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex items-center px-2.5 py-1.5 text-[13px]"
+                style={{ borderRadius: 'var(--shell-r-sm)', color: 'var(--shell-rail-text)' }}
+              >
+                {label}
+              </Link>
+            ))}
+          </>
+        )}
         <div className="flex-1" />
         <Link
           href="/clarity"

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -125,6 +125,7 @@ export async function Shell({ title, children }: ShellProps) {
           ['/dashboard/browse/grants', 'Grant recipients'],
           ['/dashboard/browse/contracts', 'Contract suppliers'],
           ['/dashboard/browse/buyers', 'Government buyers'],
+          ['/dashboard/browse/donations', 'Political donors'],
         ].map(([href, label]) => (
           <Link
             key={href}

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -122,6 +122,7 @@ export async function Shell({ title, children }: ShellProps) {
           ['/dashboard/browse/foundations', 'Foundations'],
           ['/dashboard/browse/social-enterprises', 'Social enterprises'],
           ['/dashboard/browse/charities', 'Charities'],
+          ['/dashboard/browse/grants', 'Grant recipients'],
         ].map(([href, label]) => (
           <Link
             key={href}

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -123,6 +123,8 @@ export async function Shell({ title, children }: ShellProps) {
           ['/dashboard/browse/social-enterprises', 'Social enterprises'],
           ['/dashboard/browse/charities', 'Charities'],
           ['/dashboard/browse/grants', 'Grant recipients'],
+          ['/dashboard/browse/contracts', 'Contract suppliers'],
+          ['/dashboard/browse/buyers', 'Government buyers'],
         ].map(([href, label]) => (
           <Link
             key={href}

--- a/migrations/2026-08-17-contract-browse-rpcs.sql
+++ b/migrations/2026-08-17-contract-browse-rpcs.sql
@@ -1,0 +1,169 @@
+-- Contracts + Government buyers browser RPCs (issues #248 + #249, "One shell, all data" S5+S6)
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-contract-browse-rpcs.sql
+--
+-- Both sides of austender_contracts (824K rows, so every function REQUIRES a predicate:
+-- a from-year floor is always applied, defaulting to 2020). Suppliers key on ABN when present,
+-- else lowercased name; buyers key on lowercased buyer_name. contract_start carries junk years
+-- (0140 and 3411 both occur) — the year guard doubles as data hygiene.
+
+CREATE OR REPLACE FUNCTION contract_supplier_browse(
+  p_q text DEFAULT NULL,
+  p_from_year int DEFAULT 2020,
+  p_sort text DEFAULT 'total',
+  p_limit int DEFAULT 200,
+  p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+  supplier_key text,
+  supplier_name text,
+  supplier_abn text,
+  contract_count bigint,
+  total_value numeric,
+  buyer_count bigint,
+  top_buyer text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name))) AS supplier_key,
+    max(c.supplier_name) AS supplier_name,
+    max(NULLIF(c.supplier_abn, '')) AS supplier_abn,
+    count(*) AS contract_count,
+    sum(c.contract_value) AS total_value,
+    count(DISTINCT c.buyer_name) AS buyer_count,
+    (array_agg(c.buyer_name ORDER BY c.contract_value DESC NULLS LAST))[1] AS top_buyer
+  FROM austender_contracts c
+  WHERE c.supplier_name IS NOT NULL AND btrim(c.supplier_name) <> ''
+    AND c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+    AND c.contract_start < make_date(2031, 1, 1)
+    AND (p_q IS NULL OR c.supplier_name ILIKE '%' || p_q || '%')
+  GROUP BY COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name)))
+  ORDER BY
+    CASE WHEN p_sort = 'contracts' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'buyers' THEN count(DISTINCT c.buyer_name) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name' THEN max(c.supplier_name) END ASC NULLS LAST,
+    sum(c.contract_value) DESC NULLS LAST,
+    max(c.supplier_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$$;
+
+CREATE OR REPLACE FUNCTION contract_supplier_detail(p_key text, p_from_year int DEFAULT 2020)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  WITH rows AS (
+    SELECT c.title, c.buyer_name, c.contract_value, c.contract_start, c.contract_end, c.supplier_name, c.supplier_abn
+    FROM austender_contracts c
+    WHERE COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name))) = p_key
+      AND c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+      AND c.contract_start < make_date(2031, 1, 1)
+  )
+  SELECT jsonb_build_object(
+    'supplier_name', (SELECT max(supplier_name) FROM rows),
+    'supplier_abn', (SELECT max(NULLIF(supplier_abn, '')) FROM rows),
+    'contract_count', (SELECT count(*) FROM rows),
+    'total_value', (SELECT sum(contract_value) FROM rows),
+    'buyers', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('buyer', b.buyer_name, 'value', b.v, 'contracts', b.n) ORDER BY b.v DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT buyer_name, sum(contract_value) AS v, count(*) AS n FROM rows GROUP BY buyer_name ORDER BY sum(contract_value) DESC NULLS LAST LIMIT 12) b
+    ),
+    'contracts', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'title', g.title, 'buyer', g.buyer_name, 'value', g.contract_value,
+        'start', g.contract_start, 'end', g.contract_end
+      ) ORDER BY g.contract_value DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT * FROM rows ORDER BY contract_value DESC NULLS LAST LIMIT 50) g
+    )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION contract_buyer_browse(
+  p_q text DEFAULT NULL,
+  p_from_year int DEFAULT 2020,
+  p_sort text DEFAULT 'total',
+  p_limit int DEFAULT 200,
+  p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+  buyer_key text,
+  buyer_name text,
+  contract_count bigint,
+  total_value numeric,
+  supplier_count bigint,
+  top_supplier text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    lower(btrim(c.buyer_name)) AS buyer_key,
+    max(c.buyer_name) AS buyer_name,
+    count(*) AS contract_count,
+    sum(c.contract_value) AS total_value,
+    count(DISTINCT COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name)))) AS supplier_count,
+    (array_agg(c.supplier_name ORDER BY c.contract_value DESC NULLS LAST))[1] AS top_supplier
+  FROM austender_contracts c
+  WHERE c.buyer_name IS NOT NULL AND btrim(c.buyer_name) <> ''
+    AND c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+    AND c.contract_start < make_date(2031, 1, 1)
+    AND (p_q IS NULL OR c.buyer_name ILIKE '%' || p_q || '%')
+  GROUP BY lower(btrim(c.buyer_name))
+  ORDER BY
+    CASE WHEN p_sort = 'contracts' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'suppliers' THEN count(DISTINCT COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name)))) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name' THEN max(c.buyer_name) END ASC NULLS LAST,
+    sum(c.contract_value) DESC NULLS LAST,
+    max(c.buyer_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$$;
+
+CREATE OR REPLACE FUNCTION contract_buyer_detail(p_key text, p_from_year int DEFAULT 2020)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  WITH rows AS (
+    SELECT c.title, c.supplier_name, c.contract_value, c.contract_start, c.contract_end, c.buyer_name
+    FROM austender_contracts c
+    WHERE lower(btrim(c.buyer_name)) = p_key
+      AND c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+      AND c.contract_start < make_date(2031, 1, 1)
+  )
+  SELECT jsonb_build_object(
+    'buyer_name', (SELECT max(buyer_name) FROM rows),
+    'contract_count', (SELECT count(*) FROM rows),
+    'total_value', (SELECT sum(contract_value) FROM rows),
+    'suppliers', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('supplier', s.supplier_name, 'value', s.v, 'contracts', s.n) ORDER BY s.v DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT supplier_name, sum(contract_value) AS v, count(*) AS n FROM rows GROUP BY supplier_name ORDER BY sum(contract_value) DESC NULLS LAST LIMIT 12) s
+    ),
+    'contracts', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'title', g.title, 'supplier', g.supplier_name, 'value', g.contract_value,
+        'start', g.contract_start, 'end', g.contract_end
+      ) ORDER BY g.contract_value DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT * FROM rows ORDER BY contract_value DESC NULLS LAST LIMIT 50) g
+    )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION contract_browse_stats(p_from_year int DEFAULT 2020)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'contracts', count(*),
+    'total_value', sum(contract_value),
+    'suppliers', count(DISTINCT COALESCE(NULLIF(supplier_abn, ''), lower(btrim(supplier_name)))),
+    'buyers', count(DISTINCT lower(btrim(buyer_name)))
+  )
+  FROM austender_contracts
+  WHERE contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+    AND contract_start < make_date(2031, 1, 1)
+$$;
+
+GRANT EXECUTE ON FUNCTION contract_supplier_browse(text, int, text, int, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION contract_supplier_detail(text, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION contract_buyer_browse(text, int, text, int, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION contract_buyer_detail(text, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION contract_browse_stats(int) TO anon, authenticated, service_role;

--- a/migrations/2026-08-17-donation-browse-rpcs.sql
+++ b/migrations/2026-08-17-donation-browse-rpcs.sql
@@ -1,0 +1,98 @@
+-- Donations browser RPCs (issue #250, "One shell, all data" S7)
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-donation-browse-rpcs.sql
+--
+-- Top donors rollup of political_donations. The mandatory filter is HERE, in SQL:
+-- receipt_type = 'donation received' — 'other receipt' is 72% of rows / 85% of dollars and
+-- is NOT donations. Donors key on ABN when present, else lowercased name. 2.55M-row base
+-- table, so a from-financial-year floor is always applied (default 2014-15).
+
+CREATE OR REPLACE FUNCTION donation_donor_browse(
+  p_q text DEFAULT NULL,
+  p_from_fy text DEFAULT '2014-15',
+  p_sort text DEFAULT 'total',
+  p_limit int DEFAULT 200,
+  p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+  donor_key text,
+  donor_name text,
+  donor_abn text,
+  donation_count bigint,
+  total_dollars numeric,
+  recipient_count bigint,
+  top_recipient text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    COALESCE(NULLIF(d.donor_abn, ''), lower(btrim(d.donor_name))) AS donor_key,
+    max(d.donor_name) AS donor_name,
+    max(NULLIF(d.donor_abn, '')) AS donor_abn,
+    count(*) AS donation_count,
+    sum(d.amount) AS total_dollars,
+    count(DISTINCT d.donation_to) AS recipient_count,
+    (array_agg(d.donation_to ORDER BY d.amount DESC NULLS LAST))[1] AS top_recipient
+  FROM political_donations d
+  WHERE d.receipt_type = 'donation received'
+    AND d.donor_name IS NOT NULL AND btrim(d.donor_name) <> ''
+    AND d.financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15')
+    AND (p_q IS NULL OR d.donor_name ILIKE '%' || p_q || '%')
+  GROUP BY COALESCE(NULLIF(d.donor_abn, ''), lower(btrim(d.donor_name)))
+  ORDER BY
+    CASE WHEN p_sort = 'donations' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'recipients' THEN count(DISTINCT d.donation_to) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name' THEN max(d.donor_name) END ASC NULLS LAST,
+    sum(d.amount) DESC NULLS LAST,
+    max(d.donor_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$$;
+
+CREATE OR REPLACE FUNCTION donation_donor_detail(p_key text, p_from_fy text DEFAULT '2014-15')
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  WITH rows AS (
+    SELECT d.donor_name, d.donor_abn, d.donation_to, d.amount, d.financial_year
+    FROM political_donations d
+    WHERE d.receipt_type = 'donation received'
+      AND COALESCE(NULLIF(d.donor_abn, ''), lower(btrim(d.donor_name))) = p_key
+      AND d.financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15')
+  )
+  SELECT jsonb_build_object(
+    'donor_name', (SELECT max(donor_name) FROM rows),
+    'donor_abn', (SELECT max(NULLIF(donor_abn, '')) FROM rows),
+    'donation_count', (SELECT count(*) FROM rows),
+    'total_dollars', (SELECT sum(amount) FROM rows),
+    'recipients', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('recipient', r.donation_to, 'dollars', r.v, 'donations', r.n) ORDER BY r.v DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT donation_to, sum(amount) AS v, count(*) AS n FROM rows GROUP BY donation_to ORDER BY sum(amount) DESC NULLS LAST LIMIT 15) r
+    ),
+    'by_year', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('year', y.financial_year, 'dollars', y.v, 'donations', y.n) ORDER BY y.financial_year), '[]'::jsonb)
+      FROM (SELECT financial_year, sum(amount) AS v, count(*) AS n FROM rows GROUP BY financial_year) y
+    ),
+    'donations', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'recipient', g.donation_to, 'amount', g.amount, 'year', g.financial_year
+      ) ORDER BY g.amount DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT * FROM rows ORDER BY amount DESC NULLS LAST LIMIT 50) g
+    )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION donation_browse_stats(p_from_fy text DEFAULT '2014-15')
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'donations', count(*) FILTER (WHERE receipt_type = 'donation received' AND financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15')),
+    'total_dollars', sum(amount) FILTER (WHERE receipt_type = 'donation received' AND financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15')),
+    'other_receipt_dollars', sum(amount) FILTER (WHERE receipt_type <> 'donation received' AND financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15'))
+  )
+  FROM political_donations
+$$;
+
+GRANT EXECUTE ON FUNCTION donation_donor_browse(text, text, text, int, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION donation_donor_detail(text, text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION donation_browse_stats(text) TO anon, authenticated, service_role;

--- a/migrations/2026-08-17-grant-browse-rpcs.sql
+++ b/migrations/2026-08-17-grant-browse-rpcs.sql
@@ -1,0 +1,112 @@
+-- Grants browser RPCs (issue #247, "One shell, all data" S4)
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-grant-browse-rpcs.sql
+--
+-- Entity-shaped rollup of justice_funding: top recipients, transactions in the drawer.
+-- The three mandatory filters live HERE, in SQL, once — the same predicate as
+-- isRealRecipient()/applyGrantFilters in apps/web/src/lib/justice-money.ts:
+--   measure_kind = 'grant'  ·  is_aggregate IS NOT TRUE  ·  name blocklist.
+-- Recipients are grouped by lower(trim(name)): ABNs are missing on too many rows to key on.
+
+CREATE OR REPLACE FUNCTION grant_recipient_browse(
+  p_q text DEFAULT NULL,
+  p_state text DEFAULT NULL,
+  p_topic text DEFAULT NULL,
+  p_sort text DEFAULT 'total',
+  p_limit int DEFAULT 200,
+  p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+  recipient_key text,
+  recipient_name text,
+  recipient_abn text,
+  grant_count bigint,
+  total_dollars numeric,
+  states text[],
+  first_year text,
+  last_year text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    lower(btrim(j.recipient_name)) AS recipient_key,
+    max(j.recipient_name) AS recipient_name,
+    max(j.recipient_abn) AS recipient_abn,
+    count(*) AS grant_count,
+    sum(j.amount_dollars) AS total_dollars,
+    array_agg(DISTINCT j.state) FILTER (WHERE j.state IS NOT NULL) AS states,
+    min(j.financial_year) AS first_year,
+    max(j.financial_year) AS last_year
+  FROM justice_funding j
+  WHERE j.measure_kind = 'grant'
+    AND j.is_aggregate IS NOT TRUE
+    AND j.recipient_name IS NOT NULL
+    AND btrim(j.recipient_name) <> ''
+    AND lower(btrim(j.recipient_name)) NOT IN
+        ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')
+    AND (p_q IS NULL OR j.recipient_name ILIKE '%' || p_q || '%')
+    AND (p_state IS NULL OR j.state = p_state)
+    AND (p_topic IS NULL OR j.topics @> ARRAY[p_topic])
+  GROUP BY lower(btrim(j.recipient_name))
+  ORDER BY
+    CASE WHEN p_sort = 'grants' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name' THEN max(j.recipient_name) END ASC NULLS LAST,
+    sum(j.amount_dollars) DESC NULLS LAST,
+    max(j.recipient_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$$;
+
+CREATE OR REPLACE FUNCTION grant_recipient_detail(p_key text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  WITH rows AS (
+    SELECT j.program_name, j.financial_year, j.amount_dollars, j.state, j.topics, j.recipient_abn, j.recipient_name
+    FROM justice_funding j
+    WHERE j.measure_kind = 'grant'
+      AND j.is_aggregate IS NOT TRUE
+      AND lower(btrim(j.recipient_name)) = p_key
+  )
+  SELECT jsonb_build_object(
+    'recipient_name', (SELECT max(recipient_name) FROM rows),
+    'recipient_abn', (SELECT max(recipient_abn) FROM rows),
+    'grant_count', (SELECT count(*) FROM rows),
+    'total_dollars', (SELECT sum(amount_dollars) FROM rows),
+    'by_year', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('year', y.financial_year, 'dollars', y.dollars, 'grants', y.n) ORDER BY y.financial_year), '[]'::jsonb)
+      FROM (SELECT financial_year, sum(amount_dollars) AS dollars, count(*) AS n FROM rows GROUP BY financial_year) y
+    ),
+    'grants', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'program', g.program_name, 'year', g.financial_year, 'amount', g.amount_dollars,
+        'state', g.state, 'topics', to_jsonb(g.topics)
+      ) ORDER BY g.amount_dollars DESC NULLS LAST), '[]'::jsonb)
+      FROM (SELECT * FROM rows ORDER BY amount_dollars DESC NULLS LAST LIMIT 100) g
+    )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION grant_browse_stats()
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'kept_rows', count(*) FILTER (WHERE measure_kind = 'grant' AND is_aggregate IS NOT TRUE
+      AND recipient_name IS NOT NULL AND btrim(recipient_name) <> ''
+      AND lower(btrim(recipient_name)) NOT IN
+          ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')),
+    'kept_dollars', sum(amount_dollars) FILTER (WHERE measure_kind = 'grant' AND is_aggregate IS NOT TRUE
+      AND recipient_name IS NOT NULL AND btrim(recipient_name) <> ''
+      AND lower(btrim(recipient_name)) NOT IN
+          ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')),
+    'excluded_rows', count(*) FILTER (WHERE NOT (measure_kind = 'grant' AND is_aggregate IS NOT TRUE
+      AND recipient_name IS NOT NULL AND btrim(recipient_name) <> ''
+      AND lower(btrim(recipient_name)) NOT IN
+          ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')))
+  )
+  FROM justice_funding
+$$;
+
+GRANT EXECUTE ON FUNCTION grant_recipient_browse(text, text, text, text, int, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION grant_recipient_detail(text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION grant_browse_stats() TO anon, authenticated, service_role;

--- a/migrations/2026-08-17-person-browse-rpcs.sql
+++ b/migrations/2026-08-17-person-browse-rpcs.sql
@@ -1,0 +1,103 @@
+-- People browser RPCs (issue #245, "One shell, all data" S2)
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-person-browse-rpcs.sql
+--
+-- Read-only SELECT functions over mv_person_identity_influence_v2 / mv_board_interlocks.
+-- The nominee cap stays: is_nominee_block rows and >10-board identities are excluded from the
+-- list and COUNTED in person_browse_stats so the UI can say so instead of silently capping.
+-- Money columns are the de-collided attributed_* figures, never the naive affiliated totals.
+
+CREATE OR REPLACE FUNCTION person_browse(
+  p_q text DEFAULT NULL,
+  p_sort text DEFAULT 'influence',
+  p_limit int DEFAULT 200,
+  p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+  identity_key text,
+  person_name text,
+  person_name_normalised text,
+  board_count bigint,
+  acco_boards bigint,
+  attributed_procurement numeric,
+  attributed_justice numeric,
+  attributed_donations numeric,
+  financial_system_count int,
+  influence_score numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    v.identity_key,
+    v.person_name,
+    v.person_name_normalised,
+    v.board_count,
+    v.acco_boards,
+    v.attributed_procurement,
+    v.attributed_justice,
+    v.attributed_donations,
+    v.financial_system_count,
+    v.influence_score_attributed
+  FROM mv_person_identity_influence_v2 v
+  WHERE v.is_nominee_block IS NOT TRUE
+    AND v.board_count <= 10
+    AND (p_q IS NULL OR v.person_name ILIKE '%' || p_q || '%')
+  ORDER BY
+    CASE WHEN p_sort = 'boards' THEN v.board_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'procurement' THEN v.attributed_procurement END DESC NULLS LAST,
+    CASE WHEN p_sort = 'justice' THEN v.attributed_justice END DESC NULLS LAST,
+    CASE WHEN p_sort = 'donations' THEN v.attributed_donations END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name' THEN v.person_name END ASC NULLS LAST,
+    v.influence_score_attributed DESC NULLS LAST,
+    v.person_name ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$$;
+
+CREATE OR REPLACE FUNCTION person_detail(p_norm text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'person_name', b.person_name_display,
+    'person_name_normalised', b.person_name_normalised,
+    'board_count', b.board_count,
+    'organisations', to_jsonb(b.organisations),
+    'organisation_abns', to_jsonb(b.organisation_abns),
+    'role_types', to_jsonb(b.role_types),
+    'connects_community_controlled', b.connects_community_controlled,
+    'interlock_score', b.interlock_score,
+    'attributed', (
+      SELECT jsonb_build_object(
+        'procurement', v.attributed_procurement,
+        'justice', v.attributed_justice,
+        'donations', v.attributed_donations,
+        'systems', v.financial_system_count
+      )
+      FROM mv_person_identity_influence_v2 v
+      WHERE v.person_name_normalised = b.person_name_normalised
+        AND v.is_nominee_block IS NOT TRUE
+      ORDER BY v.influence_score_attributed DESC NULLS LAST
+      LIMIT 1
+    )
+  )
+  FROM mv_board_interlocks b
+  WHERE b.person_name_normalised = p_norm
+  LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION person_browse_stats()
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'total', count(*),
+    'listable', count(*) FILTER (WHERE is_nominee_block IS NOT TRUE AND board_count <= 10),
+    'nominee_blocked', count(*) FILTER (WHERE is_nominee_block),
+    'over_cap', count(*) FILTER (WHERE is_nominee_block IS NOT TRUE AND board_count > 10)
+  )
+  FROM mv_person_identity_influence_v2
+$$;
+
+GRANT EXECUTE ON FUNCTION person_browse(text, text, int, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION person_detail(text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION person_browse_stats() TO anon, authenticated, service_role;

--- a/migrations/2026-08-17-place-browse-rpcs.sql
+++ b/migrations/2026-08-17-place-browse-rpcs.sql
@@ -1,0 +1,134 @@
+-- Places browser RPCs (issue #246, "One shell, all data" S3)
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-place-browse-rpcs.sql
+--
+-- LGA is the grain. Neither source MV is trustworthy on grain (mv_funding_by_lga: 1.7K rows over
+-- ~492 LGAs; mv_funding_deserts: 1,997 rows over 1,130 distinct lga|state) so both are
+-- re-aggregated to one row per (lga_name, state) here, in the DB, once.
+
+CREATE OR REPLACE FUNCTION place_browse(
+  p_q text DEFAULT NULL,
+  p_state text DEFAULT NULL,
+  p_sort text DEFAULT 'funding',
+  p_limit int DEFAULT 200,
+  p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+  lga_name text,
+  state text,
+  entity_count bigint,
+  community_controlled_count bigint,
+  total_funding numeric,
+  avg_seifa_decile numeric,
+  remoteness text,
+  desert_score numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  WITH lga AS (
+    SELECT f.lga_name, f.state,
+           sum(f.entity_count) AS entity_count,
+           sum(f.community_controlled_count) AS community_controlled_count,
+           sum(f.total_funding) AS total_funding,
+           avg(f.avg_seifa_decile) AS avg_seifa_decile
+    FROM mv_funding_by_lga f
+    WHERE f.lga_name IS NOT NULL
+    GROUP BY f.lga_name, f.state
+  ),
+  deserts AS (
+    SELECT d.lga_name, d.state,
+           max(d.desert_score) AS desert_score,
+           min(d.remoteness) AS remoteness
+    FROM mv_funding_deserts d
+    GROUP BY d.lga_name, d.state
+  )
+  SELECT
+    l.lga_name, l.state, l.entity_count, l.community_controlled_count,
+    l.total_funding, round(l.avg_seifa_decile, 1), d.remoteness, round(d.desert_score, 1)
+  FROM lga l
+  LEFT JOIN deserts d ON d.lga_name = l.lga_name AND d.state = l.state
+  WHERE (p_q IS NULL OR l.lga_name ILIKE '%' || p_q || '%')
+    AND (p_state IS NULL OR l.state = p_state)
+  ORDER BY
+    CASE WHEN p_sort = 'desert' THEN d.desert_score END DESC NULLS LAST,
+    CASE WHEN p_sort = 'entities' THEN l.entity_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'disadvantage' THEN l.avg_seifa_decile END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' THEN l.lga_name END ASC NULLS LAST,
+    l.total_funding DESC NULLS LAST,
+    l.lga_name ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$$;
+
+CREATE OR REPLACE FUNCTION place_detail(p_lga text, p_state text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'lga_name', p_lga,
+    'state', p_state,
+    'funding', (
+      SELECT jsonb_build_object(
+        'entity_count', sum(f.entity_count),
+        'community_controlled_count', sum(f.community_controlled_count),
+        'total_funding', sum(f.total_funding),
+        'avg_seifa_decile', round(avg(f.avg_seifa_decile), 1)
+      )
+      FROM mv_funding_by_lga f
+      WHERE f.lga_name = p_lga AND f.state = p_state
+    ),
+    -- Deserts dollars are NOT exposed: the MV's grain is not unique per LGA and its dollar
+    -- columns double-count catastrophically when aggregated (Brisbane summed to $2.5tn
+    -- procurement). Score and remoteness are safe under max/min.
+    'desert', (
+      SELECT jsonb_build_object(
+        'desert_score', round(max(d.desert_score), 1),
+        'remoteness', min(d.remoteness)
+      )
+      FROM mv_funding_deserts d
+      WHERE d.lga_name = p_lga AND d.state = p_state
+    ),
+    'postcodes', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'postcode', p.postcode,
+        'entity_count', p.entity_count,
+        'total_funding', p.total_funding,
+        'remoteness', p.remoteness
+      ) ORDER BY p.total_funding DESC NULLS LAST), '[]'::jsonb)
+      FROM (
+        SELECT DISTINCT ON (mp.postcode) mp.postcode, mp.entity_count, mp.total_funding, mp.remoteness
+        FROM mv_funding_by_postcode mp
+        WHERE mp.postcode IN (
+          SELECT DISTINCT g.postcode FROM postcode_geo g
+          WHERE g.lga_name = p_lga AND g.state = p_state
+        )
+        ORDER BY mp.postcode
+      ) p
+    ),
+    'placement', (
+      SELECT COALESCE(jsonb_object_agg(src.lga_source, src.n), '{}'::jsonb)
+      FROM (
+        SELECT e.lga_source, count(*) AS n
+        FROM gs_entities e
+        WHERE e.lga_name = p_lga AND e.state = p_state AND e.lga_source IS NOT NULL
+        GROUP BY e.lga_source
+        ORDER BY count(*) DESC
+      ) src
+    )
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION place_browse_stats()
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'lgas', (SELECT count(DISTINCT (lga_name, state)) FROM mv_funding_by_lga WHERE lga_name IS NOT NULL),
+    'entities_placed', (SELECT count(*) FROM gs_entities WHERE lga_name IS NOT NULL),
+    'unplaced_with_postcode', (SELECT count(*) FROM gs_entities WHERE lga_name IS NULL AND postcode IS NOT NULL),
+    'no_postcode', (SELECT count(*) FROM gs_entities WHERE postcode IS NULL)
+  )
+$$;
+
+GRANT EXECUTE ON FUNCTION place_browse(text, text, text, int, int) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION place_detail(text, text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION place_browse_stats() TO anon, authenticated, service_role;

--- a/thoughts/shared/plans/one-shell-all-data.md
+++ b/thoughts/shared/plans/one-shell-all-data.md
@@ -1,0 +1,37 @@
+# One shell, all data — phase spec
+
+**Date:** 2026-08-17 · **Status:** agreed with Ben (grill session, this doc is the record)
+**Goal:** extend the dashboard shell and the proven Browse pattern until every populated kind of data has a rich, honest surface, and nothing renders off-system.
+
+## Scope
+
+- **Surface existing data, not ingest.** The grantee-ingest queue (Telethon, Stan Perron, RCH, Peter Mac) stays a parallel day-shift lane, Ben-in-loop.
+- **No chrome without a data source.** New capability only where a populated table/MV already backs it.
+- **Pattern:** Browse = list → filters/sorts → drawer → links. One kind per slice. Typed `view-registry.ts`. Transaction kinds (grants/contracts/donations) browse as **entity-shaped rollups** (top recipients / suppliers / donors) with the transaction list inside the drawer — never paginated raw-row UIs.
+
+## Safety rails (apply to every slice)
+
+1. **All rollups computed in SQL.** Browse RPCs are DB-side aggregates with LIMIT+OFFSET and `NULLS LAST`. Required year-or-search predicate where the base table is >500K rows.
+2. **Mandatory money filters baked into the RPC**, not the app: `justice_funding` → `measure_kind='grant' AND is_aggregate IS NOT TRUE AND` the `isRealRecipient()` name-blocklist (port to SQL); `political_donations` → `receipt_type='donation received'`. Reference: `apps/web/src/lib/justice-money.ts`.
+3. **GRANTs in every migration** — SELECT to anon/authenticated/service_role. Missing GRANT = PostgREST silently empty (5 prior instances).
+4. **Explicit error-vs-empty states.** Replace the try/catch-to-empty-list pattern in Browse pages: an RPC failure renders an error card, an empty result renders "0 with why". Verify per slice by breaking the RPC name once.
+5. **Honesty in the UI, not silent capping:** nominee cap (board_count ≤ 10) stays with an in-UI "why some people are excluded" note; person money uses the de-collided `_v2` method; places show `lga_source` provenance.
+
+## Slices
+
+Slice 1 first; 2–7 independent after it, land in any order.
+
+- **S0 — power-dynamics-live: DONE.** Already in main (byte-identical); ledger note was stale.
+- **S1 — Shell sweep + ops fold-in.** Wrap `/ops/*` and `/admin/api-usage` in the dashboard shell (keep URLs, rail "Ops" group). Repair `/ops/health` queries (zeros / score 26). Add a **Views index** page in the rail listing all registry views (pinning stays curated ~4). Sweep every route for softened-shell language drift.
+- **S2 — People browser.** List from `mv_person_influence`/`mv_board_interlocks`, sortable by boards / financial footprint. Drawer: boards held (linking to org drawers), de-collided money footprint, exclusion note.
+- **S3 — Places browser.** LGA primary grain (dedupe `mv_funding_deserts` grain in the RPC), postcode as drawer breakdown. Drawer: funding totals, entity count, SEIFA/remoteness, desert score, "how placed" `lga_source` provenance line.
+- **S4 — Grants browser.** Top recipients rollup of `justice_funding` (filters per rail 2), transactions in drawer.
+- **S5 — Contracts browser.** Top suppliers rollup of `austender_contracts`, transactions in drawer.
+- **S6 — Government buyers browser.** Buyer-side rollup of contracts (serves the buyer-wedge strategy).
+- **S7 — Donations browser.** Top donors rollup of `political_donations` (`receipt_type='donation received'`), transactions in drawer.
+- **S8 — Entities → search/jump-off.** `/dashboard/entities` becomes search + links into the kind browsers (not a browser itself). Error-state hardening anywhere still missing.
+
+## Definition of done
+
+**Per slice:** migration applied with GRANTs · `tsc --noEmit` + `vitest run` green · smoke on 3013 with real data visible · break-the-RPC error-state check · view registered in `view-registry.ts` · PR merged on green (ship-per-slice).
+**Phase exit:** Vercel prod eyeball of the entire shell (localhost-verified is not done).


### PR DESCRIPTION
Closes #245 #246 #247 #248 #249 #250 #251 — slices S2–S8 of "One shell, all data" (`thoughts/shared/plans/one-shell-all-data.md`), batched per Ben's call after S1 (#252).

One commit per slice:
- **People** — de-collided attributed money, nominee/board-cap exclusions stated on screen, drawer joins board interlocks.
- **Places** — LGA grain (both source MVs re-aggregated; deserts DOLLARS deliberately not exposed — non-unique grain summed Brisbane to $2.5tn), postcode breakdown, `lga_source` provenance in plain words.
- **Grants** — recipients rollup with all three mandatory `justice_funding` filters in the RPC SQL; $33.96bn kept, matching the canonical basis; exclusions counted on screen.
- **Contracts + Buyers** — both sides of AusTender via one shared component; mandatory since-year floor (doubles as junk-date hygiene); hourly server cache for the ~3s rollups.
- **Donors** — `receipt_type='donation received'` only, the excluded 'other receipt' billions stated on screen; FY floor on the 2.55M-row base.
- **Entities** — search + jump-off, no longer a fake browser.

All seven RPC-backed migrations applied with GRANTs (under Ben's blanket authorization for read-only browse RPCs). Break-the-RPC error-state check performed (error card renders; detail routes 404 on unknown keys). Rail Browse group now lists all seven kinds.

Gates: tsc clean · 726 tests pass · every page + drawer API smoke-tested on 3013 with real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)