### PR TITLE
The anchor is Priority Reform 2, not Priority Reform 4

### DIFF
--- a/docs/strategy/data-standard.md
+++ b/docs/strategy/data-standard.md
@@ -1,6 +1,8 @@
 # The Data Standard — what this data is for, and what it has to be true enough for
 
 **Written:** 2026-08-19, after a full day of data-integrity work
+**Revised:** 2026-08-19, same day, after primary-source research corrected its anchor. See
+`thoughts/shared/research/2026-08-19-civic-data-mandate-sovereignty-and-evidence.md`.
 **Status:** proposed. Companion to `buyer-wedge.md` (PROVISIONAL) and map #303.
 
 ## Why this document exists
@@ -22,6 +24,116 @@ were not theirs.
 
 **Every one of these would have produced a confident, wrong number in front of a community.** That
 is the reason this document is a strategy document and not an engineering note.
+
+## What this plugs into, and the mistake it must not make
+
+**Priority Reform 2 of the National Agreement on Closing the Gap, not Priority Reform 4.**
+
+The instinct is to reach for PR4, "Shared Access to Data and Information at a Regional Level".
+That is the wrong anchor. PR4 commits governments only, is not justiciable, and its target is a
+count of projects, satisfied by six projects existing. Six years after signing it has produced six
+unfinished projects and a partnership that has met once.
+
+Worse, the Productivity Commission's 2024 review names our own instinct as the failure mode:
+
+> "The few changes that have been made have largely been about increasing the sharing of existing
+> data held by governments. For example, governments have worked on presenting data in more
+> accessible formats, such as dashboards…"
+
+That sits inside a finding of "little progress". **The PC classifies building a dashboard as the
+weakest available response.** Anything we ship that is fundamentally a dashboard has already been
+assessed, by the national reviewer, as not the thing.
+
+**PR2 is the real hook, because its target is a money-flow measurement:**
+
+> "Increase the amount of government funding for Aboriginal and Torres Strait Islander programs and
+> services going through Aboriginal and Torres Strait Islander community-controlled organisations."
+
+And clause 118(d) of the Agreement requires Parties to
+
+> "list the number of Aboriginal and Torres Strait Islander community-controlled organisations and
+> other Aboriginal and Torres Strait Islander organisations that have been allocated funding … and
+> subject to confidentiality requirements, also list the names of the organisations and the amount
+> allocated."
+
+**That is a description of a CivicGraph table.** And the PC found it is not being produced:
+
+> "In most jurisdictions, it is unclear how much funding is allocated to ACCOs and non-Indigenous,
+> non-government organisations … most governments … have either not undertaken or not published the
+> expenditure reviews that they agreed to undertake."
+
+Four governments have completed and published theirs. That is the gap, it is named in a national
+review, and it is the most defensible reason for this work to exist. **We are not offering a
+product nobody asked for. We are producing the accounting that was committed to in clause 118(d)
+and has not been delivered.**
+
+The same review supplies the sentence JusticeHub should be built around. An ACCO providing alcohol,
+drug, family and justice services told the Commission that governments do not share justice data,
+and so it
+
+> "is unable to ascertain whether its justice reinvestment programs are working."
+
+A community organisation, in the national review, saying it cannot evaluate its own work because
+the data is withheld.
+
+## Legitimacy is an architecture question, not a comms one
+
+The uncomfortable finding from the research: **no peak body has asked a third party to build this.**
+SNAICC asks the Productivity Commission. NSW CAPO asks the Data Policy Partnership. The Coalition
+of Peaks asks governments. The demand is real, specific and published. Who supplies it is contested.
+
+The Commission itself names the working pattern: Maranguka's Palimaa platform, **governed by the
+Bourke Tribal Council**, with Seer Data as the supplier. One of only two Australian exemplars of
+Indigenous Data Governance it names.
+
+**The governance body governs. The vendor supplies.** No amount of good intent substitutes for
+that arrangement, and no communications strategy fixes its absence. If this work is not in a
+community-controlled governance structure, it is a private database about other people.
+
+## Rank funders, not communities
+
+CARE principle E1 prohibits portraying Indigenous Peoples in terms of deficit, and the PC named
+deficit narratives as the thing Indigenous Data Governance exists to disrupt.
+
+This has a direct product consequence and it is not cosmetic. **A "funding desert score" attached
+to a place says the place is deficient. The same numbers pointed at the funder say who failed to
+show up.** Identical data, opposite ethics. Every ranking this project produces should be a ranking
+of the party with the money.
+
+The operative trigger for the sovereignty obligations, per the AIATSIS Code, is disaggregation: a
+national grants table is weakly in scope, and "funding to ACCOs" as a distinct cut is squarely in
+scope. That cut is also exactly what clause 118(d) asks for, so it must be built, and it must be
+built inside a governance structure rather than beside one.
+
+## The evidence base is thinner than the sector admits
+
+Every confident Australian justice reinvestment claim traces to one KPMG report on Maranguka. KPMG
+disclaims it twice in writing: "not a process or outcomes evaluation … does not include reference
+to a control group … has not undertaken attribution or contribution analysis." Pro bono, single
+year, client-supplied unverified data, not an assurance engagement. The widely quoted 14% bail
+breach reduction is **nine events**. When the PC cites Maranguka it is citing KPMG, not
+corroborating it.
+
+Meanwhile the Commonwealth has committed roughly $91.5m plus $22.6m a year in perpetuity across 28
+justice reinvestment initiatives and published **zero** evaluations; its evaluation framework was
+finalised in January 2026.
+
+This is the same shape as ALMA's own defect, where one evidence record is cited by 277
+interventions, except at national scale. **The sector's evidence problem is not that its data is
+wrong. It is that one thin study is doing all the work**, and everyone repeating it sounds
+confident. Our standard has to be higher than the field's, not equal to it.
+
+## How this work dies, if it dies
+
+Not by being refuted. The Indigenous Expenditure Report, which accounted for $33.4bn in 2015-16,
+was discontinued with a single sentence and no reason given. ANAO documents that every Commonwealth
+Indigenous expenditure mechanism was dismantled between 2014 and 2017. The Data Availability and
+Transparency Act has produced eight agreements in four years, and ACCOs are statutorily ineligible
+to be accredited users, per the government's own review.
+
+**The characteristic death here is silence.** Nothing gets argued with. It simply stops being
+published. Which means the defence is not being right; it is being held by someone with standing to
+keep publishing it.
 
 ## The mission, stated so it can be failed
 

--- a/thoughts/shared/research/2026-08-19-civic-data-mandate-sovereignty-and-evidence.md
+++ b/thoughts/shared/research/2026-08-19-civic-data-mandate-sovereignty-and-evidence.md
@@ -1,0 +1,1116 @@
+---
+date: 2026-08-19T21:30:00+10:00
+researcher: Claude (Opus 5)
+git_commit: 799ae79dc5125f81c52715ce7f6d7d3e80984ad6
+branch: main
+repository: grantscope
+topic: "What mandate, if any, three linked civic-data systems plug into in Australia: Closing the Gap PR4, Indigenous data sovereignty, justice reinvestment evidence, and the graveyard of prior attempts"
+tags: [research, closing-the-gap, priority-reform-4, indigenous-data-sovereignty, justice-reinvestment, maranguka, accountability, strategy]
+status: complete
+last_updated: 2026-08-19
+last_updated_by: Claude (Opus 5)
+---
+
+# Mandate, Sovereignty and Evidence: what CivicGraph, JusticeHub and Empathy Ledger can honestly claim
+
+## Research question
+
+How should three linked Australian civic-data systems be built so the work is genuinely useful,
+meaningful and relevant, rather than another well-meaning dashboard nobody asked for?
+
+- **CivicGraph** tracks public capital (grants, contracts, donations) and who receives it, with place attribution.
+- **JusticeHub** hosts ALMA (Australian Living Map of Alternatives), an evidence layer scoring youth-justice
+  interventions, and a Justice Reinvestment network system.
+- **Empathy Ledger** is an Indigenous story sovereignty platform, OCAP-aligned.
+
+## Executive conclusion
+
+**There is a real mandate, and it is stronger than expected, but it is not the one you would assume.**
+
+Priority Reform 4 does commit governments to share disaggregated regional data with Aboriginal and
+Torres Strait Islander communities. But the more precise fit for CivicGraph is **Priority Reform 2**,
+whose target is literally a money-flow measurement: *"Increase the amount of government funding for
+Aboriginal and Torres Strait Islander programs and services going through Aboriginal and Torres
+Strait Islander community-controlled organisations."* The Productivity Commission found in 2024 that
+**most governments cannot report against their own target** because they never did or never
+published the expenditure reviews they agreed to. That gap is the single most defensible reason for
+CivicGraph to exist.
+
+Four things follow, and three of them are constraints:
+
+1. **The obligation is real but soft.** No Australian law creates an Indigenous data sovereignty
+   obligation over public-record spending data. The binding instruments (Privacy Act, DAT Act)
+   are silent or irrelevant. The instruments that speak to this (Maiam nayri Wingara, CARE,
+   AIATSIS, the NIAA Framework) bind through ethics gates, funding conditions and relational
+   accountability, not through courts.
+2. **The sovereignty line is not where you would draw it.** Maiam nayri Wingara's definition of
+   Indigenous Data is expansive enough ("about **and may affect**") that a grant to an ACCO is
+   plausibly inside it, and the Commonwealth's own Framework says so explicitly for "all datasets".
+   The operative trigger is not the provenance of the record but the moment you **disaggregate or
+   rank by Indigenous status**.
+3. **The justice reinvestment evidence is materially thinner than the sector's confidence implies.**
+   Every prominent Australian claim traces to one pro-bono consultancy impact assessment of one town
+   in one year, which disclaims being an evaluation, twice, in writing.
+4. **Nobody has asked for this exact artefact.** Every peak body asks *government* to publish
+   funding-flow data. None has asked a third party to assemble it. That distinction is load-bearing.
+
+---
+
+## 1. Priority Reform 4: what it actually commits governments to
+
+### The verbatim text
+
+Source: [National Agreement on Closing the Gap, s6 Priority Reform Four](https://www.closingthegap.gov.au/national-agreement/national-agreement-closing-the-gap/6-priority-reform-areas/four)
+(clause numbers 69 to 77 per the site's own numbering; the rendered page strips them, so clause-number
+attribution below is **inferred** from the PC's citation of clauses 74 to 75 and 92).
+
+**Outcome** ([Priority Reforms page](https://www.closingthegap.gov.au/national-agreement/priority-reforms)):
+
+> "Aboriginal and Torres Strait Islander people have access to, and the capability to use,
+> locally-relevant data and information to set and monitor the implementation of efforts to close the
+> gap, their priorities and drive their own development."
+
+**Target:**
+
+> "Increase the number of regional data projects to support Aboriginal and Torres Strait Islander
+> communities to make decisions about Closing the Gap and their development."
+
+**The four practice elements** the Parties agree data-sharing must contain:
+
+> "There are partnerships in place between Aboriginal and Torres Strait Islander representatives and
+> government organisations to guide the improved collections, access, management and use of data to
+> inform shared decision-making for the benefit of Aboriginal and Torres Strait Islander people.
+>
+> Governments agree to provide Aboriginal and Torres Strait Islander communities and organisations
+> access to the same data and information on which any decisions are made, subject to meeting privacy
+> requirements, and ensuring data security and integrity.
+>
+> Governments collect, handle and report data at sufficient levels of disaggregation, and in an
+> accessible and timely way, to empower local Aboriginal and Torres Strait Islander communities to
+> access, use and interpret data for local decision-making.
+>
+> Aboriginal and Torres Strait Islander communities and organisations are supported by governments to
+> build capability and expertise in collecting, using and interpreting data in a meaningful way."
+
+**The four jurisdictional actions** government Parties commit to:
+
+> "share available, disaggregated regional data and information with Aboriginal and Torres Strait
+> Islander organisations and communities on Closing the Gap, subject to meeting privacy requirements
+>
+> establish partnerships between Aboriginal and Torres Strait Islander people and government agencies
+> to improve collection, access, management and use of data, including identifying improvements to
+> existing data collection and management
+>
+> **make their data more transparent by telling Aboriginal and Torres Strait Islander people what data
+> they have and how it can be accessed**
+>
+> build capacity of Aboriginal and Torres Strait Islander organisations and communities to collect,
+> and use data."
+
+**The partnership action** (clause 74):
+
+> "By 2023, the Parties will establish data projects in up to six locations across Australia to enable
+> Aboriginal and Torres Strait Islander communities and organisations to access and use
+> location-specific data on the Closing the Gap outcome areas."
+
+And the community-voice line the reform was built from:
+
+> "'Collect, analyse, use our own data to meet our own needs. It's our information and we should use it
+> for our own purposes as decided by us.' (Survey participant from New South Wales)"
+
+### Is PR4 as strong as it sounds? Partly. Read this before building the pitch.
+
+**Where it is strong.** The direction of PR4 is unambiguously toward *more* granular, *more*
+accessible, *more* place-specific data flowing to communities. Every practice element and every
+jurisdictional action is an access commitment. Nothing in PR4 restricts data availability. A system
+that makes disaggregated place-level public-spending data legible to a community is moving in the
+direction PR4 points.
+
+**Where it is weaker than it sounds.**
+
+- **It is not law.** The National Agreement is an intergovernmental agreement between governments and
+  the Coalition of Peaks. It is not legislation and it is not justiciable. No community can sue on it.
+- **It commits *governments*, not third parties.** Every actionable verb has a government subject.
+  There is no clause that a private or non-profit data platform can "comply with" or "implement".
+  You cannot honestly say CivicGraph *fulfils* a PR4 commitment. You can say it *addresses the gap
+  that governments' non-delivery of PR4 leaves*, which is a different and weaker claim.
+- **"Subject to meeting privacy requirements" is the escape hatch**, and it has been used. See
+  section 5 on the DAT Act.
+- **The target is a count of projects, not an outcome.** "Increase the number of regional data
+  projects" is satisfied by six projects existing. It measures activity.
+
+### The better hook: Priority Reform 2's target is a money-flow measurement
+
+This is the finding that reframes the relevance argument. PR2's target
+([Priority Reforms page](https://www.closingthegap.gov.au/national-agreement/priority-reforms)):
+
+> "Increase the amount of government funding for Aboriginal and Torres Strait Islander programs and
+> services going through Aboriginal and Torres Strait Islander community-controlled organisations."
+
+And clause 118(d) of the Agreement
+([s9 Being publicly accountable](https://www.closingthegap.gov.au/national-agreement/national-agreement-closing-the-gap/9-being-publicly-accountable-our-actions))
+requires Parties to:
+
+> "list the number of Aboriginal and Torres Strait Islander community-controlled organisations and
+> other Aboriginal and Torres Strait Islander organisations that have been allocated funding … and
+> subject to confidentiality requirements, also list the names of the organisations and the amount
+> allocated."
+
+**That is a description of a CivicGraph table.** And the PC found it is not being produced. See 2.3.
+
+### Implementation status (as at February 2026)
+
+| Item | Status | Source |
+|---|---|---|
+| Six community data projects, due 2023 | Locations chosen (Blacktown LGA NSW, Doomadgee Qld, the Kimberley WA, western Adelaide SA, Maningrida NT, Gippsland Vic). Deadline **missed**. Most scopes still undecided at 2024. | [PC 2024 report](https://www.pc.gov.au/inquiries-and-research/closing-the-gap-review/report/) p71 |
+| Amend Agreement to include Indigenous Data Sovereignty under PR4 (PC action 2.1) | **Agreed** June 2025. **Still not done** as at Feb 2026: PWG "resolved to provide advice to Joint Council in 2026". | [Joint Council Response](https://www.closingthegap.gov.au/sites/default/files/2025-08/Joint-Council-Response-to-the-2024-Productivity-Commission-Review.pdf); [NIAA CTG 2026 Appendix D](https://www.niaa.gov.au/sites/default/files/documents/2026-02/CTG-2026%20Appendix-D.pdf) |
+| Bureau of Indigenous Data (PC action 2.2) | **Not agreed.** Replaced by a Data Policy Partnership, endorsed June 2025, co-chaired NSW CAPO + ABS, first met October 2025, funded 4 years from 2025-26. | Same |
+| Framework for Governance of Indigenous Data | Being implemented across APS; ABS has a **seven-year** implementation horizon from 2024. | [NIAA Framework](https://www.niaa.gov.au/sites/default/files/documents/2024-05/framework-governance-indigenous-data.pdf); [ABS](https://www.abs.gov.au/about/aboriginal-and-torres-strait-islander-peoples/governance-indigenous-data-framework) |
+
+**Read that table as a clock.** Six years after signing, PR4 has produced six unfinished projects and
+a partnership that has met once.
+
+---
+
+## 2. The Productivity Commission 2024 review: the language is as blunt as reported
+
+Source: [Review of the National Agreement on Closing the Gap, Study Report, 7 February 2024](https://www.pc.gov.au/inquiries-and-research/closing-the-gap-review/report/)
+(quotes below extracted directly from the report PDF).
+
+### 2.1 The overall verdict
+
+> "The Productivity Commission's first review of the Agreement shows that governments are not
+> adequately delivering on this commitment. Despite some pockets of good practice, progress in
+> implementing the Agreement's Priority Reforms has, for the most part, been weak and reflects tweaks
+> to, or actions overlayed onto, business-as-usual approaches."
+
+> "The Commission's overarching finding is that there has been no systematic approach to determining
+> what strategies need to be implemented to disrupt business-as-usual of governments. What is needed
+> is a paradigm shift."
+
+> "It is too easy to find examples of government decisions that contradict commitments in the
+> Agreement, that do not reflect Aboriginal and Torres Strait Islander people's priorities and
+> perspectives and that exacerbate, rather than remedy, disadvantage and discrimination.
+> **This is particularly obvious in youth justice systems.**"
+
+> "The gap is not a natural phenomenon. It is a direct result of the ways in which governments have
+> used their power over many decades."
+
+> "Change can be confronting and difficult. But without fundamental change, the Agreement will fail
+> and the gap will remain."
+
+### 2.2 On Priority Reform 4 specifically
+
+> "**There has been little progress on Priority Reform 4.** Overall, there have been no large-scale
+> changes in the way governments share data, undertake data-related activities, or engage with
+> Aboriginal and Torres Strait Islander people on data-related issues."
+
+> "The few changes that have been made have largely been about increasing the sharing of existing data
+> held by governments. For example, governments have worked on presenting data in more accessible
+> formats, such as dashboards…"
+
+That sentence is a warning label for this project. **The PC classifies building a dashboard as the
+weakest available response to PR4.** Box 13 of the report lists open-data websites, the AIHW Regional
+Insights for Indigenous Communities dashboard, and NSW fine-debt dashboards as the sum of government
+progress, and the surrounding text treats that as inadequate.
+
+> "Not much has been done to rebalance the power between governments and Aboriginal and Torres Strait
+> Islander people over the collection, management and use of data about Aboriginal and Torres Strait
+> Islander people."
+
+> "There is a culture of risk avoidance in the public sector, which often manifests as a presumption
+> against data sharing…"
+
+**The single most on-point sentence in the entire report for JusticeHub:**
+
+> "an ACCO that provides alcohol and drug support and family and justice services said that governments
+> do not share the data they hold in relation to justice. As a result, **this organisation is unable to
+> ascertain whether its justice reinvestment programs are working.**"
+
+That is a community organisation, in the national review, saying it cannot evaluate its own justice
+reinvestment work because the data is withheld. It is the clearest published statement of the problem
+JusticeHub claims to address.
+
+### 2.3 On funding-flow visibility (the PR2 gap)
+
+> "In most jurisdictions, it is unclear how much funding is allocated to ACCOs and non-Indigenous,
+> non-government organisations (NGOs), as most governments (the Australian, Victorian, Queensland,
+> Northern Territory and Tasmanian governments) have either not undertaken or not published the
+> expenditure reviews that they agreed to undertake in order to identify opportunities to prioritise
+> ACCOs."
+
+> "reviews of governments' expenditure with ACCOs have only been completed in full and made public by
+> four governments."
+
+> "Transparency issues, such as unpublished plans, expenditure stocktakes, and reasons for decisions
+> hinder accountability, impeding the ability of peaks and communities to hold governments accountable."
+
+> "The Commission heard from a number of ACCOs that they are treated as passive recipients of
+> government funding… ACCOs should be seen as essential partners in commissioning services, not simply
+> as passive funding recipients."
+
+### 2.4 Recommendation 2 in full
+
+> "**Recommendation 2: Indigenous Data Sovereignty needs to be recognised and supported.** … While IDS
+> is a paradigm shift from the status quo, in many respects, Indigenous Data Governance (which is how
+> governments can give effect to IDS) is simply the practical application of Priority Reform 1 across
+> the data lifecycle. Acceptance and application of IDS and IDG in the Agreement would provide a
+> mandate for action. This would enable more effective partnerships, **disrupt the deficit narratives
+> that are dominating the interpretation of data**, and help to build trust in data collections…"
+
+Actions: amend the Agreement to include IDS/IDG under PR4; commit governments to reform data systems
+in line with IDG, strengthen ACCO technical capability, and **"invest in Indigenous data
+infrastructure"**; and establish a Bureau of Indigenous Data. The Bureau was refused.
+
+### 2.5 The PC's own line on openness, which is unexpectedly favourable
+
+> "IDG is more likely to support increased data openness than it is to erode it. There may be some
+> concerns that embedding IDG could result in greater restrictions on accessing and using some
+> government-held Indigenous data, and this may be more likely for data that is reductive and
+> problematises Aboriginal and Torres Strait Islander people. … Further, IDS and IDG does not
+> inherently preclude government custodianship nor the concept of joint control of Indigenous data."
+
+**This is the strongest available authority that sovereignty and openness are not opposed.** But note
+its own qualifier: the data most likely to be restricted is "data that is reductive and problematises
+Aboriginal and Torres Strait Islander people". Deficit-shaped analytics are the category at risk.
+
+### 2.6 The precedent the PC itself nominates: Maranguka's Palimaa
+
+The PC's Box 11, defining Indigenous Data Governance, names exactly two Australian exemplars: the
+Mayi Kuwayu study, and:
+
+> "The Maranguka Justice Reinvestment project is an Aboriginal-led justice reinvestment project in
+> Bourke, New South Wales… The collection and use of detailed local data underpins decision-making
+> within the project. The project has established an Indigenous data governance structure, which aims
+> to ensure Indigenous Data Sovereignty and leadership engagement. **It centralises data requests and
+> collection to ensure accountability can be upheld.** The structure includes the Palimaa Data
+> Platform, which automates data access and sharing from 15 contributors, including NSW Government
+> departments and services operating in Bourke."
+
+Palimaa is governed by the **Bourke Tribal Council**, with the data owned by Aboriginal people; the
+platform vendor (Seer Data) is a supplier, not the governor
+([Seer case study](https://seerdata.ai/maranguka-case-study/)). Fifteen contributors including NSW
+Health, Education, Communities & Justice, Police and DSS.
+
+**This is the governance template.** A community body governs; a technology provider supplies. If
+these three systems have an architectural north star sanctioned by the Productivity Commission, it is
+Palimaa's split of governance from infrastructure.
+
+---
+
+## 3. Indigenous data sovereignty: the concrete obligations, and where the line actually falls
+
+### 3.1 The instruments and their real force
+
+| Instrument | Force |
+|---|---|
+| [Maiam nayri Wingara Communique 2018](https://static1.squarespace.com/static/5b3043afb40b9d20411f3512/t/63ed934fe861fa061ebb9202/1676514134724/Communique-Indigenous-Data-Sovereignty-Summit.pdf) | **Aspirational.** No legal force. Power comes from adoption by others (and it has been adopted widely, including by NIAA and the PC). |
+| [CARE Principles (GIDA, 2019)](https://www.gida-global.org/careprinciples) | **Aspirational.** Interest-group principles. Binding only where incorporated. |
+| [AIATSIS Code of Ethics 2020](https://aiatsis.gov.au/sites/default/files/2020-10/aiatsis-code-ethics.pdf) | **Contractually and procedurally binding** where ARC, NHMRC or AIATSIS funding is involved, or where an institution adopts it, or where HREC approval is sought. Not legislation. |
+| [NIAA Framework for the Governance of Indigenous Data (2024)](https://www.niaa.gov.au/sites/default/files/documents/2024-05/framework-governance-indigenous-data.pdf) | **Policy, binding on APS agencies** ("should not be treated as optional"), no remedy, no enforcement. **Can flow down contractually to grantees.** |
+| National Agreement PR4 | **Intergovernmental agreement.** Not justiciable. |
+| [Data Availability and Transparency Act 2022](https://www.legislation.gov.au/C2022A00011) | **Legislation, and it contains nothing on Indigenous data.** |
+| Privacy Act 1988 | **Legislation, binding**, but individual personal information only. No collective concept. Does not cover organisations or communities. |
+
+**Bottom line: there is currently no Australian law creating an Indigenous data sovereignty obligation
+over public-record government spending data.** The obligations are real but enforced socially,
+contractually and through ethics gates. That is a reason to take them more seriously, not less: there
+is no compliance checkbox to hide behind, only the judgement of the people whose data it is.
+
+### 3.2 The definitions that decide the question
+
+Maiam nayri Wingara, verbatim:
+
+> "In Australia, 'Indigenous Data' refers to information or knowledge, in any format or medium,
+> **which is about and may affect** Indigenous peoples both collectively and individually."
+
+> "'Indigenous Data Sovereignty' refers to the right of Indigenous peoples to exercise ownership over
+> Indigenous Data. Ownership of data can be expressed through the creation, collection, access,
+> analysis, interpretation, management, dissemination and reuse of Indigenous Data."
+
+The Communique's addressing clause is wide enough to reach a platform like this:
+
+> "This Communique … is addressed to **all individuals and entities involved in the creation,
+> collection, access, analysis, interpretation, management, dissemination and reuse of data and data
+> infrastructure in Australia.**"
+
+The five asserted rights:
+
+> "Exercise control of the data ecosystem including creation, development, stewardship, analysis,
+> dissemination and infrastructure. · Data that is contextual and disaggregated (available and
+> accessible at individual, community and First Nations levels). · Data that is relevant and empowers
+> sustainable self-determination and effective self-governance. · Data structures that are accountable
+> to Indigenous peoples and First Nations. · Data that is protective and respects our individual and
+> collective interests."
+
+And the opt-out clause, which is the closest thing to a right of refusal:
+
+> "**Indigenous communities retain the right to decide which sets of data require active governance and
+> maintain the right to not participate in data processes inconsistent with the principles asserted in
+> this Communique.**"
+
+CARE's scope sentence is the most explicit on government-collected data anywhere:
+
+> "**Indigenous data, which include data collected by governments and institutions about Indigenous
+> Peoples and their territories**, are intrinsic to Indigenous Peoples' capacity and capability to
+> realise their human rights…"
+
+And the NIAA Framework refuses a narrow reading, in terms:
+
+> "this Framework is also **not limited to** Australian Government agencies with Indigenous-specific
+> data collections, **but all datasets. While Aboriginal and Torres Strait Islander people may not be
+> the focus of a dataset, the contents and outcomes may be relevant and the dataset therefore contains
+> Indigenous data.**"
+
+It also names spending data as within scope of the holdings it governs: "performance data to manage
+the expenditure of public funds".
+
+### 3.3 So where is the line?
+
+**No source draws it explicitly. There is no sentence in any of these documents saying public-record
+grant data is or is not Indigenous data.** That is the honest headline. The evidence points both ways:
+
+**Toward "yes, in scope":** the MnW definition has no public-record carve-out and only requires
+"may affect"; NIAA says "all datasets" and names expenditure data; CARE expressly includes
+government-collected data; AIATSIS's scope triggers on "Aboriginal and Torres Strait Islander
+policies" and on wishing to "do separate analysis of Indigenous-specific data".
+
+**Toward "no, or not restrictively":** CARE C2 names this exact use as a benefit ("Ethical use of open
+data has the capacity to improve transparency and decision-making … It similarly can provide greater
+insight into **third-party policies and programs affecting Indigenous Peoples**"); MnW's second
+asserted right demands *more* disaggregation, not less; the NIAA Framework's own Empowered Communities
+case study complains funding visibility is too narrow ("**the vision is to look at all funding from all
+agencies**"); NIAA states "Data are to be viewed as a common asset that should be available outside APS
+institutions"; and government spending is a fact about *government conduct*, not about a community.
+
+**The working line (INFERRED, not stated by any source, and the doc should say so):**
+
+> The instruments regulate the **inference**, not the **record**. A grant row is a fact about a
+> government transaction. An aggregation, ranking, per-capita rate or "funding desert" score attached
+> to a named community is a claim **about that community**, and at that moment CARE E1 (no deficit
+> framing), C3 (equitable benefit) and A2 (data back to community) engage.
+
+**The sharpest operative trigger found:** AIATSIS's scope includes the case where people "have been
+incidentally recruited and researchers wish to **do separate analysis of Indigenous-specific data**".
+Applied to a spending database: a national grants table is weakly in scope. **The moment you compute
+"funding to Aboriginal Community Controlled Organisations" as a distinct cut, you are doing the named
+thing.** That is a usable engineering boundary.
+
+### 3.4 The concrete obligations to design against
+
+The two provisions most worth treating as if binding, because they are what a reviewer would apply:
+
+**AIATSIS 1.11(c)** on secondary use of administrative data, which is exactly CivicGraph's situation:
+
+> "where it is impossible or impractical to obtain consent for use of secondary data, institutions and
+> researchers are responsible to ensure that: (i) a waiver is sought … from a HREC with experience in
+> Aboriginal and Torres Strait Islander research or other Indigenous review body **(ii) alternative
+> Indigenous data governance arrangements are in place, including through community engagement,
+> collective consent, or an Indigenous data governance committee.**"
+
+**CARE E1:**
+
+> "**Ethical data are data that do not stigmatize or portray Indigenous Peoples, cultures, or knowledges
+> in terms of deficit.** … Assessing ethical benefits and harms should be done **from the perspective of
+> the Indigenous Peoples, nations, or communities to whom the data relate.**"
+
+Plus, and this one settles arguments about open data:
+
+**AIATSIS 2.9:** "Institutions with responsibility for data access and use policies or **design and
+management of data ecosystems** should adopt Indigenous data sovereignty and governance principles.
+(a) **where a conflict arises between accessibility and Indigenous peoples rights, then Indigenous
+peoples' rights should prevail.** (b) researchers must be aware of and apply … FAIR … and CARE".
+
+Clause 2.9 is the one that reaches a *platform* rather than a *project*.
+
+**AIATSIS 4.3** grants the right to manage "creation, collection, analysis, interpretation, management,
+storage, dissemination, access, re-use, disposal of and access to their data", and **1.12(b)** grants
+withdrawal at any stage. Note the limit: withdrawal attaches to "partners and participants", people who
+consented in. **There is no articulated right to withdraw administrative data that was never consented
+in.** That is a silence, not a permission.
+
+**CARE E3** requires that "Metadata should acknowledge the provenance and purpose and any limitations
+or obligations in secondary use inclusive of issues of consent." A provenance layer is not optional
+decoration under CARE; it is the obligation.
+
+### 3.5 Three silences worth recording
+
+1. **Nothing addresses an independent third party** building on public-record data. AIATSIS addresses
+   researchers, NIAA addresses the APS, CARE addresses "those working with Indigenous data"
+   (undefined). MnW's addressing clause is the only one broad enough to reach a private platform, and
+   it is the least enforceable document of the set.
+2. **Organisation-level versus community-level data is never distinguished.** Whether an ACCO's grant
+   record is the *organisation's* data (a corporate fact, publicly disclosed under grant-reporting
+   rules) or the *community's* data is unaddressed. The corporation is also a legal person with its
+   own interests, which may not align with the community's.
+3. **Small-number disclosure** is the live conflict between sovereignty and ordinary privacy practice,
+   and the NIAA case study raises it and leaves it unresolved: "Disaggregated data by Indigenous status
+   can't be accessed for smaller towns."
+
+### 3.6 The Empathy Ledger line is different and much clearer
+
+Nothing above is ambiguous when applied to **stories**. Story data is unambiguously Indigenous Data
+under every instrument: it is created by Aboriginal and Torres Strait Islander people, held about
+them, and consented in. Full FPIC (CARE A1), individual **and** collective consent (AIATSIS 1.11:
+"Collective consent does not remove the requirement to respect individual rights"), the withdrawal
+right (1.12(b)) with a pre-agreed answer to what happens to prior contributions, and 4.3's full
+lifecycle control all apply directly. **The existing repo convention that stories link to projects and
+never to data rows** (see `memory/project_clarity_console.md`) is the right instinct and is supported
+by CARE E3's secondary-use limitation requirement.
+
+---
+
+## 4. Justice reinvestment: what the evidence actually supports
+
+**This section is the one most likely to change what you claim publicly.**
+
+### 4.1 Maranguka / KPMG 2018: the figures are right and the methodology is weaker than advertised
+
+Source: [KPMG, *Maranguka Justice Reinvestment Project Impact Assessment*, 27 November 2018](https://www.indigenousjustice.gov.au/wp-content/uploads/mp/files/resources/files/maranguka-justice-reinvestment-project-kpmg-impact-assessment-final-report.pdf).
+
+All the commonly cited figures **verified verbatim**, for calendar 2017 against 2016:
+
+> "Family strength, with a 23 per cent reduction in police recorded incidence of domestic violence…
+> Youth development, with a 31 per cent increase in year 12 student retention rates and a 38 per cent
+> reduction in charges across the top five juvenile offence categories. Adult empowerment, with a 14
+> per cent reduction in bail breaches and a 42 per cent reduction in days spent in custody."
+
+> "KPMG estimates the changes in Bourke during 2017, **corresponding to** the operation of the Maranguka
+> JR Project, resulted in a gross impact of $3.1 million (with operational costs of $0.6 million)."
+
+Note "corresponding to", not "caused by".
+
+**The base numbers are very small.** From the report's own indicator table:
+
+| Indicator | 2016 | 2017 | Change |
+|---|---|---|---|
+| Police-recorded DV incidents | 360 | 279 | −81 (−23%) |
+| Year 12 retention rate | 35% | 66% | +31pp |
+| Juvenile charges, top 5 categories | 91 | 56 | −35 (−38%) |
+| Adult bail breaches | 63 | 54 | **−9** (−14%) |
+| Adult days in custody | 95.8 | 55.2 | −40.6 (−42%) |
+
+The headline "14% reduction in bail breaches" is **nine events**. The Year 12 figure is one cohort in
+a town of roughly 2,000 people. The 2015 column shows the series is volatile (adult bail breaches ran
+59 → 63 → 54, so 2017 is only five below 2015), which means the choice of 2016 as the comparison year
+flatters several indicators.
+
+**KPMG's own limitations, verbatim:**
+
+> "the impact assessment is **not a process or outcomes evaluation** of the Maranguka JR Project, and
+> **the study does not include reference to a control group**; **KPMG has not undertaken attribution or
+> contribution analysis in order to isolate the impact** of the Maranguka JR Project, given limitations
+> in data availability within the permitted timeframes of the project."
+
+And from the inherent-limitations page:
+
+> "The services provided in connection with this engagement comprise an advisory engagement, **which is
+> not subject to assurance or other standards** issued by the Australian Auditing and Assurance
+> Standards Board… **No warranty of completeness, accuracy or reliability is given** in relation to the
+> statements and representations made by … Maranguka and Just Reinvest NSW … **We have not sought to
+> independently verify those sources.**"
+
+The engagement was pro bono, commissioned by Maranguka and Just Reinvest NSW, with a third-party
+reliance disclaimer.
+
+**The $7m figure is a scenario, not a finding:** "Should Bourke sustain just half of the results
+achieved in 2017, an additional gross impact of $7 million over the next five years could be delivered."
+
+### 4.2 The confounder that specifically threatens this design
+
+The AIC's literature review names it:
+
+> "Attributing impacts to the intervention being evaluated becomes problematic through the potentially
+> confounding impacts of other interventions and external factors… (such as new legislation **or
+> coincidental police activities**)."
+> ([Willis & Kapira, *Justice reinvestment in Australia: A review of the literature*, AIC Research Report 09, 2018](https://www.aic.gov.au/sites/default/files/2020-05/rr09_justice_reinvestment_in_australia_160518_0.pdf))
+
+Applied to Bourke: the headline indicators are **police-recorded** DV incidents and charge counts.
+Recorded counts are a function of policing behaviour as much as of underlying offending, and a project
+whose central mechanism is changing how police engage with the community will mechanically move
+recorded counts. Nobody has separated the two.
+
+### 4.3 The imported model's own evidence base
+
+The AIC on the US Justice Reinvestment Initiative that Australia copied:
+
+> "**as yet there remain no formal evaluations either of JR initiatives or of the overall JR approach in
+> the US.** While some other evidence of success has been published … **this has originated with
+> organisations such as the CSG and Pew, which have a substantial interest and economic involvement in
+> JR** (Austin & Coventry 2014)."
+
+On Texas, the flagship case:
+
+> "Analysis suggests that Texas prison budgets were not based on current projections, meaning that the
+> number of prisoners the calculations were based on was too low… **thereby reducing the degree of
+> change that might be attributable to JR**… **The decreased rate of prison growth also coincided with
+> increased rates of parole resulting from changes to parole guidelines unrelated to JR initiatives.**"
+
+### 4.4 The Commonwealth program: fully funded, entirely unevaluated
+
+Source: [Attorney-General's Department, Justice Reinvestment](https://www.ag.gov.au/legal-system/justice-reinvestment) (fetched 19 Aug 2026).
+
+- 2022-23 Budget: **$69m over 4 years** for a National Justice Reinvestment Program supporting up to
+  30 initiatives, plus **$20m/year ongoing from 2026-27**.
+- Same Budget: **$12.5m over 4 years** to design and establish an independent National Justice
+  Reinvestment Unit, plus **$2.6m/year ongoing**. (The $69m and $81.5m figures are the same
+  commitment, decomposed.)
+- 2023-24 Budget: a further **$10m over 4 years** for Central Australia.
+- **28 initiatives funded** (26 national, 2 Central Australia); the page then says 27 are active and
+  lists 27. **The discrepancy is unexplained.** Applications closed November 2024 as oversubscribed.
+- Evaluation: "The Measurement and Evaluation Framework … **was finalised in January 2026** … We
+  anticipate that **the first evaluation applying the framework will begin later in 2026.**"
+- The unit is still an **"Interim"** National Justice Reinvestment Unit sitting inside the department,
+  four years after an *independent* unit was funded; the RFT was to be released February 2026.
+
+**Plainly: roughly $91.5m committed over four years plus $22.6m/year in perpetuity, 28 initiatives
+funded, applications closed, and zero published evaluations.**
+
+Two ANAO performance audits exist on the work program
+([award of funding](https://www.anao.gov.au/work/performance-audit/the-award-of-funding-under-the-justice-reinvestment-program),
+[delivery of initiatives](https://www.anao.gov.au/work/performance-audit/delivery-of-community-led-justice-reinvestment-initiatives)).
+**Neither appears tabled; this could not be confirmed (ANAO blocked scraping).**
+
+### 4.5 What can honestly be claimed
+
+- **Demonstrated:** very little, causally. No Australian justice reinvestment site has a published
+  evaluation with a counterfactual.
+- **Associated:** in Bourke in 2017, police-recorded and education indicators moved favourably against
+  2016 on small base numbers, alongside the operation of Maranguka. KPMG monetised the co-movement at
+  $3.1m gross and explicitly declined to attribute it.
+- **Aspirational:** everything about scale, transferability to 27 other places, and the perpetual
+  $22.6m/year.
+- **Demonstrated and under-claimed:** the *governance* innovation. Palimaa and the Bourke Tribal
+  Council are documented, cited by the Productivity Commission as a national exemplar of Indigenous
+  Data Governance, and do not depend on the contested outcome statistics.
+
+**The circularity to watch.** Almost every confident Australian claim about JR effectiveness (the
+Productivity Commission, ANZSOG, parliamentary submissions, Just Reinvest NSW, and JusticeHub itself)
+traces back to this one pro-bono report about one town in one year. It reads as consensus. It is one
+source, repeated. **When the PC cites Maranguka favourably, that is a citation of KPMG, not independent
+verification of it.** Do not count it as a second source.
+
+None of this means Maranguka does not work. But "we do not have evidence it works" and "we have
+evidence it works" are different statements, and only the first is currently supportable.
+
+**Direct consequence for ALMA.** An evidence layer that *scores* youth-justice interventions is
+scoring against a base where almost nothing has a counterfactual. ALMA's honest output is a
+**completeness and evidence-strength disclosure**, not a ranking. The repo already has the right
+instinct here (`completeness-at-index / refusal-at-claim` in `memory/project_clarity_console.md`);
+this research says that instinct is not conservatism, it is the only defensible position.
+
+---
+
+## 5. Where prior attempts died, and why
+
+### 5.1 The Indigenous Expenditure Report: killed silently, no reason ever given
+
+Four editions: 2010, 2012, 2014, 2017. The last
+([IER 2017](https://www.pc.gov.au/ongoing/indigenous-expenditure-report/2017)) reported:
+
+> "In 2015-16, total direct government expenditure on Aboriginal and Torres Strait Islander Australians
+> was estimated to be $33.4 billion."
+> "expenditure per person was $44 886 for Aboriginal and Torres Strait Islander Australians, around
+> twice the rate for non-Indigenous Australians ($22 356)."
+
+Indigenous-specific programs were 18.0% of direct expenditure; mainstream services 82.0%. Its own
+caveats: under-identification in administrative collections, population-based estimation where service
+use data is unavailable, and it "does not assess the adequacy, effectiveness, and efficiency of
+government expenditure".
+
+**The entire public explanation for its end** is one sentence on the 2017 report page:
+
+> "The future of the IER is to be considered in the context of reporting under the National Agreement
+> on Closing the Gap. At this stage, a further IER has not been scheduled."
+
+No announcement, no review, no ministerial statement. The PC landing page still files it under
+"ongoing".
+
+**And it was not an isolated casualty.** ANAO Auditor-General Report No. 27 of 2018-19, *Closing the
+Gap* ([link](https://www.anao.gov.au/work/performance-audit/closing-the-gap)):
+
+> "From 2014 the Single Indigenous Budget Statement process ceased, and there was no longer a
+> requirement that policy proposals include an assessment of their contribution towards Closing the Gap
+> targets."
+
+> "all of the whole-of-government monitoring mechanisms … ceased with the exception of the AGIE, which
+> was last reported in the 2015-16 Portfolio Budget Statements. No additional mechanisms have been
+> developed since that time. Consequently … **there has not been any consolidated monitoring of the
+> Australian Government's contribution towards the Closing the Gap framework since 2015.**"
+
+**Timeline of the dismantling:** Single Indigenous Budget Statement ceased 2014 · AGIE last reported
+2015-16 · independent jurisdictional progress assessment last done 2015 · Indigenous Expenditure
+Report last published 2017.
+
+**The lesson.** The dataset CivicGraph reconstructs *existed*, at national scale, produced by the
+Productivity Commission, and every mechanism that produced it was ended between 2014 and 2017 without
+a public reason. It did not die of technical failure. It died of withdrawn political sponsorship. **A
+system that depends on a single sponsor dies the same way.** The defensive design implication is
+independence of funding and independence of source: build from data that is published under
+obligations that do not depend on any one program's survival (GrantConnect, AusTender, ACNC AIS, ABR),
+which is what the repo already does.
+
+### 5.2 Empowered Communities: authority was never actually devolved
+
+Source: [*Empowered Communities Partnership Joint Decision-Making: Lessons Learned Review*, ISSR, 6 May 2025, published by NIAA Nov 2025](https://www.niaa.gov.au/sites/default/files/documents/2025-11/EC-Lessons-Learned-Final-Report-6-May-2025.pdf).
+
+What was devolved: advice weighted at 75%, on **IAS ceasing grants** only, with government retaining
+the final decision:
+
+> "The Minister, or the relevant NIAA delegate, giving significant weight (75 per cent) to EC Leaders'
+> advice in making IAS funding decisions, noting government remains the final decision maker…"
+
+> "Changes to centralised government policy settings and funding systems have to date, not been a
+> feature of the current EC SDM model."
+
+It has no statutory basis; the review quotes a participant saying it "only exists as a matter of
+policy and tacit agreement", and EC Leaders' own position that "New legislative backing is crucial".
+
+On the data problem, which is precisely CivicGraph's territory:
+
+> "Indigenous communities and service delivery are dominated by public finances and the **current system
+> for governing this funding is fragmented and centralised**, impacting on local governance capability."
+
+> "Backbone teams and community panel members have **consistently raised the need for better information
+> about program and project effectiveness** to be available to assist community members involved in JDM
+> rounds."
+
+Recommendation 2c asks for what does not exist:
+
+> "Scope the potential for regional pooled funding mechanisms in EC regions and **more transparency
+> about the overall flow of funding going into EC regions** to help inform cross-government sector
+> investment strategies…"
+
+**The lesson.** Giving communities a seat at a decision they cannot see the data for produces
+consultation, not authority. The demand here is explicitly for funding-flow visibility at regional
+level. That is the closest thing to a stated user need found anywhere in this research.
+
+### 5.3 ANAO on Indigenous grant data: collected, and still unusable
+
+[Auditor-General Report No. 35 of 2016-17, *Indigenous Advancement Strategy*](https://www.anao.gov.au/work/performance-audit/indigenous-advancement-strategy):
+
+> "The department's grants administration processes fell short of the standard required to effectively
+> manage a billion dollars of Commonwealth resources. The basis by which projects were recommended to
+> the Minister was not clear…"
+
+> "The department developed a system by which entities could provide performance reporting information
+> electronically. However, **the processes to aggregate and use this information are not sufficiently
+> developed** to allow the department to report progress against outcomes at a program level, benchmark
+> similarly funded projects, or undertake other analysis of program results."
+
+[Report No. 11 of 2020-21](https://www.anao.gov.au/work/performance-audit/ias-children-and-schooling-program-and-safety-and-wellbeing-program):
+
+> "NIAA does not sufficiently validate self-reported provider data … Record-keeping practices in some
+> areas remain poor."
+
+> "Between July 2016 to June 2019, 90 per cent of the Children and Schooling program funding and 95 per
+> cent of the Safety and Wellbeing program funding was allocated on a non-competitive basis… **80 per
+> cent of the Children and Schooling program funding and 87 per cent of the Safety and Wellbeing program
+> funding was reallocated to the same providers after assessment.**"
+
+**The lesson, and it is a favourable one.** The problem was never data collection. It was aggregation,
+linkage and validation. That is exactly the layer CivicGraph occupies, and the ANAO has said in
+writing that the government does not occupy it. The non-competitive-reallocation figures are also a
+concrete, defensible analysis CivicGraph could reproduce and extend from GrantConnect.
+
+### 5.4 The DAT Act: eight agreements in four years, and ACCOs are legally locked out
+
+Sources: [DAT Act 2022](https://www.legislation.gov.au/C2022A00011);
+[Statutory Review Final Report (tabled 3 March 2026)](https://www.finance.gov.au/sites/default/files/2026-03/statutory-review-of-data-availability-and-transparency-act-final-report.pdf);
+[register of data sharing agreements](https://www.datacommissioner.gov.au/registers/data-sharing-agreements);
+[register of accredited entities](https://www.datacommissioner.gov.au/registers/accredited-entities).
+
+- **Eight** data sharing agreements exist under the scheme, total. Seven are for the National Disability
+  Data Asset. "**To date, no other requests for data under the DAT Act have been agreed to.**"
+- The NDDA agencies "have reported that the DAT Act **will no longer be used** to support the NDDA in
+  the future, due to difficulties with using the DAT Act."
+- Meanwhile: "a survey of 19 Commonwealth Government agencies revealed there were **over 11,000 data
+  sharing agreements outside of the DAT Act**." Eight inside, eleven thousand outside.
+- 43 accredited entities: 19 Commonwealth, 13 universities, 11 state/territory. **Zero non-government,
+  zero community, zero not-for-profit.**
+- The National Data Commissioner's annual **target** for data shares was **13**.
+
+The review's findings, verbatim:
+
+> "**Finding 9: The DAT Act is not well positioned to help Government achieve its commitment under the
+> National Agreement on Closing the Gap or support data sharing consistent with the Framework for the
+> Governance of Indigenous Data.**"
+
+> "**There is no explicit requirement or process in the DAT Act for data custodians to consider the
+> Priority Reforms or the Framework for the Governance of Indigenous Data** when a data sharing project
+> intends to use Indigenous data or reveal insights with a primary focus on First Nations communities."
+
+> "Section 74 of the DAT Act authorises a First Nations person or community organisation to be
+> accredited **only if they are also an 'Australian entity'** which is defined … as a Commonwealth and
+> state and territory government body or Australian university."
+
+> "the current scope of entities who are eligible to access public sector data under the DAT Act
+> **unnecessarily limits the ability of the Government to deliver on Priority Reform 4**."
+
+Finding 7 recommends expanding accreditation to ACCOs and not-for-profits. **These are recommendations,
+not law.** The Act sunsets 1 April 2027 without amendment.
+
+**The lesson.** The legal route to community data access is closed and the government knows it. This is
+the strongest structural argument for a system built from **already-public** data rather than
+negotiated data-sharing agreements: the negotiated route has produced eight agreements in four years
+and excludes ACCOs by statute.
+
+### 5.5 Place-based programs: evaluations absent, missing or de-published
+
+- **Stronger Places, Stronger People**: $35m to June 2024 plus $64m over six years to 2029. **No
+  evaluation published on dss.gov.au** as at 19 Aug 2026. The March 2025 National Leadership Group
+  communique reports the *Evaluation Reference Group* was still being established, nine months after
+  phase one ended. ([DSS](https://www.dss.gov.au/stronger-places-stronger-people);
+  [communique](https://www.dss.gov.au/system/files/documents/2025-04/spsp-national-leadership-group-communique-march-2025.pdf))
+- **Communities for Children Post Implementation Review**: DSS URL now 404s, pointing to the Trove
+  archive. **De-published.**
+- **Logan Together**: the only primary Queensland government document
+  ([Qld Cabinet, May 2017](https://cabinet.qld.gov.au/documents/2017/May/LoganTog/Attachments/Report.PDF))
+  contains one line on data: "Strengthen links and information sharing between health providers." No
+  agreement, no access mechanism.
+- **Local Drug Action Teams**: no Commonwealth-published evaluation found. Not verified either way.
+- **data.gov.au**: maintained but degrading. Per its own
+  [known issues](https://data.gov.au/recent-developments) (updated 28/05/2026), the site statistics
+  pages are unavailable, so **you cannot measure whether anyone uses data.gov.au from data.gov.au**;
+  NationalMap was decommissioned June 2025 "with no plan to replace geographic visualisations"; a June
+  2025 uplift broke URLs and API endpoints "with no automatic re-direct processes in place".
+- **Public Data Policy Statement (2015)**: 404s at every official address tried. Whether it was
+  superseded, retired, or lost in a website migration **could not be determined**. For the foundational
+  Commonwealth open-data policy, that is itself the finding.
+
+**The composite lesson: the characteristic Australian death is not failure, it is silence.** Programs
+are not cancelled, they are unscheduled. Evaluations are not negative, they are unpublished. Datasets
+are not retired, they are de-published into Trove. Any claim of the form "this replaced X" should be
+checked against whether X was ever actually replaced.
+
+---
+
+## 6. Who holds the mandate, and what they have actually asked for
+
+### 6.1 Coalition of Peaks
+
+From the [2020 national community engagements report](https://www.coalitionofpeaks.org.au/s/Full-Community-Engagement-Report.pdf),
+which is what produced PR4:
+
+> "The engagements made clear that **access to data and information, and being able to use it to support
+> achieving better outcomes, underpins the achievement of the other priority reforms** and needs to be
+> recognised and pursued as a separate priority reform."
+
+> "**Having data relating to community-controlled organisations, including the number and size, the
+> funding received, the range of services provided and how much is spent on activities compared with
+> administration is an important area identified by participants during the engagements.**"
+
+Community voices from the same report:
+
+> "Local community needs to know where the money is going, accountability trail." (Rockhampton, Qld)
+
+> "Tell us who the agencies are with Closing the Gap funding and what their [KPIs] are, then we can hold
+> them accountable; this information is not shared with Aboriginal community-controlled organisations."
+> (Adelaide, SA)
+
+> "Data is power, the people that have that information get to control what the narrative is that is
+> shared to the public and media. Community should be in control of that, but government must be willing
+> to cede some of that power." (Melbourne, Vic)
+
+From [COP Submission 58 to the PC review](https://assets.pc.gov.au/__data/assets/pdf_file/0003/367842/sub058-closing-the-gap-review.pdf):
+
+> "Government data custodians have never shared data in this way, and simply do not know how it could be
+> done, Privacy laws and legislation prevents the sharing of data, and Government data custodians not
+> understanding their commitments to Priority Reform four. Additionally, **an emphasis should be placed
+> on the data Aboriginal and Torres Islander people need, not what the government wants.**"
+
+> "We would also like to see greater accountability in government budgets, where governments produce
+> **annual Closing the Gap budget statements** that outline investment made in line with the Priority
+> Reforms and investment required to close the gap against each of the socio-economic target areas…"
+
+**Correction worth recording:** there is no *national* COP community engagements report for 2022 or
+2024. The 2022 and 2024 reports are **NSW CAPO** publications hosted on alc.org.au. Do not cite them
+as national COP positions.
+
+### 6.2 NSW CAPO: the most on-point statement found anywhere
+
+[NSW CAPO Community Engagement Report 2024](https://alc.org.au/wp-content/uploads/2024/05/NSW-CAPO-Community-Engagement-Report-v2.pdf):
+
+> "We consistently heard that **Aboriginal people in NSW would like to understand what funding is coming
+> into their community, including what service providers should be delivering for that funding and how
+> they are performing against those expectations.**"
+
+> "Participants were particularly keen to see the Mechanism boost transparency regarding government
+> funding. **The Mechanism should provide communities insight into how government decides which
+> organisations and departments receive funds, and what they are delivering for that money.**"
+
+> "Aboriginal communities also want an opportunity to **scrutinise and verify** government information,
+> to build trust in what is being reported."
+
+[NSW CAPO 2022](https://alc.org.au/wp-content/uploads/2023/01/NSW-CAPO-Community-Engagement-Report-2022.pdf):
+
+> "We have been asking for years for government to provide data about Walgett, service mapping, where
+> the money is going so that we can analyse and put together arguments for reallocation of funds."
+
+> "**Data has been weaponised and used against us.**"
+
+Those two quotes belong together. The same report contains the clearest ask for funding-flow data and
+the clearest statement of the harm.
+
+### 6.3 NACCHO: the test any aggregator will be judged against
+
+NACCHO has **no standalone data sovereignty position paper**; its positions live in sectoral
+submissions. The crispest is on the PHN business model
+([submission, 2025](https://www.naccho.org.au/wp-content/uploads/2025/05/Review-of-Primary-Health-Network-Business-Model-Mental-Health-Flexible-Funding-Model.pdf)):
+
+> "under this model, **data is solely owned by PHNs, the availability of ACCHO data and ACCHO's ability
+> to access their own data does not appear to be guaranteed. This does not meet governments' commitment
+> to Priority Reform 4.** It also fails to align with the Maiam nayri Wingara Indigenous Data
+> Sovereignty Principles…"
+
+**Read that as the review CivicGraph would receive.** An intermediary holding ACCO data without
+guaranteed access back to the ACCO is the exact pattern NACCHO condemns.
+
+On extraction without reciprocity
+([Independent Review submission](https://www.naccho.org.au/wp-content/uploads/2025/05/Independent-Review_NACCHO-submission.pdf)):
+
+> "As identified by the Productivity Commission, although **data is increasingly being requested from
+> ACCHOs, there remains a lack of reciprocity.**"
+
+> "Some member services receive funding from between 40-140 different departments, agencies, and
+> organisations, each with unique reporting requirements… this would be an average of **1 unique report
+> per 3.7 working days.** As service delivery organisations, ACCHOs are not resourced to manage this
+> level of administration."
+
+That last figure is the strongest argument for a system that **reduces** reporting burden by assembling
+what is already public, rather than asking organisations for anything.
+
+### 6.4 SNAICC: names the missing dataset precisely
+
+[Submission to the Inquiry into Measuring Outcomes for First Nations Communities, Feb 2025](https://www.snaicc.org.au/wp-content/uploads/2025/12/Submission-to-the-Inquiry-into-Measuring-Outcomes-for-First-Nations-Communities-SNAICC-Submission.pdf):
+
+> "**A critical data gap outside the Closing the Gap architecture is the lack of reporting on funding to
+> ACCOs**, making it difficult for communities and peak bodies to hold governments to account on Priority
+> Reform 2 … We know that ACCOs are not being adequately resourced … but **there is no consistent or
+> accessible data to show the true extent of the problem.**"
+
+> "SNAICC has requested data from states and territories on their expenditure to ACCOs in child
+> protection, asking jurisdictions to align their reporting with Report on Government Services (RoGS)
+> definitions and counting rules. While these insights have been valuable, they are inconsistent and not
+> reported anywhere but the annual Family Matters publication…"
+
+> "**An Independent Indigenous Data Authority (IIDA) would be valuable** to undertake and coordinate data
+> projects, address the data gaps prevalent in Closing the Gap reporting and build Indigenous Data
+> Sovereignty."
+
+On counting rules, which is a direct methodological warning
+([Family Matters Report 2024](https://www.snaicc.org.au/wp-content/uploads/2024/11/241119-Family-Matters-Report-2024.pdf)):
+
+> "National OOHC counting rules changed for all states and territories from 2018-19 and, now, exclude
+> children on third-party parental responsibility orders from the count of children in OOHC. SNAICC
+> believes that this change seriously undermines transparency and accountability, **effectively rendering
+> these children invisible in the system.**"
+
+### 6.5 Change the Record: an important negative
+
+CTR's published asks are consistently about **imprisonment and violence rates**, standardised
+cross-jurisdictional collection, and mandatory reporting on custodial practices. From the
+[Blueprint for Change (2015)](https://www.indigenousjustice.gov.au/wp-content/uploads/mp/files/resources/files/sub-55-attachment-1.v1.pdf):
+
+> "Jointly establish, or task, an independent central agency with Aboriginal and Torres Strait Islander
+> oversight to co-ordinate a comprehensive, current and consistent national approach to data collection
+> and policy development relating to Aboriginal and Torres Strait Islander imprisonment and violence
+> rates."
+
+From [Ending Youth Incarceration (HRLC + CTR, Oct 2024)](https://www.hrlc.org.au/app/uploads/2025/04/Human-Rights-Law-Centre-and-Change-the-Record-Submission-on-Youth-Justice-and-Incarceration-System-1.pdf):
+
+> "Nationally, there is a lack of basic data collection and public reporting on the use of force and
+> restraint in custody."
+
+**CTR has said nothing about grant-level, funding-flow or expenditure-transparency data.** Do not claim
+their mandate. (Dating caveat: the Blueprint predates Targets 10 and 11, agreed 2020. Its 2040
+imprisonment target is CTR's own proposal, not Target 10. Do not conflate.)
+
+### 6.6 Justice Reinvestment Network Australia: has said the most, and set the constraints
+
+JRNA has a formal
+[First Nations Data Sovereignty and Governance Principles](https://justicereinvestment.net.au/wp-content/uploads/2023/04/01-first-nations-data-sovereignty-and-governance-principles-for-jrna-1.pdf)
+statement adopting the Maiam nayri Wingara five rights, including:
+
+> "1. Exercise control of the data ecosystem including creation, development, stewardship, analysis,
+> dissemination and **infrastructure**. … 4. Data structures that are **accountable to First Nations
+> peoples**."
+
+Principle 1 explicitly claims *infrastructure*. Principle 4 is a governance constraint on whoever
+builds it.
+
+And the warning any evidence-scoring product must answer
+([Community-Government partnerships](https://justicereinvestment.net.au/community-government-partnerships/)):
+
+> "**the 'success' of justice reinvestment cannot be measured solely by population level shifts in data
+> such as offending or imprisonment.** The drivers of incarceration and various justice systems are more
+> complex and interdependent with so many of the levers for change sitting outside the strengths and
+> power of community."
+
+> "Justice reinvestment is also informed by data and evidence: used to set priorities and measure
+> progress… **Data and place in these 2 contexts must be defined by First Nations people**, including
+> with reference to Indigenous Data Sovereignty and governance principles."
+
+JRNA also publishes a data toolkit (Community Data Quick Guide, Administrative Data Quick Guide,
+informed-consent guidance and template, all May 2024) at
+[Working with data](https://justicereinvestment.net.au/working-with-data/). **Read these before
+designing JusticeHub's network features; they are the closest thing to a written spec from the actual
+constituency.**
+
+The closest sector ask to a funding/service-flow data layer is the ALRC recommendation 4-2, adopted by
+CTR and JRNA in their
+[2019 pre-budget submission](https://treasury.gov.au/sites/default/files/2021-05/171663_change_the_record_and_justice_reinvestment_network_australia.pdf):
+
+> "facilitating access to **localised data related to criminal justice and other relevant government
+> service provision, and associated costs**"
+
+> "The national body should be responsible for coordinating evidence to contribute to JR initiatives,
+> including data collection and analysis, cost-benefit analysis, evaluation and **justice mapping**. This
+> will enable communities to take a stronger data-driven approach and identify areas where savings can
+> be redirected…"
+
+---
+
+## 7. Answers to the four questions asked
+
+### 7.1 What existing commitment does this work plug into?
+
+**The honest answer, in descending order of strength:**
+
+1. **PR2's target and clause 118(d)** are a money-flow measurement commitment that governments are
+   demonstrably not meeting. The PC said so, SNAICC said so, the Coalition of Peaks said so. This is
+   the strongest and most specific hook, and it is about *money*, which is what CivicGraph holds.
+2. **PR4** points the same direction (disaggregated, regional, accessible) but commits *governments*,
+   not third parties, and the PC explicitly rates dashboards as the weakest response to it.
+3. **The PC's Recommendation 2** calls for governments to "invest in Indigenous data infrastructure".
+   That is an authorising environment, not a commitment to anyone in particular.
+4. **The DAT Act statutory review's Findings 7 and 9** establish that the legal route to community data
+   access is broken and that ACCOs are statutorily excluded. That is the argument for a public-data
+   route.
+
+**What cannot be claimed:** that any of these three systems fulfils, implements or complies with a
+government commitment. They address a gap left by non-delivery. Say that, not more.
+
+### 7.2 What it must not do: the sovereignty lines
+
+1. **Never be the sole holder of an ACCO's data with access back to that ACCO unguaranteed.** This is
+   the exact pattern NACCHO condemned in the PHN model. Access back must be a designed guarantee, not a
+   policy intention.
+2. **No deficit framing.** CARE E1 prohibits data that "portray[s] Indigenous Peoples… in terms of
+   deficit", and the PC named deficit narratives as the thing IDG exists to disrupt. This has direct
+   product consequences: "funding desert" scores, per-capita disadvantage rankings and league tables of
+   communities are precisely the shape CARE E1 names. **Rank governments and funders, not communities.**
+3. **Governance must sit with a community body, not the platform.** Palimaa (Bourke Tribal Council
+   governs; vendor supplies) is the PC-endorsed template and the only Australian model with an
+   authority to point at.
+4. **Indigenous-status disaggregation is the trigger.** A national grants table is weakly in scope; the
+   moment you compute "funding to ACCOs" as a distinct cut, AIATSIS's own scope test fires. That is the
+   point at which a standing governance arrangement (AIATSIS 1.11(c)(ii)) becomes the requirement.
+5. **Small-number suppression at place level.** Unresolved in the sources, so it must be resolved
+   explicitly here, and disclosed rather than silently applied.
+6. **Provenance metadata is an obligation, not a nicety** (CARE E3): provenance, purpose, and any
+   limitations or obligations on secondary use. The repo's existing `.provenance.md` convention is
+   already the right shape; extend it to consent and use-limitation, not just dollar sourcing.
+7. **Stories are categorically different.** Empathy Ledger content is unambiguously Indigenous Data:
+   full FPIC, individual *and* collective consent, an operational withdrawal right with a pre-agreed
+   answer for prior contributions. Keep the existing rule that stories link to projects, never to data
+   rows.
+
+### 7.3 What the evidence actually supports claiming
+
+**Supportable:**
+- Youth detention spending is rising and is measurable (already established in
+  `thoughts/shared/data-reflections/2026-08-19-what-the-capital-says.md`).
+- Governments cannot say how much funding reaches ACCOs, and have said so themselves.
+- Community-led data governance in Bourke is documented and cited by the Productivity Commission as a
+  national exemplar of Indigenous Data Governance.
+- Communities have repeatedly and specifically asked to see where money goes in their place.
+
+**Not supportable:**
+- That justice reinvestment reduces incarceration. No Australian site has a published evaluation with a
+  counterfactual.
+- Any causal reading of the Bourke 2017 figures. KPMG disclaims attribution twice.
+- Citing the PC's mention of Maranguka as independent corroboration of KPMG. It is the same source.
+- That any of the 28 Commonwealth-funded initiatives has demonstrated anything. The first evaluation
+  had not begun as of the AGD page fetched 19 Aug 2026.
+
+**The strategic consequence.** ALMA's defensible product is not a ranking of what works. It is an
+honest map of **how thin the evidence is**, which is a genuinely novel and useful thing to publish
+because the sector currently mistakes repetition for corroboration. "Here are 27 funded initiatives and
+here is the evaluation status of each" is a more valuable and more truthful artefact than a score.
+
+### 7.4 Where prior efforts died
+
+| Cause of death | Instance | Defence |
+|---|---|---|
+| Withdrawn political sponsorship, no announcement | IER, Single Indigenous Budget Statement, AGIE (2014-2017) | Build from data published under standing obligations (GrantConnect, AusTender, ACNC, ABR), not from any one program |
+| Consultation mistaken for authority | Empowered Communities (75% advisory weight, ceasing grants only, no statutory basis) | Governance body with real decision rights, or do not claim community control |
+| Legal route closed | DAT Act: 8 agreements in 4 years, ACCOs statutorily ineligible | Public-data route, deliberately |
+| Evaluation deferred indefinitely | SPSP, Commonwealth JR Program | Publish the evaluation-status map as the product |
+| De-publication and silence | Communities for Children review, data.gov.au stats, Public Data Policy Statement | Archive and version everything; assume upstream disappears |
+| Collected but not aggregated | IAS grant performance data (ANAO 2017) | This is the actual open niche |
+
+### 7.5 The uncomfortable finding
+
+**No organisation in section 6 has publicly called for a cross-jurisdictional, ABN-level, publicly
+queryable funding-flow database built by a third party.** SNAICC asks the Productivity Commission to
+do it. NSW CAPO asks the independent Mechanism to do it. COP asks governments to publish Closing the
+Gap budget statements. The ALRC asks a national body to do it. **Every one of them asks government.**
+
+Two readings, and both are worth holding:
+
+- **Sceptical:** this is a system nobody asked for, in the specific sense that the demand is for
+  government to publish, not for a third party to assemble. Building it does not discharge anyone's
+  obligation and may relieve pressure on the party that actually owes the duty.
+- **Charitable, and better supported:** government has been asked repeatedly for a decade and has
+  instead dismantled every mechanism it had (5.1), and its own statute excludes the askers (5.4).
+  The demand is real, specific and consistently stated. What is contested is only who supplies it.
+
+**The design conclusion that follows from both readings:** the artefact's legitimacy comes from
+*whose hands it is in*, not from its data quality. That is not a communications problem to solve later.
+It is the architecture. Palimaa is governed by the Bourke Tribal Council. The question for these three
+systems is who plays that role, and it must be answered before scale, not after.
+
+---
+
+## What could not be verified
+
+Flagged honestly rather than inferred:
+
+- **Clause numbers for PR4.** The published page strips them. Numbering (69 to 77) is inferred from the
+  PC's citations of clauses 74, 75 and 92. If clause numbers matter for a citation, get the signed PDF.
+- **ANAO justice reinvestment audit status.** Two audits are on the work program; neither appears
+  tabled. ANAO blocked scraping; not confirmed either way.
+- **Per-initiative funding amounts** for the 28 Commonwealth JR initiatives. Not published on the AGD
+  page. Would need assembly from GrantConnect (which CivicGraph could do).
+- **AGD's own 28-funded / 27-active discrepancy.** Unexplained on the page.
+- **BOCSAR-sourced Bourke figures** circulating in advocacy material (72% licence offences, 39% DV
+  assaults). Not traced to a BOCSAR primary source. **Treat as unverified.**
+- **Any post-2018 Maranguka outcomes evaluation.** A well-searched negative, not a proven absence. The
+  2025 ANZSOG study (Li, Katz & Raven) is a co-governance case study built on publicly available
+  material and explicitly collects no new data.
+- **SPSP evaluation.** A search result suggested one has been given to the Minister; not verifiable on
+  any DSS or ministerial page. Either it does not exist or it is not public.
+- **AIFS place-based evidence.** aifs.gov.au is Cloudflare-blocked to automated fetching. Not retrieved.
+  **This is a real gap in section 5.5 and needs a manual read.**
+- **Public Data Policy Statement (2015) status.** 404s at every official address. Cannot tell whether
+  superseded, retired, or lost.
+- **Local Drug Action Teams evaluation.** None found; not verified either way.
+- **Brown et al. (2016), Schwartz et al. (2017), ALRC ch.4.** Located but not read in full. No specific
+  claims attributed to them here.
+- **The "line" in section 3.3 is my inference**, explicitly not stated by any source. It is the
+  judgement the project has to make and document itself.
+
+## Follow-ups worth doing
+
+1. Read the JRNA data toolkit (Community Data Quick Guide, Administrative Data Quick Guide, consent
+   template) properly and check JusticeHub's network features against it.
+2. Manual fetch of AIFS place-based evaluation material.
+3. Assemble per-initiative amounts for the 28 Commonwealth JR initiatives from GrantConnect. This is a
+   concrete, publishable CivicGraph output that nobody else has produced, and it directly answers
+   SNAICC's stated gap.
+4. Reproduce the ANAO's non-competitive-reallocation analysis (90%/95% non-competitive, 80%/87%
+   same-provider) from current GrantConnect data. It is a defensible, government-shaped critique that
+   does not require any Indigenous-status disaggregation.
+5. Audit existing surfaces against CARE E1: find every place the product ranks or scores a *community*
+   rather than a *funder*, and decide deliberately whether it stays.


### PR DESCRIPTION
Lands the primary-source research and rewrites `docs/strategy/data-standard.md` around what it found. The standard was written this morning and its central claim was wrong by the afternoon.

## What changed

**PR4 was the wrong anchor.** It commits governments only, is not justiciable, and its target is a count of projects — satisfied by six projects existing. Six years after signing it has produced six unfinished projects and a partnership that has met once.

And the Productivity Commission's 2024 review names our own instinct as the failure mode:

> "The few changes that have been made have largely been about increasing the sharing of existing data held by governments. For example, governments have worked on presenting data in more accessible formats, such as dashboards…"

That sits inside a finding of "little progress". **The PC classifies building a dashboard as the weakest available response.** Anything we ship that is fundamentally a dashboard has already been assessed, by the national reviewer, as not the thing.

**PR2 is the real hook**, because its target is a money-flow measurement, and clause 118(d) requires Parties to

> "list the number of Aboriginal and Torres Strait Islander community-controlled organisations … that have been allocated funding … also list the names of the organisations and the amount allocated."

That is a description of a CivicGraph table. The PC found most governments "have either not undertaken or not published the expenditure reviews that they agreed to undertake" — four of nine have published. **We are not offering a product nobody asked for; we are producing the accounting committed to in 118(d) and not delivered.**

## Three further corrections now in the standard

**Legitimacy is architecture, not comms.** No peak body has asked a *third party* to build this — SNAICC asks the Productivity Commission, NSW CAPO asks the Data Policy Partnership, the Coalition of Peaks asks governments. The PC's own exemplar is Maranguka's Palimaa: **Bourke Tribal Council governs, Seer Data supplies.** If this is not inside a community-controlled governance structure, it is a private database about other people.

**Rank funders, not communities.** CARE E1 prohibits deficit framing. A "funding desert score" attached to a place says the place is deficient; the same numbers pointed at the funder say who failed to show up. Identical data, opposite ethics. AIATSIS's operative trigger is disaggregation, so "funding to ACCOs" as a cut is squarely in scope — and it is also exactly what 118(d) asks for.

**The evidence base is thinner than the sector admits.** Every confident Australian JR claim traces to one KPMG report that disclaims itself twice ("not a process or outcomes evaluation… no control group… no attribution analysis"); the quoted 14% bail-breach reduction is **nine events**. Against that, the Commonwealth has committed ~$91.5m plus $22.6m/year across 28 initiatives and published **zero** evaluations. Same shape as ALMA's one-record-cited-277-times, at national scale.

**And how this dies:** the Indigenous Expenditure Report ($33.4bn, 2015-16) was discontinued with one sentence and no reason. Every Commonwealth Indigenous expenditure mechanism was dismantled 2014–2017. The characteristic death is silence, not refutation.

## The research doc

`thoughts/shared/research/2026-08-19-civic-data-mandate-sovereignty-and-evidence.md` — ~46 primary sources, unverified items listed explicitly (AIFS place-based material was Cloudflare-blocked; ANAO tabling status and some BOCSAR-sourced Bourke figures unconfirmed).

Docs only.