### PR TITLE
Stop building the app for commits that cannot change it

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Vercel "Ignored Build Step". Decides whether a commit is worth a build at all.
+#
+#   exit 0 -> SKIP the build   (Vercel's convention, and the opposite of intuition)
+#   exit 1 -> BUILD
+#
+# WHY
+#
+# Every push to every branch was building the whole Next.js app at 4GB — 20 deployments in one
+# 8.9-hour session (13 preview + 7 production), a large share of them for commits that changed no
+# application code at all: migrations, ingest scripts, findings docs, the handoff ledger. A SQL file
+# cannot change what Next renders, and paying a full build to prove it is money for nothing.
+#
+# Conservative by construction: it SKIPS only when it can see the diff and every changed path is on
+# the no-build list. Anything unrecognised, any error, any missing base commit, and it BUILDS —
+# a needless build costs a few cents, a wrongly-skipped one ships nothing and looks like a deploy
+# that silently did not take.
+set -uo pipefail
+
+# Vercel provides the previous deployment's SHA. Without it we cannot diff, so build.
+BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [[ -z "$BASE" ]]; then
+  echo "no VERCEL_GIT_PREVIOUS_SHA — building"
+  exit 1
+fi
+
+if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+  echo "base $BASE not in this clone (shallow fetch?) — building"
+  exit 1
+fi
+
+CHANGED="$(git diff --name-only "$BASE" HEAD 2>/dev/null)" || {
+  echo "diff failed — building"
+  exit 1
+}
+
+if [[ -z "$CHANGED" ]]; then
+  echo "no changed files vs $BASE — skipping"
+  exit 0
+fi
+
+# Paths that cannot affect what the app renders or how it builds.
+NO_BUILD_RE='^(migrations/|scripts/|docs/|thoughts/|data/|supabase/|\.github/|\.claude/|[^/]*\.md$|LICENSE$)'
+
+NEEDS_BUILD=()
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ ! "$f" =~ $NO_BUILD_RE ]]; then
+    NEEDS_BUILD+=("$f")
+  fi
+done <<< "$CHANGED"
+
+if [[ ${#NEEDS_BUILD[@]} -eq 0 ]]; then
+  echo "skipping build — $(wc -l <<< "$CHANGED" | tr -d ' ') changed file(s), none affect the app:"
+  sed 's/^/  /' <<< "$CHANGED" | head -20
+  exit 0
+fi
+
+echo "building — ${#NEEDS_BUILD[@]} app file(s) changed:"
+printf '  %s\n' "${NEEDS_BUILD[@]}" | head -20
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,12 @@
 {
   "installCommand": "pnpm install",
   "buildCommand": "cd apps/web && NODE_OPTIONS=--max-old-space-size=4096 pnpm run build",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "outputDirectory": "apps/web/.next",
   "framework": "nextjs",
-  "regions": ["syd1"],
+  "regions": [
+    "syd1"
+  ],
   "crons": [
     {
       "path": "/api/tender-intelligence/automation/run-due",


### PR DESCRIPTION
Ben: "we are spending a lot of Vercel spend and processes on this — I want to reduce it."

## Measured

**20 deployments in one 8.9-hour session** — 13 preview, 7 production — each a full Next build at
`--max-old-space-size=4096`. A large share were commits that touched **no application code**:
migrations, ingest scripts, findings docs, the handoff ledger.

Against the last 8 commits to `main`, this rule **skips 5 of them (62%)**:

```
SKIP   0 app files  Remove $304.4M of double-counted foundation grant edges
SKIP   0 app files  Grantee ingest: one shared resolver
SKIP   0 app files  Ledger: UX pass 2 close-out
BUILD 15 app files  One declarer, one row: donor/supplier name normalisation
SKIP   0 app files  Ledger: session close-out
BUILD 11 app files  Sortable column headers
BUILD 10 app files  Shell polish: 13 of 14 UX-audit findings
SKIP   0 app files  Shell UX audit pass 1
```

The same rule applies to preview builds on every push, which is where the volume actually is.

## Safety

Conservative by construction. It skips **only** when it can see the diff and **every** changed path
is on the no-build list (`migrations/ scripts/ docs/ thoughts/ data/ supabase/ .github/ .claude/`
and root `*.md`). A missing `VERCEL_GIT_PREVIOUS_SHA`, a shallow clone, a failed diff, or any
unrecognised path all fall through to **BUILD**.

The asymmetry is deliberate: a needless build costs cents; a wrongly-skipped one ships nothing while
looking like a successful deploy, which is far more expensive to debug.

Note Vercel's inverted convention — **exit 0 skips, exit 1 builds**.

## Not done here — needs Ben's call

The project runs **13 cron jobs**, two of them hourly:

| cron | schedule | invocations/month |
|---|---|---|
| `/api/cron/usage-alerts` | `0 * * * *` | ~720 |
| `/api/tender-intelligence/automation/deliver-notifications` | `5 * * * *` | ~720 |

That is ~1,440 function invocations a month from two jobs alone, before the other eleven. Dropping
either to every 4 hours cuts it by 75%, but it changes product behaviour (notification latency), so
it is a decision rather than a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)