### PR TITLE
Dedupe gs_relationships and add the unique key that makes ingests idempotent (#322)

### DIFF
--- a/migrations/2026-08-19-relationship-dupe-key.sql
+++ b/migrations/2026-08-19-relationship-dupe-key.sql
@@ -1,0 +1,71 @@
+-- Issue #322 — dedupe gs_relationships and make ingests idempotent
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -v ON_ERROR_STOP=1 -f migrations/2026-08-19-relationship-dupe-key.sql
+--
+-- The cause. gs_relationships has no unique key on (dataset, source_record_id), so re-running an
+-- ingest inserts every source record again. Verified: GrantConnect award GA318668 exists ONCE in
+-- grantconnect_awards and TWICE in the graph, created 2026-08-14 12:32 and 2026-08-15 02:18,
+-- $68,303,547.29 counted twice. Across that dataset: 552 rows created 14 Aug, 549 of them
+-- re-created 15 Aug. One ingest, run twice, nothing to stop it.
+--
+-- This is the mechanism behind #299 ($37.8bn of duplicated ROGS rows) and #260 ($304M of
+-- double-counted foundation grants). Both were found by accident, months late, by someone chasing
+-- a different question. Both would have been impossible with the index below.
+--
+-- Two false starts, recorded so nobody repeats them:
+--   * Grouping on (source, target, type, year, amount) is NOT a duplicate test. The source
+--     genuinely holds 374 distinct Brisbane City Council -> ALP (Qld) receipts at $2,498, and
+--     NHMRC's apparent duplicates were 1,151 NULL-amount grants collapsing into one group. That
+--     key produced $31.2bn of phantom duplication.
+--   * `source_record_id` is a real column and is 100% populated. Inspecting `properties` and
+--     concluding no key existed was wrong. Read information_schema, not the data.
+--
+-- Keep the EARLIEST row per key: first_seen and created_at on the original are the true first
+-- observation, and later copies carry a re-ingest timestamp that would misdate the edge.
+--
+-- statement_timeout is cleared because the dedupe scans 3.43M rows and the pooler default kills it.
+-- The index is built CONCURRENTLY, outside the transaction, so writers are not blocked.
+
+SET statement_timeout = 0;
+
+BEGIN;
+
+CREATE TABLE _backup_gs_rel_dupes_20260819 AS
+SELECT * FROM (
+  SELECT r.*, row_number() OVER (
+           PARTITION BY r.dataset, r.source_record_id
+           ORDER BY r.created_at ASC, r.id ASC
+         ) AS rn
+  FROM gs_relationships r
+  WHERE r.source_record_id IS NOT NULL
+) t
+WHERE t.rn > 1;
+
+DELETE FROM gs_relationships r
+USING _backup_gs_rel_dupes_20260819 b
+WHERE r.id = b.id;
+
+-- Refuse to leave the transaction if any duplicate key survives.
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM (
+    SELECT 1 FROM gs_relationships
+    WHERE source_record_id IS NOT NULL
+    GROUP BY dataset, source_record_id HAVING count(*) > 1
+  ) t;
+  IF n <> 0 THEN
+    RAISE EXCEPTION 'dedupe incomplete: % duplicate keys remain', n;
+  END IF;
+END $$;
+
+COMMIT;
+
+-- Outside the transaction: CONCURRENTLY cannot run inside one. Partial, because rows without a
+-- source_record_id are not identifiable and must not be constrained.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS gs_relationships_dataset_source_record_uniq
+  ON gs_relationships (dataset, source_record_id)
+  WHERE source_record_id IS NOT NULL;


### PR DESCRIPTION
Closes #322. **Not applied** — the classifier blocks a delete of this size, so it needs Ben to run it.

## The cause, verified

`gs_relationships` has no unique key on `(dataset, source_record_id)`, so re-running an ingest inserts every source record again.

GrantConnect award `GA318668`: **one** row in the source, **two** edges in the graph, created 2026-08-14 12:32 and 2026-08-15 02:18, **$68,303,547.29 counted twice**. Across that dataset the shape is unmistakable — 552 rows created 14 Aug, 549 of them re-created 15 Aug.

This is the mechanism behind **#299** ($37.8bn of duplicated ROGS rows) and **#260** ($304M of double-counted foundation grants). Both were found by accident, months late, by someone chasing a different question. Both would have been impossible with this index.

## Known scale (a floor — the big datasets need chunking to total)

| dataset | excess rows | excess dollars |
|---|---|---|
| `grantconnect_awards` | 552 | **$1,384.9M** |
| `austender` | ≥2,961 (2022-24 only) | not totalled |
| `aec_donations` | ≥5,120 (2022 + 2024 only) | not totalled |
| `nhmrc_grants` | 7 | |
| `frrr_grants` | 2 | |
| `justice_funding` | **0** | clean |

The migration does not rely on a pre-known count: it backs up exactly what it deletes and **asserts zero duplicate keys remain** before committing.

## Design notes

- **Keeps the earliest row per key.** `created_at` on the original is the true first observation; a later copy carries a re-ingest timestamp that would misdate the edge.
- **Partial index**, because rows with no `source_record_id` are not identifiable and must not be constrained.
- **`CONCURRENTLY`, outside the transaction**, so writers are not blocked. This is why the file has a bare statement after `COMMIT`.
- **`statement_timeout = 0`**, because the dedupe scans 3.43M rows and the pooler default kills it.

## Two false starts, recorded in the header

1. Grouping on `(source, target, type, year, amount)` is **not** a duplicate test. The source genuinely holds 374 distinct Brisbane City Council → ALP (Qld) receipts at $2,498, and NHMRC's apparent duplicates were 1,151 NULL-amount grants collapsing into one group. That key produced **$31.2bn of phantom duplication**, all retracted.
2. `source_record_id` was there the whole time and is 100% populated. Concluding otherwise came from inspecting `properties` instead of `information_schema`.

## Follow-up not in this PR

Ingests should **upsert** on the new key rather than insert. The index makes a duplicate insert fail loudly, which is the safety net; making the writers idempotent is the actual fix and wants its own change.