### PR TITLE
Rank funders, not communities: the desert score describes funding behaviour

### DIFF
--- a/apps/web/src/app/agent/page.tsx
+++ b/apps/web/src/app/agent/page.tsx
@@ -30,8 +30,8 @@ const ACTIONS = [
   },
   {
     name: 'funding_deserts',
-    label: 'Funding Deserts',
-    description: 'Most underserved local government areas in Australia. Scored by disadvantage (SEIFA), remoteness, and funding shortfall.',
+    label: 'Where the money does not go',
+    description: 'Local government areas where funders and services have delivered least against measured need. Scored by disadvantage (SEIFA), remoteness, and funding shortfall. Describes funding behaviour, not the communities.',
     example: { action: 'funding_deserts', state: 'NT', limit: 10 },
     returns: 'LGAs ranked by desert_score with IRSD decile, entity counts, and dollar flows',
   },

--- a/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
+++ b/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
@@ -7,6 +7,12 @@ import { money, L, makeQs, useDrawer, Drawer, SortHeader } from '../browse/brows
  * Places browser at LGA grain. The drawer's provenance block shows HOW each entity was placed
  * (lga_source stamps from the attribution rebuild) — a null LGA elsewhere is deliberate
  * unplacement with a reason code, not missing data.
+ *
+ * The "Unfunded" column is the DB's `desert_score` with the subject of the sentence changed. The
+ * score is built entirely from absence (no money flow, participants with no provider), so it
+ * measures what funders did not do. Naming a PLACE a desert states a deficit about the community;
+ * CARE E1 prohibits that, and it is the wrong reading of the number besides. See
+ * docs/strategy/data-standard.md.
  */
 
 export interface PlaceRow {
@@ -106,7 +112,7 @@ export default function PlaceBrowser({
           <SortHeader label="ACCO" sortKey="acco" current={sort} qs={qs} width="w-[64px]" align="right" title="community-controlled organisations" />
           <SortHeader label="Funding $" sortKey="funding" current={sort} qs={qs} width="w-[92px]" align="right" />
           <SortHeader label="SEIFA" sortKey="disadvantage" current={sort} qs={qs} width="w-[56px]" align="right" title="average SEIFA disadvantage decile, 1 = most disadvantaged; sorts most-disadvantaged first" />
-          <SortHeader label="Desert" sortKey="desert" current={sort} qs={qs} width="w-[64px]" align="right" title="funding-desert score: disadvantage vs money reaching the area" />
+          <SortHeader label="Unfunded" sortKey="desert" current={sort} qs={qs} width="w-[76px]" align="right" title="how far funders and providers have fallen short of this area's measured need — a measure of funding behaviour, not of the community" />
         </div>
         {rows.map((r) => (
           <button key={r.key} onClick={() => open(r)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>
@@ -116,7 +122,7 @@ export default function PlaceBrowser({
             <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.acco || '—'}</span>
             <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.funding)}</span>
             <span className="w-[56px] shrink-0 text-right font-mono text-[12.5px]">{r.seifa ?? '—'}</span>
-            <span className="w-[64px] shrink-0 text-right font-mono text-[12.5px]">{r.desert ?? '—'}</span>
+            <span className="w-[76px] shrink-0 text-right font-mono text-[12.5px]">{r.desert ?? '—'}</span>
           </button>
         ))}
       </div>
@@ -130,7 +136,7 @@ export default function PlaceBrowser({
             <>
               <p className="mt-1 text-[12.5px]" style={{ color: 'var(--shell-muted)' }}>
                 {detail.desert?.remoteness ?? ''}
-                {detail.desert?.desert_score != null ? ` · desert score ${detail.desert.desert_score}` : ''}
+                {detail.desert?.desert_score != null ? ` · funding shortfall ${detail.desert.desert_score}` : ''}
               </p>
 
               {detail.funding ? (

--- a/apps/web/src/app/dashboard/places/page.tsx
+++ b/apps/web/src/app/dashboard/places/page.tsx
@@ -76,7 +76,7 @@ export default async function PlacesPage({
           state={state}
           sort={sort}
           statsLine={statsLine}
-          caveat="Funding attaches to an organisation's address, so head-office council areas collect their branches' figures. SEIFA decile 1 = most disadvantaged. Desert score compares disadvantage with money reaching the area — higher means more disadvantage and less money; metro councils sit around 50–70, and the extreme tail runs past 150."
+          caveat="Funding attaches to an organisation's address, so head-office council areas collect their branches' figures. SEIFA decile 1 = most disadvantaged. The Unfunded column measures what funders and providers have NOT delivered against an area's measured need — it describes funding behaviour, not the community. Higher means less money and fewer providers reached an area with more measured need; metro councils sit around 50–70, and the extreme tail runs past 150."
         />
       )}
     </div>

--- a/apps/web/src/app/graph/page.tsx
+++ b/apps/web/src/app/graph/page.tsx
@@ -2082,7 +2082,7 @@ export default function GraphPage() {
                 )}
                 {selectedNode.desert_score != null && (
                   <p className="text-[9px] text-[#f97316] font-mono">
-                    Desert score: {Math.round(selectedNode.desert_score)}
+                    Funding shortfall: {Math.round(selectedNode.desert_score)}
                   </p>
                 )}
               </div>

--- a/apps/web/src/app/org/_components/org-sections.tsx
+++ b/apps/web/src/app/org/_components/org-sections.tsx
@@ -423,20 +423,35 @@ export function RelationshipSummarySection({
 }
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-// Funding Desert Context
+// Funding shortfall context — ranks the FUNDER, never the place
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// This block used to render "Funding Desert — Severe" and "ranked #N funding desert" on an
+// organisation's own profile. An Aboriginal community-controlled organisation opening its own page
+// was told, in red, that its home is a severe desert ranked Nth worst in the country.
+//
+// CARE principle E1 prohibits portraying Indigenous Peoples in terms of deficit, and the
+// Productivity Commission's 2024 Closing the Gap review names deficit narratives as the thing
+// Indigenous Data Governance exists to disrupt. See docs/strategy/data-standard.md.
+//
+// The underlying score is built ENTIRELY from absence: points for zero or low money flow, points
+// for NDIS participants with no provider. Every component measures what funders and services did
+// not do. So attributing it to funders is not a euphemism, it is the accurate reading. The number
+// is unchanged; the subject of the sentence is not.
+//
+// The DB column stays `desert_score` because other consumers read it. The divergence is deliberate.
 
 export function FundingDesertSection({ fundingDesert }: { fundingDesert: FundingDesert | null }) {
   if (!fundingDesert) return null;
 
-  // Only show if it's meaningfully a desert (e.g., top 50% of desert scores)
-  const desertScore = Number(fundingDesert.desert_score);
-  if (desertScore <= 0) return null;
+  const shortfall = Number(fundingDesert.desert_score);
+  if (shortfall <= 0) return null;
 
+  // Severity describes the size of the FUNDING SHORTFALL, not a quality of the place.
   const severity =
-    desertScore >= 80 ? { label: 'Severe', bg: 'bg-red-50', border: 'border-red-400', text: 'text-red-800', dot: 'bg-red-500' }
-    : desertScore >= 50 ? { label: 'Significant', bg: 'bg-orange-50', border: 'border-orange-400', text: 'text-orange-800', dot: 'bg-orange-500' }
-    : { label: 'Moderate', bg: 'bg-yellow-50', border: 'border-yellow-400', text: 'text-yellow-800', dot: 'bg-yellow-500' };
+    shortfall >= 80 ? { label: 'Large shortfall', bg: 'bg-red-50', border: 'border-red-400', text: 'text-red-800', dot: 'bg-red-500' }
+    : shortfall >= 50 ? { label: 'Clear shortfall', bg: 'bg-orange-50', border: 'border-orange-400', text: 'text-orange-800', dot: 'bg-orange-500' }
+    : { label: 'Some shortfall', bg: 'bg-yellow-50', border: 'border-yellow-400', text: 'text-yellow-800', dot: 'bg-yellow-500' };
 
   return (
     <section>
@@ -445,18 +460,23 @@ export function FundingDesertSection({ fundingDesert }: { fundingDesert: Funding
           <span className={`w-3 h-3 rounded-full ${severity.dot} shrink-0 mt-1`} />
           <div className="flex-1">
             <h3 className={`font-black uppercase tracking-widest text-sm ${severity.text}`}>
-              Funding Desert — {severity.label}
+              Funders have under-served this area — {severity.label}
             </h3>
             <p className={`text-sm mt-1 ${severity.text}`}>
-              Located in <strong>{fundingDesert.lga_name}</strong> ({fundingDesert.state})
+              Less money and fewer providers have reached <strong>{fundingDesert.lga_name}</strong> ({fundingDesert.state})
+              than its measured need would warrant
               {fundingDesert.desert_rank > 0 && (
-                <> — ranked <strong>#{fundingDesert.desert_rank}</strong> funding desert</>
-              )}
+                <> — the <strong>#{fundingDesert.desert_rank}</strong> largest shortfall in the country</>
+              )}.
+            </p>
+            <p className="text-[11px] mt-1 text-gray-600">
+              This measures what funders and services delivered here. It is not a statement about the
+              community.
             </p>
             <div className="flex items-center gap-6 mt-3">
               <div>
-                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Desert Score</p>
-                <p className={`text-lg font-black ${severity.text}`}>{desertScore.toFixed(1)}</p>
+                <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Funding shortfall</p>
+                <p className={`text-lg font-black ${severity.text}`}>{shortfall.toFixed(1)}</p>
               </div>
               <div>
                 <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">Remoteness</p>
@@ -480,7 +500,7 @@ export function FundingDesertSection({ fundingDesert }: { fundingDesert: Funding
                 href="/reports/power-concentration"
                 className="text-xs text-bauhaus-blue font-bold hover:underline"
               >
-                View Funding Deserts Report
+                View where the money doesn&rsquo;t go
               </Link>
             </div>
           </div>

--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -9,18 +9,18 @@ import { DESERT_COMMUNITY_ORGS_SQL, mapDesertCommunityOrgs } from '@/lib/funding
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Funding Deserts | CivicGraph Investigation',
-  description: 'Where disadvantage is highest and investment is lowest. 568 Local Government Areas scored by SEIFA disadvantage, remoteness, entity coverage, and funding flows.',
+  title: "Where the Money Doesn't Go | CivicGraph Investigation",
+  description: 'Where funders and services have delivered least against measured need. 568 Local Government Areas scored by SEIFA disadvantage, remoteness, entity coverage, and funding flows.',
   openGraph: {
-    title: 'Funding Deserts',
-    description: 'Geographic analysis of where disadvantage is highest and funding is lowest across Australian LGAs.',
+    title: "Where the Money Doesn't Go",
+    description: 'Geographic analysis of where funders and services have delivered least against measured need across Australian LGAs.',
     type: 'article',
     siteName: 'CivicGraph',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Funding Deserts',
-    description: 'Where disadvantage is highest and investment is lowest. 568 LGAs scored.',
+    title: "Where the Money Doesn't Go",
+    description: 'Where funders and services have delivered least against measured need. 568 LGAs scored.',
   },
 };
 
@@ -196,13 +196,14 @@ export default async function FundingDesertsReport() {
         <a href="/reports" className="text-xs font-black text-bauhaus-muted uppercase tracking-widest hover:text-bauhaus-black">&larr; All Reports</a>
         <div className="text-xs font-black text-bauhaus-red mt-4 mb-1 uppercase tracking-widest">Geographic Investigation</div>
         <h1 className="text-3xl sm:text-4xl font-black text-bauhaus-black mb-3">
-          Funding Deserts
+          Where the Money Doesn&rsquo;t Go
         </h1>
         <p className="text-bauhaus-muted text-base sm:text-lg max-w-3xl leading-relaxed font-medium">
-          Where disadvantage is highest and investment is lowest &mdash; {fmt(s.total_lgas)} Local
+          Where funders and services have delivered least against measured need &mdash; {fmt(s.total_lgas)} Local
           Government Areas scored by SEIFA disadvantage, remoteness, entity coverage, and funding
-          flows. {fmt(s.severe_deserts)} LGAs score above 100, indicating severe geographic
-          underinvestment relative to need.
+          flows. {fmt(s.severe_deserts)} score above 100, meaning money and providers have fallen
+          furthest short of what the need would warrant. The score describes funding behaviour, not
+          the communities themselves.
         </p>
         <div className="mt-4 text-xs text-bauhaus-muted font-bold">
           Data updated {new Date().toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}


### PR DESCRIPTION
Implements the CARE E1 requirement from `docs/strategy/data-standard.md` (#329).

## What was on screen

An Aboriginal community-controlled organisation opening **its own profile** saw a red banner:

> **Funding Desert — Severe**
> Located in *[LGA]* — ranked **#N** funding desert

That is deficit framing pointed directly at a community, on the page most likely to be read by that community. CARE principle E1 prohibits portraying Indigenous Peoples in terms of deficit, and the Productivity Commission's 2024 Closing the Gap review names deficit narratives as the thing Indigenous Data Governance exists to disrupt.

## Why the reframe is accurate, not a euphemism

I read the score's definition before rewording anything. It is built **entirely from absence**:

- points when total money flow is zero, more points when it is under $1M
- points when an area has NDIS participants but **no NDIS provider entities**

Every component measures what funders and services did **not** do. So attributing it to funders is the correct reading of the number, not a softening of it. **The numbers are unchanged. The subject of the sentence is.**

## Six surfaces

| surface | before | after |
|---|---|---|
| org profile banner | "Funding Desert — Severe" | "Funders have under-served this area — Large shortfall" |
| org profile rank | "ranked #N funding desert" | "the #N largest shortfall in the country" |
| places browser column | "Desert" | "Unfunded" |
| places drawer | "· desert score 120" | "· funding shortfall 120" |
| graph node panel | "Desert score: 120" | "Funding shortfall: 120" |
| public report | "Funding Deserts" | **"Where the Money Doesn't Go"** |

The org banner also gains an explicit line: *"This measures what funders and services delivered here. It is not a statement about the community."*

## Deliberate non-changes

- **The DB column stays `desert_score`.** Other consumers read it, and renaming it would be a much larger change for no user benefit. The divergence between column name and label is commented at both ends so the next reader is not confused by it.
- **The `/reports/funding-deserts` URL is unchanged**, so existing links and the RSS feed keep working. Only the displayed title and framing move.

Gates: `./scripts/precheck.sh` — tsc clean, 724 vitest.

**VISIBLE** per `classify-changes.sh` — public report page and org profiles. Not auto-merging; preview wants eyes on it.