### PR TITLE
A trailing newline has been blanking 61 public report pages since April

### DIFF
--- a/apps/web/src/app/reports/donor-contractors/page.tsx
+++ b/apps/web/src/app/reports/donor-contractors/page.tsx
@@ -56,7 +56,20 @@ async function getData() {
     supabase.from('gs_relationships').select('*', { count: 'exact', head: true }).eq('relationship_type', 'contract'),
   ]);
 
-  const all = (donorContractors || []) as DonorContractor[];
+  // Postgres array columns come back NULL, not empty, when a row has no values — 3 of the 2,065
+  // rows in mv_gs_donor_contractors have a NULL contract_years. Fourteen sites below iterate or
+  // read `.length` on these four fields, so one NULL crashed the whole page with
+  // "dc.contract_years is not iterable". Normalise once here rather than guarding fourteen times.
+  //
+  // This was invisible until 2026-08-20 because the page was reading the empty-result client and
+  // never had a row to trip on. Turning live reports on is what surfaced it.
+  const all = ((donorContractors || []) as DonorContractor[]).map((dc) => ({
+    ...dc,
+    parties_donated_to: dc.parties_donated_to ?? [],
+    government_buyers: dc.government_buyers ?? [],
+    donation_years: dc.donation_years ?? [],
+    contract_years: dc.contract_years ?? [],
+  }));
 
   // Aggregate stats
   let sumDonated = 0, sumContracts = 0, totalDonationRecords = 0, totalContractRecords = 0;

--- a/apps/web/src/app/reports/funding-equity/page.tsx
+++ b/apps/web/src/app/reports/funding-equity/page.tsx
@@ -1,11 +1,14 @@
 import { getServiceSupabase } from '@/lib/report-supabase';
+import { liveReportsEnabled } from '@/lib/report-supabase';
 import { ReportCTA } from '../_components/report-cta';
 import { money, fmt } from '@/lib/format';
 import { ReportUnavailable } from '../_components/report-unavailable';
 
 export const dynamic = 'force-static';
 
-const LIVE_REPORTS = process.env.CIVICGRAPH_LIVE_REPORTS === 'true';
+// Via the helper, not a private `=== 'true'`: production's value has a trailing newline and the
+// strict form silently disabled this page. See lib/report-supabase.ts.
+const LIVE_REPORTS = liveReportsEnabled();
 
 function pct(n: number, d: number) { return d > 0 ? `${((n / d) * 100).toFixed(1)}%` : '0%'; }
 
@@ -51,7 +54,8 @@ interface DonorRow {
 /**
  * FABRICATED FALLBACK REMOVED, 2026-08-19.
  *
- * When CIVICGRAPH_LIVE_REPORTS is not 'true' — which is its state in production — this page used to
+ * When live reports are off — which was production's effective state until the flag's trailing
+ * newline was found on 2026-08-20 — this page used to
  * return buildSnapshotData(): hand-authored constants. It then rendered them under a Methodology
  * section describing how the figures were computed, and cited sources for them.
  *

--- a/apps/web/src/app/reports/philanthropy/page.tsx
+++ b/apps/web/src/app/reports/philanthropy/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
+import { liveReportsEnabled } from '@/lib/report-supabase';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import Link from 'next/link';
 import { ReportCTA } from '../_components/report-cta';
 
 export const dynamic = 'force-static';
 
-const LIVE_REPORTS = process.env.CIVICGRAPH_LIVE_REPORTS === 'true';
+// Via the helper, not a private `=== 'true'`: production's value has a trailing newline and the
+// strict form silently disabled this page. See lib/report-supabase.ts.
+const LIVE_REPORTS = liveReportsEnabled();
 
 export const metadata: Metadata = {
   title: 'Foundation Intelligence | CivicGraph Investigation',
@@ -95,7 +98,8 @@ interface Stats {
 /**
  * FABRICATED FALLBACK REMOVED, 2026-08-19.
  *
- * When CIVICGRAPH_LIVE_REPORTS is not 'true' — which is its state in production — this page used to
+ * When live reports are off — which was production's effective state until the flag's trailing
+ * newline was found on 2026-08-20 — this page used to
  * return buildSnapshotData(): hand-authored constants. It then rendered them under a Methodology
  * section describing how the figures were computed, and cited sources for them.
  *

--- a/apps/web/src/app/reports/social-enterprise/page.tsx
+++ b/apps/web/src/app/reports/social-enterprise/page.tsx
@@ -1,10 +1,13 @@
 import { getServiceSupabase } from '@/lib/report-supabase';
+import { liveReportsEnabled } from '@/lib/report-supabase';
 import { TableOfContents } from './toc';
 import { ReportCTA } from '../_components/report-cta';
 
 export const dynamic = 'force-static';
 
-const LIVE_REPORTS = process.env.CIVICGRAPH_LIVE_REPORTS === 'true';
+// Via the helper, not a private `=== 'true'`: production's value has a trailing newline and the
+// strict form silently disabled this page. See lib/report-supabase.ts.
+const LIVE_REPORTS = liveReportsEnabled();
 
 const SNAPSHOT_COUNTS = {
   total: 20000,

--- a/apps/web/src/app/reports/youth-justice/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { liveReportsEnabled } from '@/lib/report-supabase';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 import { parse } from 'csv-parse/sync';
@@ -535,7 +536,7 @@ function loadYouthJusticeSnapshot(): YouthJusticeReport | null {
 }
 
 async function getReport(): Promise<YouthJusticeReport> {
-  if (process.env.CIVICGRAPH_LIVE_REPORTS !== 'true') {
+  if (!liveReportsEnabled()) {
     const snapshot = loadYouthJusticeSnapshot();
     if (snapshot) return snapshot;
   }

--- a/apps/web/src/lib/report-client-convention.test.ts
+++ b/apps/web/src/lib/report-client-convention.test.ts
@@ -43,3 +43,35 @@ describe('report pages declare which Supabase client they want', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * Nobody re-derives the live-reports flag by hand.
+ *
+ * Production stores `CIVICGRAPH_LIVE_REPORTS` as `"true\n"`. A strict `=== 'true'` is therefore
+ * false in production, and three report pages carried their own private copy of exactly that
+ * comparison — so they read the empty client even once the shared helper was fixed. The failure is
+ * silent by construction: an unread flag renders as a page with no numbers, not as an error.
+ */
+describe('the live-reports flag is read in exactly one place', () => {
+  it('no file compares CIVICGRAPH_LIVE_REPORTS directly', () => {
+    const roots = [join(process.cwd(), 'src/app'), join(process.cwd(), 'src/lib')];
+    const offenders: string[] = [];
+    for (const root of roots) {
+      for (const file of walk(root)) {
+        // The helper itself, its test, and this file (which names the pattern it forbids).
+        if (/report-supabase(\.test)?\.ts$/.test(file) || file === __filename) continue;
+        const src = readFileSync(file, 'utf8');
+        // The env READ, not a mention of the name in prose.
+        if (src.includes('process.env.CIVICGRAPH_LIVE_REPORTS')) {
+          offenders.push(file.replace(process.cwd() + '/', ''));
+        }
+      }
+    }
+    expect(
+      offenders,
+      `These read CIVICGRAPH_LIVE_REPORTS directly. Import liveReportsEnabled() from ` +
+        `@/lib/report-supabase instead — it trims, and production's value has a trailing newline:\n` +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/report-supabase.test.ts
+++ b/apps/web/src/lib/report-supabase.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { liveReportsEnabled } from './report-supabase';
+
+const ORIGINAL = process.env.CIVICGRAPH_LIVE_REPORTS;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.CIVICGRAPH_LIVE_REPORTS;
+  else process.env.CIVICGRAPH_LIVE_REPORTS = ORIGINAL;
+});
+
+describe('liveReportsEnabled — the flag that silently blanked 61 public pages', () => {
+  it('accepts the exact string', () => {
+    process.env.CIVICGRAPH_LIVE_REPORTS = 'true';
+    expect(liveReportsEnabled()).toBe(true);
+  });
+
+  it("accepts production's actual stored value, which has a trailing newline", () => {
+    // This is not hypothetical. `vercel env pull --environment=production` on 2026-08-20 returned
+    // CIVICGRAPH_LIVE_REPORTS="true\n". Under the old strict `=== 'true'` this returned false and
+    // every report page fell through to the empty-result client with no error raised anywhere.
+    process.env.CIVICGRAPH_LIVE_REPORTS = 'true\n';
+    expect(liveReportsEnabled()).toBe(true);
+  });
+
+  it('tolerates surrounding whitespace generally', () => {
+    for (const v of [' true', 'true ', '\ttrue\r\n']) {
+      process.env.CIVICGRAPH_LIVE_REPORTS = v;
+      expect(liveReportsEnabled()).toBe(true);
+    }
+  });
+
+  it('stays off for anything that is not true', () => {
+    for (const v of ['false', '1', 'yes', 'TRUE', '']) {
+      process.env.CIVICGRAPH_LIVE_REPORTS = v;
+      expect(liveReportsEnabled()).toBe(false);
+    }
+  });
+
+  it('stays off when unset', () => {
+    delete process.env.CIVICGRAPH_LIVE_REPORTS;
+    expect(liveReportsEnabled()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/report-supabase.ts
+++ b/apps/web/src/lib/report-supabase.ts
@@ -4,8 +4,28 @@ import {
   getServiceSupabase as getLiveServiceSupabase,
 } from '@/lib/supabase';
 
+/**
+ * Whether report pages query the live database.
+ *
+ * TRIMMED, and that is not defensive tidiness. Production has had
+ * `CIVICGRAPH_LIVE_REPORTS` set since 2026-04-30, and its stored value is `"true\n"` — with a
+ * trailing newline, as pasted. `'true\n' === 'true'` is false, so the strict comparison that used
+ * to live here failed, `getReportSnapshotSupabase()` returned its empty-result Proxy, and every
+ * report page read nothing. Someone turned these pages on nearly four months ago and a stray
+ * newline turned them back off, silently, with no error anywhere.
+ *
+ * Eight of the 42 production variables carry a trailing newline (measured 2026-08-20 via
+ * `vercel env pull`): CIVICGRAPH_LIVE_REPORTS, GEMINI_API_KEY, INVESTOR_PAGE_PASSWORD,
+ * MINIMAX_API_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_URL, TELEGRAM_BOT_TOKEN and
+ * TELEGRAM_CHAT_ID. So this is a property of how they were entered, not a one-off, and any env
+ * value compared with `===` in this codebase has the same bug waiting in it.
+ */
+export function liveReportsEnabled(): boolean {
+  return process.env.CIVICGRAPH_LIVE_REPORTS?.trim() === 'true';
+}
+
 export function getServiceSupabase() {
-  if (process.env.CIVICGRAPH_LIVE_REPORTS === 'true') {
+  if (liveReportsEnabled()) {
     return getLiveServiceSupabase();
   }
 


### PR DESCRIPTION
**VISIBLE, and the highest-consequence merge on the board: this switches 61 public report pages from blank to live in one go.** Please read the blocker list before merging.

## What is actually wrong

`CIVICGRAPH_LIVE_REPORTS` has been set in production **since 2026-04-30**. Its stored value is:

```
CIVICGRAPH_LIVE_REPORTS="true\n"
```

The check was `process.env.CIVICGRAPH_LIVE_REPORTS === 'true'`. `'true\n' === 'true'` is false, so `getReportSnapshotSupabase()` returned its empty-result Proxy and every report page read nothing.

Someone turned these pages on nearly four months ago, and a stray newline turned them straight back off — silently, with no error anywhere. The handoff recorded this as *"`CIVICGRAPH_LIVE_REPORTS` is not `true` in production"* and scheduled it as a decision to take awake. It isn't a decision. It's a bug.

**Eight of the 42 production variables carry the same trailing newline** (measured via `vercel env pull`): `CIVICGRAPH_LIVE_REPORTS`, `GEMINI_API_KEY`, `INVESTOR_PAGE_PASSWORD`, `MINIMAX_API_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`. So it's how they were entered, not a one-off — **worth a look at whether any of the other seven are silently misbehaving too.**

## The fix

- `liveReportsEnabled()` trims. A test pins production's literal `"true\n"` so the regression can't come back.
- **Four pages carried their own private copy of the strict comparison** and would have stayed blank even after the shared helper was fixed. They now call the helper. One of them (`youth-justice`) used `!== 'true'`, which a grep for `=== '` does not find — the convention test does.
- A convention test fails the build if anyone reads the env var directly again.

## Also fixed here, because the flag exposes it

`/reports/donor-contractors` **crashed** (500) with `dc.contract_years is not iterable`. Postgres array columns come back `NULL` rather than empty; 3 of the 2,065 rows in `mv_gs_donor_contractors` have a `NULL contract_years`, and fourteen sites iterate or read `.length` on those fields. Normalised once at the fetch. It could never have been hit before — the page never had a row to trip on.

Without this, merging the flag fix would turn a blank page into a 500.

## Smoke test — all 61 static report routes, live database

**58 of 61 return 200.** The three that didn't were `donor-contractors` (fixed here) and two false alarms from stale Turbopack modules mid-edit, both re-verified 200 after a clean restart.

## Blockers NOT fixed here — these need their own PR

| route | problem |
|---|---|
| `/reports/influence-network` | queries `mv_revolving_door` for `in_procurement`, `in_political_donations`, `in_foundation`, `system_count`, `power_score`, `procurement_dollars`, `donation_dollars`, `distinct_govt_buyers`, `total_dollar_flow` — **none of which exist on that view**; they belong to `mv_entity_power_index`. Renders 200 with nothing. It also sums `political_donations.amount` with no `receipt_type` filter, and times out. |
| `/reports/picc` | `operator does not exist: uuid = text` |
| `/reports/youth-justice/qld/sector` | `exec_sql only accepts read-only (SELECT/WITH) queries from the app runtime`, plus a statement timeout |

None of these are regressions — those pages are blank today either way, so merging improves 58 pages and leaves 3 as they are. But `influence-network` will keep publishing a confident zero until it's fixed, which is the failure mode CLAUDE.md calls out by name.

## Verified

- `./scripts/precheck.sh` green (tsc + full vitest, 7 new tests).
- All 61 routes fetched against the live DB on 3013; failures attributed to pages from the server log, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)