### PR TITLE
The app rendered as two different products depending on whether you were signed in

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -206,8 +206,17 @@ h1, h2, h3, h4 {
   --cd-yellow: #8A6A00;
 }
 
-/* ── Workspace theme (editorial style for operational tools) ── */
-.ws {
+/* ── Workspace tokens ──
+   DEFINED AT :root, not on `.ws`, and that move is a bug fix rather than tidying.
+   `app/components/nav.tsx` — the global nav on every public page — sets
+   `background: var(--ws-surface-1)` and `color: var(--ws-text)` inline with NO fallbacks. While
+   these lived only inside `.ws`, and `.ws` was only applied to signed-in users, every logged-out
+   visitor got undefined custom properties: the nav had no background of its own, and the active,
+   inactive and muted nav states (--ws-text / --ws-text-secondary / --ws-text-tertiary) all
+   collapsed to one inherited colour. The active-page indicator was invisible to the public for
+   five months and nothing errored, because an invalid var() is silent by design.
+   Defined here, every consumer resolves the same whoever is looking. */
+:root {
   --ws-surface-0: #FDFCFB;
   --ws-surface-1: #FFFFFF;
   --ws-surface-2: #F9F8F6;
@@ -220,6 +229,12 @@ h1, h2, h3, h4 {
   --ws-red: #DC2626;
   --ws-amber: #D97706;
   --ws-green: #16A34A;
+}
+
+/* ── Workspace theme (editorial style for operational tools) ──
+   The scope class, now only ever applied deliberately — by `/org`'s layout, which pairs it with
+   `.act-workspace`. It is no longer put on `<body>` for signed-in users; see layout.tsx. */
+.ws {
   background: var(--ws-surface-0);
   color: var(--ws-text);
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -177,7 +177,21 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en">
       <body
-        className={`font-sans antialiased ${qlFontVars} ${isLoggedIn ? 'ws' : ''}`}
+        // NO `ws` class here. It used to be added for signed-in users, which meant the app
+        // rendered as two visually different products depending on auth state: `.ws` overrides
+        // every bauhaus-* colour with !important, thins border-4 to 1px, is exempt from the
+        // global `border-radius: 0`, and replaces DM Sans with the OS system font. So the
+        // "locked" design was only ever shown to logged-out visitors, and nobody working on the
+        // product was looking at it.
+        //
+        // It was never a design decision: `git log -S` dates it to d6e53129 (2026-03-14),
+        // "Phase 0 revenue infrastructure — tier enforcement, exposure API, ALMA linkage,
+        // contract alerts, NZ scaffolding". It arrived with billing.
+        //
+        // Nothing depended on it. `/org` applies its own `ws act-workspace` wrapper, and
+        // `/dashboard`, `/search` and `/clarity` use `.shell`, which is self-contained by
+        // design ("Scoped to .shell only; the public Bauhaus site is untouched").
+        className={`font-sans antialiased ${qlFontVars}`}
         data-authenticated={user ? 'true' : 'false'}
         data-user-email={user?.email ?? ''}
       >

--- a/thoughts/shared/plans/shell-migration-and-surface-triage.md
+++ b/thoughts/shared/plans/shell-migration-and-surface-triage.md
@@ -1,0 +1,159 @@
+# Moving the searchable surfaces into the shell
+
+**Date:** 2026-08-20 · **Status:** thinking, no work started
+**Trigger:** "we build some great dashboards in the admin that I liked, and not this" — the
+`/search` shell versus `/reports/youth-justice/nsw`.
+
+Every number below was measured on 2026-08-20, not carried forward from a doc.
+
+---
+
+## 1. What the shell actually is
+
+`components/shell/shell.tsx` — dark rail, light canvas, one search box, filters that belong to
+the rail. The route scanner calls it **"softened shell"**: Bauhaus identity, borders thinned to
+1px, radius allowed. It is scoped by path prefix (`/dashboard`), plus `/search` and `/clarity`
+which opt in via their own layouts.
+
+**It is on 19 of 303 routes.** Bauhaus is on 201.
+
+The rail today:
+
+| group | items |
+|---|---|
+| primary | Dashboard · Search · Clarity · Themes · Entities · People · Places · Reports |
+| browse | Foundations · Social enterprises · Charities · Grant recipients · Contract suppliers · Government buyers · Political donors |
+| saved views | Youth justice money · ACCO share · Money vs evidence · Power: top 1% |
+| ops | Overview · Data health · Claims · Grant recommendations |
+
+That is a good spine. The nouns are right and the grouping is right. The argument below is not
+"redesign it" — it is "most of what belongs in it is currently living somewhere else."
+
+## 2. The triage: three kinds of public screen, not one
+
+The mistake available here is moving all 201 Bauhaus routes into the shell. Two thirds of them
+should not go.
+
+### A. Nouns you browse, filter and search → **belong in the shell**
+
+A catalogue surface has the same job every time: a list, filters, a sort, a row that links to a
+detail page. That is exactly what the rail is for, and it is the reason `/search` feels finished
+and `/reports/youth-justice/nsw` does not.
+
+Currently living outside the shell:
+
+| public route | pages | shell equivalent |
+|---|---|---|
+| `/entities`, `/entity/*` | 10 | Entities (exists, different surface) |
+| `/foundations` | 11 | `/dashboard/browse/foundations` — **duplicate** |
+| `/charities` | 5 | `/dashboard/browse/charities` — **duplicate** |
+| `/social-enterprises` | 2 | `/dashboard/browse/social-enterprises` — **duplicate** |
+| `/grants` | 2 | `/dashboard/browse/grants` — **duplicate** |
+| `/suppliers` | 1 | none |
+| `/person/*` | 2 | People (exists) |
+| `/place/*`, `/places/*` | 8 | Places (exists) |
+| `/power`, `/rankings` | 2 | none |
+| `/procurement` | 4 | none |
+| `/opportunities` | 1 | none |
+| `/evidence`, `/evidence-packs` | 2 | none |
+| `/sector` | 1 | none |
+
+**Four nouns exist twice, in two different design systems.** Charities, foundations, social
+enterprises and grants each have a public Bauhaus browse AND a shell browse. That is not a
+styling inconsistency, it is two products. Deciding which one survives is the first decision,
+and it is worth more than any amount of retokening.
+
+### B. Arguments you read → **stay editorial, get their own treatment**
+
+The 86 `/reports/*` pages are essays with charts. A dark rail does not help you read an
+argument, and putting one there would make them worse. But "not the shell" is not the same as
+"what they look like now" — they need a consistent *report* treatment, which is a separate and
+smaller job than the shell migration.
+
+The screenshot that started this is a report page, and its problem is not that it lacks a rail.
+It is that its four hero tiles are `bg-red-50 / bg-blue-50 / bg-amber-50 / bg-emerald-50` with
+`rounded-xl` — raw Tailwind defaults, no token within reach. 907 `rounded-*` and 462 off-palette
+colour hits across `app/`. Nothing enforces the palette, which is why it accumulated silently.
+
+### C. Front door → **stays loud**
+
+`/pricing`, `/how-it-works`, `/about`, `/get-a-report`, `/home`. Bauhaus is right here. Leave them.
+
+## 3. The thing that makes the same page look like two products
+
+```
+app/layout.tsx:180
+className={`font-sans antialiased ${qlFontVars} ${isLoggedIn ? 'ws' : ''}`}
+```
+
+`.ws` repaints every `bauhaus-*` colour with `!important`, thins `border-4` to 1px, and is
+excluded from the global `border-radius: 0` rule. So **every page in the app renders differently
+depending on whether you are signed in**, and the version we show the public is the one nobody
+is looking at while they work.
+
+This needs a decision before any migration, or the migration gets evaluated against the wrong
+rendering.
+
+## 4. What we have data for and cannot search
+
+The rail's seven browse entries cover foundations, social enterprises, charities, grant
+recipients, contract suppliers, government buyers and political donors. Measured today, here is
+what the database holds that has **no searchable surface anywhere**:
+
+| dataset | rows | why it matters |
+|---|---|---|
+| `grant_opportunities` | 26,137 (**4,452 open**, 354 closing within 60 days) | the only forward-looking money in the building. Everything else is history. |
+| `state_tenders` | 199,719 | read by report pages, browsable nowhere |
+| `acnc_ais` | 360,844 | charity financials by year — the charities browse is the register, not the money |
+| `mv_entity_power_index` | 185,393 | `/power` exists as one page, not as a browsable surface |
+| `mv_board_interlocks` | 39,757 | see the people gap below |
+| `ato_tax_transparency` | 26,241 | who pays no tax — no surface at all |
+| `alma_interventions` + `alma_evidence` | 2,145 + 631 | "what works" — the evidence half of the product |
+| `mv_revolving_door` | 3,586 | entities with 2+ influence vectors |
+| `mv_funding_deserts` | 1,955 | on the Atlas, not searchable |
+| `abr_registry` | 20.0M | the ABN register |
+| `asic_companies` | 2.17M | company register |
+
+**The people gap is the sharpest.** Search returns people from `mv_board_interlocks` — which by
+definition only contains people on **two or more** boards. `person_identities` holds 230,000
+resolved identities. So roughly **83% of the people we know about cannot be found by searching
+for them**, and nothing on the page says so.
+
+`grant_opportunities` is the sharpest *product* gap: 4,452 currently-open opportunities, and no
+way for anyone to browse them. Note the data needs a date filter before it ships — the table's
+latest deadline is 2051-03-31, so an unfiltered count would claim 26,137 open opportunities.
+
+## 5. The live map
+
+`/atlas` — full-viewport, **9 layers**, 8 public and 1 consent-gated:
+
+Funding deserts · Recorded money · Justice money · Federal grants · SEIFA disadvantage ·
+Unplaced organisations · Funding renewal cliff · What works here · Goods in community (gated)
+
+`/map` 307-redirects to it. The layer registry is typed, the consent tiers are enforced in code,
+and the placement provenance is stamped per-row (`lib/atlas/stamps.ts`).
+
+**It is not in the rail.** "Places" in the rail goes to `/dashboard/places`, a different surface.
+So the best place-based thing we have built is reachable only if you already know the URL.
+
+The Atlas is also the natural home for three of the unsearchable datasets above — funding
+deserts is already a layer, and tenders and opportunities are both inherently place-shaped.
+
+## 6. The decisions, in the order they block each other
+
+1. **Signed-in vs signed-out rendering.** Is `.ws` the design, or is Bauhaus the design? Right
+   now both are, conditionally. Nothing else can be judged until this is settled.
+2. **Which of the four duplicated nouns survives** — public Bauhaus browse, or shell browse.
+   This is one decision applied four times, not four decisions.
+3. **Does the shell go public?** Today it is behind `/dashboard`. Moving catalogue surfaces into
+   it either means the shell becomes the public browse experience, or the public keeps a second
+   one. Answering (2) mostly answers this.
+4. **Report treatment** — separate track, separate PR, does not wait on 1–3.
+5. **Atlas into the rail**, and whether Places means the Atlas or the dashboard page.
+
+## 7. What is worth doing before any of it
+
+The palette drift is unenforced. Whatever design wins, a build-failing lint banning raw Tailwind
+colour classes on the surfaces we care about stops the next 462 hits from accruing while the
+migration is in flight. That is cheap, it is independent of every decision above, and without it
+the migration is a snapshot rather than a state.


### PR DESCRIPTION
**VISIBLE — shared chrome on every page. Preview before merging.**

Settles the `.ws` question from the surface-triage thinking. Two things, one cause.

## 1. `.ws` was applied to `<body>` for signed-in users only

`.ws` overrides every `bauhaus-*` colour with `!important`, thins `border-4` to 1px, is exempted from the global `border-radius: 0 !important`, and sets `font-family: ui-sans-serif, system-ui, …` — a class selector, so it beats `body { font-family: var(--font-sans) }` and **turns off DM Sans**. Satoshi survives only on `h1–h4`, which have their own rule.

So the design `DESIGN.md` describes was only ever rendered for logged-out visitors, and nobody working on the product was looking at it.

**It was never a design decision.** `git log -S "isLoggedIn ? 'ws'"` dates it to `d6e53129`, 14 March: *"feat: Phase 0 revenue infrastructure — tier enforcement, exposure API, ALMA linkage, contract alerts, NZ scaffolding."* It arrived with billing and became the de facto design for five months.

**Nothing depended on it.** `/org` applies its own `ws act-workspace` wrapper. `/dashboard`, `/search` and `/clarity` use `.shell`, which is self-contained — its own `border-4 → 1px + radius`, its own bauhaus remaps, its own shadow softening — and whose comment already says *"Scoped to .shell only; the public Bauhaus site is untouched."* **The admin dashboards are not affected by this change.**

## 2. It was hiding a live bug on every public page

The `--ws-*` custom properties were declared **only inside `.ws`**. There was no `:root` definition.

`app/components/nav.tsx` — the global nav on every public page — sets `background: var(--ws-surface-1)` and `color: var(--ws-text)` inline, with **no fallbacks**, at 12 sites. For every logged-out visitor those resolved to nothing:

- the nav had no background of its own
- the active, inactive and muted nav states (`--ws-text` / `--ws-text-secondary` / `--ws-text-tertiary`) all collapsed to one inherited colour

**The active-page indicator has been invisible to the public since March.** Nothing errored, because an invalid `var()` is silent by design. It's visible in Ben's screenshot of `/reports/youth-justice/nsw`: REPORTS in the nav is the same black as every other item.

## The change

- `--ws-*` moved from `.ws` to `:root`, so every consumer resolves the same whoever is looking. The `/org` override stays exactly where it was.
- The `isLoggedIn ? 'ws' : ''` conditional is gone from `layout.tsx`. `.ws` is now only ever applied deliberately.

Per Ben's call: **soft chrome, Bauhaus content.** The nav will look to visitors exactly as it looks to you today, and signed-in and signed-out now render identically.

## Verified

- `./scripts/precheck.sh` green including the production build (required — the diff touches the root layout).
- Inspected the **served** CSS from the dev server, not the source: `--ws-surface-1` is declared at `:root` and at `.ws.act-desk, .ws.act-workspace`, and nowhere else.

## Worth knowing, not fixed here

`route-scan.ts` already concluded that **DESIGN.md describes a system the code has moved off** — it makes no mention of `.ws`, `.shell` or `.ui`, all of which are live. Updating it belongs with whichever design wins the wider triage (`thoughts/shared/plans/shell-migration-and-surface-triage.md`), not with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)