### PR TITLE
One validated definition of an entity id, because there were seven (#324)

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -21,6 +21,7 @@ import { createClient } from '@supabase/supabase-js';
 import { spawnSync } from 'node:child_process';
 import { resolveBin, withRetry } from './lib/agent-resilience.mjs';
 import { edgeDataset, JUSTICE_PROGRAM_ENSURE_SQL, JUSTICE_BUILD_GUARD } from './lib/graph-edge-datasets.mjs';
+import { makeGsId } from './lib/gs-id.mjs';
 import 'dotenv/config';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -184,23 +185,7 @@ async function buildRelationshipsSetBased(label, cols, selectSql, prelude = '') 
   log(`  ${label}: ${m ? m[1] : '0'} inserted (existing rows skipped via ON CONFLICT)`);
 }
 
-function makeGsId({ abn, acn, icn, asx_code, buyer_id, name }) {
-  if (abn) return 'AU-ABN-' + abn.replace(/\s/g, '');
-  if (acn) return 'AU-ACN-' + acn.replace(/\s/g, '');
-  if (icn) return 'AU-ORIC-' + icn;
-  if (asx_code) return 'AU-ASX-' + asx_code.toUpperCase();
-  if (buyer_id) return 'AU-GOV-' + buyer_id;
-  if (name) {
-    let hash = 0;
-    const upper = name.toUpperCase().trim();
-    for (let i = 0; i < upper.length; i++) {
-      hash = ((hash << 5) - hash) + upper.charCodeAt(i);
-      hash |= 0;
-    }
-    return 'AU-NAME-' + Math.abs(hash).toString(36);
-  }
-  return 'AU-UNK-' + Date.now().toString(36);
-}
+// makeGsId now lives in ./lib/gs-id.mjs — see #324 for why it had to be validated and shared.
 
 
 // ─── Phase 1: Build entity registry ──────────────────────────────────────────

--- a/scripts/lib/gs-id.mjs
+++ b/scripts/lib/gs-id.mjs
@@ -1,0 +1,75 @@
+/**
+ * The one definition of a CivicGraph entity id.
+ *
+ * Written for #324. Before this, `makeGsId` existed SEVEN times across scripts/ with seven
+ * different signatures (build-entity-graph, resolve-donor-entities, import-lobbying-register,
+ * import-modern-slavery, ingest-ndis-providers, backfill-qgip-abns, link-entities-mega). Entity
+ * identity being defined seven ways is the root of the drift measured in #324: 771 government
+ * bodies carrying two identities across 45,220 edges.
+ *
+ * Two rules this enforces that the old copies did not:
+ *
+ * 1. AN INVALID ABN IS NOT AN IDENTIFIER. The old code did `if (abn) return 'AU-ABN-' + abn`,
+ *    so `abn = '0'` minted an entity, and `Saxonvale` ended up merged with
+ *    `112 Trenerry Crescent Pty Ltd` across 2,959 edges. 92 entities currently hold an ABN that is
+ *    not 11 digits, including the literal strings `#N/A`, `#VALUE!` and `(blank)` — Excel errors
+ *    that travelled all the way into entity identity. An invalid ABN now falls through to the next
+ *    identifier instead of becoming one.
+ *
+ *    Checked with the real ATO checksum, not just a length test. The 51 ten-digit values were
+ *    tested against the hypothesis that a leading zero had been stripped: ZERO validate when
+ *    zero-padded, so they are corrupt rather than recoverable.
+ *
+ * 2. THE FALLBACK MUST BE DETERMINISTIC. The old final branch was
+ *    `return 'AU-UNK-' + Date.now().toString(36)`, which mints a different id on every call for
+ *    the same input — a guaranteed duplicate generator. No `AU-UNK-` rows exist today, so it never
+ *    fired, but it was one empty name field away from doing so. It now throws instead: a record
+ *    with no identifier at all is a caller bug, not something to paper over with a clock reading.
+ */
+
+/** ATO's ABN check: subtract 1 from the first digit, weight, sum, mod 89. */
+export function isValidAbn(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') return false;
+  const digits = String(value).replace(/[^0-9]/g, '');
+  if (!/^[0-9]{11}$/.test(digits)) return false;
+  const weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+  const sum = digits
+    .split('')
+    .reduce((acc, d, i) => acc + (i === 0 ? Number(d) - 1 : Number(d)) * weights[i], 0);
+  return sum % 89 === 0;
+}
+
+/** ACNs are 9 digits. Length only — the ACN checksum is a separate algorithm and not needed here. */
+export function isValidAcn(value) {
+  if (value == null) return false;
+  return /^[0-9]{9}$/.test(String(value).replace(/[^0-9]/g, ''));
+}
+
+export function normaliseAbn(value) {
+  return String(value ?? '').replace(/[^0-9]/g, '');
+}
+
+/** Stable 36-base hash of a name. Deterministic for a given string, unlike the old clock fallback. */
+export function nameHash(name) {
+  const upper = String(name).toUpperCase().trim();
+  let hash = 0;
+  for (let i = 0; i < upper.length; i++) {
+    hash = ((hash << 5) - hash) + upper.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+/**
+ * Preference order: ABN, ACN, ORIC, ASX, government buyer id, name.
+ * Throws when a record carries no identifier of any kind.
+ */
+export function makeGsId({ abn, acn, icn, asx_code, buyer_id, name } = {}) {
+  if (isValidAbn(abn)) return 'AU-ABN-' + normaliseAbn(abn);
+  if (isValidAcn(acn)) return 'AU-ACN-' + String(acn).replace(/[^0-9]/g, '');
+  if (icn) return 'AU-ORIC-' + icn;
+  if (asx_code) return 'AU-ASX-' + String(asx_code).toUpperCase();
+  if (buyer_id) return 'AU-GOV-' + buyer_id;
+  if (name && String(name).trim()) return 'AU-NAME-' + nameHash(name);
+  throw new Error('makeGsId: record carries no usable identifier (abn/acn/icn/asx/buyer_id/name)');
+}

--- a/scripts/lib/gs-id.test.mjs
+++ b/scripts/lib/gs-id.test.mjs
@@ -1,0 +1,55 @@
+/**
+ * Tests for the one definition of an entity id.
+ * Run: node --test scripts/lib/gs-id.test.mjs
+ *
+ * Locks the two #324 defects so they cannot come back:
+ *   - an invalid ABN must NOT mint an entity (abn '0' merged Saxonvale with an unrelated company
+ *     across 2,959 edges)
+ *   - the fallback must be deterministic (the old one was Date.now(), a duplicate generator)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeGsId, isValidAbn, isValidAcn, nameHash } from './gs-id.mjs';
+
+test('accepts real ABNs, with or without spacing', () => {
+  assert.equal(isValidAbn('51824753556'), true);
+  assert.equal(isValidAbn('51 824 753 556'), true);
+  assert.equal(isValidAbn('53004085616'), true);
+});
+
+test('rejects the junk that reached production', () => {
+  // Every one of these is a real value currently sitting in gs_entities.abn.
+  for (const junk of ['0', '#N/A', '#VALUE!', '(blank)', '', '054687035', '1010000462']) {
+    assert.equal(isValidAbn(junk), false, `${junk} must not validate`);
+  }
+});
+
+test('rejects an 11-digit number that fails the checksum', () => {
+  assert.equal(isValidAbn('12345678901'), false);
+});
+
+test('an invalid ABN falls through instead of minting an entity', () => {
+  // The Saxonvale case: abn '0' must not win over the government buyer id.
+  assert.equal(makeGsId({ abn: '0', buyer_id: 'B123' }), 'AU-GOV-B123');
+  assert.equal(makeGsId({ abn: '#VALUE!', name: 'Some Agency' }), makeGsId({ name: 'Some Agency' }));
+});
+
+test('a valid ABN wins over everything else', () => {
+  assert.equal(makeGsId({ abn: '51 824 753 556', buyer_id: 'B1', name: 'X' }), 'AU-ABN-51824753556');
+});
+
+test('name ids are deterministic across case and whitespace', () => {
+  assert.equal(nameHash('Department of Finance'), nameHash('  department of FINANCE '));
+  assert.equal(makeGsId({ name: 'Department of Finance' }), makeGsId({ name: 'DEPARTMENT OF FINANCE' }));
+});
+
+test('no identifier throws rather than inventing a clock-based id', () => {
+  assert.throws(() => makeGsId({}), /no usable identifier/);
+  assert.throws(() => makeGsId({ name: '   ' }), /no usable identifier/);
+});
+
+test('ACN is length-checked', () => {
+  assert.equal(isValidAcn('004085616'), true);
+  assert.equal(isValidAcn('12345'), false);
+  assert.equal(makeGsId({ acn: '004085616' }), 'AU-ACN-004085616');
+});

--- a/thoughts/shared/handoffs/place-capital/current.md
+++ b/thoughts/shared/handoffs/place-capital/current.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-19T08:45:00Z
+date: 2026-08-19T09:30:00Z
 session_name: place-capital
 branch: main
 status: active
@@ -9,11 +9,12 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-19T08:45:00Z
+**Updated:** 2026-08-19T09:30:00Z
 **Goal:** A buildable spec for what a community organisation uses to see, then capture, the
 capital moving through its place. Map #303 is the vehicle; done when `/to-spec` can run.
 **Branch:** `main`, clean. Everything below is landed AND applied.
-Main is at `56d209ac`. Today: #313 `6e619586` · #318 `41d724dc` · #316 `cbaf6933` · #317 `56d209ac`.
+Main is at `de89a756`. Today: #313 `6e619586` · #318 `41d724dc` · #316 `cbaf6933` ·
+#317 `56d209ac` · #319 `4a34d0d6` · #320 `1aaa1f63` · #321 `1b1c8503` · #323 `de89a756`.
 **Test:** `./scripts/precheck.sh` (tsc + 724 vitest). DB reads: `node --env-file=.env
 scripts/gsql.mjs "..."` — always `cd /Users/benknight/Code/grantscope` first, cwd drifts.
 
@@ -28,6 +29,36 @@ downstream, so it goes before #306/#307/#309. **Unchanged by the data-integrity 
     'success-fallback') AND mv_name IN ('act_grant_recommendations','mv_yj_report_acco_gap',
     'mv_yj_report_alma_type_counts','mv_yj_report_state_top_orgs',
     'mv_yj_report_unfunded_programs') GROUP BY 1;`
+
+### This Session — fourth: the integrity thread, and $36bn
+
+Started as "measure self-loops in the other datasets" (#315). Ended four corrections later at a
+resolver defect. **Read the corrections, not just the conclusions — three of the four wrong answers
+were confident and specific.**
+
+- [x] **#315 CLOSED in substance.** `austender` has **595 self-loops worth $810.5M** and they are
+      **FAITHFUL TO THE REGISTER, not a bug**: AusTender publishes internal Defence project codes
+      (e.g. `AIR7000 P8 POSEIDON`) with **Defence's own ABN 68706814312** in the supplier field.
+      **Exclude at read time, do NOT delete.** `justice_funding`, `person_roles`,
+      `person_roles_crossmatch`, `acnc_register` are all **0, clean**.
+      **This retrospectively justifies scoping #290's constraint to `foundation_grantees`** — a
+      global self-loop ban would have refused legitimate rows.
+- [x] **#322/#323 APPLIED — 71,166 duplicate rows, $36.03bn removed.** Largest correction in the
+      project's history (cf. ROGS $37.8bn, foundation $304M). Per dataset: austender 35,326 rows /
+      **$28.46bn** · aec_donations 29,347 / $2.32bn · grant_opportunities 5,761 / $3.86bn ·
+      grantconnect_awards 552 / $1.38bn. `_backup_gs_rel_dupes_20260819` holds every deleted row.
+      New partial index `gs_relationships_dataset_source_record_uniq (dataset, source_record_id)`.
+- [x] **#324 OPENED — the actual cause, and it is bigger.** The duplicates were NOT re-inserts.
+      `idx_gs_rel_dedup` already existed and already blocked those. The rows **differed**:
+      45,220 in `source_entity_id`, 21,319 in `target_entity_id`, 5,483 in `relationship_type`.
+      **`makeGsId()` mints `AU-ABN-<abn>` when a source row carries an ABN and `AU-GOV-<buyer_id>`
+      when it does not, so ONE government body becomes TWO entities.** 1,891 AU-GOV entities,
+      only **78 have an ABN**. Department of Defence is the visible case.
+- [x] **Dedupe direction was verified, not assumed.** Kept-row-has-ABN vs deleted: **19,488 to 29**
+      on the target side, **34,647 to 123** on the source side. Later runs resolved to WORSE
+      entities. Keeping the earliest was right.
+- [x] **CI + tooling:** #318 E2E hang (Azure apt mirror, not a lock), #320 ship-watch stale-check
+      guard, #321 watcher timeout 30min → 10min. Pipelines now ~230s.
 
 ### This Session — third half: place data, CI, and the Custodian Ledger
 - [x] **#301 SA3 defect measured, repaired, APPLIED.** The ticket said it was blocked on
@@ -91,6 +122,16 @@ downstream, so it goes before #306/#307/#309. **Unchanged by the data-integrity 
       `project_remote_funding_intermediaries.md`.
 
 ### Next
+- [ ] **#324 — decide scope BEFORE starting.** It touches the core of the graph. A query for
+      "everything Defence bought" currently hits one of two entities and silently misses the
+      other's edges; `mv_entity_power_index` and `mv_revolving_door` split one org across two rows.
+- [ ] **#315's remaining half:** build the austender self-loop exclusion predicate alongside
+      `isRealRecipient()`/`themeMoney()` in `apps/web/src/lib/justice-money.ts`, and audit which
+      surfaces need it.
+- [ ] **Do NOT "make ingests upsert."** I proposed it and it is wrong — it would silently overwrite
+      a good entity resolution with a worse one on every run. #324 is the real fix.
+- [ ] **Every matview figure is stale until tonight's 17:00 UTC nightly** — the $36bn came out of
+      the base table after the MVs were last built.
 - [ ] **ship-watch merges on STALE checks.** #317 merged in 5s with Type Check and Unit still
       `pending`: `gh pr update-branch` made a new commit and a new run, and the watcher read the
       PREVIOUS run's green. #316 was fine only by luck of timing. **Fix: require the check run's
@@ -139,6 +180,20 @@ downstream, so it goes before #306/#307/#309. **Unchanged by the data-integrity 
   contract delivery-location extraction.
 
 ### Open Questions
+- **FOUR wrong answers in one thread today. The pattern is the lesson.** In order:
+  (1) "the nightly refresh has stopped" — it had not;
+  (2) "the E2E hang is a dpkg lock" — it was the Azure apt mirror, a network stall;
+  (3) **"$31.2bn of duplication in aec_donations"** — phantom. Grouping on
+  `(source,target,type,year,amount)` is NOT a duplicate test: the source genuinely holds 374
+  distinct Brisbane City Council → ALP(Qld) receipts at $2,498, verified 374-for-374;
+  (4) "there is no distinguishing key so this is unmeasurable" — `source_record_id` is a real
+  column, **100% populated**, found by reading `properties` instead of `information_schema`.
+  **Common fault: inferring schema and mechanism from data instead of reading the definition.**
+  CLAUDE.md Rule #2 and the context-efficiency rule both say to check `information_schema` first.
+- **Unverified: the 29 + 123 cases where the DISCARDED row held the ABN.** Small, recoverable from
+  the backup, worth revisiting during #324's merge.
+- **Unverified: was `grant_opportunities` duplication ever noticed?** 5,761 rows / $3.86bn came out
+  and that dataset was not in any prior audit. Nothing was looking at it.
 - **I was wrong twice today and both corrections were worth more than the original claim.**
   (1) "The nightly refresh has stopped" — it had not; see below. (2) "The E2E hang is a dpkg lock
   or an interactive prompt" — it is not. The log, once a timeout made it readable, is hundreds of


### PR DESCRIPTION
First increment on #324. Does **not** touch the pending identity decision (ABN vs `buyer_id` as canonical for a government body) — everything here is correct either way.

## The finding behind it

`makeGsId` exists **seven times** across `scripts/`, with seven different signatures: `build-entity-graph`, `resolve-donor-entities`, `import-lobbying-register`, `import-modern-slavery`, `ingest-ndis-providers`, `backfill-qgip-abns`, `link-entities-mega`. Entity identity defined seven ways is the root of the drift measured in #324 — 771 government bodies carrying two identities across 45,220 edges.

## Two rules the old copies did not enforce

**1. An invalid ABN is not an identifier.** The old branch was `if (abn) return 'AU-ABN-' + abn`, so `abn = '0'` minted an entity. That is how `Saxonvale` ended up merged with `112 Trenerry Crescent Pty Ltd` across 2,959 edges.

92 entities currently hold an ABN that is not 11 digits, including the literal strings `#N/A`, `#VALUE!` and `(blank)` — **Excel errors that travelled all the way into entity identity.**

Now validated with the real ATO checksum, not a length test, and an invalid value **falls through to the next identifier** rather than becoming one.

The 51 ten-digit values were tested against the obvious hypothesis that a leading zero had been stripped: **zero of 51 validate when zero-padded**, so they are corrupt rather than recoverable. Worth recording so nobody tries that fix again.

**2. The fallback must be deterministic.** The old final branch was:

```js
return 'AU-UNK-' + Date.now().toString(36);
```

A different id on every call for the same input — a guaranteed duplicate generator. No `AU-UNK-` rows exist today so it never fired, but it was one empty name field away. It throws now: a record with no identifier at all is a caller bug, not something to paper over with a clock reading.

## Scope

`build-entity-graph.mjs` (the main writer) is wired to the shared module and its local copy deleted. **The other six copies migrate separately** and are recorded on #324 — doing all seven in one change would be hard to review and hard to revert.

8 tests lock both defects, including the exact junk values found in production.

Gates: `./scripts/precheck.sh` — tsc clean, 724 vitest, plus `node --test scripts/lib/gs-id.test.mjs`.