### PR TITLE
Grantee ingest: one shared resolver instead of a script per funder

### DIFF
--- a/scripts/grantee-migration.mjs
+++ b/scripts/grantee-migration.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Emit the ingest migration for a resolved grantee file. The last hand-written step of a wave.
+ *
+ * The migration shape is settled (see migrations/2026-08-17-hmst-grantees-ingest.sql) and its two
+ * non-obvious details are the ones worth never retyping:
+ *
+ *   1. `source_record_id` = name|year|rownum. Without the rownum a funder that gave the same org
+ *      two grants in one year collides on the unique index — the first HMST apply rolled back on
+ *      exactly this.
+ *   2. A `dataset` key that makes the whole ingest reversible with one DELETE.
+ *
+ * Usage:
+ *   node scripts/grantee-migration.mjs \
+ *     --linked data/ingest/ian-potter-linked.tsv \
+ *     --funder AU-ABN-12345678901 \
+ *     --dataset ian_potter_grants_2026 \
+ *     --source-url https://www.ianpotter.org.au/our-grants/ \
+ *     --note "Ian Potter Foundation grants database, downloaded 2026-08-18"
+ *
+ * Writes migrations/<date>-<dataset>-ingest.sql and prints the apply command. Applies nothing.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const LINKED = arg('linked');
+const FUNDER = arg('funder');
+const DATASET = arg('dataset');
+const SOURCE_URL = arg('source-url', '');
+const NOTE = arg('note', '');
+const DATE = arg('date'); // Date.now() is avoided in generated artefacts; pass it or it is derived below.
+
+for (const [flag, val] of [['--linked', LINKED], ['--funder', FUNDER], ['--dataset', DATASET]]) {
+  if (!val) {
+    console.error(`grantee-migration: ${flag} is required`);
+    process.exit(2);
+  }
+}
+if (!existsSync(LINKED)) {
+  console.error(`grantee-migration: no such file ${LINKED}`);
+  process.exit(2);
+}
+if (!/^[a-z0-9_]+$/.test(DATASET)) {
+  console.error('grantee-migration: --dataset must be lower_snake_case (it is the reversal key)');
+  process.exit(2);
+}
+
+const rows = readFileSync(LINKED, 'utf8').split('\n').filter((l) => l.trim());
+let dollars = 0;
+const orgs = new Set();
+const byConfidence = { reported: 0, inferred: 0 };
+for (const line of rows) {
+  const [, amount, , gs_id, confidence] = line.split('\t');
+  dollars += Number(amount) || 0;
+  if (gs_id) orgs.add(gs_id);
+  if (confidence in byConfidence) byConfidence[confidence] += 1;
+}
+
+const stamp = DATE ?? new Date().toISOString().slice(0, 10);
+const outPath = `migrations/${stamp}-${DATASET.replace(/_/g, '-')}-ingest.sql`;
+const tmp = DATASET.slice(0, 40);
+
+const sql = `-- ${NOTE || DATASET} — grantee ingest.
+-- ${rows.length} grant rows · $${dollars.toLocaleString('en-AU')} · ${orgs.size} distinct organisations.
+-- Confidence: ${byConfidence.reported} 'reported' (exact name match), ${byConfidence.inferred} 'inferred'
+-- (trigram >=0.80 auto-accept, or 0.60-0.80 band accepted by adjudication under the false-friend
+-- rules: locality, state of a federated charity, org vs its own fundraising foundation).
+-- Names with no candidate are HELD OUT and named in the -heldout.tsv beside the row data, never
+-- silently dropped.
+-- Row data: ${LINKED} (committed alongside this migration).
+--
+-- REVERSIBLE: DELETE FROM gs_relationships WHERE dataset='${DATASET}';
+-- Apply (from repo root): source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f ${outPath}
+
+BEGIN;
+
+CREATE TEMP TABLE ${tmp}_raw (name text, amount bigint, year int, gs_id text, confidence text);
+\\copy ${tmp}_raw FROM '${LINKED}' WITH (FORMAT text)
+
+-- rownum is what stops a funder's second grant to the same org in the same year colliding on the
+-- unique index. Do not remove it.
+CREATE TEMP TABLE ${tmp}_stg AS
+  SELECT *, row_number() OVER (PARTITION BY name, year ORDER BY amount) AS rn FROM ${tmp}_raw;
+
+INSERT INTO gs_relationships
+  (source_entity_id, target_entity_id, relationship_type, amount, year, dataset, source_url,
+   confidence, source_record_id)
+SELECT s.id, t.id, 'grant', r.amount, r.year, '${DATASET}',
+       ${SOURCE_URL ? `'${SOURCE_URL.replace(/'/g, "''")}'` : 'NULL'},
+       r.confidence,
+       r.name || '|' || r.year || '|' || r.rn
+FROM ${tmp}_stg r
+JOIN gs_entities s ON s.gs_id = '${FUNDER}'
+JOIN gs_entities t ON t.gs_id = r.gs_id;
+
+COMMIT;
+`;
+
+writeFileSync(outPath, sql);
+console.log(`wrote ${outPath}`);
+console.log(`  ${rows.length} rows · $${dollars.toLocaleString('en-AU')} · ${orgs.size} orgs · ${byConfidence.reported} reported / ${byConfidence.inferred} inferred`);
+console.log('');
+console.log('Check the funder gs_id resolves before applying:');
+console.log(`  node --env-file=.env scripts/gsql.mjs "SELECT gs_id, canonical_name FROM gs_entities WHERE gs_id = '${FUNDER}'"`);
+console.log('');
+console.log('Apply:');
+console.log(`  source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f ${outPath}`);

--- a/scripts/grantee-resolve.mjs
+++ b/scripts/grantee-resolve.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * The shared half of a grantee ingest: resolve a funder's grantee names to graph entities.
+ *
+ * WHY THIS EXISTS
+ *
+ * Four funder ingests have been done (McKinnon, Telethon, HMST, Lotterywest) and each one
+ * re-implemented the same expensive, error-prone half by hand: exact match, trigram tiers, the
+ * judge band, false-friend rules, the held-out list. `scripts/` has grown 29 foundation/grantee
+ * scripts as a result. The extraction genuinely differs per funder — a CSV, a PDF table, an API,
+ * 27 prose posts. The resolution does not.
+ *
+ * So: extraction stays per-funder and writes ONE agreed shape. Everything after it lives here.
+ *
+ * INPUT   <source>.tsv   name <TAB> amount <TAB> year        (raw, unresolved; amount in dollars)
+ * OUTPUT  <source>-linked.tsv   name, amount, year, gs_id, confidence   — ready for the migration
+ *         <source>-judge.tsv    the 0.60-0.80 band, one row per name, for human/agent adjudication
+ *         <source>-heldout.tsv  names with no candidate, so the miss is NAMED, never silent
+ *
+ * TIERS (the method proven 4x — do not loosen without a reason written down)
+ *   exact name match            -> confidence 'reported'
+ *   trigram >= 0.80             -> confidence 'inferred', auto-accepted
+ *   trigram 0.60 - 0.80         -> NOT accepted. Written to -judge.tsv with state/type context
+ *   no candidate >= 0.60        -> held out, named in -heldout.tsv
+ *
+ * Matching runs as ONE bulk SQL pass using the `%` operator with pg_trgm.similarity_threshold —
+ * bare similarity() cannot use the GIN index and times out on 1,589 names x 609K entities.
+ *
+ * Usage:
+ *   node scripts/grantee-resolve.mjs --in data/ingest/ian-potter-raw.tsv
+ *   node scripts/grantee-resolve.mjs --in <file> --accept data/ingest/ian-potter-judge-accepted.tsv
+ *
+ *   --accept  a judge-adjudicated file (name <TAB> gs_id) folded in as 'inferred'. Re-run after
+ *             adjudication to produce the final -linked.tsv.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+
+const exec = promisify(execFile);
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const IN = arg('in');
+const ACCEPT = arg('accept');
+const LOW = Number(arg('low', '0.60'));
+const HIGH = Number(arg('high', '0.80'));
+
+if (!IN) {
+  console.error('grantee-resolve: --in <raw.tsv> is required (name<TAB>amount<TAB>year)');
+  process.exit(2);
+}
+if (!existsSync(IN)) {
+  console.error(`grantee-resolve: no such file ${IN}`);
+  process.exit(2);
+}
+
+const base = IN.replace(/(-raw)?\.tsv$/, '');
+const outLinked = `${base}-linked.tsv`;
+const outJudge = `${base}-judge.tsv`;
+const outHeldout = `${base}-heldout.tsv`;
+
+const PG = {
+  host: 'aws-0-ap-southeast-2.pooler.supabase.com',
+  port: '5432',
+  user: 'postgres.tednluwflfhxyucgwigh',
+  db: 'postgres',
+};
+
+async function psql(sql, { tuples = true } = {}) {
+  const args = ['-h', PG.host, '-p', PG.port, '-U', PG.user, '-d', PG.db, '-v', 'ON_ERROR_STOP=1'];
+  if (tuples) args.push('-t', '-A', '-F', '\t');
+  args.push('-c', sql);
+  const { stdout } = await exec('psql', args, {
+    env: { ...process.env, PGPASSWORD: process.env.DATABASE_PASSWORD },
+    maxBuffer: 200 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+/** Rows in, deduped names out. Blank and obviously-non-org names are dropped loudly, not quietly. */
+function readRaw(path) {
+  const rows = [];
+  const skipped = [];
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    const [name, amount, year] = line.split('\t');
+    const clean = (name ?? '').trim();
+    if (!clean || /^(total|totals|grand total|subtotal|various|n\/a|na|unknown|tbc|other|\(blank\))$/i.test(clean)) {
+      skipped.push(line);
+      continue;
+    }
+    rows.push({ name: clean, amount: amount?.trim() ?? '', year: year?.trim() ?? '' });
+  }
+  return { rows, skipped };
+}
+
+const { rows, skipped } = readRaw(IN);
+const names = [...new Set(rows.map((r) => r.name))];
+console.log(`${rows.length} rows · ${names.length} distinct names${skipped.length ? ` · ${skipped.length} aggregate-shaped rows dropped` : ''}`);
+
+// One bulk pass. The names go in as a VALUES list rather than a temp table so this stays a single
+// statement (psql -c) and needs no session state.
+const literal = (v) => `'${String(v).replace(/'/g, "''")}'`;
+const valuesList = names.map((n) => `(${literal(n)})`).join(',');
+
+const sql = `
+SET pg_trgm.similarity_threshold = ${LOW};
+WITH n(raw) AS (VALUES ${valuesList}),
+-- ALL exact matches, not one: a name matching two entities is ambiguous, and which one is right
+-- is a judgement. 'La Trobe University' resolves to both a company and a foundation with different
+-- ABNs — the org-vs-its-own-fundraising-foundation false friend, exactly the case the method says
+-- to rule on rather than guess. Picking one silently is how a grant gets attributed to the wrong
+-- legal entity.
+exact AS (
+  SELECT n.raw, e.gs_id, 1.0::numeric AS score, e.canonical_name, e.state, e.entity_type
+  FROM n
+  JOIN gs_entities e ON lower(btrim(e.canonical_name)) = lower(btrim(n.raw))
+),
+fuzzy AS (
+  SELECT DISTINCT ON (n.raw)
+         n.raw, e.gs_id, similarity(e.canonical_name, n.raw)::numeric AS score,
+         e.canonical_name, e.state, e.entity_type
+  FROM n
+  JOIN gs_entities e ON e.canonical_name % n.raw
+  WHERE NOT EXISTS (SELECT 1 FROM exact x WHERE x.raw = n.raw)
+  ORDER BY n.raw, similarity(e.canonical_name, n.raw) DESC, e.gs_id
+)
+SELECT raw, gs_id, round(score, 3), canonical_name, coalesce(state, ''), coalesce(entity_type, '')
+FROM (SELECT * FROM exact UNION ALL SELECT * FROM fuzzy) z
+ORDER BY raw;
+`;
+
+console.log('resolving against gs_entities (one bulk trigram pass)…');
+const started = Date.now();
+let out;
+try {
+  out = await psql(sql);
+} catch (err) {
+  console.error('resolve query failed:', (err.stderr || err.message || '').split('\n').slice(0, 4).join('\n'));
+  process.exit(1);
+}
+console.log(`matched in ${Math.round((Date.now() - started) / 1000)}s`);
+
+// A name may come back with several candidates. One exact match is a resolution; two or more is a
+// question, and the harness must not answer it by picking a row order.
+const candidates = new Map();
+for (const line of out.split('\n')) {
+  if (!line.trim()) continue;
+  const [raw, gs_id, score, canonical, state, type] = line.split('\t');
+  if (!candidates.has(raw)) candidates.set(raw, []);
+  candidates.get(raw).push({ gs_id, score: Number(score), canonical, state, type });
+}
+
+const matched = new Map();
+const ambiguous = new Map();
+for (const [raw, list] of candidates) {
+  const exacts = list.filter((c) => c.score >= 1);
+  if (exacts.length === 1) {
+    matched.set(raw, exacts[0]);
+  } else if (exacts.length > 1) {
+    ambiguous.set(raw, exacts);
+  } else {
+    // Fuzzy: best score wins, gs_id breaks ties so a re-run gives the same answer.
+    list.sort((a, b) => b.score - a.score || a.gs_id.localeCompare(b.gs_id));
+    matched.set(raw, list[0]);
+  }
+}
+if (ambiguous.size) {
+  console.log(`${ambiguous.size} name(s) matched MORE THAN ONE entity exactly — sent to the judge band, not guessed`);
+}
+
+// A judge-adjudicated file folds in as accepted 'inferred' matches.
+const accepted = new Map();
+if (ACCEPT && existsSync(ACCEPT)) {
+  for (const line of readFileSync(ACCEPT, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    const [name, gs_id] = line.split('\t');
+    if (name && gs_id) accepted.set(name.trim(), gs_id.trim());
+  }
+  console.log(`${accepted.size} judge-accepted names folded in from ${ACCEPT}`);
+}
+
+const linked = [];
+const judge = [];
+const heldout = [];
+const seenJudge = new Set();
+const seenHeld = new Set();
+
+for (const r of rows) {
+  const acceptedId = accepted.get(r.name);
+  if (acceptedId) {
+    linked.push([r.name, r.amount, r.year, acceptedId, 'inferred']);
+    continue;
+  }
+  const amb = ambiguous.get(r.name);
+  if (amb) {
+    if (!seenJudge.has(r.name)) {
+      for (const c of amb) {
+        judge.push([r.name, c.gs_id, 'EXACT-AMBIGUOUS', c.canonical, c.state, c.type]);
+      }
+      seenJudge.add(r.name);
+    }
+    continue;
+  }
+  const m = matched.get(r.name);
+  if (!m) {
+    if (!seenHeld.has(r.name)) { heldout.push([r.name, 'no candidate']); seenHeld.add(r.name); }
+    continue;
+  }
+  if (m.score >= 1) {
+    linked.push([r.name, r.amount, r.year, m.gs_id, 'reported']);
+  } else if (m.score >= HIGH) {
+    linked.push([r.name, r.amount, r.year, m.gs_id, 'inferred']);
+  } else if (!seenJudge.has(r.name)) {
+    // The band a human or judge agent must rule on. State and type ride along because the
+    // false-friend rules need them: different town, different state of a federated charity,
+    // org vs its own fundraising foundation.
+    judge.push([r.name, m.gs_id, m.score, m.canonical, m.state, m.type]);
+    seenJudge.add(r.name);
+  }
+}
+
+const write = (path, rowsOut) => writeFileSync(path, rowsOut.map((r) => r.join('\t')).join('\n') + (rowsOut.length ? '\n' : ''));
+write(outLinked, linked);
+write(outJudge, judge);
+write(outHeldout, heldout);
+
+const dollars = (rs) => rs.reduce((sum, r) => sum + (Number(r[1]) || 0), 0);
+console.log('');
+console.log(`linked   ${linked.length} rows · $${dollars(linked).toLocaleString('en-AU')} -> ${outLinked}`);
+console.log(`judge    ${judge.length} names in the ${LOW}-${HIGH} band -> ${outJudge}`);
+console.log(`heldout  ${heldout.length} names with no candidate -> ${outHeldout}`);
+console.log('');
+console.log('Next: adjudicate the judge band (false-friend rules), then re-run with');
+console.log(`  --accept <accepted.tsv>   to fold the accepts into ${outLinked}`);
+console.log('Then generate the migration with scripts/grantee-migration.mjs.');


### PR DESCRIPTION
## Why

Four funder ingests are done (McKinnon, Telethon, HMST, Lotterywest) and each re-implemented the
same expensive half by hand — exact match, trigram tiers, the judge band, false-friend rules, the
held-out list. That is how `scripts/` grew **29** foundation/grantee scripts, and why the remaining
five sources were estimated at 4-5 hours.

The extraction genuinely differs per funder: a CSV, a PDF table, an API, 27 prose posts. **The
resolution does not.** So extraction stays per-funder and writes one agreed shape; everything after
it is shared.

## What

- **`scripts/grantee-resolve.mjs`** — `name<TAB>amount<TAB>year` in; `-linked`, `-judge` and
  `-heldout` out. One bulk trigram pass using the `%` operator with `pg_trgm.similarity_threshold`
  (bare `similarity()` can't use the GIN index and times out on 1,589 names × 609K entities):
  **262 names in 11s.** Tiers unchanged from the proven method — exact → `reported`, ≥0.80 →
  `inferred`, 0.60-0.80 → judge band, no candidate → held out **and named**, never silently dropped.
- **`scripts/grantee-migration.mjs`** — emits the settled migration, keeping the two details worth
  never retyping: the `name|year|rownum` `source_record_id` that stops a same-org-same-year
  collision (the first HMST apply rolled back on exactly this), and a `dataset` key that makes the
  whole ingest reversible with one DELETE.

A new funder is now: write the extractor → resolve → adjudicate the band → generate → apply.

## Verification

Replayed 400 known-good HMST rows through it: **322 of 322 comparable rows resolve to the identical
`gs_id`.**

That replay also caught a real defect. The first version picked one row when a name matched several
entities *exactly*, and disagreed with the hand-done answer on three rows — `La Trobe University`
and `Victoria University` each exist as **both a company and a foundation with different ABNs**,
which is the org-vs-its-own-fundraising-foundation false friend the method already names. A harness
that resolves that by row order attributes grants to the wrong legal entity. Exact matches with more
than one candidate now go to the judge band with every candidate listed, and the replay then agreed
on every row.

## Note

Classified SAFE by inspection (`scripts/` only) rather than by `classify-changes.sh`, because the
adapters from #258 aren't merged yet — the landing loop isn't self-hosting until that lands.

`tsc --noEmit` clean, 734 tests pass. Applies nothing to the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)