### PR TITLE
Seven states' recipient tables were vanishing instead of saying why

### DIFF
--- a/apps/web/src/app/reports/_components/no-grant-level-data.tsx
+++ b/apps/web/src/app/reports/_components/no-grant-level-data.tsx
@@ -1,0 +1,104 @@
+import { money } from '@/lib/services/report-service';
+
+export interface LaneRow {
+  measure_kind: string;
+  rows: number;
+  dollars: number | null;
+  sources: number;
+  from_fy: string | null;
+  to_fy: string | null;
+}
+
+/**
+ * What a jurisdiction's recipient table renders when the jurisdiction publishes no grant-level data.
+ *
+ * Not the same thing as `ReportUnavailable`, which means "the query failed". This means "the query
+ * succeeded and the answer is that nobody publishes this". The distinction is the whole point: a
+ * hidden section reads as an oversight, an empty table reads as zero dollars, and neither is what
+ * happened. Seven of the eight states publish only system expenditure for youth justice.
+ *
+ * The lane figures are queried live rather than written into the copy, because a hand-typed figure
+ * in a paragraph about data honesty is the exact thing that rots first.
+ */
+/** Singular and plural, because a jurisdiction with exactly one row is common here. */
+const LANE_LABELS: Record<string, [singular: string, plural: string]> = {
+  grant: ['grant row naming a recipient organisation', 'grant rows naming a recipient organisation'],
+  expenditure_aggregate: ['whole-of-system expenditure row', 'whole-of-system expenditure rows'],
+  budget_announcement: ['budget announcement', 'budget announcements'],
+  contract_value: ['contract', 'contracts'],
+};
+
+function describeLane(l: LaneRow): string {
+  const pair = LANE_LABELS[l.measure_kind];
+  const fallback = l.measure_kind.replace(/_/g, ' ');
+  const label = pair ? (l.rows === 1 ? pair[0] : pair[1]) : fallback;
+  const span = l.from_fy && l.to_fy && l.from_fy !== l.to_fy ? `, ${l.from_fy} to ${l.to_fy}` : '';
+  const amount = l.dollars ? ` worth ${money(l.dollars)}` : '';
+  return `${l.rows.toLocaleString()} ${label}${amount}${span}`;
+}
+
+export function NoGrantLevelData({
+  jurisdiction,
+  topicLabel,
+  lanes,
+}: {
+  jurisdiction: string;
+  topicLabel: string;
+  lanes: LaneRow[];
+}) {
+  const grantLane = lanes.find((l) => l.measure_kind === 'grant');
+  const otherLanes = lanes.filter((l) => l.measure_kind !== 'grant' && l.rows > 0);
+
+  return (
+    <div className="border-4 border-bauhaus-black bg-bauhaus-canvas p-6">
+      <p className="text-xs font-black uppercase tracking-widest text-bauhaus-red">
+        Not published
+      </p>
+      <h3 className="mt-3 text-xl font-black text-bauhaus-black">
+        {jurisdiction} does not publish {topicLabel} funding at the level of individual recipients
+      </h3>
+      <p className="mt-4 text-sm leading-relaxed text-bauhaus-muted">
+        {grantLane && grantLane.rows > 0 ? (
+          <>
+            We hold {grantLane.rows.toLocaleString()} grant-level {topicLabel}{' '}
+            {grantLane.rows === 1 ? 'row' : 'rows'} for {jurisdiction}
+            {grantLane.dollars
+              ? ` carrying ${money(grantLane.dollars)}`
+              : grantLane.rows === 1
+                ? ', and it carries no amount'
+                : ', none of which carry an amount'}
+            . That is too thin to rank recipients from, so this table is empty rather than
+            misleading.
+          </>
+        ) : (
+          <>
+            There are no grant-level {topicLabel} records for {jurisdiction} in this database. This
+            table is empty because the data does not exist, not because the money is zero.
+          </>
+        )}
+      </p>
+      {otherLanes.length > 0 && (
+        <>
+          <p className="mt-4 text-sm leading-relaxed text-bauhaus-muted">
+            What {jurisdiction} does publish for {topicLabel}:
+          </p>
+          <ul className="mt-2 space-y-1 text-sm text-bauhaus-black">
+            {otherLanes.map((l) => (
+              <li key={l.measure_kind} className="flex gap-2">
+                <span aria-hidden className="font-black text-bauhaus-blue">
+                  ·
+                </span>
+                <span>{describeLane(l)}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-4 text-sm leading-relaxed text-bauhaus-muted">
+            Those are system totals — what the state spent running youth justice, not money
+            traceable to any organisation. They are counted separately on this page and are never
+            added to grant figures, because they measure a different thing.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/reports/youth-justice/[state]/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/[state]/page.tsx
@@ -6,10 +6,12 @@ import path from 'path';
 import { parse } from 'csv-parse/sync';
 import { FundingByProgramChart, StateComparisonChart, LgaFundingChart } from '../../_components/report-charts';
 import { qldAnnouncementHrefForProgram } from '@/lib/reports/qld-youth-justice-announcements';
+import { NoGrantLevelData, type LaneRow } from '../../_components/no-grant-level-data';
 import {
   getFundingByProgram,
   getProgramsWithPartners,
   getTopOrgs,
+  getGrantLaneCoverage,
   getAlmaInterventions,
   getAlmaCount,
   getFundingByLga,
@@ -632,6 +634,7 @@ async function getStateReport(stateCode: string) {
     outcomes,
     comparison,
     rogsExpenditure,
+    laneCoverage,
   ] = await Promise.all([
     getFundingByProgram('youth-justice', stateCode),
     getTopOrgs('youth-justice', 50, stateCode),
@@ -653,6 +656,7 @@ async function getStateReport(stateCode: string) {
       'pct_unsentenced', 'detention_5yr_trend_pct', 'cost_per_day_detention',
     ]),
     getRogsExpenditure(stateCode),
+    getGrantLaneCoverage('youth-justice', stateCode),
   ]);
 
   const stateFundingSnapshot = loadStateFundingSnapshot(stateCode);
@@ -707,6 +711,7 @@ async function getStateReport(stateCode: string) {
   return {
     programs: programRows,
     topOrgs: finalTopOrgs,
+    laneCoverage: (laneCoverage as LaneRow[] | null) || [],
     programPartners: finalProgramPartners,
     partnersByProgram,
     almaInterventions: (almaInterventions as AlmaRow[] | null) || [],
@@ -1441,6 +1446,19 @@ export default async function StateYouthJusticePage({ params }: { params: Promis
       )}
 
       {/* Top Funded Organisations */}
+      {report.topOrgs.length === 0 && report.laneCoverage.length > 0 && (
+        <section className="mb-12">
+          <h2 className="text-xl font-black text-bauhaus-black uppercase tracking-wider mb-4 border-b-4 border-bauhaus-black pb-2">
+            Top Funded Organisations
+          </h2>
+          <NoGrantLevelData
+            jurisdiction={meta.name}
+            topicLabel="youth justice"
+            lanes={report.laneCoverage}
+          />
+        </section>
+      )}
+
       {report.topOrgs.length > 0 && (
         <section className="mb-12">
           <h2 className="text-xl font-black text-bauhaus-black uppercase tracking-wider mb-4 border-b-4 border-bauhaus-black pb-2">

--- a/apps/web/src/app/reports/youth-justice/[state]/tracker/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/[state]/tracker/page.tsx
@@ -1202,7 +1202,7 @@ export default async function StateTrackerPage({ params }: { params: Promise<{ s
 
           {!hasOrgs ? (
             <NoGrantLevelData
-              jurisdiction={abbr}
+              jurisdiction={meta.name}
               topicLabel="youth justice"
               lanes={data.laneCoverage}
             />

--- a/apps/web/src/app/reports/youth-justice/[state]/tracker/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/[state]/tracker/page.tsx
@@ -1,10 +1,12 @@
 import { Fragment } from 'react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { NoGrantLevelData, type LaneRow } from '../../../_components/no-grant-level-data';
 import {
   getBudgetCommitments,
   getBudgetTotals,
   getTopOrgs,
+  getGrantLaneCoverage,
   getProgramsWithPartners,
   getTrackerLeadership,
   getTrackerInterlocks,
@@ -94,7 +96,7 @@ async function getTrackerData(abbr: string) {
     leadership, interlocks, donations, lgaFunding,
     evidenceCoverage, almaInterventions, almaCount,
     hansard, lobbying, revolvingDoor,
-    outcomes, comparison, ctgTrend, policyTimeline, oversight,
+    outcomes, comparison, ctgTrend, policyTimeline, oversight, laneCoverage,
   ] = await Promise.all([
     getBudgetCommitments(abbr),
     getBudgetTotals(abbr),
@@ -115,6 +117,7 @@ async function getTrackerData(abbr: string) {
     getCtgTrend(abbr),
     getPolicyTimeline(abbr),
     getOversightData(abbr),
+    getGrantLaneCoverage('youth-justice', abbr),
   ]);
 
   // Fetch time series data sequentially after main queries complete
@@ -136,6 +139,7 @@ async function getTrackerData(abbr: string) {
     budgetCommitments: (budgetCommitments as BudgetRow[] | null) || [],
     budgetTotals: (budgetTotals as BudgetTotal[] | null) || [],
     topOrgs: (topOrgs as OrgRow[] | null) || [],
+    laneCoverage: (laneCoverage as LaneRow[] | null) || [],
     partnersByProgram,
     leadership: (leadership as LeaderRow[] | null) || [],
     interlocks: (interlocks as InterlockRow[] | null) || [],
@@ -1187,14 +1191,22 @@ export default async function StateTrackerPage({ params }: { params: Promise<{ s
         </section>
       )}
 
-      {/* Who Gets the Money */}
-      {hasOrgs && (
+      {/* Who Gets the Money — renders even with no recipients, because a jurisdiction that
+          publishes no grant-level data is a finding, not an empty slot. */}
+      {(hasOrgs || data.laneCoverage.length > 0) && (
         <section className="mb-12">
           <h2 className="text-xl font-black text-bauhaus-black uppercase tracking-wider mb-2 border-b-4 border-bauhaus-black pb-2">
             {++sectionNum}. Who Gets the Money
           </h2>
           <p className="text-sm text-bauhaus-muted mb-4">Top funded organisations across all {abbr} youth justice programs.</p>
 
+          {!hasOrgs ? (
+            <NoGrantLevelData
+              jurisdiction={abbr}
+              topicLabel="youth justice"
+              lanes={data.laneCoverage}
+            />
+          ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -1221,6 +1233,7 @@ export default async function StateTrackerPage({ params }: { params: Promise<{ s
               </tbody>
             </table>
           </div>
+          )}
         </section>
       )}
 

--- a/apps/web/src/lib/services/report-service.ts
+++ b/apps/web/src/lib/services/report-service.ts
@@ -494,6 +494,43 @@ export async function getEntityEvidencePrograms(db: SupabaseClient, entityId: st
   return rows ?? [];
 }
 
+/**
+ * What measurement lanes a jurisdiction actually publishes for a topic.
+ *
+ * Exists because of what `grantTopicFilter` does to the state pages. Seven of the eight states
+ * publish NO grant-level youth justice data at all — what they publish is ROGS system expenditure.
+ * Before this, those pages hid the "top recipients" section when the query came back empty, and a
+ * hidden section is indistinguishable from a section we never looked at.
+ *
+ * So: instead of a silent gap, ask the database what the jurisdiction DOES have and say it. This
+ * deliberately applies NO measure filter — describing the lanes is the entire point.
+ */
+export async function getGrantLaneCoverage(topic: Topic, state?: string) {
+  assertTopic(topic);
+  const supabase = getServiceSupabase();
+  const stateFilter = state ? ` AND state = '${assertState(state)}'` : '';
+  return safe(supabase.rpc('exec_sql', {
+    query: `SELECT measure_kind,
+              COUNT(*)::int as rows,
+              SUM(amount_dollars)::bigint as dollars,
+              COUNT(DISTINCT source)::int as sources,
+              MIN(financial_year) as from_fy,
+              MAX(financial_year) as to_fy
+       FROM justice_funding
+       WHERE topics @> ARRAY['${topic}']::text[]
+         AND source NOT IN ('austender-direct')${stateFilter}
+       GROUP BY measure_kind
+       ORDER BY rows DESC`,
+  }), 'getGrantLaneCoverage') as Promise<Array<{
+    measure_kind: string;
+    rows: number;
+    dollars: number | null;
+    sources: number;
+    from_fy: string | null;
+    to_fy: string | null;
+  }> | null>;
+}
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // THE EXPENDITURE LANE — deliberately NOT grant-filtered
 //


### PR DESCRIPTION
Follow-on to #337. **VISIBLE — please eyeball the preview before merging.**

## The problem

After the grant-lane fix, `/reports/youth-justice/[state]` and `[state]/tracker` render no "Top Funded Organisations" / "Who Gets the Money" table for **NSW, VIC, WA, TAS, NT and ACT**. Both sections were wrapped in `{topOrgs.length > 0 && ...}`, so they silently disappeared.

A hidden section is indistinguishable from a section nobody thought to build. Per CLAUDE.md, a confident zero (or a confident absence) reads as a measurement.

## It is not an ingest gap

Those states publish no grant-level youth justice data at all. Measured 2026-08-20:

| state | grant rows (with $) | what they do publish |
|---|---|---|
| QLD | 4,073 — $916m | plus ROGS |
| NSW | 0 (7 rows, no amounts) | 46 ROGS/AIHW expenditure rows, $6.2bn · 2 budget announcements, $121m |
| VIC | 0 (4 rows, no amounts) | 46 rows, $6.8bn · 3 budget announcements |
| WA | 0 (1 row, no amount) | 46 rows, $2.9bn · 1 budget announcement |
| NT / TAS / ACT | 0 | 46 rows each · budget announcements |
| SA | 9 — ~$0.1m | 46 rows, $1.2bn |

Queensland is the only jurisdiction publishing money at the level of a named recipient.

## The change

The section now renders **either** the table **or** `<NoGrantLevelData>`, which states what the jurisdiction actually publishes. Lane figures come from a live query (`getGrantLaneCoverage`), not from copy — a hand-typed number inside a paragraph about data honesty is the thing that rots first.

NSW currently reads:

> **Not published.** New South Wales does not publish youth justice funding at the level of individual recipients.
> We hold 7 grant-level youth justice rows for New South Wales, none of which carry an amount. That is too thin to rank recipients from, so this table is empty rather than misleading.
> What New South Wales does publish for youth justice: · 46 whole-of-system expenditure rows worth $6.2B, 2015-16 to 2024-25 · 2 budget announcements worth $121.4M
> Those are system totals — what the state spent running youth justice, not money traceable to any organisation. They are counted separately on this page and are never added to grant figures, because they measure a different thing.

`getGrantLaneCoverage` deliberately applies **no** measure filter — describing the lanes is the point, and filtering them would defeat it.

Distinct from `ReportUnavailable`, which means the query failed. This means the query succeeded and the answer is that nobody publishes it.

## Verified

- `./scripts/precheck.sh` green (tsc + 736 tests).
- Rendered locally on 3013 with `CIVICGRAPH_LIVE_REPORTS=true` for **nsw, vic, wa, tas, nt, act** on both the state page and the tracker. SA still shows its 9-row table (correct — it has data). QLD 307-redirects to its own hand-built page and is untouched.
- Singular/plural checked against WA, which has exactly one row in two lanes.

## Preview routes worth opening

- `/reports/youth-justice/nsw` and `/reports/youth-justice/nsw/tracker`
- `/reports/youth-justice/sa` (should still show a table, not the notice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)