### PR TITLE
Alarm when nothing is scheduling agents, and fix a false SAFE

### DIFF
--- a/apps/web/src/app/api/ops/health/route.ts
+++ b/apps/web/src/app/api/ops/health/route.ts
@@ -53,7 +53,8 @@ export async function GET() {
       grantSourceIdentitySources,
       // Breakdowns + recent runs
       sourceBreakdownResult, confidenceBreakdownResult,
-      recentRuns, recentDiscoveryRuns,
+      recentRuns,
+      newestAgentRun, recentDiscoveryRuns,
       sourceHealthRuns,
       pipelineSchedules, pipelineTasks, pipelineRuns,
       // Entity graph
@@ -186,6 +187,11 @@ export async function GET() {
       safe(db.rpc('get_grant_source_breakdown'), 8000),
       safe(db.rpc('get_foundation_confidence_breakdown'), 8000),
       safe(db.from('agent_runs').select('*').order('completed_at', { ascending: false }).limit(20), 8000),
+      // Orchestrator heartbeat. The pm2 orchestrator daemon was found stopped on 2026-08-18 having
+      // been down ~2 days: 86 scheduled tasks had fired into nothing, verified_at stopped being
+      // refreshed, and the entire opportunity feed quarantined. NOTHING reported it — it was found
+      // by hand. The newest agent_run of ANY kind is the cheapest proof the scheduler is alive.
+      safe(db.from('agent_runs').select('started_at').order('started_at', { ascending: false }).limit(1), 8000),
       safe(db.from('grant_discovery_runs').select('*').order('started_at', { ascending: false }).limit(10), 8000),
       // Per-source ingest health — latest run per source:* agent
       safe(db.from('agent_runs')
@@ -421,6 +427,14 @@ export async function GET() {
       sourceBreakdown: sourceBreakdownResult.data ?? [],
       confidenceBreakdown: confidenceBreakdownResult.data ?? [],
       recentRuns: recentRuns.data ?? [],
+      // See the heartbeat query above. Null lastRunAt means we could not read it, which is NOT the
+      // same as "no runs" — the UI must not turn an unreadable heartbeat into a dead one.
+      orchestrator: (() => {
+        const at = newestAgentRun.data?.[0]?.started_at ?? null;
+        if (!at) return { lastRunAt: null, hoursSince: null, stale: false, unknown: true };
+        const hours = (Date.now() - new Date(at).getTime()) / 3_600_000;
+        return { lastRunAt: at, hoursSince: Math.round(hours * 10) / 10, stale: hours > 6, unknown: false };
+      })(),
       discoveryRuns: recentDiscoveryRuns.data ?? [],
       sourceHealth,
       pipelineHealth,

--- a/apps/web/src/app/ops/health/health-client.tsx
+++ b/apps/web/src/app/ops/health/health-client.tsx
@@ -11,6 +11,8 @@ function tableToSlug(table: string): string {
 }
 
 interface HealthData {
+  /** Is anything scheduling agents at all? See the API route for why this exists. */
+  orchestrator?: { lastRunAt: string | null; hoursSince: number | null; stale: boolean; unknown: boolean };
   stats: {
     // A13: null means the count timed out and was never measured — NOT that it is zero.
     grants: { total: number; withDescription: number | null; enriched: number | null; embedded: number | null; open: number | null };
@@ -437,6 +439,27 @@ export function HealthClient() {
           </div>
         </div>
       </div>
+
+      {/* The scheduler being dead outranks every number below it: if nothing is running, every
+          figure on this page is a snapshot of whenever it last ran. */}
+      {data.orchestrator?.stale && (
+        <section className="mb-6">
+          <div className="border-4 border-bauhaus-red p-5">
+            <div className="text-xs font-black uppercase tracking-widest text-bauhaus-red mb-1">
+              No agent has run in {data.orchestrator.hoursSince} hours
+            </div>
+            <div className="text-sm">
+              The orchestrator schedules every agent. Nothing has run since{' '}
+              {data.orchestrator.lastRunAt
+                ? new Date(data.orchestrator.lastRunAt).toLocaleString('en-AU')
+                : 'unknown'}
+              , so the figures below are as stale as that. Check it with{' '}
+              <code className="font-mono text-xs">pm2 describe orchestrator</code> and start it with{' '}
+              <code className="font-mono text-xs">pm2 start orchestrator</code>.
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ===== COMPOSITE HEALTH SCORE ===== */}
       <section className="mb-10">

--- a/scripts/classify-changes.sh
+++ b/scripts/classify-changes.sh
@@ -18,9 +18,14 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 BASE="${1:-origin/main}"
 
-FILES="$(git diff --name-only "$BASE"...HEAD)"
+# Committed changes vs the base, PLUS anything still in the working tree. Without the second part
+# this reported "no changes -> SAFE" whenever it ran before the commit — a false SAFE, which is the
+# one answer that must never be wrong, because SAFE is what auto-merges.
+FILES="$(
+  { git diff --name-only "$BASE"...HEAD; git status --porcelain | awk '{print $NF}'; } | sort -u
+)"
 if [[ -z "$FILES" ]]; then
-  echo "no changes vs $BASE" >&2
+  echo "no changes vs $BASE and nothing uncommitted" >&2
   echo "SAFE"
   exit 0
 fi


### PR DESCRIPTION
## Why

The pm2 orchestrator was found stopped today, having been down ~2 days. On restart it logged
*"Recovered 1 stuck task"* and *"Coalesced 86 superseded scheduled tasks"* — two days of schedules
firing into nothing. That is why `verified_at` stopped being refreshed and the entire opportunity
feed quarantined.

**Nothing reported it.** It was found by hand, two days late, and only because Ben asked me to check
the nightly run. This also corrects today's earlier A1 diagnosis: the `persist()` crash was real and
is fixed, but it was **necessary, not sufficient** — with the daemon down, nothing schedules the work
regardless.

## What

`/ops/health` now reads the newest `agent_run` of any kind as a heartbeat and leads with a red
banner when nothing has run in 6 hours. It sits **above** the composite score deliberately: a dead
scheduler outranks every number below it, because if nothing is running, every figure on that page
is a snapshot of whenever it last ran.

An unreadable heartbeat reports as `unknown`, not as dead — same principle as A13 earlier today:
never turn "I could not measure" into a confident claim.

Verified live: `{"lastRunAt":"2026-08-18T05:10:45Z","hoursSince":0,"stale":false}` with the
orchestrator running. It would have read ~48 hours before I started it.

## Also: a false SAFE in classify-changes.sh

Caught while using it on this very branch. It compared `origin/main...HEAD` only, so running it
**before committing** answered "no changes → SAFE". SAFE is the answer that auto-merges, so a false
SAFE is the single error the classifier must never make. It now includes the working tree.

SAFE (ops/api/scripts only). `precheck.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)