### PR TITLE
Disarm the periphery: four dead schedules off, and the stamp stops lying

### DIFF
--- a/migrations/2026-08-18-disarm-periphery.sql
+++ b/migrations/2026-08-18-disarm-periphery.sql
@@ -1,0 +1,73 @@
+-- =============================================================================
+-- 2026-08-18-disarm-periphery.sql
+--
+-- The periphery sweep (thoughts/shared/plans/periphery-sweep-2026-08-18.md) found
+-- four scheduled things outliving the 2026-04-24 scope cut, and all four reported
+-- success while doing it. This disarms them and fixes the column that lied.
+--
+-- APPLY:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-18-disarm-periphery.sql
+--
+-- REVERSE (every step, in one block — nothing here is destructive):
+--   UPDATE agent_schedules SET enabled = true WHERE agent_id IN (
+--     'send-billing-reminders','bridge-community-directories','scrape-community-directories',
+--     'ingest-open-community-directories','ingest-infoxchange-services');
+--   SELECT cron.schedule('retry-missed-reactions','*/15 * * * *','SELECT retry_missed_reactions()');
+--   -- last_scheduled_at can simply be dropped; nothing outside the orchestrator reads it.
+-- =============================================================================
+
+BEGIN;
+
+-- ── 1. Split the scheduling stamp from the run stamp ─────────────────────────
+-- agent_schedules.last_run_at was written when the orchestrator CREATED a task, not
+-- when work succeeded. Four schedules therefore read "ran within the last two weeks"
+-- while agent_runs said 2026-06-06 — or, for ingest-infoxchange-services, never.
+-- The interval gate genuinely needs a "when did we last schedule" value, so this adds
+-- one rather than moving the meaning of an existing column.
+ALTER TABLE agent_schedules ADD COLUMN IF NOT EXISTS last_scheduled_at timestamptz;
+
+COMMENT ON COLUMN agent_schedules.last_scheduled_at IS
+  'When the orchestrator last created a task for this agent. Drives the interval gate. Written on task creation.';
+COMMENT ON COLUMN agent_schedules.last_run_at IS
+  'When work for this agent last SUCCEEDED. Written only on task completion — never on task creation. Compare with agent_runs; they must agree.';
+
+-- Seed the new column from the old one: the existing values were scheduling stamps
+-- all along, so this is a rename-in-place, not a guess.
+UPDATE agent_schedules SET last_scheduled_at = last_run_at WHERE last_scheduled_at IS NULL;
+
+-- Now make last_run_at tell the truth for the four that were lying: their real last
+-- run comes from agent_runs, and NULL is correct for one that has never run.
+UPDATE agent_schedules s
+SET    last_run_at = (SELECT max(r.started_at) FROM agent_runs r WHERE r.agent_id = s.agent_id)
+WHERE  s.agent_id IN ('bridge-community-directories','scrape-community-directories',
+                      'ingest-open-community-directories','ingest-infoxchange-services');
+
+-- ── 2. Disarm the billing reminders ──────────────────────────────────────────
+-- Enabled, auto-creating, 24h, 33 runs, last 2026-08-18 05:31, and its registry command
+-- carried no --dry-run: it calls sendEmail() as "CivicGraph Billing" for a subscription
+-- product cut in April. It has mailed nobody because org_profiles happens to hold nobody
+-- in a billing window — not because anything stopped it. The registry now also carries
+-- --dry-run, so this is the first of two latches.
+UPDATE agent_schedules SET enabled = false, updated_at = now()
+WHERE  agent_id = 'send-billing-reminders';
+
+-- ── 3. Disable the four schedules whose agents no longer exist ───────────────
+-- None is present in scripts/lib/agent-registry.mjs (185 agents) and none has a script
+-- on disk, so every task minted for them fails "Unknown agent" in executeTask.
+UPDATE agent_schedules SET enabled = false, auto_create_task = false, updated_at = now()
+WHERE  agent_id IN ('bridge-community-directories','scrape-community-directories',
+                    'ingest-open-community-directories','ingest-infoxchange-services');
+
+COMMIT;
+
+-- ── 4. Unschedule the reactor ────────────────────────────────────────────────
+-- pg_cron job 1, every 15 minutes = ~2,880 runs/month, and the top source of cron
+-- failures in this database. event_reactions holds ONE row, written 2026-02-27;
+-- integration_events went 8,860 (Mar) -> 543 (Apr) -> 0 (May) -> 61 (Aug). The flow it
+-- retries died with the April cut. The function itself is left in place — this removes
+-- only the schedule.
+-- Outside the transaction: cron.unschedule() is not transactional.
+SELECT cron.unschedule('retry-missed-reactions');

--- a/scripts/agent-orchestrator.mjs
+++ b/scripts/agent-orchestrator.mjs
@@ -243,6 +243,13 @@ async function executeTask(task) {
           })
           .eq('id', task.id);
 
+        // The honest freshness signal: work succeeded, so the schedule may say it ran.
+        // Nothing else writes this column.
+        await supabase
+          .from('agent_schedules')
+          .update({ last_run_at: new Date().toISOString() })
+          .eq('agent_id', task.agent_id);
+
         // Parse stats from stdout if available (look for JSON on last line)
         let stats = {};
         try {
@@ -309,8 +316,10 @@ async function runScheduler() {
 
     for (const schedule of schedules) {
       const thresholdMs = schedule.interval_hours * 3600_000;
-      const lastRun = schedule.last_run_at ? new Date(schedule.last_run_at).getTime() : 0;
-      const elapsed = Date.now() - lastRun;
+      // Gate on when we last SCHEDULED, not when work last succeeded. Those are different
+      // questions and conflating them is what made last_run_at lie: see the fix below.
+      const lastScheduled = schedule.last_scheduled_at ? new Date(schedule.last_scheduled_at).getTime() : 0;
+      const elapsed = Date.now() - lastScheduled;
 
       if (elapsed < thresholdMs) continue;
 
@@ -338,10 +347,12 @@ async function runScheduler() {
         continue;
       }
 
-      // Update last_run_at
+      // Stamp the SCHEDULING, not the run. last_run_at is written only when the work actually
+      // succeeds (see executeTask), so a schedule can no longer report a freshness the run log
+      // contradicts — four schedules read "ran this week" while agent_runs said June, or never.
       await supabase
         .from('agent_schedules')
-        .update({ last_run_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+        .update({ last_scheduled_at: new Date().toISOString(), updated_at: new Date().toISOString() })
         .eq('id', schedule.id);
 
       console.log(`[${timestamp()}] Scheduler created task: ${schedule.agent_id}`);

--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -1069,7 +1069,11 @@ export const AGENTS = {
     dependencies: ['scout-grants-for-profiles'],
   },
   'send-billing-reminders': {
-    command: ['npx', 'tsx', '--tsconfig', 'apps/web/tsconfig.json', 'scripts/send-billing-reminders.ts'],
+    // --dry-run is NOT optional here. This mails real people as "CivicGraph Billing" about a
+    // subscription product cut 2026-04-24. Its schedule is disabled (2026-08-18-disarm-periphery.sql);
+    // this flag is the second latch, so re-enabling the schedule alone cannot send. Remove it only
+    // when billing is a live product again.
+    command: ['npx', 'tsx', '--tsconfig', 'apps/web/tsconfig.json', 'scripts/send-billing-reminders.ts', '--dry-run'],
     displayName: 'Send Billing Reminders',
     category: 'intelligence',
     defaultPriority: 3,

--- a/scripts/scheduler.mjs
+++ b/scripts/scheduler.mjs
@@ -96,10 +96,12 @@ async function getDueAgents() {
 
   const now = Date.now();
   let due = (data || []).filter(schedule => {
-    if (!schedule.last_run_at) return true; // never run
-    const lastRun = new Date(schedule.last_run_at).getTime();
+    // Gate on the last ATTEMPT, not the last success — that is what stops retry thrash.
+    // last_run_at means "work succeeded" and must not be used for this.
+    if (!schedule.last_scheduled_at) return true; // never attempted
+    const lastAttempt = new Date(schedule.last_scheduled_at).getTime();
     const intervalMs = (schedule.interval_hours || 24) * 3600000;
-    return now - lastRun >= intervalMs;
+    return now - lastAttempt >= intervalMs;
   });
 
   if (ONLY_AGENTS?.length) {
@@ -158,13 +160,22 @@ async function runAgent(schedule) {
   }
 }
 
-async function updateLastRun(agentId) {
+/**
+ * Two stamps, two meanings. last_scheduled_at records the attempt and drives the interval
+ * gate (so a failing agent still cannot thrash); last_run_at records SUCCESS and is what
+ * any freshness reading should trust. Writing one value for both is what let four schedules
+ * claim they had run this week when agent_runs said June.
+ */
+async function updateStamps(agentId, succeeded) {
+  const patch = { last_scheduled_at: new Date().toISOString() };
+  if (succeeded) patch.last_run_at = patch.last_scheduled_at;
+
   const { error } = await supabase
     .from('agent_schedules')
-    .update({ last_run_at: new Date().toISOString() })
+    .update(patch)
     .eq('agent_id', agentId);
 
-  if (error) log(`  Failed to update last_run_at: ${error.message}`);
+  if (error) log(`  Failed to update schedule stamps: ${error.message}`);
 }
 
 async function cleanupStaleRuns() {
@@ -213,8 +224,8 @@ async function main() {
     }
 
     const ok = await runAgent(schedule);
-    await updateLastRun(schedule.agent_id);
-    if (!ok) log(`  Marked last_run_at despite failure to avoid retry thrash.`);
+    await updateStamps(schedule.agent_id, ok);
+    if (!ok) log(`  Marked last_scheduled_at (not last_run_at) to avoid retry thrash.`);
   }
 
   log(`\nScheduler complete`);


### PR DESCRIPTION
All four items from the sweep (#277), **applied to the database 2026-08-18** and verified. Every change is reversible and the reverse SQL is in the migration header.

## Billing — two latches, not one

You did not pick between them, so both: the schedule is **disabled**, and the registry command now carries **`--dry-run`**. A mailer for a product cut in April should not be one flag away from a real inbox — it had run 33 times, last that morning, with no dry-run guard and a live `sendEmail()` call as "CivicGraph Billing".

## Four dead schedules

`bridge-`, `scrape-`, `ingest-open-community-directories` and `ingest-infoxchange-services` are `enabled = false, auto_create_task = false`. None is in the 185-agent registry; every task they minted failed "Unknown agent" in `executeTask`.

## The reactor

`retry-missed-reactions` unscheduled — ~2,880 runs/month, top source of cron failures, against a flow whose only recorded reaction is dated 2026-02-27. **The function is left in place; only the schedule goes.** pg_cron is now 6 jobs, all doing real work.

## The stamp — a new column, not a moved meaning

The interval gate genuinely needs "when did we last schedule", so taking that meaning away from `last_run_at` would have broken it. `last_scheduled_at` now carries the attempt; `last_run_at` is written **only on success**. Both columns are `COMMENT`ed with which is which.

**Both writers fixed, which is why this is not a one-line change:**
- `agent-orchestrator.mjs` stamped `last_run_at` immediately after the task INSERT.
- `scripts/scheduler.mjs` stamped after every attempt, success or failure, and said so in its own log line. Not scheduled anywhere, but one manual run would have re-poisoned the column.

`last_run_at` for the four liars is backfilled from `agent_runs` — June dates, and NULL where an agent has never run.

## Verified after applying

| | |
|---|---|
| pg_cron | 6 jobs, `retry-missed-reactions` gone |
| the five schedules | all `enabled = false` |
| `bridge-community-directories` | `last_run_at` 2026-06-06, `last_scheduled_at` 2026-08-18 — the gap is now visible instead of hidden |
| `ingest-infoxchange-services` | `last_run_at` NULL, which is the honest value |

`precheck.sh` green (tsc + 742 tests).

## One thing left, and it is yours

**The orchestrator is running the old code under pm2.** The stamp fix is live in the repo but not in the process until it restarts. I have not touched it — restarting that daemon is your call, and the ledger records that recreating pm2 procs from a bare shell strips inherited secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)