### PR TITLE
Dollar-less funder edges: mark what can never be backfilled, disclose the rest

### DIFF
--- a/apps/web/src/app/dashboard/browse/foundations/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/browse/foundations/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function FoundationProfile({ params }: { params: Promise<{ 
         {Array.isArray(f.thematic_focus) && f.thematic_focus.length ? ` · focus: ${f.thematic_focus.slice(0, 5).join(', ')}` : ''}
       </p>
 
-      <Section title="Who it funds" note={`${grantees.length} linked grantees${grantees.length === 200 ? ' (first 200)' : ''} · each link states its method`}>
+      <Section title="Who it funds" note={`${grantees.length} linked grantees${grantees.length === 200 ? ' (first 200)' : ''}${grantees.filter((g) => !g.grant_amount).length > 0 ? ` · ${grantees.filter((g) => !g.grant_amount).length} with no amount on record` : ''} · each link states its method`}>
         {grantees.length === 0 ? (
           <p className="text-[13px]" style={{ color: 'var(--shell-muted)' }}>
             No grantee links recorded. That is a statement about our data, not about the foundation.

--- a/apps/web/src/app/foundation/[abn]/page.tsx
+++ b/apps/web/src/app/foundation/[abn]/page.tsx
@@ -225,6 +225,10 @@ export default async function FoundationDetailPage({ params }: { params: Promise
 
   // Aggregate grantee stats
   const uniqueGrantees = new Set(grantees.map(g => g.grantee_abn || g.grantee_name)).size;
+  // Disclose rather than hide: a grantee link with no dollar figure is a real relationship the
+  // funder published, but counting it silently alongside funded ones overstates what we know.
+  // Policy: issues/285. A $0 row adds nothing to any total here — only to the count.
+  const granteesNoAmount = grantees.filter(g => !g.grant_amount).length;
   const ccGrantees = grantees.filter(g => g.grantee_community_controlled).length;
   const stateDistribution = new Map<string, number>();
   for (const g of grantees) {
@@ -378,7 +382,8 @@ export default async function FoundationDetailPage({ params }: { params: Promise
         <section className="mb-12">
           <h2 className="text-xl font-black text-bauhaus-black mb-2 uppercase tracking-widest">Grantees</h2>
           <p className="text-sm text-bauhaus-muted mb-4">
-            {uniqueGrantees} traceable grantees across {sortedStates.length} states.
+            {uniqueGrantees} traceable grantees across {sortedStates.length} states
+            {granteesNoAmount > 0 ? `, ${granteesNoAmount} of them with no amount on record` : ''}.
             {ccGrantees > 0 && ` ${ccGrantees} community-controlled.`}
           </p>
 

--- a/apps/web/src/lib/services/org-dashboard-service.ts
+++ b/apps/web/src/lib/services/org-dashboard-service.ts
@@ -354,6 +354,8 @@ export interface FoundationFunder {
   foundation_abn: string;
   total_giving_annual: number;
   grant_count: number;
+  /** How many of grant_count carry no dollar figure — so a reader can tell what total_grant_amount covers. */
+  grants_without_amount: number;
   total_grant_amount: number;
   grant_years: string[];
   foundation_score: number | null;
@@ -1568,6 +1570,10 @@ export async function getOrgFoundationFunders(abn: string | string[]): Promise<F
     query: `SELECT fg.foundation_name, fg.foundation_abn,
               MAX(fg.total_giving_annual)::bigint as total_giving_annual,
               COUNT(*)::int as grant_count,
+              -- Disclose, do not hide (issues/285): grant_count includes links whose source
+              -- published no dollar figure, so "N grants, $X" understates the average unless the
+              -- reader knows how many of the N carry no amount at all.
+              COUNT(*) FILTER (WHERE fg.grant_amount IS NULL OR fg.grant_amount = 0)::int as grants_without_amount,
               SUM(fg.grant_amount)::bigint as total_grant_amount,
               array_agg(DISTINCT fg.grant_year) FILTER (WHERE fg.grant_year IS NOT NULL) as grant_years,
               MAX(fs.foundation_score)::int as foundation_score,

--- a/migrations/2026-08-19-amount-unknown-policy.sql
+++ b/migrations/2026-08-19-amount-unknown-policy.sql
@@ -1,0 +1,60 @@
+-- =============================================================================
+-- 2026-08-19-amount-unknown-policy.sql
+--
+-- Policy for dollar-less funder edges, decided in issue #285.
+--
+-- `foundation_grantees` holds 6,001 rows across 181 funders; 1,065 carry no amount.
+-- Those 1,065 are NOT one thing, and one flat rule would have been wrong either way:
+-- deleting them destroys facts a funder published deliberately, keeping them silently
+-- inflates every grantee count.
+--
+-- The zero-rate tracks the SOURCE TYPE, not our extraction:
+--     official_grants_database_backfill    0.2%   <- databases publish amounts
+--     official_grantee_surface_backfill   16.2%
+--     official_annual_report_backfill     48.1%
+--     canonical_relationship_backfill      100%   <- never published amounts, by design
+--     prf_annual_review_partner_list       100%   <- a PARTNER LIST, not a grant list
+--     official_impact_report_backfill      100%   <- an impact report names partners
+--
+-- So: the three 100% classes (202 rows) are marked `amount_unknown` — the source told us
+-- WHO, never HOW MUCH, and no backfill can fix that because there is nothing to fetch.
+-- The middle band stays unmarked: a missing amount there is plausibly our miss, and it is
+-- backfill work (issue #291 takes VFFF's 7 as the test case).
+--
+-- 234 of the 1,065 are self-loops from a broken backfill and are NOT handled here — they
+-- are a money-integrity bug worth $98.69M, split out to issue #290.
+--
+-- APPLY:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql \
+--     -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 \
+--     -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-19-amount-unknown-policy.sql
+--
+-- REVERSE:  ALTER TABLE foundation_grantees DROP COLUMN amount_unknown;
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE foundation_grantees
+  ADD COLUMN IF NOT EXISTS amount_unknown boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN foundation_grantees.amount_unknown IS
+  'TRUE where the SOURCE published a relationship without a sum (partner lists, impact reports, '
+  'canonical relationship backfills). Distinct from a NULL grant_amount, which may equally mean our '
+  'extraction missed a figure the source does publish. The distinction is the whole point: '
+  'amount_unknown rows are not a backfill queue, they are facts with no dollar figure to find. '
+  'Decided in github.com/Acurioustractor/grantscope/issues/285.';
+
+-- The three classes whose sources never carried amounts. Self-loops are deliberately excluded:
+-- they are a bug (#290), not a source that declined to publish a figure.
+UPDATE foundation_grantees
+SET    amount_unknown = true
+WHERE  extraction_method IN (
+         'canonical_relationship_backfill',
+         'prf_annual_review_partner_list',
+         'official_impact_report_backfill'
+       )
+  AND  (grant_amount IS NULL OR grant_amount = 0)
+  AND  lower(trim(foundation_name)) <> lower(trim(grantee_name));
+
+COMMIT;


### PR DESCRIPTION
Resolves #285. **VISIBLE — two foundation pages change what they say, so it stops for your eyeball.** Migration already applied (202 rows marked, verified).

## The policy

The 1,065 dollar-less rows in `foundation_grantees` were never one thing, and either flat rule was wrong: **delete** destroys facts a funder published deliberately; **keep** silently inflates every grantee count.

The zero-rate tracks the **source type**, not our extraction:

| method | zero-rate | verdict |
|---|---|---|
| `official_grants_database_backfill` | 0.2% | — |
| `official_grantee_surface_backfill` | 16.2% | backfill band |
| `official_annual_report_backfill` | 48.1% | backfill band |
| `canonical_relationship_backfill` · `prf_annual_review_partner_list` · `official_impact_report_backfill` | **100%** | **`amount_unknown`** |

**202 rows** in those three classes are now `amount_unknown = true`. A *partner list* and an *impact report* name who a funder works with; they never published amounts. No backfill can fix that, because there is nothing at the source to fetch — and that is exactly what the flag records, so the next session doesn't treat them as a backfill queue.

The middle band stays unmarked: a missing amount there is plausibly our miss. #291 takes **VFFF's 7 as the test case** for the ~590 behind it — if VFFF's amounts aren't published either, the whole band belongs in `amount_unknown`, learned for the price of seven rows.

## Two things this turned up

**All three count surfaces read `mv_foundation_grantees`, which is built from `gs_relationships` — not from `foundation_grantees`.** So the flag cannot reach them, and "thread it into the matview" isn't possible without the graph propagation deliberately ruled out. They disclose by deriving from the amount instead, which answers the display question exactly ("N grantees, M with no amount on record"). The column serves the *policy* question — what is backfillable — not the UI.

**234 of the 1,065 are self-loops** from a broken backfill, excluded here and split to **#290** — where the sharper finding is the 72 self-loops that *do* carry money: **$98.69M, largest single row $50M**, plus 157 already in the graph. Those were never in the 1,065 at all, because having an amount let them pass every filter this repo has.

## What changes on screen

- `/foundation/[abn]` — "N traceable grantees across N states**, M of them with no amount on record**"
- `/dashboard/browse/foundations/[id]` — "N linked grantees **· M with no amount on record**"
- `org-dashboard-service.ts:1571` — `grant_count` now ships with `grants_without_amount`, so "N grants, $X" can no longer imply $X covers all N

Money totals were always correct — a $0 row adds nothing to a `SUM`. Counts were the exposure.

`precheck.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)