### PR TITLE
Remove two crons whose endpoints were deleted months ago

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,14 +9,6 @@
   ],
   "crons": [
     {
-      "path": "/api/tender-intelligence/automation/run-due",
-      "schedule": "0 21 * * *"
-    },
-    {
-      "path": "/api/tender-intelligence/automation/deliver-notifications",
-      "schedule": "5 * * * *"
-    },
-    {
       "path": "/api/civicscope/cron?mode=statements",
       "schedule": "0 3 * * *"
     },


### PR DESCRIPTION
Item 2 on the queue was "decide the two hourly crons". It turned out not to be a decision.

**Checked all 13 cron paths against the filesystem: 11 resolve, 2 never did.**

| cron | schedule | reality |
|---|---|---|
| `/api/tender-intelligence/automation/deliver-notifications` | hourly | route does not exist |
| `/api/tender-intelligence/automation/run-due` | daily | route does not exist |

Commit `bd20a8ce` — *"scope cut to portfolio mode — kill SaaS-shaped surfaces"* — deleted the whole `tender-intelligence` API directory and left its crons in `vercel.json`. Vercel has been calling them **~750 times a month and getting 404s** ever since.

Nothing is lost: there has been no behaviour to lose since the routes were removed. That is ~750 of the ~1,440 monthly invocations I flagged, gone without a product trade-off.

**Still Ben's call — `/api/cron/usage-alerts`:** it runs hourly (~720/month) checking whether any API key exceeds 80% of its rate limit. `api_keys` currently holds **0 rows**, so it is inert — it cannot alert on anything. Dropping it to daily keeps the capability at 1/24th the cost, but if the API-key product is about to launch, hourly is the right frequency and it should stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)