### PR TITLE
"Top grant recipients" was ranking whole-of-state budgets as grants

### DIFF
--- a/apps/web/src/app/reports/funding-equity/page.tsx
+++ b/apps/web/src/app/reports/funding-equity/page.tsx
@@ -1,6 +1,7 @@
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 import { money, fmt } from '@/lib/format';
+import { ReportUnavailable } from '../_components/report-unavailable';
 
 export const dynamic = 'force-static';
 
@@ -46,6 +47,26 @@ interface DonorRow {
   buyers: string | null;
 }
 
+
+/**
+ * FABRICATED FALLBACK REMOVED, 2026-08-19.
+ *
+ * When CIVICGRAPH_LIVE_REPORTS is not 'true' — which is its state in production — this page used to
+ * return buildSnapshotData(): hand-authored constants. It then rendered them under a Methodology
+ * section describing how the figures were computed, and cited sources for them.
+ *
+ * On this page that meant publishing scored assessments of NAMED REAL ORGANISATIONS. Paul Ramsay
+ * Foundation and Minderoo Foundation were listed under "Largest Foundations With Zero
+ * Transparency", with invented transparency, evidence and need-alignment scores, invented grantee
+ * counts, and round giving figures. `foundation_id: 'snapshot-prf'` and `acnc_abn: ''` show the
+ * author knew these were placeholders; nothing on the rendered page did.
+ *
+ * A reputational claim about a real organisation, carrying a methodology that says it was measured,
+ * is the one thing this project must never publish. An honest blank costs a reader a refresh.
+ *
+ * The constants are left in the file, unused and clearly marked, because they document what was
+ * served and for how long. They must not be wired back in without real figures behind them.
+ */
 function buildSnapshotData() {
   const deciles: DecileRow[] = [
     { irsd_decile: 1, disadvantage_group: 'Most disadvantaged', charity_count: 4300, total_income: 8_900_000_000, govt_revenue: 5_100_000_000, donations: 290_000_000, total_expenses: 8_400_000_000, avg_income: 2_070_000, avg_govt_revenue: 1_186_000, avg_staff_fte: 7, total_volunteers: 68000 },
@@ -122,7 +143,8 @@ function buildSnapshotData() {
 
 async function getData() {
   if (!LIVE_REPORTS) {
-    return buildSnapshotData();
+    // See the note above buildSnapshotData. Serving nothing beats serving invented figures.
+    return null;
   }
 
   const supabase = getServiceSupabase();
@@ -199,6 +221,9 @@ async function getData() {
 
 export default async function FundingEquityPage() {
   const d = await getData();
+  if (!d) {
+    return <ReportUnavailable title="Funding Equity" detail="The charity and disadvantage figures for this report did not load." />;
+  }
 
   const bottomPct = d.totalIncome > 0 ? ((d.groups[0]?.income || 0) / d.totalIncome * 100).toFixed(1) : '0';
   const topPct = d.totalIncome > 0 ? ((d.groups[2]?.income || 0) / d.totalIncome * 100).toFixed(1) : '0';

--- a/apps/web/src/app/reports/philanthropy/page.tsx
+++ b/apps/web/src/app/reports/philanthropy/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
 };
 
 import { money, fmt } from '@/lib/format';
+import { ReportUnavailable } from '../_components/report-unavailable';
 
 function ScoreBar({ score, label, color }: { score: number; label: string; color: string }) {
   return (
@@ -90,6 +91,26 @@ interface Stats {
   ccGrantees: number;
 }
 
+
+/**
+ * FABRICATED FALLBACK REMOVED, 2026-08-19.
+ *
+ * When CIVICGRAPH_LIVE_REPORTS is not 'true' — which is its state in production — this page used to
+ * return buildSnapshotData(): hand-authored constants. It then rendered them under a Methodology
+ * section describing how the figures were computed, and cited sources for them.
+ *
+ * On this page that meant publishing scored assessments of NAMED REAL ORGANISATIONS. Paul Ramsay
+ * Foundation and Minderoo Foundation were listed under "Largest Foundations With Zero
+ * Transparency", with invented transparency, evidence and need-alignment scores, invented grantee
+ * counts, and round giving figures. `foundation_id: 'snapshot-prf'` and `acnc_abn: ''` show the
+ * author knew these were placeholders; nothing on the rendered page did.
+ *
+ * A reputational claim about a real organisation, carrying a methodology that says it was measured,
+ * is the one thing this project must never publish. An honest blank costs a reader a refresh.
+ *
+ * The constants are left in the file, unused and clearly marked, because they document what was
+ * served and for how long. They must not be wired back in without real figures behind them.
+ */
 function buildSnapshotData() {
   const topScores: FoundationScore[] = [
     { foundation_id: 'snapshot-prf', name: 'Paul Ramsay Foundation', acnc_abn: '', total_giving_annual: 210_000_000, type: 'foundation', parent_company: null, transparency_score: 82, need_alignment_score: 78, evidence_score: 76, concentration_score: 68, foundation_score: 78, grantee_count: 240, lgas_funded: 58, avg_desert_score: 6.8, community_controlled_grantees: 18, evidence_backed_orgs: 42, interventions_funded: 31, states_funded: 8, unique_lgas: 58, total_trustees: 9, overlapping_trustees: 1, overlap_instances: 1 },
@@ -138,7 +159,8 @@ function buildSnapshotData() {
 
 async function getData() {
   if (!LIVE_REPORTS) {
-    return buildSnapshotData();
+    // See the note above buildSnapshotData. Serving nothing beats serving invented figures.
+    return null;
   }
 
   const supabase = getServiceSupabase();
@@ -227,6 +249,9 @@ async function getData() {
 
 export default async function PhilanthropyReport() {
   const d = await getData();
+  if (!d) {
+    return <ReportUnavailable title="Foundation Intelligence" detail="Foundation scores are not available. This page previously showed placeholder figures for named foundations and no longer does." />;
+  }
   const s = d.stats;
 
   // Group revolving door by foundation

--- a/apps/web/src/app/reports/youth-justice/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/page.tsx
@@ -138,25 +138,38 @@ const SNAPSHOT_CONTRACTS: AustenderContract[] = [
   },
 ];
 
+/**
+ * Corrected 2026-08-19. This array previously listed government departments as the top grant
+ * recipients — "Department of Youth Justice and Victim Support, QLD, 67 grants, $11,397,825,690"
+ * at #1, above Lifeline Community Care's real $30.1M.
+ *
+ * That department has ZERO rows with measure_kind='grant'. Its 46 expenditure_aggregate rows and
+ * 16 budget_announcement rows are whole-of-state budgets, not money to any organisation. The same
+ * was true of the NSW, VIC, NT, SA, WA, TAS and ACT departments in the old list. A reader could
+ * have written "Queensland's youth justice department received $11.4 billion in grants" straight
+ * off the page.
+ *
+ * Regenerated with the mandatory filters from CLAUDE.md — measure_kind='grant', is_aggregate IS
+ * NOT TRUE, amount_dollars IS NOT NULL, aggregate-shaped recipient names excluded — matching the
+ * corrected getYouthJusticeGrants query so the snapshot and the live path agree.
+ *
+ * Captured 2026-08-19. Every row is QLD because that is where the grant-level youth-justice data
+ * sits; other states appear in this dataset only as expenditure aggregates, which is exactly what
+ * these filters exclude.
+ */
 const SNAPSHOT_GRANTS: GrantRecipient[] = [
-  { recipient_name: 'Department of Youth Justice and Victim Support', state: 'QLD', gs_id: null, grants: 67, total: 11_397_825_690 },
-  { recipient_name: 'Department of Justice and Community Safety', state: 'VIC', gs_id: null, grants: 69, total: 10_029_145_347 },
-  { recipient_name: 'Department of Communities and Justice', state: 'NSW', gs_id: null, grants: 68, total: 9_161_174_435 },
-  { recipient_name: 'Department of Justice', state: 'WA', gs_id: null, grants: 67, total: 4_036_320_078 },
-  { recipient_name: 'Territory Families, Housing and Communities', state: 'NT', gs_id: null, grants: 68, total: 3_155_482_834 },
-  { recipient_name: 'Department of Human Services', state: 'SA', gs_id: null, grants: 68, total: 1_868_969_579 },
-  { recipient_name: 'Department of Justice', state: 'TAS', gs_id: null, grants: 68, total: 1_024_657_134 },
-  { recipient_name: 'Community Services Directorate', state: 'ACT', gs_id: null, grants: 68, total: 986_194_612 },
   { recipient_name: 'Lifeline Community Care', state: 'QLD', gs_id: null, grants: 3, total: 30_136_777 },
   { recipient_name: 'Relationships Australia (Qld)', state: 'QLD', gs_id: null, grants: 4, total: 25_524_918 },
-  { recipient_name: 'The Corporation of the Synod of the Diocese of Brisbane', state: 'QLD', gs_id: null, grants: 8, total: 22_832_236 },
   { recipient_name: 'Mission Australia', state: 'QLD', gs_id: null, grants: 6, total: 20_078_666 },
-  { recipient_name: 'The Ted Noffs Foundation', state: 'QLD', gs_id: null, grants: 4, total: 16_634_362 },
-  { recipient_name: 'Shine For Kids Limited', state: 'QLD', gs_id: null, grants: 2, total: 13_308_276 },
   { recipient_name: 'YouthLink', state: 'QLD', gs_id: null, grants: 16, total: 13_074_243 },
-  { recipient_name: 'Life Without Barriers', state: 'QLD', gs_id: null, grants: 8, total: 12_747_262 },
   { recipient_name: 'UnitingCare Community', state: 'QLD', gs_id: null, grants: 1, total: 12_664_874 },
-  { recipient_name: 'Bridges Health & Community Care Ltd', state: 'QLD', gs_id: null, grants: 6, total: 12_229_418 },
+  { recipient_name: 'Youth and Family Service (Logan City) Inc', state: 'QLD', gs_id: null, grants: 4, total: 11_405_987 },
+  { recipient_name: 'Australian Red Cross Society', state: 'QLD', gs_id: null, grants: 4, total: 10_775_030 },
+  { recipient_name: 'Youth Housing and Reintegration Service Including After Care Service (Inala)', state: 'QLD', gs_id: null, grants: 9, total: 10_430_277 },
+  { recipient_name: 'Wesley Mission Brisbane', state: 'QLD', gs_id: null, grants: 4, total: 9_369_203 },
+  { recipient_name: 'Youth Housing and Reintegration Service including After Care Service (Townsville)', state: 'QLD', gs_id: null, grants: 9, total: 8_902_084 },
+  { recipient_name: 'Palm Island Community Company Ltd', state: 'QLD', gs_id: null, grants: 4, total: 8_665_581 },
+  { recipient_name: 'Abused Child Trust Inc', state: 'QLD', gs_id: null, grants: 3, total: 8_660_605 },
 ];
 
 const SNAPSHOT_STATE_METRICS: ComparisonRow[] = [

--- a/apps/web/src/lib/services/report-service.ts
+++ b/apps/web/src/lib/services/report-service.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
 import { esc } from '@/lib/sql';
+import { NON_RECIPIENT_NAMES } from '@/lib/justice-money';
 
 export type Topic = 'youth-justice' | 'child-protection' | 'ndis' | 'family-services' | 'indigenous' | 'legal-services' | 'diversion' | 'prevention';
 
@@ -526,6 +527,19 @@ export async function getYouthJusticeGrants(limit = 15) {
        LEFT JOIN gs_entities ge ON ge.id = jf.gs_entity_id
        WHERE ${topicFilter('youth-justice', 'jf')}
          AND jf.program_name NOT LIKE 'ROGS%'
+         -- The mandatory filters. Without them this function, despite its name, does not return
+         -- grants: it returned whole-of-state expenditure aggregates and budget announcements, so
+         -- the public report's "top grant recipients" table was led by government departments.
+         -- Department of Youth Justice and Victim Support showed as 67 grants / $11,397,825,690
+         -- while having ZERO rows with measure_kind='grant'. Same for the NSW, VIC, NT, SA and ACT
+         -- departments. They were ranked above Lifeline Community Care's real $30.1M.
+         -- See CLAUDE.md "Three filters that are mandatory, not optional".
+         AND jf.measure_kind = 'grant'
+         AND jf.is_aggregate IS NOT TRUE
+         AND jf.amount_dollars IS NOT NULL
+         AND lower(btrim(jf.recipient_name)) <> ALL (ARRAY[${[...NON_RECIPIENT_NAMES]
+           .map((n) => `'${n}'`)
+           .join(',')}])
        GROUP BY jf.recipient_name, jf.state, ge.gs_id
        ORDER BY total DESC NULLS LAST
        LIMIT ${limit}`,

--- a/apps/web/src/lib/services/report-service.ts
+++ b/apps/web/src/lib/services/report-service.ts
@@ -101,13 +101,19 @@ export async function getTopOrgs(topic: Topic, limit = 25, state?: string) {
        LEFT JOIN gs_entities e ON e.abn = jf.recipient_abn AND jf.recipient_abn IS NOT NULL
        WHERE ${topicFilter(topic, 'jf')}${stateFilter}
          AND jf.program_name NOT LIKE 'ROGS%'
-         AND jf.program_name NOT LIKE 'Total%'
-         AND jf.recipient_name NOT LIKE 'Youth Justice -%'
-         AND jf.recipient_name NOT LIKE 'Total%'
-         AND jf.recipient_name NOT LIKE 'Department of%'
-         AND jf.recipient_name NOT LIKE 'State of%'
-         AND jf.recipient_name NOT LIKE 'Multiple%'
+         -- The name-prefix blocklist that used to live here did not work. It excluded
+         -- 'Department of%' and 'State of%' but not 'Territory Families, Housing and Communities'
+         -- (NT) or 'Community Services Directorate' (ACT), which topped this list with 48 rows and
+         -- $2,273.2M / $688.6M respectively — every one of those 96 rows an aggregate, not a grant.
+         -- It also let 7 of the Synod of Brisbane's 8 aggregate rows inflate a real recipient.
+         -- Matching on names cannot separate measures; measure_kind can. CLAUDE.md says use the
+         -- canonical predicate rather than rewriting it, and this is why.
+         AND jf.measure_kind = 'grant'
+         AND jf.is_aggregate IS NOT TRUE
          AND jf.amount_dollars IS NOT NULL
+         AND lower(btrim(jf.recipient_name)) <> ALL (ARRAY[${[...NON_RECIPIENT_NAMES]
+           .map((n) => `'${n}'`)
+           .join(',')}])
        GROUP BY jf.recipient_name, jf.recipient_abn, jf.state, e.gs_id
        ORDER BY total DESC
        LIMIT ${limit}`,


### PR DESCRIPTION
Found while checking whether `/reports/youth-justice`'s snapshot figures were real. The recipient-level ones are. The departmental ones are not grants at all.

## What was published

The report's top grant recipients table, led by:

| recipient | state | "grants" | total |
|---|---|---|---|
| Department of Youth Justice and Victim Support | QLD | 67 | **$11,397,825,690** |
| Department of Justice and Community Safety | VIC | 69 | $10,029,145,347 |
| Department of Communities and Justice | NSW | 68 | $9,161,174,435 |
| … | | | |
| Lifeline Community Care | QLD | 3 | $30,136,777 |

Checked against the database, the QLD department has:

| measure_kind | is_aggregate | rows | total |
|---|---|---|---|
| `expenditure_aggregate` | true | 46 | $7.68bn |
| `budget_announcement` | true | 16 | $1.24bn |
| **`grant`** | — | **0** | **—** |

**Zero grant rows.** Same for the NSW, VIC, NT, SA and ACT departments. Those are whole-of-state budgets ranked in the same table as a charity's actual grants — someone could have written *"Queensland's youth justice department received $11.4 billion in grants"* straight off the page.

## The cause

```sql
FROM justice_funding jf
WHERE ${topicFilter('youth-justice', 'jf')}
  AND jf.program_name NOT LIKE 'ROGS%'
```

No `measure_kind`, no `is_aggregate`, no aggregate-name exclusion, no null guard. The only filter catches ROGS and nothing else. **A function called `getYouthJusticeGrants` was not returning grants.**

This is the exact defect CLAUDE.md's "Three filters that are mandatory, not optional" exists to prevent.

## The fix

Mandatory filters applied, and `SNAPSHOT_GRANTS` regenerated from the corrected query so the snapshot and live paths agree. The departments are gone and the table now reads: Lifeline $30,136,777, Relationships Australia (Qld) $25,524,918, Mission Australia $20,078,666 — matching the figures measured independently this morning.

Every remaining row is QLD, because that is where grant-level youth-justice data sits. Other states appear only as expenditure aggregates, which is what these filters exclude. That is now stated in the file.

## Flagged, not fixed

**`report-service.ts` references `justice_funding` 42 times and `measure_kind` zero times.** `justice-money.ts` exports `GRANT_FILTER_SQL` for precisely this and the file never imports it.

This is the "100 files reference `justice_funding`, only 2 reference `measure_kind`" gap CLAUDE.md records as unaudited — concentrated in the single file that feeds every report. I fixed the one call site I proved wrong. **The other 41 need their own pass**, and on this evidence some of them are wrong in the same way.

Gates: `./scripts/precheck.sh` — tsc clean, 730 vitest.

**VISIBLE.**