### PR TITLE
Measure the traffic Lever 2 was going to optimise

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@sentry/nextjs": "^10.43.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.49.1",
+    "@vercel/analytics": "^2.0.1",
     "ai": "^6.0.105",
     "import-in-the-middle": "^2.0.6",
     "leaflet": "^1.9.4",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -38,6 +38,10 @@ import { resolveSubscriptionTier } from '@/lib/subscription';
 import { isAdminEmail } from '@/lib/admin';
 import type { User } from '@supabase/supabase-js';
 import { cookies, headers } from 'next/headers';
+// Vercel Web Analytics. Added 2026-08-19 because Lever 2 was cut for the want of exactly this
+// number: the restructure would flip 78 routes to static, and nothing on this project measured
+// whether those routes are ever hit. See #284 and the Cut table's "returns if" column.
+import { Analytics } from '@vercel/analytics/next';
 
 export const metadata: Metadata = {
   title: "CivicGraph — Australia's Accountability Atlas",
@@ -121,6 +125,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <body className={`font-sans antialiased bg-transparent ${qlFontVars}`}>
           <BrandFontLinks />
           {children}
+          <Analytics />
         </body>
       </html>
     );
@@ -263,6 +268,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           </>
         )}
         <ShortlistBar />
+        <Analytics />
         {/* The Atlas is a full-viewport map; the chat bubble sat on its
             bottom corner controls (Ben, 2026-08-09: no AI button there). */}
         {!pathname.startsWith('/atlas') && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.98.0
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@15.5.12(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       ai:
         specifier: ^6.0.105
         version: 6.0.105(zod@4.3.6)
@@ -2144,6 +2147,35 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -6295,6 +6327,11 @@ snapshots:
     dependencies:
       '@types/node': 22.19.13
     optional: true
+
+  '@vercel/analytics@2.0.1(next@15.5.12(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      next: 15.5.12(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   '@vercel/oidc@3.1.0': {}
 


### PR DESCRIPTION
Follow-on from #284. **VISIBLE — touches the root layout, so it stops for your eyeball**, though the change is three lines of mount plus a dependency.

Lever 2 was cut for the want of one number: whether anyone actually hits the 78 routes the restructure would have made static. That number does not exist, because **Web Analytics has never been enabled on this project**.

"Just turn it on" turned out to be wrong — `@vercel/analytics` was not installed and `<Analytics />` was not mounted anywhere. So: install, and mount.

**Both branches of the root layout get it.** `app/layout.tsx` returns early for chromeless routes (`/dashboard`, `/clarity`, `/ops`, `/admin`, `/embed`, `/share`, `/account`, `/atlas`…) before ever reaching the main return. Mounting only in the main branch would leave every one of those reporting nothing — and the gap would read as *no traffic* rather than *no instrument*, which is the exact confident-zero failure this repo keeps finding.

**Still yours:** the dashboard toggle in Vercel. The code ships the collector; the project setting turns it on.

Once there is a month of data, the Cut table's "returns if" condition on Lever 2 can be evaluated against a real figure instead of an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)