### PR TITLE
Map #303: the payer is an intermediary, and the two research findings behind that

### DIFF
--- a/docs/strategy/buyer-wedge.md
+++ b/docs/strategy/buyer-wedge.md
@@ -1,7 +1,23 @@
 # The Buyer Wedge — CivicGraph SE Registry Strategy
 
 **Decided:** 2026-06-08 (Ben, strategy checkpoint session)
-**Status:** ACTIVE — every SE-registry feature decision gets evaluated against this.
+**Status:** **PROVISIONAL** as of 2026-08-19 — superseded on completion of map #303.
+
+> **Why provisional.** This document's central premise is that revenue comes from the buyer side.
+> Ten weeks after it was written there are 438 buyer prospects, **zero paying buyers**, and
+> `api_keys` holds 0 rows. The three rows in `org_profiles` are Palm Island Community Company,
+> JusticeHub and A Curious Tractor — all internal or adjacent. Buyer revenue is the best available
+> theory of revenue and it has not survived contact with a buyer yet.
+>
+> Map [#303](https://github.com/Acurioustractor/grantscope/issues/303) decided
+> ([#304](https://github.com/Acurioustractor/grantscope/issues/304)) that a community-first capital
+> product is **infrastructure for everyone and a product for one named payer**, and that the payer
+> is a **place-based intermediary** — council, land council, regional body — buying to keep spend
+> local, not a procurement buyer. That is a **second lane**, not a replacement, and it has the same
+> untested-demand problem this document does, which is why it has its own validation ticket.
+>
+> Until #303 completes, evaluate SE-registry decisions against this document **and** against #303,
+> and prefer #303 where they conflict.
 
 ## The one sentence
 

--- a/thoughts/shared/analysis/2026-08-19-what-bankable-means.md
+++ b/thoughts/shared/analysis/2026-08-19-what-bankable-means.md
@@ -1,0 +1,262 @@
+# What "bankable" means, measurably, from data we already hold
+
+Issue #308, part of map #303. Date: 2026-08-19.
+All figures below are **Verified** unless labelled otherwise — each was produced by a `SELECT`
+run against Supabase `tednluwflfhxyucgwigh` via `scripts/gsql.mjs` on 2026-08-19. Queries are
+inlined so they can be re-run.
+
+**No score is built here.** The output is a signal inventory with coverage and reliability, plus
+the empirical difference between two populations.
+
+---
+
+## 1. The two populations
+
+Cohorts, defined over `gs_entities WHERE is_community_controlled = true AND abn IS NOT NULL`
+(9,167 of 12,479 community-controlled orgs carry an ABN — **the other 3,312 cannot be joined to
+any money at all**, which is itself the first coverage finding):
+
+| cohort | definition | n |
+|---|---|---|
+| **contract** | ABN appears in `austender_contracts.supplier_abn` | **1,048** |
+| **grant_only** | receives `justice_funding` (grant filters) or `grantconnect_awards`, no contract | **1,448** |
+| **neither** | in neither | **6,671** |
+
+Money: contracts $5.433bn · justice grants $1.618bn (661 orgs) · GrantConnect $22.973bn
+(1,758 orgs). This reproduces the ticket's $5.43bn / ~$1.65bn framing. Verified.
+
+`justice_funding` figures carry the three mandatory filters from CLAUDE.md
+(`measure_kind='grant' AND is_aggregate IS NOT TRUE`).
+
+### The first correction to the ticket's framing
+
+**Contract-holders are not grant-holders who graduated.** Of the 1,048 contract-holders,
+**541 (52%) have never received a recorded grant** and 507 hold both. Verified.
+
+So the gap is not one population maturing into another. It is substantially two different
+populations that both satisfy `is_community_controlled`.
+
+---
+
+## 2. What contract-holders have that grant-only ones do not
+
+### 2a. Scale, by a factor of five
+
+Latest ACNC AIS per ABN, `ais_year >= 2021`:
+
+| cohort | n | has AIS | median total revenue | median total assets | median net assets | median FTE | median current ratio | earned-income share | govt-revenue share |
+|---|---|---|---|---|---|---|---|---|---|
+| contract | 1,048 | 168 (16.0%) | **$4,092,000** | $5,498,440 | $2,693,946 | **18.0** | 1.90 | 0.129 | 0.701 |
+| grant_only | 1,448 | 265 (18.3%) | $808,587 | $2,991,626 | $1,962,354 | 3.0 | 2.17 | 0.090 | 0.720 |
+| neither | 6,671 | 217 (3.3%) | $110,998 | $288,653 | $179,076 | 0.0 | 4.72 | 0.000 | 0.000 |
+
+**Revenue 5.1x. Paid staff 6x.** Assets and net assets differ by less than 2x. The separation is
+in *throughput and payroll*, not in balance sheet.
+
+### 2b. Reserves are NOT the differentiator — they run the wrong way
+
+Months of reserves = `12 * net_assets_liabilities / total_expenses`, median of latest AIS:
+
+| cohort | n with AIS | median months of reserves | negative equity | median volunteers |
+|---|---|---|---|---|
+| contract | 168 | **7.8** | 8 | 0 |
+| grant_only | 265 | **17.9** | 8 | 3 |
+| neither | 217 | 30.9 | 10 | 2 |
+
+Contract-holders hold **less than half** the reserve cover of grant-only orgs. This is the single
+most counter-intuitive result here and it should stop any design that treats reserves as the
+bankability proxy. The mechanism is arithmetic: reserves are measured *against expenses*, and a
+trading organisation has large expenses. A dormant organisation with $180K in the bank and no
+activity scores 30.9 months and is not bankable by any reading.
+
+**Implication:** "months of reserves" is a *liquidity* signal, not a *capability* signal, and
+inverts against capability across this population. Do not combine the two.
+
+### 2c. Registered size, where ACNC covers the org
+
+`acnc_charities.charity_size`, among those matched:
+
+| cohort | matched to ACNC | Large | Medium | Small |
+|---|---|---|---|---|
+| contract | 429 (40.9%) | **139** | 47 | 19 |
+| grant_only | 900 (62.2%) | 108 | 111 | 105 |
+| neither | 814 (12.2%) | 24 | 58 | 187 |
+
+Among sized rows, contract-holders are 68% Large; grant-only are 33% Large.
+Note grant-only orgs are **more likely to be ACNC-registered at all** (62% vs 41%) — see §2d.
+
+### 2d. Legal form is the sharpest single split
+
+`gs_entities.entity_type`:
+
+| entity_type | contract | grant_only | neither |
+|---|---|---|---|
+| social_enterprise | 404 | 167 | 3,036 |
+| indigenous_corp | 337 | **958** | 3,096 |
+| company | **155** | 50 | 137 |
+| charity | 129 | 252 | 267 |
+| foundation | 23 | 15 | 82 |
+
+Grant-only is **66% indigenous_corp**. Contract is 39% social_enterprise + 15% company.
+`company`-typed community-controlled entities are **3.1x more likely to hold a contract than to
+hold only grants** — the only form where that ratio exceeds 1 by a wide margin. Read the honesty
+caveat in §4 before using this.
+
+### 2e. Place: proximity to Canberra is a real edge
+
+| state | contract | grant_only |
+|---|---|---|
+| NSW | 291 | 340 |
+| QLD | 205 | 456 |
+| NT | 188 | 191 |
+| WA | 140 | 253 |
+| **ACT** | **85** | **16** |
+| VIC | 67 | 86 |
+| SA | 49 | 67 |
+| TAS | 12 | 14 |
+
+**ACT is the only jurisdiction where contract-holders outnumber grant-only orgs, and it does so
+5.3:1.** Everywhere else the ratio runs 0.4–1.0. QLD is the worst at 0.45.
+Remote/very-remote counts are similar between cohorts (278 vs 470), so remoteness is not the
+primary axis — *distance from the buyer* is.
+
+### 2f. Repeat is where the money actually is
+
+Contract counts per community-controlled supplier:
+
+| contracts held | orgs | contracts | total value | median org total | median largest contract | avg distinct buyers | avg span (yrs) |
+|---|---|---|---|---|---|---|---|
+| 1 | 328 | 328 | $233.7M | $50,000 | $50,000 | 1.0 | 0.0 |
+| 2–4 | 372 | 965 | $1,171.0M | $377,960 | $205,425 | 1.6 | 1.9 |
+| 5–20 | 265 | 2,480 | $1,650.2M | $1,189,350 | $349,491 | 3.3 | 6.4 |
+| **21+** | **83** | **7,144** | **$2,378.3M** | $11,087,388 | $1,964,780 | **12.8** | 12.8 |
+
+**83 organisations — 0.9% of the ABN-bearing community-controlled population — hold 65% of the
+contracts and 44% of the dollars.** Buyer diversity rises monotonically with contract count and
+is the cleanest continuous correlate available (1.0 → 12.8).
+
+### 2g. Entry contract size does NOT predict compounding
+
+First contract by `contract_start`, against lifetime contract count:
+
+| first contract value | orgs | avg lifetime contracts | % reaching 5+ contracts |
+|---|---|---|---|
+| < $50K | 431 | 11.5 | **32.7%** |
+| $50–250K | 342 | 10.1 | 30.1% |
+| $250K–1M | 177 | 5.8 | 26.6% |
+| $1M+ | 98 | 9.2 | 28.6% |
+
+Flat-to-inverse. **Starting small does not cap an organisation** — the sub-$50K entrants have the
+*highest* rate of reaching five contracts. This is the most product-relevant finding in the note:
+the barrier is at contract #1, not at contract size. A community organisation does not need to be
+big to enter; it needs to enter at all.
+
+---
+
+## 3. Signal inventory: coverage and reliability
+
+| signal | source | coverage over CC orgs | reliability | verdict |
+|---|---|---|---|---|
+| **Repeat-contract count + distinct buyers** | `austender_contracts` | 1,048 / 12,479 (8.4%) of CC orgs; 60,603 distinct suppliers overall | High. First-party AusTender notices, ABN-keyed. Known defect: ~$126bn of contracts have no matched supplier entity (#303), and ~658K dual-key duplicate rows exist in the graph build — but the *per-supplier* aggregation used here reads the source table, not the graph. | **Most trustworthy.** Use it. |
+| **ACNC AIS financials** | `acnc_ais`, 360K rows | **16–18% of contract/grant cohorts; 3.3% of "neither"** | Medium, with two hard caveats: (a) **latest year is 2023** — one stray 2025 row (FECCA, ABN 23684792947) and nothing for 2024. The data is ~3 years stale. (b) Coverage is a *selection* — being ACNC-registered is itself correlated with the cohort (62% grant-only vs 41% contract), so any AIS-derived median is computed on a biased 1-in-6 subsample. | Usable for **direction**, not for a per-org verdict. Never show an org "you have N months of reserves" from a 2023 filing. |
+| **Reserves / current ratio** | `acnc_ais` derived | as above | **Actively misleading in this population** (§2b). Inverts against capability. | Do not use as a bankability signal. Keep as a disclosed liquidity fact only. |
+| **`mv_entity_power_index`** | matview, 185,393 rows | **3,010 of 12,479 CC orgs (24%)** | The ticket's suspicion is **confirmed for `system_count`** and **wrong about the MV as a whole**. `system_count` distribution: 161,227 at 1, 21,078 at 2, 2,529 at 3, 483 at 4, 72 at 5, 4 at 6. For CC orgs, rising system_count tracks median dollar flow strongly ($0 → $117K → $1.52M → $3.60M → $9.09M) but tracks contract count only weakly (3.1 → 4.6 → 5.2 → 6.4 → 4.8, non-monotonic at 5). It measures **dataset presence and money size**, not capability. | Use the MV's *columns* — it already carries `contract_count`, `distinct_govt_buyers`, `distinct_grant_programs`, `total_dollar_flow`, `charity_size`. Do **not** use `system_count` or `power_score`. |
+| **`grantconnect_awards` repeat receipt** | 291K rows | 1,758 CC orgs | High for the award facts, ABN-keyed. **Place fields are hazardous** — `delivery_postcode` contains literal `'Multiple'`, `delivery_state` holds 318 values including comma-lists and `National`/`Overseas` (#303 standing hazard). | Usable for repeat/program-diversity. Never for place without the #303 corrections. |
+| **`justice_funding`** | 157K rows | 661 CC orgs after filters | High **only with all three mandatory filters**. Without them the headline is overstated by 26% ($12.12bn). | Usable, filters non-negotiable. |
+| **`v_grant_place_capture`** | view | verified live, returns `captured_locally` boolean with `delivery_lga`/`recipient_lga` | Inherits the #301 `postcode_geo` SA3 fan-out risk and the #303 delivery-field hazards; it already encodes the four corrections from `2026-08-19-grant-place-capture.md`. | Usable as an "already cleared a bar" flag. Not a financial signal. |
+| **Board composition** | `person_roles`, `mv_board_interlocks` | — | **Unusable as-is.** `mv_board_interlocks` max `board_count` is 745, a known nominee-block artefact (see memory `project_person_disambiguation`). Raw board counts are not real. | Excluded from this analysis deliberately. Would need the nominee-block cap applied first. |
+| **Organisation age** | — | — | **Not available.** No reliable incorporation-date column was found on `gs_entities`; `abr_registry` and `asic_companies` hold registration dates but were not joined here. **Unverified — flagged as a gap.** | Untested. Worth a follow-up: age is the one classic lender signal absent from this note. |
+
+---
+
+## 4. The honesty caveat that must travel with this
+
+The 83 highest-volume community-controlled contract holders are, by value:
+
+| org | type | state | contracts | buyers | $M |
+|---|---|---|---|---|---|
+| AMNESIUM PTY LTD | company | ACT | 1,173 | 59 | 229 |
+| Pacific Services Group Holdings Pty Ltd | company | NSW | 111 | 12 | 208 |
+| Servegate Australia Pty Ltd | charity | ACT | 272 | 17 | 148 |
+| National Aboriginal Community Controlled Health Organisation Ltd | foundation | ACT | 30 | 8 | 135 |
+| E-Bisglobal Pty Ltd | social_enterprise | NSW | 24 | 10 | 107 |
+| Kennelly Constructions Pty Ltd | social_enterprise | QLD | 32 | 6 | 94 |
+| GULANGA GROUP PTY LTD | company | ACT | 275 | 54 | 80 |
+| First Grade Group | company | QLD | 448 | 27 | 68 |
+| Ninti One Limited | charity | NT | 57 | 16 | 68 |
+| Pattemore Consultants Pty Ltd | social_enterprise | NT | 27 | 2 | 63 |
+| GEBIE CIVIL AND CONSTRUCTION PTY LTD | social_enterprise | NT | 45 | 13 | 59 |
+| CALLEO INDIGENOUS PTY LTD | company | ACT | 161 | 34 | 56 |
+
+These are **Supply-Nation-shaped Indigenous-owned commercial businesses** — labour hire, ICT
+resale, facilities, civil construction — clustered in Canberra and Sydney. They are not the
+community service organisations the map's primary user is.
+
+So the honest statement of the finding is:
+
+> **Empirically, "bankable" in this dataset means: a trading Pty Ltd or social enterprise, in or
+> near a capital city, with paid staff and multi-million-dollar throughput, selling a
+> commoditised service to many government buyers under IPP-style set-asides. It does not mean a
+> well-reserved, well-governed, remotely-located community service organisation — those sit
+> almost entirely in the grant-only cohort.**
+
+The gap between the cohorts is therefore **partly a capability gap and partly a business-model
+gap**. Nothing in the data separates the two. Presenting the difference as "here is what you must
+become" would be telling remote Aboriginal corporations that bankability means becoming a
+Canberra labour-hire company. That is a real finding about Commonwealth procurement, and it is
+not advice.
+
+---
+
+## 5. What this means for the map (#303)
+
+1. **Do not build a bankability score.** Two of the classic inputs (reserves, board counts) are
+   respectively inverted and artefactual in this population, and the ACNC financial layer covers
+   one org in six and is three years stale. Any composite would dress that noise as signal.
+2. **The one honest, well-covered, actionable signal is the contract ladder itself**: contract
+   count, distinct buyers, span. It is 100%-covered for the orgs that have one and unambiguously
+   absent for those that do not.
+3. **The product question is entry, not growth.** §2g shows entry contract size does not cap the
+   trajectory and §2f shows a third of contract-holders never got a second contract. The
+   measurable bar is *the first contract*, and 11,431 of 12,479 community-controlled
+   organisations have not cleared it.
+4. **Legal form and location are the strongest structural correlates and are both actionable in
+   principle** (incorporate a trading arm; register against the right buyer), unlike revenue,
+   which is a consequence rather than a cause.
+5. **Follow-ups worth a ticket:** organisation age from `abr_registry`/`asic_companies` (§3 gap);
+   whether the 3,312 ABN-less community-controlled orgs are a data gap or a real population; and
+   whether the ACT effect survives controlling for entity_type.
+
+## 6. Every query in this note
+
+Run from repo root: `node --env-file=.env scripts/gsql.mjs "<sql>"`. All SELECT-only.
+The cohort CTE reused throughout:
+
+```sql
+WITH cc AS (SELECT abn FROM gs_entities
+            WHERE is_community_controlled = true AND abn IS NOT NULL),
+con AS (SELECT DISTINCT supplier_abn AS abn FROM austender_contracts
+        WHERE supplier_abn IN (SELECT abn FROM cc)),
+gr AS (SELECT DISTINCT abn FROM (
+         SELECT recipient_abn abn FROM justice_funding
+          WHERE measure_kind='grant' AND is_aggregate IS NOT TRUE
+            AND recipient_abn IN (SELECT abn FROM cc)
+         UNION
+         SELECT recipient_abn FROM grantconnect_awards
+          WHERE recipient_abn IN (SELECT abn FROM cc)) z),
+coh AS (SELECT cc.abn,
+          CASE WHEN con.abn IS NOT NULL THEN 'contract'
+               WHEN gr.abn IS NOT NULL THEN 'grant_only'
+               ELSE 'neither' END AS cohort
+        FROM cc LEFT JOIN con ON con.abn=cc.abn LEFT JOIN gr ON gr.abn=cc.abn)
+```
+
+Latest-AIS CTE:
+
+```sql
+ais AS (SELECT DISTINCT ON (abn) abn, charity_size, total_revenue,
+          revenue_from_government, revenue_from_goods_services, total_assets,
+          net_assets_liabilities, total_current_assets, total_current_liabilities,
+          total_expenses, staff_fte, staff_volunteers
+        FROM acnc_ais WHERE ais_year >= 2021 ORDER BY abn, ais_year DESC)
+```

--- a/thoughts/shared/analysis/2026-08-19-what-is-showable.md
+++ b/thoughts/shared/analysis/2026-08-19-what-is-showable.md
@@ -1,0 +1,142 @@
+# What a community organisation can honestly be shown about money moving through its place
+
+*19 August 2026. Resolves research ticket #305, part of map #303.*
+
+Every figure below is labelled **Verified** (I ran the query today), **Inferred** (derived from
+verified figures, not directly measured) or **Unverified**. Queries ran through
+`scripts/gsql.mjs` against `tednluwflfhxyucgwigh`.
+
+Prior work this builds on, not repeated here: `2026-08-19-grant-place-capture.md` (the capture
+measure and its four corrections) and `2026-08-19-delivery-location-scoping.md` (why federal
+contract delivery location does not exist).
+
+---
+
+## 1. Per-lane table
+
+| lane | rows / dollars | geography available | honest grain | coverage | bias |
+|---|---|---|---|---|---|
+| **Grants** `grantconnect_awards` | 291,264 / $230bn | `delivery_postcode` + `delivery_state`, **separate** from recipient postcode/state | **LGA** where both resolve; **state** otherwise | LGA: 85,898 awards, **$33.75bn (14.7% of grant dollars)**, 426 LGAs. State: 281,003 awards, $200.21bn | `delivery_postcode` holds the literal `'Multiple'`; `delivery_state` holds 318 values incl. comma-lists, `National`, `Overseas`. Government-owned corporations (ARTC $940M) dominate any per-place ranking |
+| **Federal contracts** `austender_contracts` | 825,222 / $1,268.2bn | **supplier registered address only** — no delivery location anywhere in the source (settled) | LGA of the supplier's registered office. **Not a delivery claim** | supplier ABN present 767,369 rows / $1,199.8bn; joins to a `gs_entities` LGA on 725,631 rows / **$1,141.8bn (90.0% of dollars)** | Registered-address bias, quantified in §2. 91.5% of contract dollars land in "Major Cities" by this measure; Remote + Very Remote together are **$3.1bn, 0.26%** |
+| **Justice funding** `justice_funding` | 125,300 / $33.98bn (after the three mandatory filters) | `state` (99.8%), `location` free text (82.9%), `gs_entity_id` → recipient entity (96.4%, $32.38bn) | **State.** Recipient-entity LGA where linked — again a registered-address claim | `state` 125,028 rows; `location` 103,838 rows but **7,913 distinct unnormalised values** incl. `Multiple`, `Statewide`, `Not applicable`, `n/a`, mixed casing, `SOUTHPORT, Gold Coast (C)` | `location` is a lead, not a place key. Recipient link is registered address, same bias as contracts |
+| **Political donations** `political_donations` | 557,491 / $25.27bn (`receipt_type='donation received'`) | `source_state` = **the disclosure jurisdiction**, not a place. `donor_abn` on 109,315 rows (19.6%) | Effectively **unplaceable**. 104,279 rows / $12.59bn join an entity; 95,389 get an LGA | ≤ 50% of donation dollars, and only as donor head office | `source_state` looks like a place and is not. Donor address is head office |
+| **ACNC** `acnc_charities` | 66,143 charities | registered address `postcode`/`state` (90.5% / 90.3%), plus `operates_in_*` booleans / `operating_states` (77.7%) | **Registered address at postcode grain**; `operating_states` is a genuine *operating footprint* signal at **state** grain | 59,858 with postcode; 51,369 with operating states | Registered address ≠ where services are delivered. `operating_states` is self-declared and state-grain only |
+| **State tenders** `state_tenders` | 199,719 / $37.82bn | `state` column only | **Not a delivery location.** See §3 | 100% populated — but **199,679 of 199,719 rows are QLD** | It is a portal-jurisdiction label on an almost entirely Queensland dataset |
+
+All row counts and dollar figures in this table: **Verified** today.
+
+**The asymmetry, stated plainly.** The lane that can be placed to an LGA by *where the work
+happened* is $33.75bn. The lane holding the money is $1,268bn and cannot be placed at all.
+Delivery-placeable money is about **2.2% of the ~$1,557bn across these lanes** (Inferred:
+33.75 / (1268.2 + 230 + 33.98 + 25.27)).
+
+---
+
+## 2. The registered-address bias, measured
+
+This has been documented as an artefact and never quantified. It can be quantified, because the
+grant lane is the one place where we hold **both** locations for the same dollar. Attribute those
+dollars twice — once by delivery location, once by recipient registered address — and the
+difference *is* the bias that every other lane silently carries.
+
+Population: awards where **both** delivery and recipient postcode resolve to a single trustworthy
+LGA (an inner join, so smaller than the $33.75bn view): **$23.06bn**. **Verified.**
+
+| remoteness | $m by delivery location | $m by recipient registered address | shift |
+|---|---|---|---|
+| Major Cities | 15,214 | 15,597 | **+2.5%** |
+| Inner Regional | 2,831 | 2,691 | −4.9% |
+| Outer Regional | 1,680 | 1,233 | **−26.6%** |
+| Remote | 536 | 345 | **−35.6%** |
+| Very Remote | 445 | 345 | **−22.5%** |
+| (postcode unmapped) | 2,354 | 2,851 | +21.1% |
+
+**Verified.** Read the middle column as "what a contracts-style, registered-address-only dataset
+would tell a remote community it received".
+
+**Remote Australia loses just over a third of its money to the city when you attribute by
+registered address instead of by where the work happens.** Every contract, donation and
+justice-funding place figure we can produce today is computed the way the right-hand column is.
+
+### The surprise: it is not mostly land councils
+
+The remote-intermediary story predicts community-sector hubs — a land council's town office
+crediting the regional centre. The largest Very-Remote-delivered / Major-Cities-received awards
+are not that. Top five by value, **Verified**:
+
+| recipient | $ | delivered into | recipient LGA |
+|---|---|---|---|
+| Southern Cross Operations Pty Ltd | 30.8M | Burke (Very Remote) | Melbourne |
+| Santos Limited | 16.5M | Unincorporated SA | Adelaide |
+| Lynas Kalgoorlie Pty Ltd | 15.6M | Kalgoorlie-Boulder | Vincent |
+| Metso Minerals Australia Ltd | 5.2M | Karratha | Perth |
+| Engie Hydrogen Pty Ltd | 3.3M | Ashburton | Melbourne |
+
+Mining, gas and energy corporates with capital-city head offices. The bias is real and large; its
+*composition* at the top end is corporate head-office registration, not community intermediation.
+The land-council effect may still exist further down the distribution — that is **Unverified** and
+would need the community-sector subset isolated before anyone claims it.
+
+This also means the ARTC caveat from the capture analysis generalises: **the top of any per-place
+capture ranking is a list of places that had a mine, a railway or a transmission line built.**
+
+---
+
+## 3. Is there a second source for contract delivery location?
+
+**No.** Three routes checked:
+
+1. **Federal OCDS** — settled by the scoping doc: zero `deliveryAddress`, zero `deliveryLocation`
+   across 100 live releases. Not re-investigated.
+2. **`state_tenders`** — the `state` column is 100% populated and 99.98% of it is the single value
+   `QLD` (199,679 of 199,719 rows; VIC 30, NSW 10). **Verified.** It is a jurisdiction label on a
+   Queensland-only scrape, not a delivery geography, and it offers no sub-state field at all.
+3. **`state_tenders` free text** — average description length **26 characters**; only **108 of
+   199,719 rows (0.05%)** contain any of `region|district|shire|council|north|south|central`.
+   **Verified.** Text extraction fails here even harder than it failed on AusTender titles.
+
+Defence remains the largest single unplaceable block and is an FOI-shaped ask, not a data problem.
+
+---
+
+## 4. The largest honest claim available today
+
+> **"Of the grant money the Commonwealth delivered into your local government area, this share was
+> received by an organisation based in your local government area — and this share was not."**
+
+Available for **426 LGAs**, on **85,898 awards worth $33.75bn**, via `v_grant_place_capture`.
+Nationally the answer is **85.1% of awards and 59.6% of dollars** captured locally. **Verified.**
+
+It is the largest honest claim because it is the only one in the whole database where *where the
+work happened* and *who got paid* are both recorded for the same dollar. Everything else is a head
+office address.
+
+**The caveat that must sit beside it, every time:**
+
+> This covers 14.7% of Commonwealth grant dollars and about 2% of all public money we track. The
+> $1.27 trillion federal contract lane records no delivery location at all, so it is absent from
+> this figure — not zero, absent. Large national infrastructure delivered by government-owned
+> corporations can dominate a single LGA's result and does not mean what the rest of the measure
+> means.
+
+### One more claim worth having, at state grain
+
+**96.8% of grant dollars are received in the state they were delivered into**, across 281,003
+awards / $200.21bn (from the prior analysis, not re-run: **Unverified today**). Set against 59.6%
+at LGA grain, the leak is entirely *within* state. Money delivered into a place stays in the
+jurisdiction and leaves the town. Any pitch aimed at interstate extraction is aimed at something
+that is not happening.
+
+---
+
+## Implications for the map (#303)
+
+- A community-facing "money through my place" screen is buildable **today** for the grant lane at
+  LGA grain, with a coverage number on the face of it.
+- It must show the contract lane as **absent, with a stated reason**, not as a small number. A
+  confident zero is the failure mode CLAUDE.md already warns about.
+- Any contract, donation or justice-funding place figure that does ship must carry the §2 number:
+  registered-address attribution understates remote places by 22–36%.
+- Two follow-ups worth tickets: isolate the community-sector subset of §2 to test the land-council
+  hypothesis properly; and normalise `justice_funding.location` (7,913 distinct values over
+  103,838 rows) if state grain is ever not enough.

--- a/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md
+++ b/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md
@@ -111,7 +111,21 @@ rather than as grant, which means it compounds, which means an organisation can 
 something at the end. Preston in Lancashire did exactly this and did it without new
 money: measure where institutional spend leaks out of the local economy, then close the
 leak. Locally retained spend went from 5 per cent to 18.2 per cent inside Preston and
-39 per cent to 79.2 per cent across Lancashire. Around £70 million rerouted, 4,500 jobs.
+39 per cent to 79.2 per cent across Lancashire, on the council's own accounting.
+
+The independent evidence is better than the council's. A difference-in-differences study
+in a peer-reviewed journal compared Preston against sixteen matched local authorities in
+the north and midlands of England, similar in size and deprivation, none of them running
+a community wealth building programme. Across 95,476 survey respondents from 2011 to
+2019, **employment rates rose 4 per cent** against those comparators, with a confidence
+interval of 2.4 to 5.7.
+
+The distribution is the part worth sitting with. The effect was larger for the people
+usually left out of a recovery: **22.1 per cent for disabled people** whose condition
+affects the type of work they can do, 6 per cent for minority ethnic groups, 5 per cent
+for people with lower levels of education. Redirecting procurement did not just move
+money. It moved it toward the people furthest from work.
+
 No new appropriation. A measuring instrument and the will to act on it.
 
 Nobody has built that instrument in Australia. The 0.43 per cent is the leak, unmeasured

--- a/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.provenance.md
+++ b/thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.provenance.md
@@ -55,13 +55,38 @@ Verified, same join, `GROUP BY e.remoteness`. Same registered-address caveat.
 
 ## External sources
 
-**Preston: 5% to 18.2% local retention, 39% to 79.2% across Lancashire, ~£70M rerouted,
-4,500 jobs.** Unverified against primary documents. Taken from CLES and Preston City
-Council summaries via web search, which agree with each other.
+**Preston local retention: 5% to 18.2% within Preston, 39% to 79.2% across Lancashire.**
+Unverified against primary documents, and now explicitly attributed in the essay to the
+council's own accounting rather than stated as independent fact. From CLES and Preston
+City Council summaries, which agree with each other.
 - https://cles.org.uk/community-wealth-building-in-practice/community-wealth-building-places/community-wealth-building-in-preston/
 - https://pec.ac.uk/policy_briefing_entr/stimulating-local-growth-through-procurement-lessons-from-the-preston-model/
-Before publishing, read the CLES evaluation directly. The jobs figure in particular is
-the kind of number that gets repeated without a source.
+
+**CORRECTED 2026-08-19: the "4,500 jobs" claim has been REMOVED from the essay.**
+Two faults with it. First, **4,500 is the Lancashire figure, not Preston** — the Preston
+number is roughly 1,648, and the essay's sentence structure implied both belonged to
+Preston. Second, the careful sources say jobs **"supported"**, not "created", which is a
+materially weaker claim. It is exactly the kind of number that gets repeated without a
+source, which is what I was doing.
+
+**REPLACED WITH a peer-reviewed difference-in-differences study.** Verified by reading the
+paper. Preston compared against **sixteen matched local authorities** in the north and
+midlands of England (population 90,000–250,000, within the 25% most deprived, none running
+a CWB programme). Annual Population Survey, **2011–2019**, intervention dated 2015,
+**95,476 respondents**.
+- **Employment rate +4%** (95% CI 2.4 to 5.7) against comparators.
+- Disabled people, condition affecting work type: **+22.1%** (95% CI 15.1 to 29.2).
+- Disabled people, condition affecting work amount: +16.4% (95% CI 13.5 to 19.4).
+- Minority ethnic groups: +6% (95% CI 0.5 to 11.5). Lower education: +5% (95% CI 3.1 to 6.9).
+- Men: +5.8% (95% CI 4.6 to 7).
+- **Stated limitations, carried here:** the authors cannot fully rule out concurrent
+  unobserved economic changes, and subgroup analyses have reduced statistical power.
+- https://pmc.ncbi.nlm.nih.gov/articles/PMC12418530/
+
+This is a stronger evidence base than the essay originally rested on, and it changes the
+argument rather than only shoring it up: the distributional finding (largest effects for
+disabled people and minority ethnic groups) is a claim about who a redirected procurement
+pound reaches, which is the essay's actual subject.
 
 ## Claims made without a number
 

--- a/thoughts/shared/handoffs/place-capital/current.md
+++ b/thoughts/shared/handoffs/place-capital/current.md
@@ -1,0 +1,131 @@
+---
+date: 2026-08-19T07:05:00Z
+session_name: place-capital
+branch: map/304-who-pays
+status: active
+---
+
+# Work Stream: place-capital
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-08-19T07:05:00Z
+**Goal:** A buildable spec for what a community organisation uses to see, then capture, the
+capital moving through its place. Map #303 is the vehicle; done when `/to-spec` can run.
+**Branch:** `map/304-who-pays` (PR #312 open, CI running, watcher set to merge on green).
+Main is at `9164f08d` (PR #302 merged).
+**Test:** `./scripts/precheck.sh` (tsc + 724 vitest). DB reads: `node --env-file=.env
+scripts/gsql.mjs "..."` — always `cd /Users/benknight/Code/grantscope` first, cwd drifts.
+
+### Now
+[->] **#311 — talk to three place-based intermediaries.** HITL, Ben only. The single
+assumption today produced that nobody has tested. It can invalidate #304 and everything
+downstream, so it goes before #306/#307/#309.
+
+### This Session
+- [x] **ROGS double-count fixed and APPLIED** (#299 closed). 848 rows/$66.13bn → 368/$28.35bn.
+      483 exact duplicates from the same PC table ingested twice on 2026-03-14. Per-lane series
+      verified UNCHANGED (2024-25 detention $1,141M, conferencing $62M).
+- [x] **Essay written** — `thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md`
+      + provenance sidecar. Detention recurrent +93% in 9y; conferencing +5% (real-terms cut);
+      capital $1,791M detention vs $20M conferencing.
+- [x] **Place capture measured, view APPLIED.** `v_grant_place_capture` live: 85,898 awards,
+      $33.75bn, 85.1% of awards / 59.6% of dollars captured in the delivery LGA.
+- [x] **State cut:** 97.5% of awards, 96.8% of dollars stay in-state ($200.21bn).
+      **The leak is entirely WITHIN states.**
+- [x] **Delivery-location extraction scoped out with evidence.** Zero deliveryAddress/
+      deliveryLocation across 100 live OCDS releases. Federal contracts do not record it.
+- [x] **Spec #300** published (`ready-for-agent`), then corrected by comment.
+- [x] **Map #303 charted.** #305, #308 (research) and #304 resolved. #311 split out.
+- [x] **Memory updated** — new `solution_place_money_traps.md`; refined
+      `project_remote_funding_intermediaries.md`.
+
+### Next
+- [ ] **#311** validate the intermediary payer (HITL, Ben).
+- [ ] **#309** the first surface — now UNBLOCKED (304/305/308 all closed). Must fold in #304's
+      `is_community_controlled` split constraint.
+- [ ] **#306** how the four products compose. **#307** pilot place (see Open Questions).
+- [ ] **#301** postcode_geo — needs the ABS SA3→LGA correspondence file, NOT a migration.
+- [ ] Confirm PR #312 merged; report SHA.
+
+### Decisions
+- **The buyer wedge does not survive** a community-first product. 438 prospects, ZERO paying
+  buyers after 10 weeks. `docs/strategy/buyer-wedge.md` marked PROVISIONAL, superseded on #303.
+- **Infrastructure for everyone, a product for ONE named payer**, and the payer is a
+  **place-based intermediary** (council, land council, regional body) buying to keep spend local.
+- **Every capture figure carries an `is_community_controlled` split.** An intermediary's failure
+  mode is "local" meaning the biggest business in town. Makes the substitution visible.
+- **Segmentation is place-bounded + self-selecting, never scored.** #308 showed why: reserves
+  invert (measured against expenses, so dormant orgs rank best).
+- **Bankable = trading throughput, not balance sheet.** 5.1x revenue, 6x FTE, only 1.8x assets.
+  **The bar is contract #1**; 11,431 of 12,479 community-controlled orgs have never won one.
+- Out of scope, deliberately: governing a capital pool, the Goods/QBE raise, art as a product,
+  contract delivery-location extraction.
+
+### Open Questions
+- **Palm Island Community Company already has an `org_profiles` row.** #307 is written as if no
+  community has a relationship with this work. That premise is wrong and the ticket needs
+  rewriting — the question is what we already owe someone already here. **Ben's call.**
+- **UNCONFIRMED: does the intermediary payer exist?** Exactly the defect that killed the wedge.
+  #311 is the test. Do not build until it reports.
+- **UNCONFIRMED: extent of the postcode_geo SA3 defect.** Unknowable from inside the DB — only
+  4 of 443 rows have a cross-checkable sibling. 4816→Croydon is the one proven case.
+- The two research docs rode in on #312 because the second subagent branched off the first's
+  branch, not main. Harmless, landed deliberately.
+
+### Workflow State
+pattern: wayfinder-map
+phase: 2
+total_phases: 5
+retries: 0
+max_retries: 3
+
+#### Resolved
+- goal: "what CivicGraph builds so a community can capture the capital moving through it"
+- resource_allocation: balanced
+
+#### Unknowns
+- intermediary_payer_demand: UNKNOWN (#311)
+- postcode_geo_sa3_extent: UNKNOWN (#301, needs external ABS source)
+
+#### Last Failure
+(none — PR #302 merged clean, both migrations applied and verified against prediction)
+
+---
+
+## Context
+
+**Five numbers were wrong before they reached anything public today.** Each was caught by
+checking a specific case, never by general care. This is the session's main lesson and it is
+now in memory as `solution_place_money_traps.md`:
+
+1. `delivery_postcode = 'Multiple'` (5,978 rows, $19.55bn) counted as off-site → cross-state read
+   $17.79bn instead of $3.95bn, **wrong by 4.5x**.
+2. `delivery_state` holds **318 distinct values** including comma-lists, `National`, `Overseas`.
+3. `postcode_geo` is locality-grain — joining without dedupe inflated dollars ~5x.
+4. `postcode_geo` 4816 = `Townsville - South` → LGA `Croydon`, ~900km away. Made Croydon QLD the
+   worst-capturing LGA in Australia on Palm Island money.
+5. Wangaratta's 8.3% capture = **Australian Rail Track Corporation, SA-registered, $940M,
+   Inland Rail**. GOCs dominate any per-place ranking.
+
+Plus: count-weighted and dollar-weighted versions of the same measure tell **opposite** stories.
+Local capture falls monotonically by award count (86.8%→66.0% by remoteness) and has **no
+gradient** by dollars (55.2% vs 68.1%). Show both or mislead.
+
+**Also corrected:** the remote-intermediary framing is not supported at the top end. Largest
+very-remote-delivered / city-received awards go to Santos, Lynas, Metso, Engie — corporate head
+offices, not land councils. The *mechanism* is real and now quantified (registered-address
+attribution moves 26.6%/35.6%/22.5% of Outer Regional/Remote/Very Remote dollars city-ward);
+the *population* is mostly corporate.
+
+**Key documents**
+- `thoughts/shared/analysis/2026-08-19-grant-place-capture.md` — the measure + 4 corrections
+- `thoughts/shared/analysis/2026-08-19-delivery-location-scoping.md` — why contracts are out
+- `thoughts/shared/analysis/2026-08-19-what-is-showable.md` — per-lane geography (#305)
+- `thoughts/shared/analysis/2026-08-19-what-bankable-means.md` — the two populations (#308)
+- `thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md` — the essay
+- Map #303; issues #300, #301, #306, #307, #309, #310, #311
+
+**Before publishing the essay:** the Preston figures are unverified (CLES/Preston City Council
+summaries agreeing with each other; the 4,500 jobs number needs the primary evaluation), and
+"group conferencing is the lane with the evidence behind it" is asserted, not cited.


### PR DESCRIPTION
Three commits from wayfinder map #303. All docs and strategy — no code, no schema.

## The decision (#304)

**The buyer wedge does not survive contact with a community-first product.**

Ten weeks after `docs/strategy/buyer-wedge.md` was marked ACTIVE: **438 buyer prospects, zero paying buyers**, `api_keys` 0 rows, and the only three `org_profiles` rows are Palm Island Community Company, JusticeHub and A Curious Tractor — all internal or adjacent. That is a hypothesis, not a plan, and nothing in the map may depend on it.

Decided instead: **infrastructure for everyone, a product for one named payer**, and the payer is a **place-based intermediary** — council, land council, regional body — buying to keep spend local. The only candidate whose interest points the same way as the community organisation's.

The wedge is marked **PROVISIONAL** with a pointer to #303, so the next session does not evaluate a decision against a premise we know is shaky.

**The load-bearing constraint:** every capture figure must carry an `is_community_controlled` split. An intermediary's failure mode is "local" meaning the biggest business in town while the Aboriginal corporation three streets away stays at zero — the measure would report success and deliver nothing the destination asked for. Making the substitution visible is the only honest thing a measurement instrument can do.

The new payer has the **same untested-demand defect** as the wedge, so it is ticketed (#311) before any build rather than discovered in eighteen months.

## Research: what is showable (#305)

- **Grants are the only lane placeable by where work happened.** $33.75bn of $230bn, 426 LGAs.
- **Federal contracts have supplier registered address only.** 91.5% of $1,141.8bn "lands" in Major Cities; Remote + Very Remote is $3.1bn (0.26%). Not a delivery claim.
- **The bias is quantified for the first time:** attributing by recipient address rather than delivery moves **26.6% / 35.6% / 22.5%** of Outer Regional / Remote / Very Remote dollars into the cities.
- **No second source.** `state_tenders` is 99.98% QLD with no sub-state field.
- **The remote-intermediary framing is NOT supported.** Top very-remote-delivered/city-received awards are Santos, Lynas, Metso, Engie — corporate head offices, not land councils.
- Largest honest claim covers **14.7% of grant dollars, ~2% of all tracked money**. The contract lane is *absent, not zero*.

## Research: what bankable means (#308)

- **Trading throughput, not balance sheet.** Contract-holders vs grant-only: 5.1x median revenue ($4.09M vs $0.81M), 6x paid FTE (18 vs 3), only 1.8x assets.
- **The bar is contract #1.** Sub-$50K first contracts reach 5+ contracts at 32.7%, the highest band — but **11,431 of 12,479 community-controlled orgs have never won one**.
- **Reserves run backwards** (7.8 months vs 17.9). Measured against expenses, so dormant orgs score best. Any score using them inverts.
- **52% of contract-holders never held a grant** — a second population, not graduates. Top holders are Canberra/Sydney Supply-Nation labour-hire and ICT Pty Ltds.
- **ACT is the only state where contract-holders outnumber grant-only** (5.3:1) vs QLD 0.45:1. Distance from the buyer, not remoteness.

## Note on the branch

The two research commits are here because the second subagent branched off the first's branch rather than main. Harmless, and I chose to land both documents rather than leave 400 lines of measured analysis on throwaway local branches that the map now cites.

## Gates

`scripts/precheck.sh` green. `classify-changes.sh`: SAFE.