### PR TITLE
Code-review follow-ups: shared browse scaffolding, trigram entity search, complete Views index

### DIFF
--- a/apps/web/src/app/dashboard/browse/ContractSideBrowser.tsx
+++ b/apps/web/src/app/dashboard/browse/ContractSideBrowser.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
+import { money, L, makeQs, useDrawer, Drawer } from './browse-ui';
 
 /**
  * Shared browser for the two sides of AusTender: suppliers (who wins contracts) and buyers
@@ -39,27 +39,12 @@ interface SideDetail {
   contracts: { title: string | null; counterparty: string | null; value: number | null; start: string | null; end: string | null }[];
 }
 
-function money(n: number | null | undefined): string {
-  if (!n || n <= 0) return '—';
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
-  return `$${Math.round(n / 1e3)}k`;
-}
-
 const SORTS: [string, string][] = [
   ['total', 'Total $'],
   ['contracts', 'Contracts'],
   ['name', 'A–Z'],
 ];
 const DEFAULT_YEARS = ['2015', '2020', '2023'];
-
-function L({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
-      {children}
-    </div>
-  );
-}
 
 export default function ContractSideBrowser({
   rows,
@@ -78,29 +63,11 @@ export default function ContractSideBrowser({
   statsLine: string;
   caveat: string;
 }) {
-  const [openKey, setOpenKey] = useState<string | null>(null);
-  const [detail, setDetail] = useState<SideDetail | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-
-  function open(key: string) {
-    setOpenKey(key);
-    setDetail(null);
-    setErr(null);
-    fetch(`${cfg.detailApi}?key=${encodeURIComponent(key)}&from=${encodeURIComponent(fromYear || '2020')}`)
-      .then(async (r) => {
-        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
-        return r.json() as Promise<SideDetail>;
-      })
-      .then(setDetail)
-      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
-  }
-
-  const qs = (over: Record<string, string>) => {
-    const p = new URLSearchParams();
-    for (const [k, v] of Object.entries({ q, from: fromYear, sort, ...over })) if (v) p.set(k, v);
-    const s = p.toString();
-    return `${cfg.basePath}${s ? `?${s}` : ''}`;
-  };
+  const drawer = useDrawer<SideDetail>();
+  const detail = drawer.detail;
+  const open = (key: string) =>
+    drawer.open(key, `${cfg.detailApi}?key=${encodeURIComponent(key)}&from=${encodeURIComponent(fromYear || '2020')}`);
+  const qs = makeQs(cfg.basePath, { q, from: fromYear, sort });
 
   return (
     <>
@@ -155,13 +122,8 @@ export default function ContractSideBrowser({
         {caveat}
       </p>
 
-      {openKey ? (
-        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
-          <div className="flex items-start justify-between gap-3">
-            <h2 className="font-display text-[17px] font-extrabold">{detail?.name ?? 'loading…'}</h2>
-            <button onClick={() => setOpenKey(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
-          </div>
-          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+      {drawer.openKey ? (
+        <Drawer title={detail?.name ?? 'loading…'} err={drawer.err} onClose={drawer.close}>
           {detail ? (
             <>
               <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
@@ -206,7 +168,7 @@ export default function ContractSideBrowser({
               ) : null}
             </>
           ) : null}
-        </aside>
+        </Drawer>
       ) : null}
     </>
   );

--- a/apps/web/src/app/dashboard/browse/browse-ui.tsx
+++ b/apps/web/src/app/dashboard/browse/browse-ui.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Shared scaffolding for every kind browser: the money formatter, the drawer label, the
+ * drawer shell, and the drawer-fetch state machine. Extracted after the code-review pass
+ * found all four browsers redefining these verbatim — columns stay per-kind, chrome is shared.
+ */
+
+export function money(n: number | null | undefined): string {
+  if (!n || n <= 0) return '—';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
+  return `$${Math.round(n / 1e3)}k`;
+}
+
+export function L({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
+      {children}
+    </div>
+  );
+}
+
+/** Shareable-URL builder: current filter state, overridden per chip. */
+export function makeQs(basePath: string, params: Record<string, string>) {
+  return (over: Record<string, string>) => {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries({ ...params, ...over })) if (v) p.set(k, v);
+    const s = p.toString();
+    return `${basePath}${s ? `?${s}` : ''}`;
+  };
+}
+
+/** Drawer state: open(key, url) fetches url and lands it in detail; errors land in err. */
+export function useDrawer<T>() {
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<T | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  function open(key: string, url: string) {
+    setOpenKey(key);
+    setDetail(null);
+    setErr(null);
+    fetch(url)
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
+        return r.json() as Promise<T>;
+      })
+      .then(setDetail)
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }
+
+  return { openKey, detail, err, open, close: () => setOpenKey(null) };
+}
+
+export function Drawer({
+  title,
+  err,
+  onClose,
+  children,
+}: {
+  title: string;
+  err: string | null;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
+      <div className="flex items-start justify-between gap-3">
+        <h2 className="font-display text-[17px] font-extrabold">{title}</h2>
+        <button onClick={onClose} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
+      </div>
+      {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+      {children}
+    </aside>
+  );
+}

--- a/apps/web/src/app/dashboard/browse/grants/GrantBrowser.tsx
+++ b/apps/web/src/app/dashboard/browse/grants/GrantBrowser.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
+import { money, L, makeQs, useDrawer, Drawer } from '../browse-ui';
 
 /**
  * Grants browser: recipients of justice_funding as entity-shaped rollups, the individual grants
@@ -28,13 +28,6 @@ interface RecipientDetail {
   grants: { program: string | null; year: string | null; amount: number | null; state: string | null; topics: string[] | null }[];
 }
 
-function money(n: number | null | undefined): string {
-  if (!n || n <= 0) return '—';
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
-  return `$${Math.round(n / 1e3)}k`;
-}
-
 const SORTS: [string, string][] = [
   ['total', 'Total $'],
   ['grants', 'Grant count'],
@@ -42,14 +35,6 @@ const SORTS: [string, string][] = [
 ];
 const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT', 'FED'];
 const TOPICS = ['child-protection', 'family-services', 'youth-justice', 'indigenous', 'community-led', 'diversion'];
-
-function L({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
-      {children}
-    </div>
-  );
-}
 
 export default function GrantBrowser({
   rows,
@@ -68,29 +53,10 @@ export default function GrantBrowser({
   statsLine: string;
   caveat: string;
 }) {
-  const [openKey, setOpenKey] = useState<string | null>(null);
-  const [detail, setDetail] = useState<RecipientDetail | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-
-  function open(key: string) {
-    setOpenKey(key);
-    setDetail(null);
-    setErr(null);
-    fetch(`/api/browse/grant-recipient?key=${encodeURIComponent(key)}`)
-      .then(async (r) => {
-        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
-        return r.json() as Promise<RecipientDetail>;
-      })
-      .then(setDetail)
-      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
-  }
-
-  const qs = (over: Record<string, string>) => {
-    const p = new URLSearchParams();
-    for (const [k, v] of Object.entries({ q, state, topic, sort, ...over })) if (v) p.set(k, v);
-    const s = p.toString();
-    return `/dashboard/browse/grants${s ? `?${s}` : ''}`;
-  };
+  const drawer = useDrawer<RecipientDetail>();
+  const detail = drawer.detail;
+  const open = (key: string) => drawer.open(key, `/api/browse/grant-recipient?key=${encodeURIComponent(key)}`);
+  const qs = makeQs('/dashboard/browse/grants', { q, state, topic, sort });
 
   return (
     <>
@@ -155,13 +121,8 @@ export default function GrantBrowser({
         {caveat}
       </p>
 
-      {openKey ? (
-        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
-          <div className="flex items-start justify-between gap-3">
-            <h2 className="font-display text-[17px] font-extrabold">{detail?.recipient_name ?? 'loading…'}</h2>
-            <button onClick={() => setOpenKey(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
-          </div>
-          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+      {drawer.openKey ? (
+        <Drawer title={detail?.recipient_name ?? 'loading…'} err={drawer.err} onClose={drawer.close}>
           {detail ? (
             <>
               <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
@@ -206,7 +167,7 @@ export default function GrantBrowser({
               ) : null}
             </>
           ) : null}
-        </aside>
+        </Drawer>
       ) : null}
     </>
   );

--- a/apps/web/src/app/dashboard/people/PersonBrowser.tsx
+++ b/apps/web/src/app/dashboard/people/PersonBrowser.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
+import { money, L, makeQs, useDrawer, Drawer } from '../browse/browse-ui';
 
 /**
  * People browser: board interlocks + de-collided money footprint. The list excludes nominee
@@ -36,13 +36,6 @@ interface PersonDetail {
   } | null;
 }
 
-function money(n: number | null | undefined): string {
-  if (!n || n <= 0) return '—';
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
-  return `$${Math.round(n / 1e3)}k`;
-}
-
 const SORTS: [string, string][] = [
   ['influence', 'Influence'],
   ['boards', 'Boards'],
@@ -51,14 +44,6 @@ const SORTS: [string, string][] = [
   ['donations', 'Donations $'],
   ['name', 'A–Z'],
 ];
-
-function L({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
-      {children}
-    </div>
-  );
-}
 
 export default function PersonBrowser({
   rows,
@@ -73,29 +58,10 @@ export default function PersonBrowser({
   statsLine: string;
   exclusionNote: string;
 }) {
-  const [openNorm, setOpenNorm] = useState<string | null>(null);
-  const [detail, setDetail] = useState<PersonDetail | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-
-  function open(norm: string) {
-    setOpenNorm(norm);
-    setDetail(null);
-    setErr(null);
-    fetch(`/api/browse/person?norm=${encodeURIComponent(norm)}`)
-      .then(async (r) => {
-        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
-        return r.json() as Promise<PersonDetail>;
-      })
-      .then(setDetail)
-      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
-  }
-
-  const qs = (over: Record<string, string>) => {
-    const p = new URLSearchParams();
-    for (const [k, v] of Object.entries({ q, sort, ...over })) if (v) p.set(k, v);
-    const s = p.toString();
-    return `/dashboard/people${s ? `?${s}` : ''}`;
-  };
+  const drawer = useDrawer<PersonDetail>();
+  const detail = drawer.detail;
+  const open = (norm: string) => drawer.open(norm, `/api/browse/person?norm=${encodeURIComponent(norm)}`);
+  const qs = makeQs('/dashboard/people', { q, sort });
 
   return (
     <>
@@ -152,13 +118,8 @@ export default function PersonBrowser({
         {exclusionNote}
       </p>
 
-      {openNorm ? (
-        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
-          <div className="flex items-start justify-between gap-3">
-            <h2 className="font-display text-[17px] font-extrabold">{detail?.person_name ?? 'loading…'}</h2>
-            <button onClick={() => setOpenNorm(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
-          </div>
-          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+      {drawer.openKey ? (
+        <Drawer title={drawer.detail?.person_name ?? 'loading…'} err={drawer.err} onClose={drawer.close}>
           {detail ? (
             <>
               <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
@@ -199,7 +160,7 @@ export default function PersonBrowser({
               ) : null}
             </>
           ) : null}
-        </aside>
+        </Drawer>
       ) : null}
     </>
   );

--- a/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
+++ b/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
+import { money, L, makeQs, useDrawer, Drawer } from '../browse/browse-ui';
 
 /**
  * Places browser at LGA grain. The drawer's provenance block shows HOW each entity was placed
@@ -35,13 +35,6 @@ interface PlaceDetail {
   placement: Record<string, number>;
 }
 
-function money(n: number | null | undefined): string {
-  if (!n || n <= 0) return '—';
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
-  return `$${Math.round(n / 1e3)}k`;
-}
-
 const SORTS: [string, string][] = [
   ['funding', 'Funding $'],
   ['desert', 'Desert score'],
@@ -66,14 +59,6 @@ const PLACEMENT_LABEL: Record<string, string> = {
   'acnc_street_line+sal_ratio_dominant': 'charity register street address',
 };
 
-function L({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mt-4 mb-1 font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>
-      {children}
-    </div>
-  );
-}
-
 export default function PlaceBrowser({
   rows,
   q,
@@ -89,29 +74,11 @@ export default function PlaceBrowser({
   statsLine: string;
   caveat: string;
 }) {
-  const [openKey, setOpenKey] = useState<string | null>(null);
-  const [detail, setDetail] = useState<PlaceDetail | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-
-  function open(row: PlaceRow) {
-    setOpenKey(row.key);
-    setDetail(null);
-    setErr(null);
-    fetch(`/api/browse/place?lga=${encodeURIComponent(row.lga)}&state=${encodeURIComponent(row.state)}`)
-      .then(async (r) => {
-        if (!r.ok) throw new Error((await r.json())?.error ?? `HTTP ${r.status}`);
-        return r.json() as Promise<PlaceDetail>;
-      })
-      .then(setDetail)
-      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
-  }
-
-  const qs = (over: Record<string, string>) => {
-    const p = new URLSearchParams();
-    for (const [k, v] of Object.entries({ q, state, sort, ...over })) if (v) p.set(k, v);
-    const s = p.toString();
-    return `/dashboard/places${s ? `?${s}` : ''}`;
-  };
+  const drawer = useDrawer<PlaceDetail>();
+  const detail = drawer.detail;
+  const open = (row: PlaceRow) =>
+    drawer.open(row.key, `/api/browse/place?lga=${encodeURIComponent(row.lga)}&state=${encodeURIComponent(row.state)}`);
+  const qs = makeQs('/dashboard/places', { q, state, sort });
 
   return (
     <>
@@ -172,13 +139,8 @@ export default function PlaceBrowser({
         {caveat}
       </p>
 
-      {openKey ? (
-        <aside className="fixed inset-y-0 right-0 z-40 w-full max-w-[460px] overflow-y-auto border-l bg-white p-5" style={{ borderColor: 'var(--shell-line)', boxShadow: '-8px 0 24px rgba(0,0,0,0.08)' }}>
-          <div className="flex items-start justify-between gap-3">
-            <h2 className="font-display text-[17px] font-extrabold">{detail ? `${detail.lga_name} (${detail.state})` : 'loading…'}</h2>
-            <button onClick={() => setOpenKey(null)} aria-label="close" className="shrink-0 px-2 py-0.5 font-mono text-[11px] font-black shell-control">✕</button>
-          </div>
-          {err ? <p className="mt-3 text-[13px]" style={{ color: '#D02020' }}>Could not load: {err}</p> : null}
+      {drawer.openKey ? (
+        <Drawer title={detail ? `${detail.lga_name} (${detail.state})` : 'loading…'} err={drawer.err} onClose={drawer.close}>
           {detail ? (
             <>
               <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
@@ -245,7 +207,7 @@ export default function PlaceBrowser({
               ) : null}
             </>
           ) : null}
-        </aside>
+        </Drawer>
       ) : null}
     </>
   );

--- a/apps/web/src/app/dashboard/views/page.tsx
+++ b/apps/web/src/app/dashboard/views/page.tsx
@@ -13,15 +13,30 @@ const VIEW_DOT: Record<string, string> = {
 };
 
 /**
- * The complete views index. The rail pins a curated few; this page lists every registered view,
- * so nothing in the registry is reachable only by knowing its URL.
+ * The complete index of ways to look at the graph: every curated view in the registry, then
+ * every kind browser. Nothing on either list is reachable only by knowing its URL. The registry
+ * stays scoped to question-shaped views; browsers are nouns, listed separately (ruling from the
+ * 2026-08-17 code-review pass).
  */
+const KIND_BROWSERS: { href: string; label: string; blurb: string }[] = [
+  { href: '/dashboard/browse/foundations', label: 'Foundations', blurb: 'who gives, and to whom' },
+  { href: '/dashboard/browse/social-enterprises', label: 'Social enterprises', blurb: 'the register and what we know' },
+  { href: '/dashboard/browse/charities', label: 'Charities', blurb: 'ACNC register with six years of returns' },
+  { href: '/dashboard/browse/grants', label: 'Grant recipients', blurb: 'who receives justice-system grants' },
+  { href: '/dashboard/browse/contracts', label: 'Contract suppliers', blurb: 'who wins Commonwealth contracts' },
+  { href: '/dashboard/browse/buyers', label: 'Government buyers', blurb: 'which agencies let them' },
+  { href: '/dashboard/browse/donations', label: 'Political donors', blurb: 'declared donations only' },
+  { href: '/dashboard/people', label: 'People', blurb: 'boards and the money past them' },
+  { href: '/dashboard/places', label: 'Places', blurb: 'council areas: money vs disadvantage' },
+];
+
 export default function ViewsIndexPage() {
   return (
     <div className="mx-auto max-w-[1100px] px-6 py-6">
       <h1 className="font-display text-[22px] font-extrabold">Views</h1>
       <p className="mt-1 text-[13.5px]" style={{ color: 'var(--shell-muted)' }}>
-        Every saved view on the graph. Pinned views also sit in the rail; the rest live only here.
+        Curated views answer one question each; kind browsers below let you walk a whole kind of
+        thing. Pinned views also sit in the rail.
       </p>
       <div className="mt-5 grid gap-4 sm:grid-cols-2">
         {VIEW_REGISTRY.map((v) => (
@@ -54,6 +69,21 @@ export default function ViewsIndexPage() {
                 {v.caveat}
               </p>
             )}
+          </Link>
+        ))}
+      </div>
+
+      <h2 className="mt-8 font-display text-[16px] font-extrabold">Kind browsers</h2>
+      <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {KIND_BROWSERS.map((k) => (
+          <Link
+            key={k.href}
+            href={k.href}
+            className="block bg-white p-4"
+            style={{ borderRadius: 'var(--shell-r)', border: '1px solid var(--shell-line)' }}
+          >
+            <div className="font-display text-[14px] font-bold">{k.label}</div>
+            <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>{k.blurb}</p>
           </Link>
         ))}
       </div>

--- a/migrations/2026-08-17-gs-entities-name-trgm.sql
+++ b/migrations/2026-08-17-gs-entities-name-trgm.sql
@@ -1,0 +1,9 @@
+-- Trigram index for the entities search (code-review follow-up, phase "One shell, all data").
+-- Apply: source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-17-gs-entities-name-trgm.sql
+--
+-- /dashboard/entities searches gs_entities (609K rows) with a leading-wildcard ILIKE, which
+-- forces a sequential scan per request without this. GIN trigram serves %q% directly.
+-- CONCURRENTLY: not inside a transaction — psql -f runs it standalone.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gs_entities_canonical_name_trgm
+  ON gs_entities USING gin (canonical_name extensions.gin_trgm_ops);


### PR DESCRIPTION
Follow-ups from the two-axis review of the "One shell, all data" phase (#252/#253):

- **Duplicated scaffolding (Standards, worst finding):** new `browse-ui.tsx` exports `money`, `L`, `makeQs`, `useDrawer`, `Drawer`; PersonBrowser, PlaceBrowser, GrantBrowser and ContractSideBrowser now share them instead of redefining each verbatim. Net −196 lines of duplication, behaviour unchanged.
- **Entity search scan:** GIN trigram index on `gs_entities.canonical_name` (migration applied with CONCURRENTLY) — the `%q%` ILIKE is now index-served.
- **Views index (Spec finding):** registry stays curated to question-shaped views (decision recorded in the page docstring); the Views page adds a "Kind browsers" section listing all nine, restoring its "nothing reachable only by URL" promise.

Gates: tsc clean · 726 tests pass · all seven refactored surfaces + a drawer API re-smoked on 3013 (all 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)