### PR TITLE
Promote the five on_demand matviews that live code reads (#314)

### DIFF
--- a/migrations/2026-08-19-refresh-tier-promote.sql
+++ b/migrations/2026-08-19-refresh-tier-promote.sql
@@ -1,0 +1,69 @@
+-- Issue #314 — promote the five on_demand matviews that live app code actually reads
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -v ON_ERROR_STOP=1 -f migrations/2026-08-19-refresh-tier-promote.sql
+--
+-- Context, and a correction. #314 was opened claiming the nightly refresh had stopped running.
+-- It has not. Measured 2026-08-19 against cron.job_run_details: job 4
+-- (refresh-civicgraph-mvs-nightly, 0 17 * * *) succeeded on 18 Aug in 11m48s, and every one of
+-- the 56 nightly-tier matviews carries a success timestamp from that run. The weekly job (13,
+-- Sundays 15:00 UTC) last ran 16 Aug, on cadence. There is no cron fault.
+--
+-- Two measurement errors produced the false alarm, both worth remembering:
+--   1. The eight matviews that "went up" after a manual refresh were weekly- and retire-tier.
+--      They were exactly as fresh as their tier says they should be.
+--   2. The first staleness query filtered status='success' and missed 264 'success-fallback'
+--      rows -- the non-concurrent retry path inside refresh_civicgraph_mvs_run(). Filtering for
+--      literal 'success' understates freshness across the whole registry.
+--
+-- What IS real: refresh_civicgraph_mvs_run() drives off mv_refresh_plan(p_tier), so tier decides
+-- whether a matview is ever refreshed by anything. 23 of the 24 on_demand matviews have never
+-- logged a refresh at all. Five of them are read by live application code:
+--
+--   act_grant_recommendations        13 files
+--   mv_yj_report_acco_gap             2 files
+--   mv_yj_report_unfunded_programs    2 files
+--   mv_yj_report_alma_type_counts     1 file
+--   mv_yj_report_state_top_orgs       1 file
+--
+-- A matview that nothing refreshes, read by a live surface, serves a number with no as-of date.
+-- That is not a confident zero -- it is a confident stale non-zero, which is harder to notice.
+-- The youth-justice report ones are public.
+--
+-- Tier choice: nightly rather than weekly. These sit behind report surfaces where a week of drift
+-- is a week of wrong, and the nightly window has headroom -- 56 matviews finish in under 12
+-- minutes, so five more is minutes, not hours. Measured before promoting, all five refresh
+-- cleanly: act_grant_recommendations 20.3s, the four mv_yj_report_* under 1s each -- ~22s total
+-- added to a 12-minute window.
+--
+-- Deliberately NOT in this migration: the 9 retire-tier matviews. They are read by zero
+-- application code and should be dropped, but dropping is destructive and gets its own ticket.
+
+BEGIN;
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n
+  FROM mv_refresh_registry
+  WHERE mv_name IN ('act_grant_recommendations','mv_yj_report_acco_gap',
+                    'mv_yj_report_alma_type_counts','mv_yj_report_state_top_orgs',
+                    'mv_yj_report_unfunded_programs')
+    AND tier = 'on_demand';
+  IF n <> 5 THEN
+    RAISE EXCEPTION 'expected 5 on_demand rows to promote, found %', n;
+  END IF;
+END $$;
+
+UPDATE mv_refresh_registry
+SET tier = 'nightly',
+    notes = concat_ws(' | ', nullif(notes,''),
+            'promoted from on_demand 2026-08-19 (#314): read by live app code, never refreshed'),
+    updated_at = now()
+WHERE mv_name IN ('act_grant_recommendations','mv_yj_report_acco_gap',
+                  'mv_yj_report_alma_type_counts','mv_yj_report_state_top_orgs',
+                  'mv_yj_report_unfunded_programs');
+
+COMMIT;

--- a/thoughts/shared/handoffs/place-capital/current.md
+++ b/thoughts/shared/handoffs/place-capital/current.md
@@ -1,7 +1,7 @@
 ---
-date: 2026-08-19T07:05:00Z
+date: 2026-08-19T08:05:00Z
 session_name: place-capital
-branch: map/304-who-pays
+branch: fix/314-refresh-tiers
 status: active
 ---
 
@@ -9,18 +9,43 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-19T07:05:00Z
+**Updated:** 2026-08-19T08:05:00Z
 **Goal:** A buildable spec for what a community organisation uses to see, then capture, the
 capital moving through its place. Map #303 is the vehicle; done when `/to-spec` can run.
-**Branch:** `map/304-who-pays` (PR #312 open, CI running, watcher set to merge on green).
-Main is at `9164f08d` (PR #302 merged).
+**Branch:** `fix/314-refresh-tiers` (PR #316 open, CI running, watcher set to merge on green).
+Main is at `6e619586` (PR #312 merged `83720ba6`, then PR #313 merged `6e619586`).
 **Test:** `./scripts/precheck.sh` (tsc + 724 vitest). DB reads: `node --env-file=.env
 scripts/gsql.mjs "..."` — always `cd /Users/benknight/Code/grantscope` first, cwd drifts.
 
 ### Now
 [->] **#311 — talk to three place-based intermediaries.** HITL, Ben only. The single
 assumption today produced that nobody has tested. It can invalidate #304 and everything
-downstream, so it goes before #306/#307/#309.
+downstream, so it goes before #306/#307/#309. **Unchanged by the data-integrity detour below.**
+
+[ ] **Tomorrow, one query:** did the five promoted matviews log a success in the 17:00 UTC
+    nightly? Plan membership is not proof; the log is.
+    `SELECT mv_name, max(finished_at) FROM mv_refresh_log WHERE status IN ('success',
+    'success-fallback') AND mv_name IN ('act_grant_recommendations','mv_yj_report_acco_gap',
+    'mv_yj_report_alma_type_counts','mv_yj_report_state_top_orgs',
+    'mv_yj_report_unfunded_programs') GROUP BY 1;`
+
+### This Session — data integrity (second half, after #312 landed)
+- [x] **#290 CLOSED, applied.** 306 foundation self-loops deleted (**$98,694,338**), 157
+      `gs_relationships` edges (**$34,636,088**). Backups `_backup_foundation_selfloops_20260819`
+      and `_backup_gs_rel_foundation_selfloops_20260819`. Verified 0 remaining. PR #313 →
+      `6e619586`. Guards live: `foundation_grantees_no_selfloop` (validated) and
+      `gs_relationships_foundation_grantees_no_selfloop` (NOT VALID by design — 3.43M rows,
+      validation scan exceeds the pooler timeout; enforced on write, which is the point).
+- [x] **Producer identified and already dead.** `scripts/run-reviewability-backlog-batch.mjs`,
+      deleted in the 2026-04-24 scope cut (last at `f187e12a`).
+      `getGenericGrantOpportunityPipeline()` read a foundation's own `grant_opportunities` rows as
+      grantee rows — an opportunity describes the funder, so the "grantee" came back as the funder.
+      **Five LIVE writers can recreate the shape and none checked**, hence a constraint not five
+      patches. Explicit skips added to the two bulk writers.
+- [x] **#314 opened, then CORRECTED BY ME, then retitled.** PR #316 open.
+- [x] **#315 opened** — self-loops in the other `gs_relationships` datasets are unmeasured.
+- [x] **Five on_demand matviews promoted to nightly and APPLIED** (`UPDATE 5`, all five now in
+      `mv_refresh_plan('nightly')`). Registry now nightly 61 / weekly 15 / on_demand 19 / retire 9.
 
 ### This Session
 - [x] **ROGS double-count fixed and APPLIED** (#299 closed). 848 rows/$66.13bn → 368/$28.35bn.
@@ -41,6 +66,14 @@ downstream, so it goes before #306/#307/#309.
       `project_remote_funding_intermediaries.md`.
 
 ### Next
+- [ ] Confirm PR #316 merged; report SHA. Then the nightly-log check above.
+- [ ] **#314 residue** — `health` is NULL on all 104 registry rows, no max-age anywhere, so
+      staleness is still only findable by hand. Decide what a surface does when its matview is
+      stale: serving it silently is current behaviour and is wrong. Disclose the as-of date.
+- [ ] **Drop the 9 `retire`-tier matviews** — read by ZERO app code (one appears only in a doc
+      comment in `clarity/nouns.ts`) yet still `enabled`. Destructive, needs its own ticket.
+- [ ] **#315** — measure self-loops per `(dataset, relationship_type)`. The naive
+      `GROUP BY dataset` over 3.43M rows times out; needs a partial index or a chunked scan.
 - [ ] **#311** validate the intermediary payer (HITL, Ben).
 - [ ] **#309** the first surface — now UNBLOCKED (304/305/308 all closed). Must fold in #304's
       `is_community_controlled` split constraint.
@@ -49,6 +82,13 @@ downstream, so it goes before #306/#307/#309.
 - [ ] Confirm PR #312 merged; report SHA.
 
 ### Decisions
+- **Guard at the constraint, not at the writer.** #290 found five live scripts that could each
+  recreate the bug. One dataset-scoped CHECK covers all five and anything written later; five
+  patches would have drifted. `NOT VALID` is the right shape on a 3.43M-row table — enforcement on
+  write is the whole point and a history scan will not finish inside the statement timeout.
+- **`on_demand` is not a cadence, it is "nothing refreshes this".** A matview on that tier read by
+  a live surface serves a number with no as-of date. Five were; they are now nightly. Check the
+  tier before trusting any matview-derived figure.
 - **The buyer wedge does not survive** a community-first product. 438 prospects, ZERO paying
   buyers after 10 weeks. `docs/strategy/buyer-wedge.md` marked PROVISIONAL, superseded on #303.
 - **Infrastructure for everyone, a product for ONE named payer**, and the payer is a
@@ -63,6 +103,26 @@ downstream, so it goes before #306/#307/#309.
   contract delivery-location extraction.
 
 ### Open Questions
+- **I raised a false alarm on #314 and corrected it — keep the lesson.** I inferred "the nightly
+  refresh has stopped" from matview row counts moving UP after a manual refresh. The nightly had
+  run fine (job 4, 18 Aug, 11m48s, all 56 nightly-tier MVs stamped). Two errors: the eight MVs I
+  measured were weekly-/retire-tier and exactly as fresh as their tier says, and my query filtered
+  `status='success'`, missing **264 `success-fallback` rows** — the non-concurrent retry path
+  inside `refresh_civicgraph_mvs_run()`. **Always filter
+  `status IN ('success','success-fallback')`.** And check the scheduler's own history before
+  concluding a scheduler failed: the count moving the unexpected way was the signal my model was
+  wrong, not the system.
+- **Unverified: does the nightly actually refresh the five promoted MVs?** Plan membership is not
+  proof. `act_grant_recommendations` is scheduled `use_concurrent=true` and my pre-flight refresh
+  was non-concurrent, so that path is untested — it does have a unique index
+  (`act_grant_recommendations_pk_idx`), and the proc falls back non-concurrently if it fails.
+- **Unmeasured, NOT clean: self-loops in the rest of `gs_relationships`** (#315). The
+  #290 constraint is dataset-scoped because the measuring query times out, not because other
+  datasets were checked. Some relationship types may self-reference legitimately, so the verdict
+  is per `(dataset, relationship_type)` — a blanket constraint could be wrong.
+- **The #290 dollar delta per surface was never obtainable** and I did not fake one. The refresh
+  that would have measured it also folded in unrelated tier-lag. Exact figure is the deletion
+  itself: $98,694,338.
 - **Palm Island Community Company already has an `org_profiles` row.** #307 is written as if no
   community has a relationship with this work. That premise is wrong and the ticket needs
   rewriting — the question is what we already owe someone already here. **Ben's call.**


### PR DESCRIPTION
Toward #314 — and it **corrects that issue's premise**, which I got wrong.

## The nightly refresh has not stopped

`cron.job_run_details`, measured 2026-08-19:

| job | schedule | last run | result |
|---|---|---|---|
| 4 `refresh-civicgraph-mvs-nightly` | `0 17 * * *` | 2026-08-18 17:00 UTC | succeeded, 11m48s |
| 13 `refresh-civicgraph-mvs-weekly` | `0 15 * * 0` | 2026-08-16 15:00 UTC | succeeded |

All 56 nightly-tier matviews carry a success timestamp from that 18 Aug run. The next nightly is due 19 Aug 17:00 UTC and simply has not fired yet. **There is no cron fault.**

## Two measurement errors made it look like one

1. **The eight matviews that "went up" after a manual refresh were weekly- and retire-tier.** One was nightly. They were exactly as fresh as their tier says they should be. I read a tier design as a failure.
2. **The staleness query filtered `status='success'` and missed 264 `success-fallback` rows** — the non-concurrent retry path inside `refresh_civicgraph_mvs_run()`, which fires when a `CONCURRENTLY` refresh hits an unusable unique index. Filtering for literal `'success'` understates freshness across the whole registry. Worth remembering; it is an easy filter to write.

Corrected picture:

| tier | matviews | never logged | last success |
|---|---|---|---|
| nightly | 56 | 0 | 2026-08-18 |
| weekly | 15 | 0 | 2026-08-16 |
| retire | 9 | 0 | 2026-08-15 |
| **on_demand** | **24** | **23** | — |

## What is actually broken

`refresh_civicgraph_mvs_run()` drives off `mv_refresh_plan(p_tier)`, so **tier decides whether a matview is ever refreshed by anything**. `on_demand` means nothing refreshes it. Five on_demand matviews are read by live application code:

| matview | files referencing it |
|---|---|
| `act_grant_recommendations` | 13 |
| `mv_yj_report_acco_gap` | 2 |
| `mv_yj_report_unfunded_programs` | 2 |
| `mv_yj_report_alma_type_counts` | 1 |
| `mv_yj_report_state_top_orgs` | 1 |

None has ever logged a refresh. A matview nothing refreshes, read by a live surface, serves a number with **no as-of date** — a confident stale non-zero, harder to notice than the confident zero the scope-cut note warns about. The `mv_yj_report_*` ones are public.

This PR promotes those five to `nightly`, with a `DO` block that aborts unless exactly five on_demand rows match.

**Measured before promoting** — all five refresh cleanly: `act_grant_recommendations` 20.3s, the four `mv_yj_report_*` under 1s each. ~22s added to a 12-minute window.

## Deliberately not here

- **The 9 `retire`-tier matviews are read by zero application code** (only one appears anywhere, in a doc comment in `clarity/nouns.ts`). They should be dropped. Destructive, so it gets its own ticket rather than riding along.
- **`health` is NULL on all 104 registry rows** and there is no max-age anywhere, so staleness remains something you discover by hand. That part of #314 stands and stays open after this merges.

Gates: `./scripts/precheck.sh` — tsc clean, 724 vitest. Migration is **not applied**; apply command is in the file header.
