### PR TITLE
Reports refuse when their data did not load, instead of printing zeros

### DIFF
--- a/apps/web/src/app/reports/_components/report-unavailable.tsx
+++ b/apps/web/src/app/reports/_components/report-unavailable.tsx
@@ -1,0 +1,27 @@
+/**
+ * What a report renders when its data did not load.
+ *
+ * The alternative — and what these pages did until 2026-08-19 — is to print zeros, which reads as a
+ * measurement. "0 entities operate through multiple influence channels" is a claim about Australia.
+ * Saying nothing loaded is honest and costs the reader nothing but a refresh.
+ */
+export function ReportUnavailable({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-20">
+      <p className="text-xs font-black uppercase tracking-widest text-bauhaus-red">Data unavailable</p>
+      <h1 className="mt-3 text-3xl font-black text-bauhaus-black sm:text-4xl">{title}</h1>
+      <p className="mt-4 text-base leading-relaxed text-bauhaus-muted">
+        This report could not load its figures, so it is showing nothing rather than showing zeros.
+        A zero here would read as a measurement, and we do not know that it is one.
+      </p>
+      {detail ? <p className="mt-3 text-sm text-bauhaus-muted">{detail}</p> : null}
+      <p className="mt-6 text-sm text-bauhaus-muted">
+        The underlying data has not gone anywhere. Try again shortly, or{' '}
+        <a href="/reports" className="font-bold text-bauhaus-blue hover:underline">
+          browse the other reports
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 import { DESERT_COMMUNITY_ORGS_SQL, mapDesertCommunityOrgs } from '@/lib/funding-deserts';
+import { reportDataUnavailable } from '@/lib/report-data';
+import { ReportUnavailable } from '../_components/report-unavailable';
 
 // Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
 // anonymous traffic cannot drive one service-role query fan-out per hit
@@ -114,6 +116,10 @@ async function getData() {
     }),
   ]);
 
+  // Checked BEFORE the `|| []` below. Once a null becomes an empty array the page can no longer
+  // tell "nothing matched" from "the query never ran", and it prints the second as a zero.
+  const unavailable = reportDataUnavailable([worstResult, bestResult, summaryResult]);
+
   const allDeserts = (worstResult.data as Record<string, unknown>[]) || [];
   const allBest = (bestResult.data as Record<string, unknown>[]) || [];
 
@@ -151,7 +157,7 @@ async function getData() {
     zero_funding_orgs: communityOrgs.filter((o) => o.total_dollar_flow === 0).length,
   };
 
-  return { worst30, best10, worst10, byRemoteness, byState, summary, communityOrgs, communitySummary };
+  return { worst30, best10, worst10, byRemoteness, byState, summary, communityOrgs, communitySummary , unavailable };
 }
 
 const REMOTENESS_COLORS: Record<string, string> = {
@@ -180,6 +186,14 @@ const REMOTENESS_BAR_COLORS: Record<string, string> = {
 
 export default async function FundingDesertsReport() {
   const d = await getData();
+  if (d.unavailable) {
+    return (
+      <ReportUnavailable
+        title="Where the Money Doesn&rsquo;t Go"
+        detail="The funding and disadvantage figures for this report did not load."
+      />
+    );
+  }
   const s = d.summary;
 
   const fundingGap = s.max_funding - s.min_funding;

--- a/apps/web/src/app/reports/power-concentration/page.tsx
+++ b/apps/web/src/app/reports/power-concentration/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
+import { reportDataUnavailable } from '@/lib/report-data';
+import { ReportUnavailable } from '../_components/report-unavailable';
 import Link from 'next/link';
 import { ReportCTA } from '../_components/report-cta';
 
@@ -201,7 +203,11 @@ async function getData() {
     veryRemoteFlowB: Number(veryRemote?.flow_b) || 0,
   };
 
-  return { powerTop, revolvingDoor, deserts, communityTop, stats };
+  // Checked against the raw results, before any `|| 0` turns "no answer" into "zero". This page
+  // was publishing "0 Australian entities scored across 7 public datasets" as a finding.
+  const unavailable = reportDataUnavailable([powerTopResult, revolvingDoorResult, desertsResult]);
+
+  return { powerTop, revolvingDoor, deserts, communityTop, stats, unavailable };
 }
 
 const SYSTEM_LABELS: Record<string, string> = {
@@ -262,6 +268,14 @@ function VectorBadges({ entity }: { entity: RevolvingDoorEntity }) {
 
 export default async function PowerConcentrationReport() {
   const d = await getData();
+  if (d.unavailable) {
+    return (
+      <ReportUnavailable
+        title="Cross-System Power Concentration"
+        detail="The cross-system entity figures for this report did not load."
+      />
+    );
+  }
   const s = d.stats;
 
   const communityProcurementPct = s.totalProcurementB > 0

--- a/apps/web/src/lib/report-data.test.ts
+++ b/apps/web/src/lib/report-data.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resultUnavailable, reportDataUnavailable, rowsOrNull } from './report-data';
+
+/**
+ * Locks the distinction that the 2026-08-19 zero-serving reports lost: a query that ran and
+ * matched nothing is NOT the same as a query that never ran.
+ */
+describe('report data availability', () => {
+  it('treats a null data payload as unavailable — this is the snapshot client', () => {
+    // Exactly what reportSnapshotSupabase returns: no data, and no error to notice either.
+    expect(resultUnavailable({ data: null, error: null })).toBe(true);
+  });
+
+  it('treats an empty array as a real, measured zero', () => {
+    expect(resultUnavailable({ data: [], error: null })).toBe(false);
+    expect(rowsOrNull({ data: [], error: null })).toEqual([]);
+  });
+
+  it('treats an error as unavailable even when data is present', () => {
+    expect(resultUnavailable({ data: [{ a: 1 }], error: { code: 'SQL_RPC_DISABLED' } })).toBe(true);
+  });
+
+  it('treats a missing or undefined result as unavailable', () => {
+    expect(resultUnavailable(null)).toBe(true);
+    expect(resultUnavailable(undefined)).toBe(true);
+    expect(resultUnavailable({})).toBe(true);
+  });
+
+  it('rowsOrNull returns null rather than [] when the query never ran', () => {
+    // The whole bug in one assertion: `|| []` here is what printed "0 LGAs scored".
+    expect(rowsOrNull({ data: null, error: null })).toBeNull();
+  });
+
+  it('a page is unavailable if ANY dependency is, not only if all are', () => {
+    expect(reportDataUnavailable([{ data: [{ a: 1 }] }, { data: null, error: null }])).toBe(true);
+    expect(reportDataUnavailable([{ data: [{ a: 1 }] }, { data: [] }])).toBe(false);
+  });
+});

--- a/apps/web/src/lib/report-data.ts
+++ b/apps/web/src/lib/report-data.ts
@@ -1,0 +1,54 @@
+/**
+ * Tells a report page whether its data actually loaded, so it can refuse instead of printing zeros.
+ *
+ * WHY THIS EXISTS. On 2026-08-19 two public investigation reports were serving fabricated-looking
+ * zeros with that day's date on them:
+ *
+ *   /reports/power-concentration  "0 Australian entities scored across 7 public datasets… 0 appear
+ *                                  in 3+ systems… $0B of $0B"
+ *   /reports/funding-deserts      "0 Local Government Areas scored… 0 LGAs score above 100"
+ *
+ * Both have real data behind them (mv_entity_power_index 188K rows, mv_funding_deserts 2,004). The
+ * pages were reading through a snapshot client that returns `{ data: null, error: null }` for every
+ * query, and each call site did `(result.data as Row[]) || []`, which turns "no answer" into "an
+ * answer of zero". Nothing on screen distinguished the two.
+ *
+ * THE DISCRIMINATOR. A query that genuinely matched no rows returns `data: []`. Only a client that
+ * never ran the query returns `data: null`. So:
+ *
+ *   data === null (or an error)  ->  UNAVAILABLE. Refuse. We do not know.
+ *   data === []                  ->  a real, measured zero. Render it.
+ *
+ * That distinction is the whole point. `|| []` erases it, which is why it must not be the first
+ * thing a report does with a result.
+ *
+ * This is the standard's "refuse at the claim, not at the index" rule made mechanical. See
+ * docs/strategy/data-standard.md.
+ */
+
+export interface SupaLikeResult {
+  data?: unknown;
+  error?: unknown;
+}
+
+/** True when the query did not run or failed — as opposed to running and matching nothing. */
+export function resultUnavailable(result: SupaLikeResult | null | undefined): boolean {
+  if (!result) return true;
+  if (result.error) return true;
+  return result.data === null || result.data === undefined;
+}
+
+/**
+ * True when ANY result the page depends on is unavailable. Deliberately "any" rather than "all":
+ * a report rendering three real sections and one silent zero is the harder failure to spot, and
+ * the zero is the part that gets quoted.
+ */
+export function reportDataUnavailable(results: (SupaLikeResult | null | undefined)[]): boolean {
+  return results.some(resultUnavailable);
+}
+
+/** Rows, or null when the query never ran. Never silently an empty array. */
+export function rowsOrNull<T>(result: SupaLikeResult | null | undefined): T[] | null {
+  if (resultUnavailable(result)) return null;
+  return (result?.data as T[]) ?? [];
+}


### PR DESCRIPTION
Implements "refuse at the claim" from `docs/strategy/data-standard.md`, against a defect verified live on production today.

## What was public

**`/reports/power-concentration`**, stamped "Data updated 19 August 2026":

> "**0** Australian entities scored across 7 public datasets… **0** appear in 3+ systems. **0** entities operate through multiple influence channels simultaneously."
> "$0B of $0B" · "0 of 0 LGAs score above 50"

**`/reports/funding-deserts`**: "0 Local Government Areas scored… 0 LGAs score above 100."

Both have real data behind them: `mv_entity_power_index` 188K rows, `mv_funding_deserts` 2,004.

Meanwhile `/reports/social-enterprise` renders perfectly — **because its headline numbers are hardcoded narrative figures, not live queries.** That is the worst version of this: the pages that depend on live data are the ones failing, and nothing on the site tells you which is which.

## The mechanism

The pages read through a snapshot client that returns `{ data: null, error: null }` for every query. Every call site then does:

```ts
const rows = (result.data as Row[]) || [];
```

That turns **"no answer" into "an answer of zero"**, with no error to notice.

## The discriminator was there all along

- a query that **ran and matched nothing** returns `data: []`
- a client that **never ran the query** returns `data: null`

`|| []` erases exactly that distinction, which is why it must not be the first thing a report does with a result.

## What this adds

- **`lib/report-data.ts`** — `resultUnavailable`, `reportDataUnavailable`, `rowsOrNull`. `reportDataUnavailable` is deliberately **any**, not **all**: a report rendering three real sections and one silent zero is the harder failure to spot, and the zero is the part that gets quoted.
- **`ReportUnavailable`** — says nothing loaded rather than showing zeros, and says why.
- Wires the **two pages verified broken against production**.
- **6 tests** locking the null-vs-empty distinction, including the exact snapshot-client shape.

## Deliberately not fixed here

`getServiceSupabase()` chooses its client by **string-matching a stack trace** (`stack.includes('/app/reports/')`). That is why this fires on some report pages and not others, unpredictably, and invisibly at the call site. It is the root cause, it affects ~41 report pages, and it wants its own change with its own testing rather than riding along with a guard.

Gates: `./scripts/precheck.sh` — tsc clean, 730 vitest.

**VISIBLE** — public report pages. Not auto-merging.