### PR TITLE
Cache seven public pages; leave seven uncached on purpose

### DIFF
--- a/apps/web/src/app/changes/page.tsx
+++ b/apps/web/src/app/changes/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { getLiveReportSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -5,7 +6,7 @@ import { safe } from '@/lib/services/utils';
 export const dynamic = 'force-dynamic';
 export const metadata = {
   title: "What's changing — CivicGraph",
-  description: 'Live data feed from across the platform. Latest watchhouse snapshot, recent ingestion runs, new reports, recent feedback. Refreshed every page load.',
+  description: 'Live data feed from across the platform. Latest watchhouse snapshot, recent ingestion runs, new reports, recent feedback. Refreshed every five minutes.',
 };
 
 type AgentRun = { agent_id: string; agent_name: string | null; status: string; items_found: number | null; items_new: number | null; duration_ms: number | null; started_at: string };
@@ -88,8 +89,13 @@ async function getChanges() {
   };
 }
 
+/** Cost + pooler load: this page ran six queries on every request. Five minutes, not the hour
+ *  used elsewhere, because this screen's whole job is to show what just changed — and the copy
+ *  below says so, so the window has to stay short enough for that to remain true. */
+const getChangesCached = unstable_cache(getChanges, ['changes-feed'], { revalidate: 300 });
+
 export default async function ChangesPage() {
-  const r = await getChanges();
+  const r = await getChangesCached();
   const ws = r.watchhouse;
   const fnPctChild = ws && ws.total_children > 0 ? Math.round((ws.child_first_nations / ws.total_children) * 100) : 0;
 
@@ -108,7 +114,7 @@ export default async function ChangesPage() {
           What&apos;s changing on CivicGraph
         </h1>
         <p className="text-xl text-bauhaus-muted leading-tight font-medium max-w-3xl">
-          Live activity from across the platform. Watchhouse refreshes, ingestion runs, new reports, recent feedback. Refreshed every page load.
+          Live activity from across the platform. Watchhouse refreshes, ingestion runs, new reports, recent feedback. Refreshed every five minutes.
         </p>
       </div>
 

--- a/apps/web/src/app/charities/insights/page.tsx
+++ b/apps/web/src/app/charities/insights/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/supabase';
 import { TableOfContents } from './toc';
 import {
@@ -84,8 +85,12 @@ async function getSnapshot(): Promise<SnapshotData> {
   };
 }
 
+/** Cost + pooler load: Uncached, every request rebuilt the whole ACNC snapshot. The register is refreshed nightly
+ *  at most. */
+const getSnapshotCached = unstable_cache(getSnapshot, ['charities-insights-snapshot'], { revalidate: 3600 });
+
 export default async function CharityInsightsPage() {
-  const snapshot = await getSnapshot();
+  const snapshot = await getSnapshotCached();
 
   const totalCharities = snapshot.bySize.reduce((s, r) => s + r.count, 0);
   const totalRevenue = snapshot.bySize.reduce((s, r) => s + r.total_revenue, 0);

--- a/apps/web/src/app/embed/entity/[identifier]/page.tsx
+++ b/apps/web/src/app/embed/entity/[identifier]/page.tsx
@@ -38,7 +38,9 @@ export default async function EntityEmbedPage({
   try {
     const res = await fetch(
       `${baseUrl}/api/data/entity/${encodeURIComponent(identifier)}`,
-      { cache: 'no-store' }
+      // An entity card embedded in partner sites: served from cache for five minutes
+      // rather than re-queried on every iframe render on every page of every partner.
+      { next: { revalidate: 300 } }
     );
     if (!res.ok) {
       if (res.status === 404) notFound();

--- a/apps/web/src/app/giving/quality/page.tsx
+++ b/apps/web/src/app/giving/quality/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getServiceSupabase } from '@/lib/supabase';
 import { PUBLIC_DATASET_KEYS, PUBLIC_DATASETS } from '@/lib/giving-commons';
 import { GivingHeader, GivingSubnav } from '../_components';
@@ -53,14 +54,19 @@ async function getCatalogHealth() {
       .select('table_name, snapshot_at, row_count, freshness_hours, provenance_coverage_pct, confidence_coverage_pct, sla_hours')
       .in('table_name', tables);
 
-    return new Map((data ?? []).map((row) => [row.table_name, row as CatalogHealth]));
+    return (data ?? []) as CatalogHealth[];
   } catch {
-    return new Map<string, CatalogHealth>();
+    return [] as CatalogHealth[];
   }
 }
 
+/** Cost + pooler load: catalog health is a nightly-grain measure; it does not need recomputing
+ *  per request. Note the row shape above: this used to return a Map, which does NOT survive the
+ *  cache — only plain JSON does — so the fetcher returns rows and the Map is built per render. */
+const getCatalogHealthCached = unstable_cache(getCatalogHealth, ['giving-quality-catalog-health'], { revalidate: 3600 });
+
 export default async function GivingQualityPage() {
-  const health = await getCatalogHealth();
+  const health = new Map((await getCatalogHealthCached()).map((row) => [row.table_name, row]));
   const statuses = PUBLIC_DATASET_KEYS.map((key) => statusFor(health.get(PUBLIC_DATASETS[key].table)));
   const freshCount = statuses.filter((status) => status === 'fresh').length;
   const staleCount = statuses.filter((status) => status === 'stale').length;

--- a/apps/web/src/app/opportunities/ecosystem/page.tsx
+++ b/apps/web/src/app/opportunities/ecosystem/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
@@ -338,11 +339,14 @@ async function getLiveContext(): Promise<{
   };
 }
 
+/** Cost + pooler load: Three queries (one an exec_sql aggregate) ran on every request for data that moves nightly. */
+const getLiveContextCached = unstable_cache(getLiveContext, ['opportunities-ecosystem-live-context'], { revalidate: 3600 });
+
 export default async function OpportunityEcosystemPage() {
   const opportunities = rankedEcosystemOpportunities();
   const actions = rankedEcosystemActions();
   const [live, intelligence, goodsSnapshot] = await Promise.all([
-    getLiveContext(),
+    getLiveContextCached(),
     getOpportunityIntelligence({ minScore: 55 }),
     getGoodsReadinessSnapshot(),
   ]);

--- a/apps/web/src/app/pipeline/page.tsx
+++ b/apps/web/src/app/pipeline/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getServiceSupabase } from '@/lib/supabase';
@@ -79,6 +80,77 @@ function get(sp: SP, key: string, fallback: string = ''): string {
   return v ?? fallback;
 }
 
+interface PipelineQuery {
+  q: string; entityType: string; state: string; ccOnly: boolean; snOnly: boolean;
+  minSystems: number; minFlow: number; sortBy: string; sortDir: string;
+  offset: number; pageSize: number;
+}
+
+/** The whole read for one filter combination, lifted out of the component so it can be cached.
+ *  Returns errorMessage rather than the PostgrestError itself: only plain values survive the
+ *  cache, and the page renders the message. */
+async function getPipelineData(p: PipelineQuery) {
+  const supabase = getServiceSupabase();
+
+  let query = supabase
+    .from('mv_entity_power_index')
+    .select(
+      'gs_id, canonical_name, entity_type, abn, state, lga_name, is_community_controlled, in_procurement, in_recorded_grants, in_political_donations, in_charity_registry, in_foundation, in_alma_evidence, in_ndis_provider, system_count, procurement_dollars, recorded_grants_dollars, donation_dollars, foundation_giving, total_dollar_flow, contract_count, recorded_grants_count, donation_count, power_score, charity_size',
+      { count: 'exact' },
+    );
+
+  if (p.q) query = query.ilike('canonical_name', `%${p.q}%`);
+  if (p.entityType) query = query.eq('entity_type', p.entityType);
+  if (p.state) query = query.eq('state', p.state);
+  if (p.ccOnly) query = query.eq('is_community_controlled', true);
+  if (p.minSystems > 0) query = query.gte('system_count', p.minSystems);
+  if (p.minFlow > 0) query = query.gte('total_dollar_flow', p.minFlow);
+
+  query = query.order(p.sortBy, { ascending: p.sortDir === 'asc', nullsFirst: false });
+  query = query.range(p.offset, p.offset + p.pageSize - 1);
+
+  const { data: rows, count, error } = await query;
+
+  const results: Row[] = (rows as Row[] | null) ?? [];
+
+  // Summary stats (separate cheaper query)
+  const { data: statsData } = await supabase
+    .from('mv_entity_power_index')
+    .select('total_dollar_flow.sum(), is_community_controlled.count()', { count: 'exact', head: false })
+    .limit(1);
+  const totalDollarFlow = ((statsData as Record<string, number>[] | null)?.[0]?.sum) ?? 0;
+  const ccCount = ((statsData as Record<string, number>[] | null)?.[0]?.count) ?? 0;
+
+  const stats: Stats = {
+    total_entities: count ?? 0,
+    filtered: results.length,
+    total_dollar_flow: Number(totalDollarFlow) || 0,
+    cc_count: Number(ccCount) || 0,
+  };
+
+  // Supply Nation filter (post-query because mv_entity_power_index doesn't include the flag yet)
+  let filteredResults = results;
+  if (p.snOnly) {
+    const abns = results.map((r) => r.abn).filter(Boolean);
+    if (abns.length > 0) {
+      const { data: snEntities } = await supabase
+        .from('gs_entities')
+        .select('abn')
+        .eq('is_supply_nation_certified', true)
+        .in('abn', abns);
+      const snAbns = new Set((snEntities ?? []).map((e) => e.abn));
+      filteredResults = results.filter((r) => r.abn && snAbns.has(r.abn));
+    }
+  }
+
+  return { results: filteredResults, count: count ?? 0, stats, errorMessage: error?.message ?? null };
+}
+
+/** Cost + pooler load: this page ran two mv_entity_power_index queries on every request,
+ *  including the unfiltered default that every visitor lands on. The MV is refreshed nightly.
+ *  unstable_cache folds the arguments into the key, so each filter combination caches separately. */
+const getPipelineDataCached = unstable_cache(getPipelineData, ['pipeline-power-index'], { revalidate: 3600 });
+
 export default async function PipelinePage({
   searchParams,
 }: {
@@ -99,59 +171,9 @@ export default async function PipelinePage({
   const PAGE_SIZE = 50;
   const offset = (page - 1) * PAGE_SIZE;
 
-  const supabase = getServiceSupabase();
-
-  let query = supabase
-    .from('mv_entity_power_index')
-    .select(
-      'gs_id, canonical_name, entity_type, abn, state, lga_name, is_community_controlled, in_procurement, in_recorded_grants, in_political_donations, in_charity_registry, in_foundation, in_alma_evidence, in_ndis_provider, system_count, procurement_dollars, recorded_grants_dollars, donation_dollars, foundation_giving, total_dollar_flow, contract_count, recorded_grants_count, donation_count, power_score, charity_size',
-      { count: 'exact' },
-    );
-
-  if (q) query = query.ilike('canonical_name', `%${q}%`);
-  if (entityType) query = query.eq('entity_type', entityType);
-  if (state) query = query.eq('state', state);
-  if (ccOnly) query = query.eq('is_community_controlled', true);
-  if (minSystems > 0) query = query.gte('system_count', minSystems);
-  if (minFlow > 0) query = query.gte('total_dollar_flow', minFlow);
-
-  query = query.order(sortBy, { ascending: sortDir === 'asc', nullsFirst: false });
-  query = query.range(offset, offset + PAGE_SIZE - 1);
-
-  const { data: rows, count, error } = await query;
-
-  const results: Row[] = (rows as Row[] | null) ?? [];
-
-  // Summary stats (separate cheaper query)
-  const statsPromise = supabase
-    .from('mv_entity_power_index')
-    .select('total_dollar_flow.sum(), is_community_controlled.count()', { count: 'exact', head: false })
-    .limit(1);
-  const { data: statsData } = await statsPromise;
-  const totalDollarFlow = ((statsData as Record<string, number>[] | null)?.[0]?.sum) ?? 0;
-  const ccCount = ((statsData as Record<string, number>[] | null)?.[0]?.count) ?? 0;
-
-  const stats: Stats = {
-    total_entities: count ?? 0,
-    filtered: results.length,
-    total_dollar_flow: Number(totalDollarFlow) || 0,
-    cc_count: Number(ccCount) || 0,
-  };
-
-  // Supply Nation filter (post-query because mv_entity_power_index doesn't include the flag yet)
-  let filteredResults = results;
-  if (snOnly) {
-    const abns = results.map((r) => r.abn).filter(Boolean);
-    if (abns.length > 0) {
-      const { data: snEntities } = await supabase
-        .from('gs_entities')
-        .select('abn')
-        .eq('is_supply_nation_certified', true)
-        .in('abn', abns);
-      const snAbns = new Set((snEntities ?? []).map((e) => e.abn));
-      filteredResults = results.filter((r) => r.abn && snAbns.has(r.abn));
-    }
-  }
+  const { results: filteredResults, count, stats, errorMessage } = await getPipelineDataCached({
+    q, entityType, state, ccOnly, snOnly, minSystems, minFlow, sortBy, sortDir, offset, pageSize: PAGE_SIZE,
+  });
 
   // Build share URL
   const qp = new URLSearchParams();
@@ -338,13 +360,13 @@ export default async function PipelinePage({
           </p>
         </div>
 
-        {error && (
+        {errorMessage && (
           <div className="px-5 py-4 text-sm font-medium text-bauhaus-red">
-            Query error: {error.message}
+            Query error: {errorMessage}
           </div>
         )}
 
-        {filteredResults.length === 0 && !error && (
+        {filteredResults.length === 0 && !errorMessage && (
           <div className="px-5 py-10 text-center text-sm font-medium text-bauhaus-muted">
             No matches. Try widening filters or searching a different name.
           </div>

--- a/apps/web/src/app/suppliers/page.tsx
+++ b/apps/web/src/app/suppliers/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { searchSuppliers, getRegistryStats, getProvenOutcomesSuppliers, type SupplierResult } from '@/lib/services/supplier-search';
@@ -165,6 +166,15 @@ function safeTerm(value: string) {
   return value.replace(/[,%()]/g, ' ').trim().slice(0, 120);
 }
 
+/** Cost + pooler load: the unsearched landing state ran the registry stats and the featured
+ *  suppliers on every visit, and it is the state most visitors see. The search path stays
+ *  uncached on purpose: its keyspace is whatever a stranger types. */
+const getLandingCached = unstable_cache(
+  async () => Promise.all([getRegistryStats(), getProvenOutcomesSuppliers(6)]),
+  ['suppliers-landing'],
+  { revalidate: 3600 },
+);
+
 export default async function SupplierSearchPage({
   searchParams,
 }: {
@@ -179,7 +189,7 @@ export default async function SupplierSearchPage({
   const results = searched ? await searchSuppliers(q, state) : [];
   const [stats, featured] = searched
     ? ([null, []] as const)
-    : await Promise.all([getRegistryStats(), getProvenOutcomesSuppliers(6)]);
+    : await getLandingCached();
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-10">


### PR DESCRIPTION
Queue item 3. **VISIBLE — do not merge until you have eyeballed the Vercel preview.**

## Cached

| page | window | note |
|---|---|---|
| `/charities/insights` | 1h | whole ACNC snapshot rebuilt per request before |
| `/giving/quality` | 1h | |
| `/opportunities/ecosystem` | 1h | three queries incl. an `exec_sql` aggregate |
| `/changes` | 5 min | copy said "refreshed every page load" — now says five minutes, and the window matches |
| `/suppliers` landing | 1h | search path deliberately uncached: its keyspace is whatever a stranger types |
| `/embed/entity/[identifier]` | 5 min | on the fetch, replacing `cache: 'no-store'` |
| `/pipeline` | 1h | two `mv_entity_power_index` reads lifted out of the component; args fold into the key |

Same `unstable_cache` shape as the 22 report pages (#262). Render mode untouched — nothing starts querying at build time.

## Not cached, and why the list of 14 was wrong

- **Nothing to cache:** `/` returns a hardcoded constant and queries nothing. `/giving` returns `[]` for a query under two characters without touching the DB.
- **Per-viewer — caching would leak, not save:** `/grants/[id]` gates award-history winner names on `getCurrentTier()`, deliberately asking the RPC for zero winners on the free tier so names never reach the response. One cache shared across tiers serves a paid viewer's page to a free one. `/home` and `/charities/[abn]` read `auth.getUser()` the same way. **Do not cache these three without splitting the viewer-dependent read out first.**
- **Not a one-hour job:** `/grants` (1,433 lines) and `/places/[postcode]` (360-line inline fetch region) need real extraction inside VISIBLE files.

## The trap worth remembering

`getCatalogHealth` returned a `Map`. Only plain JSON survives `unstable_cache`, so `/giving/quality` 500'd with `health.get is not a function` — **on the second hit, not the first**, which is exactly what a single smoke test misses. Fetchers now return rows; the Map is rebuilt per render.

## Unrelated, found and left alone

`/embed/entity/[identifier]` falls back to `http://localhost:3003` when `NEXT_PUBLIC_SITE_URL` is unset — on this machine that is The Harvest, not GrantScope, so the embed 404s locally while its own API route returns 200.

## Verification

`scripts/precheck.sh` green (tsc + 742 tests). All seven return 200 on 3013 with second-hit times of 0.28–0.54s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)