### PR TITLE
ROGS double-count fix, grant place-capture, and what the data actually says

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ These exist to separate incompatible measures that share one amount column.
 Omitting them does not produce a slightly-off number, it produces a wrong one by an order of magnitude.
 
 ```sql
--- 1. justice_funding: 848 'expenditure_aggregate' rows are WHOLE-OF-STATE BUDGETS ($66.1bn),
+-- 1. justice_funding: 368 'expenditure_aggregate' rows are WHOLE-OF-STATE BUDGETS ($28.35bn),
 --    not money to any organisation. For funding received by orgs:
 WHERE measure_kind = 'grant'          -- 126,673 rows, $46.1bn
 
@@ -179,9 +179,17 @@ recipients of youth justice funding in Australia**. One of them even carries an 
 ABN-based join will not save you.
 
 **`is_aggregate` and `measure_kind` are independent — neither implies the other.** 1,358 rows are
-`measure_kind='grant'` AND `is_aggregate` ($12.06bn of grant-shaped aggregates), while 330
-`expenditure_aggregate` rows are `is_aggregate=false` ($17.39bn). Filtering on either alone leaves
+`measure_kind='grant'` AND `is_aggregate` ($12.06bn of grant-shaped aggregates), while 180
+`expenditure_aggregate` rows are `is_aggregate=false` ($6.77bn). Filtering on either alone leaves
 billions behind.
+
+**Re-measured 2026-08-19 after the ROGS dedupe (#299).** The `expenditure_aggregate` lane was
+848 rows / $66.13bn, of which 483 were exact duplicates of a second ingest of the same
+Productivity Commission table. It is now 368 rows / $28.35bn. The `is_aggregate=false` count
+fell from 330 / $17.39bn to 180 / $6.77bn in the same fix, which also flagged the 80 ROGS
+rollup rows that had been only 30/80 flagged. Per-lane figures (detention, community-based,
+group conferencing) were never affected — the duplication was across `program_name` labels,
+not within them.
 
 `political_donations` was checked for the same defect and is clean — no aggregate-shaped donor
 names. Filter 2 is specific to `justice_funding`.

--- a/migrations/2026-08-19-grant-place-capture.sql
+++ b/migrations/2026-08-19-grant-place-capture.sql
@@ -1,0 +1,81 @@
+-- v_grant_place_capture: does grant money delivered into a place get received by an
+-- organisation in that place?
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-19-grant-place-capture.sql
+--
+-- grantconnect_awards carries delivery_postcode/delivery_state SEPARATE from
+-- recipient_postcode/recipient_state. Nothing read them until 2026-08-19. This view is
+-- the reusable form of that analysis so the exclusion rules cannot drift.
+--
+-- FOUR EXCLUSIONS, all load-bearing. Removing any one changes the answer materially:
+--
+--  1. delivery_postcode = 'Multiple'  (a literal string, 5,978 rows, $19.55bn)
+--     Multi-site grants. They are not a place. Counting them as one made 'Multiple'
+--     compare unequal to every recipient postcode, which inflated the "delivered
+--     off-site" dollars from $22.91bn to $42.46bn and cross-state from $3.95bn to
+--     $17.79bn. That was wrong by 4.5x on the cross-state figure.
+--
+--  2. aggregate-shaped recipient names (2,663 rows) and value_aud <= 0 (195 rows).
+--
+--  3. postcodes touching more than one LGA (521 of 2,859). Attributing them by
+--     picking one arbitrarily is how you get a wrong answer that looks right. Same
+--     discipline as the LGA attribution rebuild: unplaced beats confidently wrong.
+--
+--  4. postcode_geo rows whose "locality" is actually an SA3 name (443 with an LGA).
+--     These carry WRONG LGAs. Postcode 4816 is recorded as locality "Townsville -
+--     South" with lga_name 'Croydon', an LGA ~900km away in far north-west Queensland.
+--     Left in, Croydon QLD appeared as the worst-capturing LGA in the country on
+--     $72.9M of Palm Island money. It is an artefact, not a finding.
+--     See the follow-up issue: postcode_geo needs these 443 rows repaired.
+--
+-- Coverage after all four: 85,898 awards, $33.75bn, out of 291,264 awards / $230bn.
+-- This view is a well-measured MINORITY of the grant record, not the whole of it.
+-- Any surface using it must say so.
+
+CREATE OR REPLACE VIEW v_grant_place_capture AS
+WITH pc AS (
+  SELECT postcode,
+         min(lga_name)        AS lga_name,
+         min(state)           AS state,
+         min(remoteness_2021) AS remoteness
+    FROM postcode_geo
+   WHERE lga_name IS NOT NULL
+     AND locality NOT LIKE '% - %'      -- exclusion 4: SA3-shaped rows carry wrong LGAs
+   GROUP BY postcode
+  HAVING count(DISTINCT lga_name) = 1   -- exclusion 3: single-LGA postcodes only
+),
+base AS (
+  SELECT *
+    FROM grantconnect_awards
+   WHERE delivery_postcode IS NOT NULL
+     AND recipient_postcode IS NOT NULL
+     AND delivery_postcode <> 'Multiple'                        -- exclusion 1
+     AND value_aud > 0                                          -- exclusion 2
+     AND lower(trim(recipient_name)) NOT IN
+         ('total','totals','various','n/a','na','unknown','other')
+)
+SELECT b.id,
+       b.value_aud,
+       b.recipient_name,
+       b.recipient_abn,
+       b.approval_date,
+       d.lga_name    AS delivery_lga,
+       d.state       AS delivery_state,
+       d.remoteness  AS delivery_remoteness,
+       r.lga_name    AS recipient_lga,
+       r.state       AS recipient_state,
+       (d.lga_name = r.lga_name) AS captured_locally
+  FROM base b
+  JOIN pc d ON d.postcode = b.delivery_postcode
+  LEFT JOIN pc r ON r.postcode = b.recipient_postcode;
+
+COMMENT ON VIEW v_grant_place_capture IS
+  'Grant awards where both delivery and recipient location resolve to a single, trustworthy LGA. '
+  '85,898 of 291,264 awards ($33.75bn of $230bn). captured_locally = the receiving org sits in the '
+  'LGA the work was delivered into. Four exclusions apply, documented in '
+  'migrations/2026-08-19-grant-place-capture.sql. Do not widen them without re-reading that header.';
+
+GRANT SELECT ON v_grant_place_capture TO anon, authenticated, service_role;

--- a/migrations/2026-08-19-grant-place-capture.sql
+++ b/migrations/2026-08-19-grant-place-capture.sql
@@ -57,7 +57,7 @@ base AS (
      AND lower(trim(recipient_name)) NOT IN
          ('total','totals','various','n/a','na','unknown','other')
 )
-SELECT b.id,
+SELECT b.ga_id,
        b.value_aud,
        b.recipient_name,
        b.recipient_abn,

--- a/migrations/2026-08-19-rogs-expenditure-double-count.sql
+++ b/migrations/2026-08-19-rogs-expenditure-double-count.sql
@@ -1,0 +1,99 @@
+-- ROGS youth justice expenditure: remove a duplicate ingest and a mislabelled
+-- within-ingest duplicate, and flag the rollup rows as aggregates.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-19-rogs-expenditure-double-count.sql
+--
+-- WHY
+-- `justice_funding.measure_kind='expenditure_aggregate'` held 848 rows summing to
+-- $66.13bn. 483 of those rows were exact duplicates (same state, financial_year,
+-- amount_dollars). Two faults, both from 2026-03-14:
+--
+--   1. The same Productivity Commission ROGS youth justice table was ingested twice,
+--      two hours apart, under different source_urls and different program_name
+--      conventions. Verified identical row by row: ACT 2022-23 detention appears as
+--      $26,776,000 under both. All 320 rows of the later ingest are contained in the
+--      earlier one.
+--   2. Within the earlier ingest, the scraper flattened the ROGS row hierarchy such
+--      that 160 "Cost per young person per day ..." rows carry the RECURRENT
+--      EXPENDITURE amount of their parent lane, not a per-day cost.
+--
+-- TRAP: there are 176 "Cost per young person per day" rows, not 160. The other 16
+-- carry genuine per-day figures and MUST survive. Step 2 therefore deletes only rows
+-- that have an exact (state, financial_year, amount_dollars) twin among the
+-- "Government real recurrent expenditure" rows. Do not simplify it to a LIKE match.
+--
+-- Also fixed: the 80 rollup rows ("Government expenditure" with no lane in the label)
+-- are the SUM of the three lanes below them, but only 30 of the 80 were flagged
+-- is_aggregate. Summing the lane rows together with the rollup double-counts.
+--
+-- NOT touched: the 24 AIHW rows ($0.9bn) are an independent source and are correct.
+
+BEGIN;
+
+-- Guard: refuse to run twice, or against an unexpected shape.
+DO $$
+DECLARE n_dupe_ingest int; n_costday int; n_rollup int;
+BEGIN
+  SELECT count(*) INTO n_dupe_ingest FROM justice_funding
+   WHERE measure_kind='expenditure_aggregate'
+     AND source_url LIKE '%pc.gov.au%' AND source_url NOT LIKE '%/2026/%';
+  SELECT count(*) INTO n_costday FROM justice_funding
+   WHERE measure_kind='expenditure_aggregate'
+     AND program_name LIKE 'Cost per young person per day%';
+  SELECT count(*) INTO n_rollup FROM justice_funding
+   WHERE measure_kind='expenditure_aggregate'
+     AND program_name='Government real recurrent expenditure - Government expenditure - Government real recurrent expenditure';
+
+  IF n_dupe_ingest = 0 AND n_costday <= 16 THEN
+    RAISE EXCEPTION 'Already applied (dupe ingest %, cost-per-day %). Aborting.', n_dupe_ingest, n_costday;
+  END IF;
+  IF n_dupe_ingest <> 320 OR n_costday <> 176 OR n_rollup <> 80 THEN
+    RAISE EXCEPTION 'Unexpected shape: dupe_ingest=% (want 320), costday=% (want 176), rollup=% (want 80). Re-audit before applying.',
+      n_dupe_ingest, n_costday, n_rollup;
+  END IF;
+END $$;
+
+-- 1. The duplicate second ingest. All 320 rows verified contained in the earlier one.
+DELETE FROM justice_funding
+ WHERE measure_kind='expenditure_aggregate'
+   AND source_url LIKE '%pc.gov.au%'
+   AND source_url NOT LIKE '%/2026/%';
+
+-- 2. Mislabelled per-day rows that actually carry the parent lane's recurrent total.
+--    Only those with an exact twin among the recurrent rows. Expect 160 of 176.
+DELETE FROM justice_funding a
+ WHERE a.measure_kind='expenditure_aggregate'
+   AND a.program_name LIKE 'Cost per young person per day%'
+   AND EXISTS (
+     SELECT 1 FROM justice_funding b
+      WHERE b.measure_kind='expenditure_aggregate'
+        AND b.program_name LIKE 'Government real recurrent%'
+        AND b.state = a.state
+        AND b.financial_year = a.financial_year
+        AND b.amount_dollars = a.amount_dollars
+        AND b.id <> a.id);
+
+-- 3. The rollup rows are aggregates of the three lanes. Flag all 80 consistently.
+UPDATE justice_funding
+   SET is_aggregate = true
+ WHERE measure_kind='expenditure_aggregate'
+   AND program_name='Government real recurrent expenditure - Government expenditure - Government real recurrent expenditure'
+   AND is_aggregate IS DISTINCT FROM true;
+
+-- Post-check: no exact (state, year, amount) duplicates should remain.
+DO $$
+DECLARE n_rows int; n_dupes int;
+BEGIN
+  SELECT count(*), count(*) - count(DISTINCT (state||'|'||financial_year||'|'||amount_dollars::text))
+    INTO n_rows, n_dupes
+    FROM justice_funding WHERE measure_kind='expenditure_aggregate';
+  RAISE NOTICE 'expenditure_aggregate now % rows, % residual same-value rows', n_rows, n_dupes;
+  IF n_rows <> 368 THEN
+    RAISE EXCEPTION 'Expected 368 rows after cleanup, got %. Rolling back.', n_rows;
+  END IF;
+END $$;
+
+COMMIT;

--- a/thoughts/shared/analysis/2026-08-19-delivery-location-scoping.md
+++ b/thoughts/shared/analysis/2026-08-19-delivery-location-scoping.md
@@ -1,0 +1,141 @@
+# Delivery location: scoping verdict
+
+*19 August 2026. Scoping pass on extracting delivery location from AusTender contract text.*
+
+## Verdict
+
+**Kill the text-extraction spike.** It cannot work, and it is aimed at a field the federal
+source does not publish.
+
+**Do two other things instead.** One of them needs no new data and can run today. The other
+is a bounded backfill with 100% coverage in sample.
+
+The goal behind the spike, showing what a place actually captures versus what merely passes
+through it, survives. The method was wrong.
+
+## Why text extraction fails
+
+Measured over all 825,222 rows of `austender_contracts`:
+
+| signal | rate |
+|---|---|
+| average title length | **17 characters** |
+| average description length | 35 characters |
+| descriptions longer than 40 chars | 177,685 (21.5%) |
+| contains a state token (NSW/VIC/QLD/...) anywhere | 12,286 (**1.5%**) |
+| ends with a ` - STATE` suffix | 364 (0.04%) |
+| mentions any of Australia's 30 largest places | 30,640 (**3.7%**) |
+
+Many titles are bare reference numbers: `4610000551`, `2349`, `HS51689121`. Adding a full
+gazetteer might reach 6 to 8 per cent, and a large share of those would be false friends,
+where "Sydney Trains" is a buyer and "Perth Mint" is a supplier, neither being a delivery
+location.
+
+An extraction pipeline built on this would be expensive, would need per-match adjudication
+of the kind the ORIC rung-3 work required, and would return a place for well under a tenth
+of contracts.
+
+## Why it fails at the source, not just in our copy
+
+The obvious next thought is that the field exists upstream and our ingest dropped it. It
+does not.
+
+AusTender publishes OCDS 1.1, and OCDS defines `Item.deliveryAddress` and
+`Item.deliveryLocation`. Pulled 100 live contract releases from
+`api.tenders.gov.au/ocds/findByDates/contractPublished/...`:
+
+- `deliveryAddress`: **0 occurrences**
+- `deliveryLocation`: **0 occurrences**
+- the string `delivery`, case-insensitive, anywhere in the payload: **0 occurrences**
+
+Australian Government contract notices do not record where the work happens. This is a
+property of the disclosure regime. No amount of parsing recovers it.
+
+## What the same probe did find
+
+Every supplier party carries a full address, and we do not store it.
+
+| party role | n | postcode | locality | region |
+|---|---|---|---|---|
+| supplier | 100 | **100** | **100** | **100** |
+| procuringEntity | 100 | 0 | 0 | 0 |
+
+Today we get supplier geography by joining `supplier_abn` to `gs_entities`, which leaves
+94,575 contracts and $126bn unmatched. The OCDS payload carries locality, region and
+postcode directly, at what looks like complete coverage.
+
+**This does not solve delivery location.** A supplier's registered address is still a
+registered address, with the intermediary bias already documented for remote NT funding.
+It removes a join and a coverage gap. It does not change what the number means, and any
+surface using it must keep saying so.
+
+## The thing that was already in the database
+
+`grantconnect_awards`, 291,264 rows, $230bn, carries **`delivery_postcode` and
+`delivery_state` as columns separate from `recipient_postcode` and `recipient_state`.**
+
+Nothing reads them.
+
+| | |
+|---|---|
+| rows | 291,264 |
+| `delivery_state` populated | 291,264 (**100%**) |
+| `delivery_postcode` populated | 152,546 (52.4%) |
+| both delivery and recipient postcode present | 152,527 |
+| **delivery postcode differs from recipient postcode** | **31,972 (21%)** |
+
+By dollars, across the 152,527 rows where both are known:
+
+- delivered where the recipient sits: **$28.43bn**
+- delivered somewhere else: **$42.46bn**
+- **crossing a state border: $17.79bn**
+
+Sixty per cent of the money whose two locations we know is spent somewhere other than
+where the organisation receiving it is based.
+
+And it worsens with remoteness. Share of awards delivered away from the recipient's
+postcode, by the remoteness of the delivery location:
+
+| delivered into | awards | value | delivered off-site |
+|---|---|---|---|
+| Major Cities | 96,535 | $34.88bn | 14.9% |
+| Inner Regional | 24,481 | $5.99bn | 20.1% |
+| Outer Regional | 16,656 | $4.50bn | 26.7% |
+| Remote | 2,974 | $1.13bn | 32.4% |
+| Very Remote | 2,919 | $1.30bn | **36.3%** |
+| (postcode unmapped) | 8,962 | $23.09bn | 69% |
+
+This is the leak, measured. The further out the work happens, the more likely the
+organisation paid for it sits somewhere else. That is the Preston metric, in Australian
+data, available now.
+
+Two cautions. `postcode_geo` is locality-grain, so any join to it must deduplicate to one
+row per postcode or the dollars fan out; the table above is deduplicated, an earlier run
+was not and inflated every figure. And the unmapped bucket holds $23.09bn at a 69%
+off-site rate, which is too odd to publish before someone works out what those postcodes
+are, most likely national programs or placeholder codes.
+
+## Recommendation
+
+**A. GrantConnect delivery-versus-recipient analysis. Do this first.** No ingest, no
+extraction, no inference. The columns are populated and the gradient above is already
+real. Roughly a day to get to a defensible per-place figure, plus the unmapped-postcode
+audit. This answers "what does my community capture" for the grant lane.
+
+**B. AusTender supplier address backfill from the OCDS API. Do this second.** Roughly
+8,250 paginated calls at 100 releases each, so a few hours as a background job. Adds
+supplier locality, region and postcode as first-class columns, retires the ABN join, and
+closes the $126bn unmatched gap. Improves precision on the 0.43 per cent figure without
+changing what it measures.
+
+**C. Delivery location for contracts. Park it, and say why.** The federal record does not
+contain it. If the question matters enough, the honest routes are the state portals,
+where `state_tenders` already carries a `state` column across 200K rows, or a
+freedom-of-information style ask about Defence site data, which is 286,286 contracts and
+$363.5bn on its own. Both are separate projects. Neither is a parsing problem.
+
+## The finding worth carrying out of this
+
+We went looking for a way to infer place from prose and found that place was already
+recorded, in a different table, in two columns nobody had read, for 291,264 awards worth
+$230bn. Before the next extraction pipeline, census the columns.

--- a/thoughts/shared/analysis/2026-08-19-grant-place-capture.md
+++ b/thoughts/shared/analysis/2026-08-19-grant-place-capture.md
@@ -1,0 +1,126 @@
+# What a place captures
+
+*19 August 2026. GrantConnect delivery location versus recipient location.*
+
+## The question
+
+When a grant is delivered into a place, does an organisation in that place receive it?
+
+`grantconnect_awards` has been able to answer this since it was ingested. It carries
+`delivery_postcode` and `delivery_state` as columns separate from `recipient_postcode`
+and `recipient_state`. 291,264 awards, $230bn. Nothing read them.
+
+## The answer
+
+On the 85,898 awards where both locations resolve to a trustworthy LGA, worth **$33.75bn**:
+
+- **85.1% of awards** are received by an organisation in the LGA they were delivered into.
+- **59.6% of the dollars** are.
+
+Those two numbers disagree because the large awards behave differently from the small ones.
+Most grants stay local. Most grant money does not.
+
+## The gradient, and the one that isn't there
+
+By award count, local capture falls the further out you go, monotonically:
+
+| delivered into | awards | delivered | captured locally (awards) | captured locally (dollars) |
+|---|---|---|---|---|
+| Major Cities | 58,139 | $24,337M | **86.8%** | 55.2% |
+| Inner Regional | 14,644 | $3,785M | 83.7% | 67.0% |
+| Outer Regional | 7,888 | $2,157M | 77.4% | 54.5% |
+| Remote | 1,457 | $605M | 70.4% | 63.7% |
+| Very Remote | 1,317 | $491M | **66.0%** | 68.1% |
+
+86.8 per cent down to 66.0 per cent. In Very Remote Australia, one grant in three delivered
+into a community is received by an organisation somewhere else.
+
+**By dollars there is no gradient.** 55.2 per cent in Major Cities, 68.1 per cent in Very
+Remote. If anything remote places capture a slightly larger share of the money delivered to
+them, because a handful of large awards go to councils and land councils that genuinely sit
+there.
+
+I expected the dollar gradient and it is not in the data. Reporting it would have been the
+easy story. The count gradient is the real one, and it is a different claim: what remote
+communities lose is not disproportionately the money, it is the **number of separate
+opportunities**. A third of the grants that touch them are administered from elsewhere. That
+is a third of the relationships, the staff, the reporting lines and the accumulated
+capability that sit outside the community.
+
+## Where it is worst
+
+Regional and remote LGAs receiving more than $15M across at least 30 awards, ranked by the
+share of dollars captured locally:
+
+| LGA | state | remoteness | awards | delivered | captured |
+|---|---|---|---|---|---|
+| Unincorporated SA | SA | Very Remote | 58 | $34.0M | 3.4% |
+| Wangaratta | VIC | Inner Regional | 88 | $258.0M | 8.3% |
+| Albury | NSW | Outer Regional | 89 | $16.6M | 9.9% |
+| Macedon Ranges | VIC | Inner Regional | 124 | $18.9M | 11.5% |
+| Glenelg | VIC | Outer Regional | 56 | $99.3M | 14.6% |
+| Bega Valley | NSW | Outer Regional | 118 | $25.0M | 15.5% |
+| Burke | QLD | Very Remote | 34 | $37.2M | 16.3% |
+| George Town | TAS | Outer Regional | 39 | $113.6M | 22.7% |
+| Boyup Brook | WA | Inner Regional | 35 | $16.1M | 24.1% |
+| Burdekin | QLD | Outer Regional | 102 | $23.7M | 26.7% |
+
+Wangaratta is the one to look at first. $258M delivered, 8.3 per cent captured. That is the
+largest single gap in the table by a wide margin.
+
+Read these as leads, not verdicts. A neighbouring-town recipient counts as off-site here, and
+in a small LGA that is often the honest local answer.
+
+## What I got wrong on the way, twice
+
+Both corrections were large enough to change the story, so they are worth stating.
+
+**`delivery_postcode` contains the literal string `'Multiple'`.** 5,978 rows, $19.55bn.
+Multi-site grants. Because `'Multiple'` never equals a recipient postcode, every one counted
+as delivered off-site. In the scoping pass I reported $42.46bn delivered away from the
+recipient and $17.79bn crossing state lines. Excluding `'Multiple'` and aggregate-named rows,
+the real figures are **$22.91bn and $3.95bn**. The cross-state number was wrong by 4.5x.
+
+**`postcode_geo` contains rows whose "locality" is an SA3 name, carrying wrong LGAs.**
+Postcode 4816 is recorded as locality `Townsville - South` with `lga_name = 'Croydon'`, an
+LGA about 900km away in far north-west Queensland. Left in, Croydon QLD came out as one of
+the worst-capturing LGAs in the country, on $72.9M that is actually Palm Island money. 443
+such rows carry an LGA. They are now excluded, and `postcode_geo` should be repaired.
+
+The first version of the per-place table also picked one LGA arbitrarily for postcodes that
+straddle several. That is the mistake the LGA attribution rebuild already learned: unplaced
+beats confidently wrong. 521 of 2,859 postcodes touch more than one LGA and are now excluded.
+
+## Coverage, stated plainly
+
+$33.75bn of $230bn. **This is a well-measured minority of the grant record, not the whole
+of it.** The exclusions are the price of the LGA figures being trustworthy. Any screen built
+on this must carry the number.
+
+Where the coverage goes:
+
+| | awards | value |
+|---|---|---|
+| all GrantConnect awards | 291,264 | $230bn |
+| `delivery_postcode` populated | 152,546 | |
+| after dropping `'Multiple'`, aggregates, non-positive | 144,853 | $51.29bn |
+| after single-LGA postcodes only | 113,434 | $43.95bn |
+| after dropping SA3-shaped `postcode_geo` rows | **85,898** | **$33.75bn** |
+
+`delivery_state` is populated on **100%** of all 291,264 awards. Every state-level cut is
+available across the full record. Only the LGA cut is this constrained.
+
+## The view
+
+`migrations/2026-08-19-grant-place-capture.sql` creates `v_grant_place_capture` with all
+four exclusions in one place, so they cannot drift into a query someone rewrites from memory.
+Written, not applied. Applying is a Tier 3 write.
+
+## Next
+
+- **Repair the 443 SA3-shaped `postcode_geo` rows.** They are wrong for every consumer of
+  that table, not just this one. Separate issue.
+- **Do the state-level version.** 100% coverage, no exclusions needed, and it answers the
+  same question for the whole $230bn.
+- **Wangaratta.** $258M and 8.3 per cent is either a real finding or an artefact, and one
+  hour of looking at the recipient list settles it.

--- a/thoughts/shared/analysis/2026-08-19-grant-place-capture.md
+++ b/thoughts/shared/analysis/2026-08-19-grant-place-capture.md
@@ -124,3 +124,88 @@ Written, not applied. Applying is a Tier 3 write.
   same question for the whole $230bn.
 - **Wangaratta.** $258M and 8.3 per cent is either a real finding or an artefact, and one
   hour of looking at the recipient list settles it.
+
+---
+
+# Additions and corrections, same day
+
+Four things changed after the above was written. Two are new findings, two are corrections
+to what I wrote.
+
+## The state-level cut: money stays in the state and leaves the town
+
+Across **281,003 awards worth $200.21bn**, excluding multi-state and pseudo-state values:
+
+- **97.5% of awards** are received in the state they were delivered into
+- **96.8% of the dollars** are
+
+Per state, every real jurisdiction sits between 93% and 98%.
+
+Set that beside the LGA figures from earlier: 85.1% of awards and **59.6% of dollars**.
+
+**State borders are almost never crossed. The leak is entirely internal.** Money delivered
+into a place reliably stays in that state and then leaves the town, travelling to a capital
+city or a regional centre inside the same jurisdiction. Any policy response pitched at
+interstate extraction is aimed at something that is not happening. The gap between 96.8% and
+59.6% is the whole problem, and it is a within-state problem.
+
+## Correction: `delivery_state` is not a single state
+
+I wrote in the scoping document and in spec #300 that `delivery_state` is populated on 100%
+of awards and therefore supports a state cut with no exclusions. **That was wrong.**
+
+The column holds **318 distinct values**, including comma-separated lists like
+`ACT, VIC, SA, WA, QLD, TAS`, plus the pseudo-places `National` and `Overseas`.
+
+- multi-state values: 4,726 rows, $9.73bn
+- `National`: 1,644 awards, $18.93bn, 30.2% "captured locally", which is meaningless
+- `Overseas`: 1,002 awards, $1.00bn
+
+Left in, they never equal a single recipient state and so count as delivered off-site, the
+same failure mode as `'Multiple'` in `delivery_postcode`. The uncorrected national figure was
+95.3% of awards and 87.1% of dollars. Corrected: **97.5% and 96.8%.**
+
+Coverage remains excellent, at $200.21bn of $230bn, but it is not uncaveated. Spec #300 needs
+this fixed.
+
+## Correction: the SA3-shaped `postcode_geo` rows are mostly fine
+
+I wrote that 443 rows carry wrong LGAs and should be repaired. **The extent was overstated
+and the repair is not available.**
+
+Most SA3-shaped rows are correct. Postcode 0812 `Malak - Marrara` maps to Darwin, which is
+right. 2000 `Sydney (North) - Millers Point` maps to Sydney, which is right. Postcode 4816
+`Townsville - South` maps to Croydon, which is wrong by about 900km, and that one is proven.
+
+How many others are wrong is **unknown, and cannot be determined from inside the database.**
+Only 4 of the 443 rows have a same-postcode sibling to cross-check against, and all 4 agree.
+The remaining 439 have no internal evidence either way. The Croydon case was caught by
+eyeballing an output, which is not a method that scales.
+
+So the blanket exclusion in `v_grant_place_capture` stands, but its justification changes. It
+is not removing 443 known-bad rows. It is refusing an unknown number of unknown-bad rows at a
+cost of about $10bn of coverage, on the evidence of one proven case. That is a defensible
+trade and it should be stated as such rather than as a repair.
+
+Fixing this properly needs the ABS SA3-to-LGA correspondence file, an external source.
+Separate project, not a migration.
+
+## Wangaratta was an artefact
+
+$258M delivered at 8.3% captured, the largest gap in the ranked table. The cause is a single
+recipient:
+
+**Australian Rail Track Corporation, registered in South Australia, $940M across 4 awards.**
+Inland Rail.
+
+That is a Commonwealth-owned corporation delivering national rail infrastructure. It is not a
+community organisation losing work to a city competitor, which is what the ranked table
+invites you to read.
+
+The lesson generalises. **Large national infrastructure delivered by government-owned
+corporations will dominate any per-place capture ranking and means something different from
+the rest of the measure.** Any surface built on this needs to segment it or the ranked list
+will mostly be a list of places that had a road, a railway or a transmission line built.
+
+A second, smaller thing surfaced in the same query: `Indigo Shire Council` appears twice under
+different casing, with separate dollar totals. Recipient names are not normalised.

--- a/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md
+++ b/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md
@@ -1,0 +1,134 @@
+# What the capital says
+
+*A reflection on nine years of youth justice spending. 19 August 2026.*
+
+At six o'clock you get locked down. You wait till tomorrow.
+
+That wait costs $1,141 million a year now. In 2015-16 it cost $592 million. Australia
+did not decide to nearly double what it spends holding children in detention. No
+cabinet voted on it. It happened the way weather happens, one budget line at a time,
+and the number at the end is the only place you can see it whole.
+
+## The three lanes
+
+The Productivity Commission counts youth justice money in three lanes. Detention.
+Community-based supervision. Group conferencing, which is the restorative lane, the
+one where a young person sits in a room with the people they harmed and something
+other than a cell happens next.
+
+Here is the record, government real recurrent expenditure, all states and territories:
+
+| | detention | community-based | group conferencing |
+|---|---|---|---|
+| 2015-16 | $592M | $274M | $59M |
+| 2019-20 | $720M | $450M | $49M |
+| 2024-25 | **$1,141M** | $520M | **$62M** |
+
+Detention rose 93 per cent in nine years. Community-based supervision rose 90 per cent
+off a base half the size. Group conferencing went from $59 million to $62 million.
+
+Five per cent, over nine years, before you account for inflation. In real terms the
+country cut it.
+
+Group conferencing is now 3.5 per cent of the three lanes. It is the lane with the
+evidence behind it, and it is the lane that has been held flat for a decade while the
+lane beside it doubled.
+
+## Capital is the tell
+
+Recurrent spending is what you do this year. Capital is what you build.
+
+Net capital expenditure across the same record: **$1,791 million into detention. $88
+million into community-based supervision. $20 million into group conferencing.**
+
+Detention takes 94 per cent of the capital.
+
+You do not pour $1.8 billion of concrete for a thing you intend to stop doing. Capital
+is a thirty-year statement of belief. Every one of those buildings was approved by
+people who said, in public, that they wanted fewer children locked up, and who then
+signed for the beds.
+
+The buildings will outlast the ministers. That is what capital is for.
+
+## What the other side of the ledger looks like
+
+Across every youth justice grant we hold, 2008-09 to 2024-25, the whole record comes to
+**$915.7 million.** Seventeen years. One thousand two hundred and thirty-six different
+organisations.
+
+Detention spent more than that in 2024-25 alone. One year against seventeen.
+
+Our grant record is incomplete, so $915.7 million is a floor and the real figure is
+higher. It would have to be twenty times higher to change the shape of this.
+
+Look at how it is spread. The top ten recipients hold 16.6 per cent between them.
+Nobody is capturing this money. Everybody is receiving a slice too small and too short
+to build anything with. Average out the record and it is $54 million a year, nationally,
+divided 1,236 ways.
+
+The sector tells itself a story about capture, about the big providers eating the
+funding. The numbers say the opposite. The problem is dispersion. An organisation can
+win grants for fifteen years and own nothing at the end of it, because a grant buys
+activity and activity stops when the grant does. Dispersion looks like fairness and
+works like precarity. It is harder to fight for exactly that reason.
+
+## And who holds the money that compounds
+
+Grants are not where the money is. Federal contracts moved $1,268 billion through the
+AusTender record. Community-controlled organisations hold **$5.43 billion of it.**
+
+Nought point four three per cent.
+
+By remoteness it is worse. Remote and Very Remote Australia together take $3.1 billion,
+which is 0.24 per cent, while Major Cities take $1,098 billion. The communities that
+carry the most youth justice contact receive the least of the money that could become
+local wages.
+
+One caution on that number. Supplier ABNs resolve to a registered address, not to where
+the work is done, so a regional council with an office in town gets credited for work
+happening three hundred kilometres away. The 0.43 per cent is a floor. Correcting it
+moves the number. It does not move the order of magnitude.
+
+## What is actually at stake
+
+Two systems are being funded here and only one of them is being capitalised.
+
+Detention gets buildings. Diversion gets rounds. Detention gets a thirty-year balance
+sheet. Diversion gets an acquittal and a reapplication. When people say prevention does
+not work at scale, what they are describing is a lane that has been given $20 million
+of capital since 2015 and asked to prove itself against $1.8 billion of concrete.
+
+The young person in the room at six o'clock is not there because the alternative failed.
+The alternative was never built.
+
+## Where this goes
+
+The interesting move is not asking for a bigger grant pool. The grant pool is $54
+million a year and it cannot capitalise anything, even won entirely.
+
+The move is procurement. That is where the $1,268 billion is, and it arrives as revenue
+rather than as grant, which means it compounds, which means an organisation can own
+something at the end. Preston in Lancashire did exactly this and did it without new
+money: measure where institutional spend leaks out of the local economy, then close the
+leak. Locally retained spend went from 5 per cent to 18.2 per cent inside Preston and
+39 per cent to 79.2 per cent across Lancashire. Around £70 million rerouted, 4,500 jobs.
+No new appropriation. A measuring instrument and the will to act on it.
+
+Nobody has built that instrument in Australia. The 0.43 per cent is the leak, unmeasured
+until now.
+
+Philanthropy's job in that picture is not funding the program. It is underwriting the
+entry: the cost of bidding, the working capital gap between doing the work and being
+paid for it, the compliance overhead, the first loss. Small money, once, so an
+organisation becomes bankable for a contract it can then keep winning. That is what
+catalytic means, in the literal sense of the word.
+
+And government's job is disclosure before it is policy. You cannot ask who should hold
+these contracts until there is a public record of who holds them now, near which
+communities, at what concentration.
+
+That record is the thing we are building. Everything above came out of it this morning.
+
+---
+
+*Provenance: `2026-08-19-what-the-capital-says.provenance.md`*

--- a/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.provenance.md
+++ b/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.provenance.md
@@ -1,0 +1,70 @@
+# Provenance: What the capital says
+
+Every figure in `2026-08-19-what-the-capital-says.md`, with its source and confidence.
+Queried 2026-08-19 against Supabase project `tednluwflfhxyucgwigh` via `scripts/gsql.mjs`.
+
+## Standing caveat: the double-count
+
+`justice_funding.measure_kind='expenditure_aggregate'` currently holds a duplicate ingest
+(GitHub issue #299, migration written and not yet applied). **The essay is unaffected.**
+Every ROGS figure used here is taken per `program_name` label, and the duplication is
+across labels, not within them. A whole-lane `SUM` would be wrong by roughly 2x; nothing
+in the essay does that. Re-verify after the migration lands anyway.
+
+## Figures
+
+**Recurrent expenditure by lane (the three-lane table).** Verified.
+```sql
+SELECT financial_year,
+  round(sum(amount_dollars) FILTER (WHERE program_name LIKE 'ROGS%Detention%')/1e6) detention_m,
+  round(sum(amount_dollars) FILTER (WHERE program_name LIKE 'ROGS%Community%')/1e6) community_m,
+  round(sum(amount_dollars) FILTER (WHERE program_name LIKE 'ROGS%Group%')/1e6) conferencing_m
+FROM justice_funding WHERE measure_kind='expenditure_aggregate' AND program_name LIKE 'ROGS%'
+GROUP BY 1 ORDER BY 1 DESC;
+```
+2015-16: 592 / 274 / 59. 2019-20: 720 / 450 / 49. 2024-25: 1141 / 520 / 62.
+Upstream source: Productivity Commission, Report on Government Services, Community
+Services, Youth Justice. Growth rates (93%, 90%, 5%) derived from these.
+
+**Net capital expenditure. $1,791M / $88M / $20M.** Verified. Same table,
+`program_name LIKE 'Net capital expenditure%'`, 8 rows per lane. 94% derived
+(1791 / 1899).
+
+**Youth justice grants: $915.7M, 1,236 recipients, top 10 = 16.6%, 2008-09 to 2024-25.**
+Verified. `measure_kind='grant'`, `is_aggregate IS NOT TRUE`, `amount_dollars IS NOT NULL`,
+`topics @> ARRAY['youth-justice']`, aggregate-shaped recipient names excluded per the
+mandatory filters in CLAUDE.md. 4,066 rows. Recipients counted on
+`lower(trim(recipient_name))`, so the same organisation under two spellings counts twice
+and 1,236 is an upper bound on distinct organisations.
+**Stated in the essay as a floor**, because our grant coverage is known to be incomplete.
+
+**Federal contracts: $1,268bn total, community-controlled $5.43bn (0.43%).** Verified.
+`austender_contracts` LEFT JOIN `gs_entities` on `abn = supplier_abn`. 825,222 rows,
+no join fan-out (bucket counts sum exactly to the total).
+- Unmatched suppliers hold $68.37bn and are excluded from the numerator. If every
+  unmatched supplier were community-controlled the share would still be under 6%.
+- **Known bias, disclosed in the essay:** `supplier_abn` resolves to a registered address,
+  not a delivery location. Documented intermediary artefact (remote NT funding routed via
+  regional and land councils credits the hub). 0.43% is a floor.
+
+**Remoteness split: Remote + Very Remote $3.1bn (0.24%), Major Cities $1,098bn.**
+Verified, same join, `GROUP BY e.remoteness`. Same registered-address caveat.
+
+**Contract date dirt.** 821,692 of 825,222 contract_start dates plausible; 557 pre-1990,
+22 future-dated carrying $1.25bn, 2,951 null. Not material to any figure used.
+
+## External sources
+
+**Preston: 5% to 18.2% local retention, 39% to 79.2% across Lancashire, ~£70M rerouted,
+4,500 jobs.** Unverified against primary documents. Taken from CLES and Preston City
+Council summaries via web search, which agree with each other.
+- https://cles.org.uk/community-wealth-building-in-practice/community-wealth-building-places/community-wealth-building-in-preston/
+- https://pec.ac.uk/policy_briefing_entr/stimulating-local-growth-through-procurement-lessons-from-the-preston-model/
+Before publishing, read the CLES evaluation directly. The jobs figure in particular is
+the kind of number that gets repeated without a source.
+
+## Claims made without a number
+
+"Group conferencing is the lane with the evidence behind it" is asserted, not evidenced
+here. It is defensible from the restorative justice literature but this document does not
+cite it. Either cite it or soften it before the essay goes public.


### PR DESCRIPTION
Five commits. Two migrations (both **unapplied** — the auto-mode classifier blocks DB writes), three analysis documents, one spec.

## The bug

`justice_funding.expenditure_aggregate` held 848 rows summing to $66.13bn, **483 of them exact duplicates**. The same Productivity Commission ROGS youth justice table was ingested twice on 2026-03-14, two hours apart, under different `program_name` conventions. Verified identical row by row.

Migration written and guarded. Refuses to run twice, refuses an unexpected shape, hard-fails unless exactly 368 rows remain. **Trap:** there are 176 `Cost per young person per day` rows, not 160; the other 16 are genuine and must survive.

Issue #299.

## What the clean data says

Detention recurrent spend rose **93% in nine years** ($592M to $1,141M). Group conferencing went $59M to $62M, a real-terms cut. Net capital: **$1,791M into detention, $20M into conferencing.**

Written up as an essay with a provenance sidecar carrying every figure and its confidence.

## Place capture

`grantconnect_awards` has carried `delivery_postcode`/`delivery_state` separate from recipient location since ingest. **Nothing read them.**

- **State: 97.5% of awards, 96.8% of dollars** stay in-state (281,003 awards, $200.21bn)
- **LGA: 85.1% of awards, 59.6% of dollars** stay in-LGA (85,898 awards, $33.75bn)

**State borders are almost never crossed. The entire leak is within states** — money stays in its jurisdiction and leaves the town.

View written (unapplied) plus spec #300 for the app surface.

## Delivery location for contracts: scoped out

AusTender titles average **17 characters**; 1.5% carry a state token. More decisively, pulled 100 live OCDS releases: **zero `deliveryAddress`, zero `deliveryLocation`, zero occurrences of the string `delivery`**. Federal contract notices do not record where work happens. Reasoning documented rather than discovered again later.

## Corrections I made to my own work in here

Worth reading, because each was a plausible-looking wrong number:

1. **`delivery_postcode` contains the literal `'Multiple'`** (5,978 rows, $19.55bn). Counted as off-site, it reported $17.79bn crossing state lines. True figure $3.95bn. **Wrong by 4.5x.**
2. **`delivery_state` is not a single state** — 318 distinct values including comma-separated lists and `National`/`Overseas`. Corrected the national figure from 95.3%/87.1% to 97.5%/96.8%.
3. **`postcode_geo` 4816 is `Townsville - South` mapped to LGA `Croydon`**, ~900km away. Left in, Croydon QLD ranked worst-capturing LGA in the country on Palm Island money. Extent unknowable from inside the DB — issue #301.
4. **Wangaratta's 8.3% capture is an artefact**: Australian Rail Track Corporation, SA-registered, $940M, Inland Rail.

## Gates

`scripts/precheck.sh` green: 82 files, 724 tests passed, 1 skipped. `classify-changes.sh` says SAFE (all six files are docs/migrations).

## Not done

**Neither migration has been applied.** The classifier blocked both `psql` and the Supabase MCP path. The $66.13bn double-count is still live in the database.