### PR TITLE
Stop publishing invented scores about named foundations

### DIFF
--- a/apps/web/src/app/reports/funding-equity/page.tsx
+++ b/apps/web/src/app/reports/funding-equity/page.tsx
@@ -1,6 +1,7 @@
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 import { money, fmt } from '@/lib/format';
+import { ReportUnavailable } from '../_components/report-unavailable';
 
 export const dynamic = 'force-static';
 
@@ -46,6 +47,26 @@ interface DonorRow {
   buyers: string | null;
 }
 
+
+/**
+ * FABRICATED FALLBACK REMOVED, 2026-08-19.
+ *
+ * When CIVICGRAPH_LIVE_REPORTS is not 'true' — which is its state in production — this page used to
+ * return buildSnapshotData(): hand-authored constants. It then rendered them under a Methodology
+ * section describing how the figures were computed, and cited sources for them.
+ *
+ * On this page that meant publishing scored assessments of NAMED REAL ORGANISATIONS. Paul Ramsay
+ * Foundation and Minderoo Foundation were listed under "Largest Foundations With Zero
+ * Transparency", with invented transparency, evidence and need-alignment scores, invented grantee
+ * counts, and round giving figures. `foundation_id: 'snapshot-prf'` and `acnc_abn: ''` show the
+ * author knew these were placeholders; nothing on the rendered page did.
+ *
+ * A reputational claim about a real organisation, carrying a methodology that says it was measured,
+ * is the one thing this project must never publish. An honest blank costs a reader a refresh.
+ *
+ * The constants are left in the file, unused and clearly marked, because they document what was
+ * served and for how long. They must not be wired back in without real figures behind them.
+ */
 function buildSnapshotData() {
   const deciles: DecileRow[] = [
     { irsd_decile: 1, disadvantage_group: 'Most disadvantaged', charity_count: 4300, total_income: 8_900_000_000, govt_revenue: 5_100_000_000, donations: 290_000_000, total_expenses: 8_400_000_000, avg_income: 2_070_000, avg_govt_revenue: 1_186_000, avg_staff_fte: 7, total_volunteers: 68000 },
@@ -122,7 +143,8 @@ function buildSnapshotData() {
 
 async function getData() {
   if (!LIVE_REPORTS) {
-    return buildSnapshotData();
+    // See the note above buildSnapshotData. Serving nothing beats serving invented figures.
+    return null;
   }
 
   const supabase = getServiceSupabase();
@@ -199,6 +221,9 @@ async function getData() {
 
 export default async function FundingEquityPage() {
   const d = await getData();
+  if (!d) {
+    return <ReportUnavailable title="Funding Equity" detail="The charity and disadvantage figures for this report did not load." />;
+  }
 
   const bottomPct = d.totalIncome > 0 ? ((d.groups[0]?.income || 0) / d.totalIncome * 100).toFixed(1) : '0';
   const topPct = d.totalIncome > 0 ? ((d.groups[2]?.income || 0) / d.totalIncome * 100).toFixed(1) : '0';

--- a/apps/web/src/app/reports/philanthropy/page.tsx
+++ b/apps/web/src/app/reports/philanthropy/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
 };
 
 import { money, fmt } from '@/lib/format';
+import { ReportUnavailable } from '../_components/report-unavailable';
 
 function ScoreBar({ score, label, color }: { score: number; label: string; color: string }) {
   return (
@@ -90,6 +91,26 @@ interface Stats {
   ccGrantees: number;
 }
 
+
+/**
+ * FABRICATED FALLBACK REMOVED, 2026-08-19.
+ *
+ * When CIVICGRAPH_LIVE_REPORTS is not 'true' — which is its state in production — this page used to
+ * return buildSnapshotData(): hand-authored constants. It then rendered them under a Methodology
+ * section describing how the figures were computed, and cited sources for them.
+ *
+ * On this page that meant publishing scored assessments of NAMED REAL ORGANISATIONS. Paul Ramsay
+ * Foundation and Minderoo Foundation were listed under "Largest Foundations With Zero
+ * Transparency", with invented transparency, evidence and need-alignment scores, invented grantee
+ * counts, and round giving figures. `foundation_id: 'snapshot-prf'` and `acnc_abn: ''` show the
+ * author knew these were placeholders; nothing on the rendered page did.
+ *
+ * A reputational claim about a real organisation, carrying a methodology that says it was measured,
+ * is the one thing this project must never publish. An honest blank costs a reader a refresh.
+ *
+ * The constants are left in the file, unused and clearly marked, because they document what was
+ * served and for how long. They must not be wired back in without real figures behind them.
+ */
 function buildSnapshotData() {
   const topScores: FoundationScore[] = [
     { foundation_id: 'snapshot-prf', name: 'Paul Ramsay Foundation', acnc_abn: '', total_giving_annual: 210_000_000, type: 'foundation', parent_company: null, transparency_score: 82, need_alignment_score: 78, evidence_score: 76, concentration_score: 68, foundation_score: 78, grantee_count: 240, lgas_funded: 58, avg_desert_score: 6.8, community_controlled_grantees: 18, evidence_backed_orgs: 42, interventions_funded: 31, states_funded: 8, unique_lgas: 58, total_trustees: 9, overlapping_trustees: 1, overlap_instances: 1 },
@@ -138,7 +159,8 @@ function buildSnapshotData() {
 
 async function getData() {
   if (!LIVE_REPORTS) {
-    return buildSnapshotData();
+    // See the note above buildSnapshotData. Serving nothing beats serving invented figures.
+    return null;
   }
 
   const supabase = getServiceSupabase();
@@ -227,6 +249,9 @@ async function getData() {
 
 export default async function PhilanthropyReport() {
   const d = await getData();
+  if (!d) {
+    return <ReportUnavailable title="Foundation Intelligence" detail="Foundation scores are not available. This page previously showed placeholder figures for named foundations and no longer does." />;
+  }
   const s = d.stats;
 
   // Group revolving door by foundation


### PR DESCRIPTION
**Verified live on production before writing this.** Recommend merging tonight.

## What is public right now

`civicgraph.app/reports/philanthropy` — titled **"Foundation Intelligence"** — serves:

- **Paul Ramsay Foundation**, ranked #1, "240 grantees", **$210.0M**
- **Minderoo Foundation**, ranked #2, "180 grantees", **$268.0M**
- Both under the heading **"Largest Foundations With Zero Transparency"**
- A table attributing programs to them: "Justice Evidence Partner", "Community-led diversion", "promising"
- *"Of 2,466 scored, only 252+ have any publicly traceable grantee data"*
- A **Methodology** section: *"Transparency score (25% weight): Based on the number of publicly identifiable grantees. 5 points per grantee, capped at 100…"*

**None of it was computed.** `CIVICGRAPH_LIVE_REPORTS` is not `'true'` in production, so `getData()` returned `buildSnapshotData()` — hand-authored constants with `foundation_id: 'snapshot-prf'` and `acnc_abn: ''`. The author knew they were placeholders. Nothing on the rendered page did.

A reputational claim about a real organisation, carrying a methodology that says it was measured, is the one thing this project must not publish. These are also the two foundations named as approach targets in current strategy conversations.

## The same shape, lower stakes

`/reports/funding-equity` renders constants (4300, 5100, $8.9bn, avg_staff_fte 7) under *"We matched each charity's registered postcode to its decile and summed their financial data"*, citing ACNC AIS and ABS Census 2021.

Computing that directly:

| IRSD decile | page shows | direct computation |
|---|---|---|
| 1 | 4,300 | 4,573 |
| 2 | 5,100 | **4,107** |
| 3 | 5,600 | 4,993 |

Decile 2 is out by ~24% and the errors run in **both** directions, so this is not a stale snapshot that drifted.

## The change

Both pages return the `ReportUnavailable` state from #331 when not live, instead of fabricated figures.

The constants stay in both files, **unused and clearly marked**, because they document what was served and for how long. The comment says they must not be wired back in without real figures behind them.

## Deliberately not changed

`/reports/youth-justice` substitutes snapshot data too — but **its figures are real.** "Lifeline Community Care, 3 grants, $30,136,777" matches the database exactly, as does Relationships Australia (Qld) at $25,524,918. That page needs **dating and labelling**, not removal, and it is a separate change with a different fix.

Gates: `./scripts/precheck.sh` — tsc clean, 730 vitest.

**VISIBLE, and it names real organisations — this one should be yours to merge.**