### PR TITLE
Bound the E2E job so a hung apt call cannot squat for six hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,21 +67,17 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
-      # `--with-deps` shells out to apt, which is the part that hangs: it blocks on a dpkg lock or
-      # an interactive prompt and never returns. DEBIAN_FRONTEND removes the prompt, the step
-      # timeout bounds the lock, and on a cache hit only the apt half runs.
+      # No `--with-deps`, deliberately. That flag runs `sudo apt-get update && install`, and the
+      # Azure Ubuntu mirror these runners default to is what actually hangs: the log is hundreds of
+      # `Ign: http://azure.archive.ubuntu.com` lines, a partial fallback to archive.ubuntu.com, then
+      # five minutes of dead air. It is a network stall, not a dpkg lock, so DEBIAN_FRONTEND does
+      # nothing for it. The ubuntu-latest image already ships Playwright's chromium system
+      # libraries, so the apt call bought nothing and cost the whole pipeline.
+      # If a library ever is missing, chromium fails to launch with a named error instead of hanging.
       - name: Install Playwright browsers
         if: steps.pw-cache.outputs.cache-hit != 'true'
         timeout-minutes: 6
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: cd apps/web && npx playwright install --with-deps chromium
-      - name: Install Playwright system dependencies
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        timeout-minutes: 6
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: cd apps/web && npx playwright install-deps chromium
+        run: cd apps/web && npx playwright install chromium
 
       - run: cd apps/web && pnpm test:e2e
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -27,6 +28,7 @@ jobs:
   unit-tests:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -41,6 +43,10 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [typecheck, unit-tests]
+    # Without this a hung step squats for GitHub's 6-hour default. On 2026-08-19 two runs sat on
+    # `playwright install --with-deps` for close to an hour and blocked two PRs; the same step
+    # normally takes 62 seconds.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -49,8 +55,36 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: cd apps/web && npx playwright install --with-deps chromium
+
+      # Cache the browser binaries so the usual run does no download at all. The cache key has to
+      # move with the Playwright version or a version bump silently reuses the wrong browsers.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('./apps/web/node_modules/@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      # `--with-deps` shells out to apt, which is the part that hangs: it blocks on a dpkg lock or
+      # an interactive prompt and never returns. DEBIAN_FRONTEND removes the prompt, the step
+      # timeout bounds the lock, and on a cache hit only the apt half runs.
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 6
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: cd apps/web && npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: cd apps/web && npx playwright install-deps chromium
+
       - run: cd apps/web && pnpm test:e2e
+        timeout-minutes: 10
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/migrations/2026-08-19-palm-island-4816.sql
+++ b/migrations/2026-08-19-palm-island-4816.sql
@@ -1,0 +1,72 @@
+-- Issue #301 — postcode 4816 is not Croydon, and the SA3 defect is 451 postcodes wide
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -v ON_ERROR_STOP=1 -f migrations/2026-08-19-palm-island-4816.sql
+--
+-- The defect. postcode_geo's row for 4816 carries locality 'Townsville - South', which is an ABS
+-- SA3 name, not a gazetted locality, and stamps lga_name='Croydon' (32600). Croydon Shire is in
+-- the Gulf Country, roughly 700km away. 135 gs_entities on 4816 inherited it, including 20 Palm
+-- Island organisations: Kootana Women's Centre, Bwgcolman Arts, Bwgcolman Hornets, Coolgaree,
+-- Coonawarra Media, the Men's Business Group, the Community Justice Group, the Rodeo Corporation.
+-- Only one row on the island is right, the Aboriginal Shire Council, placed by a different rung
+-- (council_serves_shire).
+--
+-- Trap, and it is why this migration does not simply write 'Palm Island' across 4816: **4816
+-- genuinely straddles two LGAs.** It covers Great Palm Island (Palm Island Aboriginal Shire,
+-- 35790) AND mainland localities south of Townsville -- Alligator Creek, and entities naming
+-- Cardwell, Burdekin, Hinchinbrook and Bowie also sit on it. So the postcode has no single right
+-- answer, and asserting one would replace a wrong LGA with a differently wrong LGA.
+--
+-- Therefore: place only what name evidence supports, and unplace the rest rather than guess. That
+-- follows the standing rule from the LGA attribution rebuild -- entities are deliberately left
+-- unplaced rather than confidently wrong, and every row stays reason-coded.
+--
+-- Extent, measured 2026-08-19 and previously recorded as unknown: **451 postcode_geo rows carry
+-- SA3/SA2-shaped locality names, across 446 postcodes holding 66,024 gs_entities.** In a random
+-- sample of 12, at least 6 had verifiably wrong LGAs (Scottsdale-Bridport 7260 stamped Launceston
+-- not Dorset; Beauty Point-Beaconsfield 7270 stamped Latrobe not West Tamar; Aldgate-Stirling 5153
+-- stamped Alexandrina not Adelaide Hills; Southern Downs-East 4373 stamped Scenic Rim not Southern
+-- Downs; Bourke-Brewarrina 2839 stamped Brewarrina not Bourke; Dilston-Lilydale 7268 stamped
+-- Dorset). This migration fixes ONE of the 451. The rest need the ABS SA3-to-LGA correspondence
+-- file and stay open on #301.
+
+BEGIN;
+
+CREATE TABLE _backup_gs_entities_4816_20260819 AS
+SELECT id, gs_id, canonical_name, postcode, lga_name, lga_code, lga_source
+FROM gs_entities WHERE postcode = '4816';
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM gs_entities WHERE postcode='4816' AND lga_name='Croydon';
+  IF n <> 135 THEN
+    RAISE EXCEPTION 'expected 135 entities on 4816 stamped Croydon, found %', n;
+  END IF;
+END $$;
+
+-- 1. The source row. 4816 straddles Palm Island Aboriginal Shire and Townsville City, so it gets
+--    no LGA at all rather than a wrong one. Leaving Croydon here would re-poison every rebuild.
+UPDATE postcode_geo
+SET lga_name = NULL, lga_code = NULL
+WHERE postcode = '4816' AND lga_name = 'Croydon';
+
+-- 2. Palm Island organisations, by name evidence. Bwgcolman is the people's name for the island;
+--    Coolgaree and Kootana are Palm Island bodies. All verified against the entity list.
+UPDATE gs_entities
+SET lga_name = 'Palm Island', lga_code = '35790',
+    lga_source = 'own_name_town+manual_verified'
+WHERE postcode = '4816'
+  AND lga_name = 'Croydon'
+  AND canonical_name ~* 'palm island|bwgcolman|coolgaree|kootana';
+
+-- 3. Everyone else on 4816. Mainland, multi-LGA, no name evidence: unplaced and reason-coded,
+--    not guessed.
+UPDATE gs_entities
+SET lga_name = NULL, lga_code = NULL,
+    lga_source = 'unresolved_multi_lga_postcode'
+WHERE postcode = '4816' AND lga_name = 'Croydon';
+
+COMMIT;

--- a/migrations/2026-08-19-sa3-locality-lga-repair.sql
+++ b/migrations/2026-08-19-sa3-locality-lga-repair.sql
@@ -1,0 +1,110 @@
+-- Issue #301 — repair the SA3-shaped locality rows using ABS data already in this database
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -v ON_ERROR_STOP=1 -f migrations/2026-08-19-sa3-locality-lga-repair.sql
+--
+-- THE HANDOFF NOTE WAS WRONG, AND IT COST FOUR MONTHS OF "BLOCKED".
+-- #301 was recorded as needing the ABS SA3-to-LGA correspondence file, an external download.
+-- It does not. `abs_poa_lga_ratio` is already loaded -- 3,968 rows over 2,641 postcodes -- and it
+-- is a BETTER instrument than the SA3 file, because it maps postcode directly to LGA with a
+-- population ratio, skipping the SA3 hop entirely. It covers 435 of the 451 defective postcodes.
+-- Before declaring a data task blocked on an external file, check whether the correspondence is
+-- already in the warehouse under a different name.
+--
+-- The defect. 451 postcode_geo rows carry ABS statistical-area names in `locality`
+-- ('Townsville - South', 'Nerang - Mount Nathan', 'Chatswood - East') rather than gazetted
+-- localities, and the LGA attached to those rows is frequently wrong. Entities inherit it.
+--
+-- Measured against ABS dominance, 2026-08-19. The earlier "at least 6 of a random 12 are wrong"
+-- read high -- the true rate is 133 of 451, about 29%:
+--
+--   dominant (>=90% one LGA), stamp AGREES     298   <- already correct, untouched
+--   dominant, stamp DISAGREES                   87   <- fixed below, 9,101 entities
+--   genuinely split (<90%), stamp DISAGREES     46   <- unplaced below, 6,110 entities
+--   no ABS ratio data                           16   <- untouched, still open
+--   dominant, currently unstamped                2   <- filled below
+--
+-- Every one of the 46 split postcodes disagrees with the ABS majority and NOT ONE agrees. That is
+-- systematic, not noise, so the stamps on split postcodes are not trustworthy either. They cannot
+-- be corrected (no LGA reaches 90%), so they are unplaced and reason-coded rather than guessed --
+-- the standing rule from the LGA rebuild: deliberately unplaced beats confidently wrong.
+--
+-- Sample of what is being corrected, all ratios 0.93 to 1.00:
+--   4211 Nerang           Scenic Rim      -> Gold Coast     711 entities
+--   2067 Chatswood-East   Ryde            -> Willoughby     635
+--   2830 Dubbo-South      Warrumbungle    -> Dubbo          601
+--   4817 Kirwan-West      Charters Towers -> Townsville     298
+--   0830 Durack           Litchfield      -> Palmerston     276
+--
+-- Not in scope: the 16 postcodes with no ABS ratio row, and the 298 that were already right.
+
+BEGIN;
+
+CREATE TABLE _backup_postcode_geo_sa3_20260819 AS
+SELECT * FROM postcode_geo WHERE locality LIKE '% - %';
+
+CREATE TABLE _backup_gs_entities_sa3_20260819 AS
+SELECT id, gs_id, canonical_name, postcode, lga_name, lga_code, lga_source
+FROM gs_entities
+WHERE postcode IN (SELECT postcode FROM postcode_geo WHERE locality LIKE '% - %');
+
+CREATE TEMP TABLE _dom ON COMMIT DROP AS
+SELECT DISTINCT ON (poa_code) poa_code, lga_name, lga_code, ratio
+FROM abs_poa_lga_ratio ORDER BY poa_code, ratio DESC;
+
+-- The 87 correctable postcodes, plus the 2 that carry no stamp at all.
+CREATE TEMP TABLE _fix ON COMMIT DROP AS
+SELECT g.postcode, g.lga_name AS old_lga, d.lga_name AS new_lga, d.lga_code AS new_code
+FROM postcode_geo g JOIN _dom d ON d.poa_code = g.postcode
+WHERE g.locality LIKE '% - %'
+  AND d.ratio >= 0.90
+  AND (g.lga_name IS NULL OR lower(g.lga_name) <> lower(d.lga_name));
+
+-- The 46 genuinely-split postcodes whose stamp disagrees with the ABS majority.
+CREATE TEMP TABLE _unplace ON COMMIT DROP AS
+SELECT g.postcode, g.lga_name AS old_lga
+FROM postcode_geo g JOIN _dom d ON d.poa_code = g.postcode
+WHERE g.locality LIKE '% - %'
+  AND d.ratio < 0.90
+  AND g.lga_name IS NOT NULL
+  AND lower(g.lga_name) <> lower(d.lga_name);
+
+DO $$
+DECLARE n_fix int; n_un int;
+BEGIN
+  SELECT count(*) INTO n_fix FROM _fix;
+  SELECT count(*) INTO n_un  FROM _unplace;
+  IF n_fix <> 89 THEN RAISE EXCEPTION 'expected 89 correctable postcodes (87 wrong + 2 unstamped), found %', n_fix; END IF;
+  IF n_un  <> 46 THEN RAISE EXCEPTION 'expected 46 split-and-disagreeing postcodes, found %', n_un; END IF;
+END $$;
+
+-- 1. Correct the source rows.
+UPDATE postcode_geo g SET lga_name = f.new_lga, lga_code = f.new_code
+FROM _fix f WHERE f.postcode = g.postcode AND g.locality LIKE '% - %';
+
+-- 2. Re-stamp entities that inherited the wrong LGA. Only rows still carrying the OLD value are
+--    touched; anything placed by street address, ORIC register or own-name evidence keeps its
+--    better provenance.
+UPDATE gs_entities e
+SET lga_name = f.new_lga, lga_code = f.new_code,
+    lga_source = 'poa_ratio_dominant+sa3_defect_repair'
+FROM _fix f
+WHERE e.postcode = f.postcode
+  AND f.old_lga IS NOT NULL
+  AND lower(e.lga_name) = lower(f.old_lga);
+
+-- 3. Unplace the split postcodes at source.
+UPDATE postcode_geo g SET lga_name = NULL, lga_code = NULL
+FROM _unplace u WHERE u.postcode = g.postcode AND g.locality LIKE '% - %';
+
+-- 4. And unplace the entities that inherited those stamps.
+UPDATE gs_entities e
+SET lga_name = NULL, lga_code = NULL,
+    lga_source = 'unresolved_multi_lga_postcode'
+FROM _unplace u
+WHERE e.postcode = u.postcode
+  AND lower(e.lga_name) = lower(u.old_lga);
+
+COMMIT;


### PR DESCRIPTION
Diagnosis of the E2E hang that blocked #316 and #317 today.

## What was actually stuck

Not the tests. The job never reached them. Step timings from run `32229056639`:

| step | started | finished |
|---|---|---|
| pnpm install | 07:44:54 | 07:44:59 |
| **`playwright install --with-deps chromium`** | **07:44:59** | **never** |
| `pnpm test:e2e` | — | never started |

The same step on run `32231053992`, twenty minutes later on the same workflow and runner image, took **62 seconds** (08:10:02 to 08:11:04) and the whole job finished in 2m30s. So it is intermittent, not slow.

Two runs were stuck simultaneously, on different refs: PR #316's branch and the push-to-`main` for #290's merge. Both on the same step.

## Why it hangs, and why it hangs *forever*

`--with-deps` shells out to `sudo apt-get install`. That blocks when `unattended-upgrades` holds the dpkg lock, or when a package prompts. It does not fail, it waits.

The compounding problem is that **no job or step in this workflow had a timeout**, so a blocked apt call runs to GitHub's 6-hour default. That is the actual defect. The apt flakiness is upstream and occasional; a check that hangs for six hours instead of failing in six minutes is ours.

`concurrency` with `cancel-in-progress: true` was already configured and was **not** the cause. Both stuck runs were the latest for their ref, with nothing behind them to cancel them.

## The fix

1. **`timeout-minutes` on all three jobs** (10/10/20) and on the slow steps. A hang now fails fast and reads as a failure rather than as a slow suite.
2. **`DEBIAN_FRONTEND=noninteractive`** plus a 6-minute bound on the apt step, removing the prompt failure mode and bounding the lock one.
3. **A version-keyed cache of `~/.cache/ms-playwright`**, so the normal run downloads no browsers at all and only the cheap `install-deps` runs. The key tracks the resolved `@playwright/test` version (verified locally: 1.58.2) because a static key would silently serve stale browsers after a version bump.

## Housekeeping

I cancelled the two hung runs so #316 and #317 are not waiting on them. Neither had produced any test signal.

`yaml.safe_load` parses the file, and the version-resolution command is verified against the real tree.