### PR TITLE
Close the six browser issues that shipped days ago

### DIFF
--- a/thoughts/shared/plans/backlog-2026-08.md
+++ b/thoughts/shared/plans/backlog-2026-08.md
@@ -51,10 +51,6 @@ build-skip and report caching were the affordable wins.
 - **VFFF amounts** — its 7 edges all carry $0, so the data is currently inert. Either get amounts or
   delete the 7 rows; a funder→grantee edge with no dollars earns nothing in a money graph.
 
-### 5. Close the 6 stale issues · 5 min
-#246-#251 are open for browsers that shipped days ago. A tracker that lies about what is outstanding
-is worse than no tracker.
-
 ---
 
 ## Cut — with the reason, so nobody re-adds them


### PR DESCRIPTION
Queue item 5. #246-#251 (S3-S8) were open for browsers already merged into main. Verified each one before closing — page, RPC migration, and explicit error state on disk — rather than closing on the strength of a commit message.

| issue | surface | migration |
|---|---|---|
| #246 S3 Places | `dashboard/places/` | `2026-08-17-place-browse-rpcs.sql` |
| #247 S4 Grants | `dashboard/browse/grants/` | `2026-08-17-grant-browse-rpcs.sql` |
| #248 S5 Contracts | `dashboard/browse/contracts/` | `2026-08-17-contract-browse-rpcs.sql` |
| #249 S6 Buyers | `dashboard/browse/buyers/` | on the contract-browse RPCs |
| #250 S7 Donations | `dashboard/browse/donations/` | `2026-08-17-donation-browse-rpcs.sql` |
| #251 S8 Entities | `dashboard/entities/` search + jump-off (#255) | — |

All nine browse pages render an explicit error card rather than an empty list. One issue now open repo-wide (#190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)