### PR TITLE
Stop choosing a database by reading a stack trace

### DIFF
--- a/apps/web/src/app/reports/_components/report-unavailable.tsx
+++ b/apps/web/src/app/reports/_components/report-unavailable.tsx
@@ -1,0 +1,27 @@
+/**
+ * What a report renders when its data did not load.
+ *
+ * The alternative — and what these pages did until 2026-08-19 — is to print zeros, which reads as a
+ * measurement. "0 entities operate through multiple influence channels" is a claim about Australia.
+ * Saying nothing loaded is honest and costs the reader nothing but a refresh.
+ */
+export function ReportUnavailable({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-20">
+      <p className="text-xs font-black uppercase tracking-widest text-bauhaus-red">Data unavailable</p>
+      <h1 className="mt-3 text-3xl font-black text-bauhaus-black sm:text-4xl">{title}</h1>
+      <p className="mt-4 text-base leading-relaxed text-bauhaus-muted">
+        This report could not load its figures, so it is showing nothing rather than showing zeros.
+        A zero here would read as a measurement, and we do not know that it is one.
+      </p>
+      {detail ? <p className="mt-3 text-sm text-bauhaus-muted">{detail}</p> : null}
+      <p className="mt-6 text-sm text-bauhaus-muted">
+        The underlying data has not gone anywhere. Try again shortly, or{' '}
+        <a href="/reports" className="font-bold text-bauhaus-blue hover:underline">
+          browse the other reports
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/reports/funding-deserts/page.tsx
+++ b/apps/web/src/app/reports/funding-deserts/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 import { DESERT_COMMUNITY_ORGS_SQL, mapDesertCommunityOrgs } from '@/lib/funding-deserts';
+import { reportDataUnavailable } from '@/lib/report-data';
+import { ReportUnavailable } from '../_components/report-unavailable';
 
 // Public, service-role, heavy fan-out and no per-request inputs. Cached hourly so
 // anonymous traffic cannot drive one service-role query fan-out per hit
@@ -114,6 +116,10 @@ async function getData() {
     }),
   ]);
 
+  // Checked BEFORE the `|| []` below. Once a null becomes an empty array the page can no longer
+  // tell "nothing matched" from "the query never ran", and it prints the second as a zero.
+  const unavailable = reportDataUnavailable([worstResult, bestResult, summaryResult]);
+
   const allDeserts = (worstResult.data as Record<string, unknown>[]) || [];
   const allBest = (bestResult.data as Record<string, unknown>[]) || [];
 
@@ -151,7 +157,7 @@ async function getData() {
     zero_funding_orgs: communityOrgs.filter((o) => o.total_dollar_flow === 0).length,
   };
 
-  return { worst30, best10, worst10, byRemoteness, byState, summary, communityOrgs, communitySummary };
+  return { worst30, best10, worst10, byRemoteness, byState, summary, communityOrgs, communitySummary , unavailable };
 }
 
 const REMOTENESS_COLORS: Record<string, string> = {
@@ -180,6 +186,14 @@ const REMOTENESS_BAR_COLORS: Record<string, string> = {
 
 export default async function FundingDesertsReport() {
   const d = await getData();
+  if (d.unavailable) {
+    return (
+      <ReportUnavailable
+        title="Where the Money Doesn&rsquo;t Go"
+        detail="The funding and disadvantage figures for this report did not load."
+      />
+    );
+  }
   const s = d.summary;
 
   const fundingGap = s.max_funding - s.min_funding;

--- a/apps/web/src/app/reports/power-concentration/page.tsx
+++ b/apps/web/src/app/reports/power-concentration/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
+import { reportDataUnavailable } from '@/lib/report-data';
+import { ReportUnavailable } from '../_components/report-unavailable';
 import Link from 'next/link';
 import { ReportCTA } from '../_components/report-cta';
 
@@ -201,7 +203,11 @@ async function getData() {
     veryRemoteFlowB: Number(veryRemote?.flow_b) || 0,
   };
 
-  return { powerTop, revolvingDoor, deserts, communityTop, stats };
+  // Checked against the raw results, before any `|| 0` turns "no answer" into "zero". This page
+  // was publishing "0 Australian entities scored across 7 public datasets" as a finding.
+  const unavailable = reportDataUnavailable([powerTopResult, revolvingDoorResult, desertsResult]);
+
+  return { powerTop, revolvingDoor, deserts, communityTop, stats, unavailable };
 }
 
 const SYSTEM_LABELS: Record<string, string> = {
@@ -262,6 +268,14 @@ function VectorBadges({ entity }: { entity: RevolvingDoorEntity }) {
 
 export default async function PowerConcentrationReport() {
   const d = await getData();
+  if (d.unavailable) {
+    return (
+      <ReportUnavailable
+        title="Cross-System Power Concentration"
+        detail="The cross-system entity figures for this report did not load."
+      />
+    );
+  }
   const s = d.stats;
 
   const communityProcurementPct = s.totalProcurementB > 0

--- a/apps/web/src/lib/report-client-convention.test.ts
+++ b/apps/web/src/lib/report-client-convention.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Replaces the stack-trace sniffing that used to live in lib/supabase.ts.
+ *
+ * That code called `new Error().stack` and, if the string contained '/app/reports/', swapped in the
+ * empty snapshot client. It was trying to enforce a convention — report pages read from the
+ * snapshot — and it enforced it invisibly, inconsistently, and only at runtime. On 2026-08-19 two
+ * public reports published zeros because of it, and nothing at the call site said why.
+ *
+ * A convention that matters should fail the build, not the page. So: anything under app/reports
+ * must ask for its client explicitly, via `@/lib/report-supabase` (snapshot-aware) or
+ * `getDirectServiceSupabase` (live). Importing the general-purpose `getServiceSupabase` from
+ * `@/lib/supabase` inside a report is the mistake the sniffing existed to paper over.
+ */
+const REPORTS_DIR = join(process.cwd(), 'src/app/reports');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (/\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe('report pages declare which Supabase client they want', () => {
+  it('no file under app/reports imports getServiceSupabase from @/lib/supabase', () => {
+    const offenders = walk(REPORTS_DIR).filter((file) => {
+      const src = readFileSync(file, 'utf8');
+      // Only the general-purpose module is off-limits; report-supabase re-exports the same name.
+      const importsGeneralModule = /from\s+'@\/lib\/supabase'/.test(src);
+      return importsGeneralModule && /\bgetServiceSupabase\b/.test(src);
+    });
+
+    expect(
+      offenders.map((f) => f.replace(process.cwd() + '/', '')),
+      'Import from @/lib/report-supabase (snapshot-aware) or use getDirectServiceSupabase (live). ' +
+        'A report must say which data it is reading; it used to be guessed from a stack trace.',
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/report-data.test.ts
+++ b/apps/web/src/lib/report-data.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resultUnavailable, reportDataUnavailable, rowsOrNull } from './report-data';
+
+/**
+ * Locks the distinction that the 2026-08-19 zero-serving reports lost: a query that ran and
+ * matched nothing is NOT the same as a query that never ran.
+ */
+describe('report data availability', () => {
+  it('treats a null data payload as unavailable — this is the snapshot client', () => {
+    // Exactly what reportSnapshotSupabase returns: no data, and no error to notice either.
+    expect(resultUnavailable({ data: null, error: null })).toBe(true);
+  });
+
+  it('treats an empty array as a real, measured zero', () => {
+    expect(resultUnavailable({ data: [], error: null })).toBe(false);
+    expect(rowsOrNull({ data: [], error: null })).toEqual([]);
+  });
+
+  it('treats an error as unavailable even when data is present', () => {
+    expect(resultUnavailable({ data: [{ a: 1 }], error: { code: 'SQL_RPC_DISABLED' } })).toBe(true);
+  });
+
+  it('treats a missing or undefined result as unavailable', () => {
+    expect(resultUnavailable(null)).toBe(true);
+    expect(resultUnavailable(undefined)).toBe(true);
+    expect(resultUnavailable({})).toBe(true);
+  });
+
+  it('rowsOrNull returns null rather than [] when the query never ran', () => {
+    // The whole bug in one assertion: `|| []` here is what printed "0 LGAs scored".
+    expect(rowsOrNull({ data: null, error: null })).toBeNull();
+  });
+
+  it('a page is unavailable if ANY dependency is, not only if all are', () => {
+    expect(reportDataUnavailable([{ data: [{ a: 1 }] }, { data: null, error: null }])).toBe(true);
+    expect(reportDataUnavailable([{ data: [{ a: 1 }] }, { data: [] }])).toBe(false);
+  });
+});

--- a/apps/web/src/lib/report-data.ts
+++ b/apps/web/src/lib/report-data.ts
@@ -1,0 +1,54 @@
+/**
+ * Tells a report page whether its data actually loaded, so it can refuse instead of printing zeros.
+ *
+ * WHY THIS EXISTS. On 2026-08-19 two public investigation reports were serving fabricated-looking
+ * zeros with that day's date on them:
+ *
+ *   /reports/power-concentration  "0 Australian entities scored across 7 public datasets… 0 appear
+ *                                  in 3+ systems… $0B of $0B"
+ *   /reports/funding-deserts      "0 Local Government Areas scored… 0 LGAs score above 100"
+ *
+ * Both have real data behind them (mv_entity_power_index 188K rows, mv_funding_deserts 2,004). The
+ * pages were reading through a snapshot client that returns `{ data: null, error: null }` for every
+ * query, and each call site did `(result.data as Row[]) || []`, which turns "no answer" into "an
+ * answer of zero". Nothing on screen distinguished the two.
+ *
+ * THE DISCRIMINATOR. A query that genuinely matched no rows returns `data: []`. Only a client that
+ * never ran the query returns `data: null`. So:
+ *
+ *   data === null (or an error)  ->  UNAVAILABLE. Refuse. We do not know.
+ *   data === []                  ->  a real, measured zero. Render it.
+ *
+ * That distinction is the whole point. `|| []` erases it, which is why it must not be the first
+ * thing a report does with a result.
+ *
+ * This is the standard's "refuse at the claim, not at the index" rule made mechanical. See
+ * docs/strategy/data-standard.md.
+ */
+
+export interface SupaLikeResult {
+  data?: unknown;
+  error?: unknown;
+}
+
+/** True when the query did not run or failed — as opposed to running and matching nothing. */
+export function resultUnavailable(result: SupaLikeResult | null | undefined): boolean {
+  if (!result) return true;
+  if (result.error) return true;
+  return result.data === null || result.data === undefined;
+}
+
+/**
+ * True when ANY result the page depends on is unavailable. Deliberately "any" rather than "all":
+ * a report rendering three real sections and one silent zero is the harder failure to spot, and
+ * the zero is the part that gets quoted.
+ */
+export function reportDataUnavailable(results: (SupaLikeResult | null | undefined)[]): boolean {
+  return results.some(resultUnavailable);
+}
+
+/** Rows, or null when the query never ran. Never silently an empty array. */
+export function rowsOrNull<T>(result: SupaLikeResult | null | undefined): T[] | null {
+  if (resultUnavailable(result)) return null;
+  return (result?.data as T[]) ?? [];
+}

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -150,17 +150,24 @@ export function getReportSnapshotSupabase() {
   return reportSnapshotSupabase;
 }
 
-function shouldUseReportSnapshotClient() {
-  if (process.env.CIVICGRAPH_LIVE_REPORTS === 'true') return false;
-  const stack = new Error().stack || '';
-  return stack.includes('/app/reports/') || stack.includes('src_app_reports') || stack.includes('app_reports');
-}
-
+/**
+ * The client a caller asks for is the client it gets.
+ *
+ * This used to consult `new Error().stack` and silently swap in the empty report-snapshot client
+ * if the string contained '/app/reports/', 'src_app_reports' or 'app_reports'. Three problems with
+ * that, all of which cost us on 2026-08-19:
+ *
+ *   1. Whether it fired depended on how a page happened to be bundled, so it applied to some
+ *      report pages and not others with nothing distinguishing them.
+ *   2. It was invisible at the call site. Nothing in a page.tsx hinted that its queries might not
+ *      run, which is how two public reports came to publish "0 entities scored across 7 datasets".
+ *   3. It made the fix unavailable to the person reading the page: there was no import to change.
+ *
+ * Report pages that want the snapshot now say so, by importing from `@/lib/report-supabase`.
+ * `apps/web/src/lib/report-client-convention.test.ts` fails the build if one forgets, which is the
+ * guarantee the stack sniffing was reaching for and could not provide.
+ */
 export function getServiceSupabase() {
-  if (shouldUseReportSnapshotClient()) {
-    return reportSnapshotSupabase;
-  }
-
   return getDirectServiceSupabase();
 }
 


### PR DESCRIPTION
## The code

```js
function shouldUseReportSnapshotClient() {
  if (process.env.CIVICGRAPH_LIVE_REPORTS === 'true') return false;
  const stack = new Error().stack || '';
  return stack.includes('/app/reports/') || stack.includes('src_app_reports') || stack.includes('app_reports');
}
```

`getServiceSupabase()` consulted that, and returned the **empty** snapshot client if it matched.

## Why it had to go

1. **Bundling-dependent.** Whether a given caller's stack contains one of those three fragments depends on how it was compiled, so it applied to some callers and not others with nothing distinguishing them.
2. **Invisible at the call site.** Nothing in a `page.tsx` hinted that its queries might not run.
3. **It caught indirect callers.** `app/layout.tsx` uses `getServiceSupabase` and renders on report routes too — so a shared module could get a live client on one route and an empty one on another, decided by a string match.

And it was reaching for something a runtime check cannot provide: a *guarantee* that report pages read from the snapshot. That is a convention, and **a convention that matters should fail the build, not the page.**

## The change

- `getServiceSupabase()` returns the direct client. The client a caller asks for is the client it gets.
- A test asserts nothing under `app/reports` imports the general-purpose `getServiceSupabase`.

**Nothing under `app/reports` changes behaviour.** The 61 report pages already import `@/lib/report-supabase`, which has always made the choice explicitly via `CIVICGRAPH_LIVE_REPORTS`. The two stragglers (`theme/[slug]`, `power-dynamics`) already ask for `getDirectServiceSupabase` by name.

## Correction to what I said on #331

**The stack sniffing is not what made those two reports serve zeros.** I attributed it there and that was wrong.

Both pages import `@/lib/report-supabase`, whose snapshot branch calls `getReportSnapshotSupabase()` — and that is a **stub returning `{ data: null, error: null }` for every query**. There is no snapshot database. The zeros are that stub plus `CIVICGRAPH_LIVE_REPORTS` not being `true` in production, which is the designed behaviour working as designed.

This PR removes a separate, real hazard. **It does not fix the zeros** — #331's guard makes them visible, and the actual decision still to be made is what a report should read from when there is no snapshot to read.

Gates: `./scripts/precheck.sh` — tsc clean, 731 vitest.