### PR TITLE
Cache the 22 public report pages instead of querying on every request

### DIFF
--- a/apps/web/src/app/reports/access-gap/page.tsx
+++ b/apps/web/src/app/reports/access-gap/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { estimateAdminBurden } from '@grant-engine/foundations/community-profiler';
 import { AccessGapCharts } from './charts';
@@ -101,8 +102,12 @@ function buildFallbackReport() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-access-gap'], { revalidate: 3600 });
+
 export default async function AccessGapPage() {
-  const report = await getReport();
+  const report = await getReportCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/board-interlocks/page.tsx
+++ b/apps/web/src/app/reports/board-interlocks/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -292,8 +293,12 @@ function computeReport(
 
 /* ── page ── */
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-board-interlocks'], { revalidate: 3600 });
+
 export default async function BoardInterlocksReport() {
-  const { personRoles, aisRecords, accoAbns } = await getData();
+  const { personRoles, aisRecords, accoAbns } = await getDataCached();
   const r = computeReport(personRoles, aisRecords, accoAbns);
 
   return (

--- a/apps/web/src/app/reports/charity-contracts/page.tsx
+++ b/apps/web/src/app/reports/charity-contracts/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
@@ -249,6 +250,10 @@ async function getData() {
 
 /* ---------- page ---------- */
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-charity-contracts'], { revalidate: 3600 });
+
 export default async function CharityContractsReport() {
   const {
     totalWithBoth,
@@ -261,7 +266,7 @@ export default async function CharityContractsReport() {
     mainstreamStats,
     totalExecPayAllCharities,
     execAsPctOfContracts,
-  } = await getData();
+  } = await getDataCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/child-protection/page.tsx
+++ b/apps/web/src/app/reports/child-protection/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
@@ -116,8 +117,12 @@ async function getReport() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-child-protection'], { revalidate: 3600 });
+
 export default async function ChildProtectionReportPage() {
-  const report = await getReport();
+  const report = await getReportCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/cross-reference/page.tsx
+++ b/apps/web/src/app/reports/cross-reference/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { money, fmt } from '@/lib/format';
 
@@ -80,8 +81,12 @@ async function getData() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-cross-reference'], { revalidate: 3600 });
+
 export default async function CrossReferencePage() {
-  const d = await getData();
+  const d = await getDataCached();
 
   const totalValue = Number(d.stats.total_value) || 0;
   const totalContracts = Number(d.stats.total_contracts) || 0;

--- a/apps/web/src/app/reports/data-quality/page.tsx
+++ b/apps/web/src/app/reports/data-quality/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/report-supabase';
 
 export const dynamic = 'force-dynamic';
@@ -63,8 +64,12 @@ async function getData() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-data-quality'], { revalidate: 3600 });
+
 export default async function DataQualityPage() {
-  const { quality, crossref } = await getData();
+  const { quality, crossref } = await getDataCached();
 
   // Calculate overall score (average of non-null percentages across all datasets)
   const allPcts = quality.flatMap(q => [q.pct_name, q.pct_description, q.pct_website, q.pct_abn, q.pct_amount, q.pct_geo].filter(p => p !== null)) as number[];

--- a/apps/web/src/app/reports/desert-overhead/page.tsx
+++ b/apps/web/src/app/reports/desert-overhead/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
@@ -399,8 +400,12 @@ const REMOTENESS_BAR_COLORS: Record<string, string> = {
 
 /* ---------- page ---------- */
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-desert-overhead'], { revalidate: 3600 });
+
 export default async function DesertOverheadReport() {
-  const d = await getData();
+  const d = await getDataCached();
 
   const maxOverhead = d.byRemoteness.length > 0
     ? Math.max(...d.byRemoteness.map((r) => r.avgOverhead))

--- a/apps/web/src/app/reports/donor-contractors/page.tsx
+++ b/apps/web/src/app/reports/donor-contractors/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
@@ -141,8 +142,12 @@ async function getData() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-donor-contractors'], { revalidate: 3600 });
+
 export default async function DonorContractorsReport() {
-  const d = await getData();
+  const d = await getDataCached();
   const s = d.stats;
 
   return (

--- a/apps/web/src/app/reports/exec-remuneration/page.tsx
+++ b/apps/web/src/app/reports/exec-remuneration/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
@@ -290,6 +291,10 @@ async function getData() {
 
 /* ---------- page ---------- */
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-exec-remuneration'], { revalidate: 3600 });
+
 export default async function ExecRemunerationReport() {
   const {
     totalCharities,
@@ -301,7 +306,7 @@ export default async function ExecRemunerationReport() {
     top20Pay,
     top20Overhead,
     govFunded,
-  } = await getData();
+  } = await getDataCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/grant-frontier/page.tsx
+++ b/apps/web/src/app/reports/grant-frontier/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -469,8 +470,12 @@ async function getData() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-grant-frontier'], { revalidate: 3600 });
+
 export default async function GrantFrontierPage() {
-  const { grantSummary, grantSources, frontierKinds, frontierQueue, automations, snapshots, failures, foundationSummary, longTailFounders, longTailDiscoveries, pipelineFunnel } = await getData();
+  const { grantSummary, grantSources, frontierKinds, frontierQueue, automations, snapshots, failures, foundationSummary, longTailFounders, longTailDiscoveries, pipelineFunnel } = await getDataCached();
   const totalFrontierRows = frontierKinds.reduce((sum, row) => sum + Number(row.rows || 0), 0);
   const totalDueNow = frontierKinds.reduce((sum, row) => sum + Number(row.due_now || 0), 0);
   const totalNeverSucceeded = frontierKinds.reduce((sum, row) => sum + Number(row.never_succeeded || 0), 0);

--- a/apps/web/src/app/reports/influence-network/page.tsx
+++ b/apps/web/src/app/reports/influence-network/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -203,8 +204,12 @@ async function getData() {
 
 /* --- Page ------------------------------------------------------ */
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-influence-network'], { revalidate: 3600 });
+
 export default async function InfluenceNetworkReport() {
-  const d = await getData();
+  const d = await getDataCached();
   if (!d) return <div className="p-8 text-bauhaus-muted">No data available.</div>;
 
   const s = d.stats;

--- a/apps/web/src/app/reports/money-flow/page.tsx
+++ b/apps/web/src/app/reports/money-flow/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { buildSankeyData } from '@grant-engine/reports/money-flow';
 import { MoneyFlowCharts } from './charts';
@@ -60,8 +61,12 @@ async function getReport() {
   }
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-money-flow'], { revalidate: 3600 });
+
 export default async function MoneyFlowPage() {
-  const report = await getReport();
+  const report = await getReportCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/multicultural-sector/fecca-eccv/long-read/page.tsx
+++ b/apps/web/src/app/reports/multicultural-sector/fecca-eccv/long-read/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -61,9 +62,13 @@ async function getNumbers() {
   return { fecca, eccvAisArr, eccvLatest, eccvPrior, totals: totalsRow, ames: amesRow, topics };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getNumbersCached = unstable_cache(getNumbers, ['reports-multicultural-sector-fecca-eccv-long-read'], { revalidate: 3600 });
+
 export default async function FeccaEccvLongRead({ mode = 'full' }: { mode?: 'full' | 'share' } = {}) {
   const isShare = mode === 'share';
-  const r = await getNumbers();
+  const r = await getNumbersCached();
   const eccvDropPct = r.eccvLatest && r.eccvPrior && r.eccvPrior.rev > 0
     ? (((r.eccvLatest.rev - r.eccvPrior.rev) / r.eccvPrior.rev) * 100)
     : 0;

--- a/apps/web/src/app/reports/multicultural-sector/fecca-eccv/page.tsx
+++ b/apps/web/src/app/reports/multicultural-sector/fecca-eccv/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
@@ -789,12 +790,16 @@ function MoneyAndStaffCard({ row, label }: { row: AisFinancialsRow | null; label
   );
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-multicultural-sector-fecca-eccv'], { revalidate: 3600 });
+
 export default async function FeccaEccvPage() {
   const hdrs = await headers();
   const isShare = (hdrs.get('x-pathname') ?? '').startsWith('/share/');
   const dashboardPath = isShare ? '/share/fecca-eccv' : '/reports/multicultural-sector/fecca-eccv';
   const longReadPath = isShare ? '/share/fecca-eccv/long-read' : '/reports/multicultural-sector/fecca-eccv/long-read';
-  const r = await getReport();
+  const r = await getReportCached();
 
   // ECCV revenue trajectory — render as horizontal bars normalised to peak
   const eccvPeak = Math.max(...r.eccv_ais.map(a => a.total || 0), 1);

--- a/apps/web/src/app/reports/multicultural-sector/page.tsx
+++ b/apps/web/src/app/reports/multicultural-sector/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
@@ -190,8 +191,12 @@ async function getReport() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-multicultural-sector'], { revalidate: 3600 });
+
 export default async function MulticulturalSectorPage() {
-  const r = await getReport();
+  const r = await getReportCached();
   const hdrs = await headers();
   const isShare = (hdrs.get('x-pathname') ?? '').startsWith('/share/');
 

--- a/apps/web/src/app/reports/ndis-market/page.tsx
+++ b/apps/web/src/app/reports/ndis-market/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { getServiceSupabase } from '@/lib/report-supabase';
 
@@ -225,8 +226,12 @@ async function getReport() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-ndis-market'], { revalidate: 3600 });
+
 export default async function NdisMarketPage() {
-  const report = await getReport();
+  const report = await getReportCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/power-map/page.tsx
+++ b/apps/web/src/app/reports/power-map/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/report-supabase';
 
 export const dynamic = 'force-dynamic';
@@ -47,8 +48,12 @@ async function getStats() {
 
 function fmt(n: number) { return n.toLocaleString(); }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getStatsCached = unstable_cache(getStats, ['reports-power-map'], { revalidate: 3600 });
+
 export default async function PowerMapPage() {
-  const s = await getStats();
+  const s = await getStatsCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/state-of-the-nation/page.tsx
+++ b/apps/web/src/app/reports/state-of-the-nation/page.tsx
@@ -1,3 +1,5 @@
+import { unstable_cache } from 'next/cache';
+
 export const dynamic = 'force-dynamic';
 
 const SNAPSHOT_LABEL = 'April 2026 data snapshot';
@@ -42,8 +44,12 @@ function fmtDollar(n: number | null) {
   return `$${n.toLocaleString()}`;
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getStatsCached = unstable_cache(getStats, ['reports-state-of-the-nation'], { revalidate: 3600 });
+
 export default async function StateOfTheNationPage() {
-  const s = await getStats();
+  const s = await getStatsCached();
 
   return (
     <div>

--- a/apps/web/src/app/reports/triple-play/page.tsx
+++ b/apps/web/src/app/reports/triple-play/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
@@ -162,8 +163,12 @@ async function getData() {
   };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-triple-play'], { revalidate: 3600 });
+
 export default async function TriplePlayReport() {
-  const d = await getData();
+  const d = await getDataCached();
   if (!d) return <div className="p-8 text-bauhaus-muted">No data available.</div>;
 
   const s = d.stats;

--- a/apps/web/src/app/reports/who-runs-australia/page.tsx
+++ b/apps/web/src/app/reports/who-runs-australia/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -162,8 +163,12 @@ function VectorBadges({ entity }: { entity: RevolvingDoorEntity }) {
   );
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getDataCached = unstable_cache(getData, ['reports-who-runs-australia'], { revalidate: 3600 });
+
 export default async function WhoRunsAustraliaReport() {
-  const d = await getData();
+  const d = await getDataCached();
   const s = d.stats;
 
   return (

--- a/apps/web/src/app/reports/youth-justice/qld/sector/long-read/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/qld/sector/long-read/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
@@ -265,13 +266,17 @@ async function getNumbers() {
  };
 }
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getNumbersCached = unstable_cache(getNumbers, ['reports-youth-justice-qld-sector-long-read'], { revalidate: 3600 });
+
 export default async function QldYjLongRead() {
  const hdrs = await headers();
  const isShare = (hdrs.get('x-pathname') ?? '').startsWith('/share/');
  const dashboardHref = isShare ? '/share/qld-youth-justice' : '/reports/youth-justice/qld/sector';
  const longReadHref = isShare ? '/share/qld-youth-justice/long-read' : '/reports/youth-justice/qld/sector/long-read';
 
- const r = await getNumbers();
+ const r = await getNumbersCached();
  const fnPctChild = r.l && r.l.total_children > 0 ? Math.round((r.l.child_first_nations / r.l.total_children) * 100) : 0;
  const fnPctAdult = r.l && r.l.total_adults > 0 ? Math.round((r.l.adult_first_nations / r.l.total_adults) * 100) : 0;
  const childOver2 = r.l ? r.l.child_3_7_days + r.l.child_over_7_days : 0;

--- a/apps/web/src/app/reports/youth-justice/qld/sector/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/qld/sector/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
@@ -903,12 +904,16 @@ function classifyStatement(s: { headline: string; portfolio: string | null }): '
 
 /* ─── Dashboard ─────────────────────────────────────────────────────── */
 
+/** Cost + pooler load: this page was force-dynamic with no caching, so every request ran
+ *  its query. The report's underlying data changes nightly at most. */
+const getReportCached = unstable_cache(getReport, ['reports-youth-justice-qld-sector'], { revalidate: 3600 });
+
 export default async function QldYjSectorPage() {
  const hdrs = await headers();
  const isShare = (hdrs.get('x-pathname') ?? '').startsWith('/share/');
  const dashboardPath = isShare ? '/share/qld-youth-justice' : '/reports/youth-justice/qld/sector';
  const longReadPath = isShare ? '/share/qld-youth-justice/long-read' : '/reports/youth-justice/qld/sector/long-read';
- const r = await getReport();
+ const r = await getReportCached();
 
  const ws = r.latest;
  const fnPctChild = ws && ws.total_children > 0 ? Math.round((ws.child_first_nations / ws.total_children) * 100) : 0;


### PR DESCRIPTION
Lever 1 of the Vercel/Supabase cost work. Caching only — no visual change, no change to what any
page shows.

## The problem

Of 164 `force-dynamic` pages, **151 have no caching at all** and only **11** have a per-user reason
to be uncached. All 28 report pages take no `searchParams` and are fully public, yet
`reports/access-gap` pulls 500 rows from `community_orgs` **on every request** — for a report whose
data changes nightly at most.

That is two problems with one root: Vercel invocation cost, and the Supabase pooler pressure that
produced this session's charities timeout, social-enterprises timeout, and the A13 "measured zero"
bug.

## What this does

Wraps each page's no-arg fetch in `unstable_cache` with a route-derived key and a one-hour window.

**Render mode is deliberately untouched.** These pages stay dynamic. Switching `force-dynamic` →
`revalidate` is what would cut serverless *invocations*, but it makes Next prerender at build time,
which means the build itself queries Supabase — a known way to break builds in this repo. That is
Lever 2 and deserves to be proven on one page first, not applied to 28.

So: this cuts database load hard and invocation cost not at all. Worth being clear about.

## Notes

`state-of-the-nation` needed its import added by hand — the file has no imports at all, starting
straight at `export const dynamic`, so the automated insert had nothing to anchor to and left the
wrapper referencing an undefined symbol. `tsc` caught it immediately.

129 of the 151 uncached pages remain, mostly under `/org` (47) and `/clarity` (16).

## Verification

Five pages return 200 with second-hit times of 0.18-0.99s, consistent with cache serving. `tsc`
clean, 734 tests pass. I have not proven zero database queries — only that responses are fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)