### PR TITLE
Three skills for the three audits that each found an expensive bug today

### DIFF
--- a/.claude/skills/config-truth/SKILL.md
+++ b/.claude/skills/config-truth/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: config-truth
+description: Compare DEPLOYED environment values against what the code actually expects — not just whether a var is set. Catches trailing whitespace, case mismatches, and strict === comparisons the stored value cannot satisfy. Use on /config-truth, "check the env", "is the flag actually on", "why is this feature not working in prod", or whenever a feature is configured-but-inert. Also run it when adding any new env flag.
+---
+
+# /config-truth — the variable is set; that is not the same as correct
+
+On 2026-08-20 this check found that `CIVICGRAPH_LIVE_REPORTS` had been set in Vercel production
+since **2026-04-30**, and that its stored value was:
+
+```
+CIVICGRAPH_LIVE_REPORTS="true\n"
+```
+
+The code read `process.env.CIVICGRAPH_LIVE_REPORTS === 'true'`. `'true\n' === 'true'` is false.
+So the flag was on, the check failed, and **61 public report pages read from an empty-result stub
+for four months.** Nothing errored. The handoff had recorded it as a decision nobody had taken —
+"do it awake" — when it was a stray newline.
+
+**Presence is not truth.** `/preflight` checks that vars exist. This checks that their values can
+satisfy the comparisons the code performs on them.
+
+## Procedure
+
+### 1. Pull the real deployed values
+
+```bash
+cd /tmp && vercel env pull .envcheck --environment=production --yes
+```
+
+Run from a writable directory — the pull silently fails from some working directories and leaves
+no file, which reads as "no vars" if you do not check.
+
+### 2. Find the whitespace class first — it is invisible and it is common
+
+```bash
+grep -c '\\n"$' /tmp/.envcheck        # vars whose stored value ends in a newline
+grep '\\n"$' /tmp/.envcheck | cut -d= -f1
+```
+
+Match `\n"$` (literal backslash-n), **not** `n"$` — the latter also matches any value ending in
+the letter n and will overcount. Measured 2026-08-20: **8 of 42** production vars carry a trailing
+newline, including `SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `INVESTOR_PAGE_PASSWORD` and
+both `TELEGRAM_*` vars. It is how they were pasted, so assume more will arrive the same way.
+
+Never print a value. Names only.
+
+### 3. Find every strict comparison the code makes
+
+```bash
+grep -rn "process\.env\.[A-Z_]* ===\|process\.env\.[A-Z_]* !==" apps/web/src --include=*.ts --include=*.tsx
+```
+
+Cross-reference against step 2. **Any var in both lists is a live bug.** Also look for the same
+var read in more than one place — four files carried their own private copy of the
+`CIVICGRAPH_LIVE_REPORTS` comparison, so fixing the shared helper alone would have left them
+broken. A grep for `=== '` misses `!== '`; search both.
+
+### 4. Fix the code, not just the variable
+
+Editing the Vercel value is a Tier 2 action and it is **Ben's**, not yours. What you can do
+without asking is make the code tolerant:
+
+```ts
+export function liveReportsEnabled(): boolean {
+  return process.env.CIVICGRAPH_LIVE_REPORTS?.trim() === 'true';
+}
+```
+
+Then read the flag in **exactly one place**, and add a convention test that fails the build if
+anyone reads `process.env.<FLAG>` directly again. `apps/web/src/lib/report-client-convention.test.ts`
+has the pattern; it caught a fourth offender using `!==` that the grep had missed.
+
+### 5. Check for undefined CSS custom properties too — same failure shape
+
+A `var(--thing)` that resolves to nothing is silent in exactly the way a failed `===` is. On the
+same day, `--ws-*` was declared only inside `.ws`, while `components/nav.tsx` read it inline with
+no fallbacks — so every logged-out visitor got a nav with no background and an invisible
+active-page state.
+
+```bash
+grep -rn "var(--[a-z-]*)" apps/web/src --include=*.tsx | grep -v "var(--[a-z-]*," | head -40
+```
+
+Anything without a fallback comma needs a `:root` definition, or a fallback.
+
+## The general shape
+
+**Configuration fails silently by design.** A wrong value does not throw; it takes a different
+branch. So the only way to find these is to compare the two sides — what is stored, and what the
+code can accept — and no amount of reading either side alone will do it.
+
+Before shipping any new env flag, ask: what does this render as when the flag is wrong? If the
+answer is "an empty page" rather than "an error", it needs a `.trim()`, one read site, and a test.
+
+## Definition of done
+
+- [ ] Deployed values pulled, whitespace class counted precisely, names reported (never values)
+- [ ] Every `===` / `!==` env comparison in the codebase cross-referenced
+- [ ] Each flag read in exactly one place, with a build-failing test enforcing it
+- [ ] Comparisons made whitespace-tolerant
+- [ ] CSS custom properties checked for undefined-and-unguarded reads
+- [ ] Any change to a deployed value handed to Ben; never made autonomously

--- a/.claude/skills/money-audit/SKILL.md
+++ b/.claude/skills/money-audit/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: money-audit
+description: Audit a surface's dollar figures against the three mandatory justice_funding filters before anyone reads them. Enumerates every money-summing site, classifies each as grant-lane or expenditure-lane, MEASURES the delta in SQL before changing anything, then applies the canonical predicate. Use on /money-audit, "audit the money on X", "are these figures filtered", "check this page's numbers", or before shipping any surface that renders a dollar amount from justice_funding, political_donations or austender_contracts.
+---
+
+# /money-audit — do the figures survive their own filters
+
+CivicGraph's entire claim is that its numbers are trustworthy. `justice_funding.amount_dollars`
+carries **two incompatible measures in one column**: grants paid to organisations, and
+whole-of-state expenditure budgets. Adding them does not produce a slightly-off number.
+
+Measured 2026-08-20 on the youth-justice topic:
+
+| filter | rows | total |
+|---|---|---|
+| topic tag alone | 5,100 | **$31.66bn** |
+| topic tag + grant lane | 4,090 | **$0.92bn** |
+
+**34x.** It was published as "funding by state" and "top funded programs" for months. This skill
+exists because that is not a bug you find by reading code — you find it by measuring.
+
+## The rule that makes this skill necessary
+
+**Never state that a figure is "fixed" without stating the delta.** A filter applied without a
+before-and-after is indistinguishable from a filter that did nothing. Every finding in this audit
+ends with a number that changed, or it is not a finding.
+
+## Procedure
+
+### 1. Enumerate, do not sample
+
+Every site on the surface that sums, averages, ranks or counts money:
+
+```bash
+awk '/^export (async )?function /{name=$4} /justice_funding|political_donations|austender_contracts/{print NR": "name}' <file>
+```
+
+Read the body of each. Ranking and averaging count — a `MAX`, an `ORDER BY amount DESC` and a
+`SUM(x)/COUNT(y)` are all money figures.
+
+### 2. Classify each site into a lane — this is judgement, not a sweep
+
+| lane | means | filter |
+|---|---|---|
+| **grant** | money that reached a named organisation | `grantFilterSql(alias)` — all three filters |
+| **expenditure** | what a government spent running a system | **NO grant filter.** Scope by `source` instead |
+| **count-only** | rows, sources, coverage; no dollars | nothing |
+
+**Sweeping is how you replace one silent error with another.** `getRogsExpenditure`,
+`getBudgetTotals`, `getBudgetCommitments` and the `getQgip*` pair are expenditure BY DESIGN —
+17 of the 18 `%-budget-sds` rows are `is_aggregate = true` and that IS the measurement. Applying
+the grant filter to those empties them.
+
+The tell: **does the site scope by `source`, or by topic?** Source-scoped is usually a deliberate
+expenditure lane. Topic-scoped is asking about organisations and needs the grant filter.
+
+### 3. MEASURE before you change anything
+
+For each grant-lane site, run the before and after:
+
+```bash
+node --env-file=.env scripts/gsql.mjs "
+SELECT 'unfiltered' AS lane, count(*) AS n, sum(amount_dollars) AS amt
+  FROM justice_funding WHERE <the site's existing predicate>
+UNION ALL SELECT 'filtered', count(*), sum(amount_dollars)
+  FROM justice_funding WHERE <existing> AND measure_kind='grant' AND is_aggregate IS NOT TRUE"
+```
+
+`gsql.mjs` chokes on `UNION ALL` of bare literals — if it errors with `row_to_json(text) does not
+exist`, use a single row of subqueries instead.
+
+**If the delta is zero, say so and move on.** A site that was already correct is a finding worth
+recording, not a place to add a redundant filter.
+
+### 4. Apply the canonical predicate — never retype it
+
+`apps/web/src/lib/justice-money.ts` exports all of it:
+
+- `grantFilterSql(alias?)` — the three filters as SQL, column-prefixed
+- `donationFilterSql(alias?)` — `receipt_type = 'donation received'`
+- `applyGrantFilters(query)` — the PostgREST builder form
+- `isRealRecipient(name)` / `themeMoney(topics)` — the in-memory forms
+
+Retyping the predicate is how the drift starts: two functions in `report-service.ts` carried
+hand-rolled copies, and the other eighteen call sites had none.
+
+**Prefer folding the filter into the shared helper over adding it at N call sites.** If every
+caller of a filter function wants the grant lane, put it in the filter function.
+
+### 5. Check the traps that are not about filters
+
+- **NULLs sort FIRST in a `DESC` ordering.** A naive "top recipients" returns the rows with no
+  amount. Needs `amount_dollars IS NOT NULL` or `NULLS LAST`.
+- **Topic tags overlap** — `youth-justice ∩ diversion` = 98 rows. Querying tag by tag and
+  concatenating double-counts. Deduplicate by `id`.
+- **Hyphens, not underscores.** `topics @> ARRAY['youth_justice']` returns zero rows silently.
+- **Postgres array columns come back NULL, not empty.** One NULL crashes any `for…of`.
+
+### 6. Report
+
+For each site: lane, delta, action. Then the two things that are easy to skip:
+
+- **What you did NOT change, and why.** The expenditure lane needs naming, or the next reader
+  "fixes" it.
+- **What the change does to the page.** After filtering, youth-justice grant money is 99.99% QLD —
+  seven states' tables go empty. A correct number that renders as a confident zero is not finished
+  work; it needs a disclosure, per CLAUDE.md.
+
+## Definition of done
+
+- [ ] Every money site on the surface enumerated, none sampled
+- [ ] Each classified grant / expenditure / count-only, with the reason recorded
+- [ ] Every grant-lane change has a measured before-and-after
+- [ ] Predicates come from `justice-money.ts`, not retyped
+- [ ] The expenditure lane is commented so nobody "fixes" it
+- [ ] Any figure that now renders empty has a disclosure, or is flagged as needing one
+
+## Reference
+
+CLAUDE.md, "Three filters that are mandatory, not optional" — the source of truth for the filters
+and the measured national impact ($12.12bn, 26%, stripped by filters 1 and 2 together).

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -17,3 +17,13 @@ node --env-file=.env scripts/preflight.mjs
    - **Port 3013:** Show what process is using it
 
 3. If all checks pass, confirm the session is ready for work.
+
+## What preflight does NOT check
+
+It checks local env vars are **present**. It does not check that their *deployed* values can
+satisfy the comparisons the code makes on them — and a var can be set, non-empty, and still wrong.
+`CIVICGRAPH_LIVE_REPORTS` was stored in production as `"true\n"` against a `=== 'true'` check, so
+61 public pages read nothing for four months and preflight passed every day of it.
+
+Run **`/config-truth`** when a feature is configured but inert, and whenever a new env flag is
+added.

--- a/.claude/skills/surface-sweep/SKILL.md
+++ b/.claude/skills/surface-sweep/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: surface-sweep
+description: Render every route in a section against the live database and report which are broken, blank, silently-partial or slow — attributing each failure to a page from the server log rather than guessing. Catches the pages that return 200 while all their queries fail. Use on /surface-sweep, "check the reports still work", "which pages are broken", before turning on a flag that changes what many pages read, or after a shared data-layer change.
+---
+
+# /surface-sweep — 200 is not the same as working
+
+Before turning on `CIVICGRAPH_LIVE_REPORTS` — a one-line change that switched 61 public pages
+from an empty stub to live queries — this sweep found:
+
+- `/reports/donor-contractors` **crashed**: `dc.contract_years is not iterable`. Three of 2,065
+  rows have a NULL array column, and fourteen sites iterate it. It could never have been hit while
+  the page had no rows.
+- `/reports/influence-network` returned **200 while every query failed** — it reads
+  `mv_revolving_door` for nine columns that live on `mv_entity_power_index`, plus a statement
+  timeout. It renders a confident zero.
+- `/reports/picc` — `operator does not exist: uuid = text`.
+- `/reports/youth-justice/qld/sector` — a write-shaped query rejected by `exec_sql`, plus a timeout.
+
+**Three of those four return HTTP 200.** A status-code sweep would have passed them all. The
+server log is where the truth is.
+
+## Procedure
+
+### 1. Start the server in the state you are testing
+
+```bash
+cd apps/web && CIVICGRAPH_LIVE_REPORTS=true npm run dev -- --turbopack -p 3013 \
+  > <scratchpad>/dev.log 2>&1
+```
+
+Run it in the background and **keep the log** — step 4 depends on it. Port 3013 is canonical;
+JusticeHub squats 3014, so verify the port maps to this repo before trusting any 200.
+
+### 2. Enumerate routes from the filesystem, never by hand
+
+```bash
+cd apps/web/src/app/<section>
+find . -name page.tsx | grep -v '\[' | sed 's|^\./||; s|/page.tsx$||' | sort
+```
+
+Dynamic routes (`[state]`, `[id]`) need real ids — fetch a handful from the database and test
+those separately. A hand-written route list starts lying the first time someone adds a page.
+
+### 3. Fetch each, recording more than the status code
+
+Status, byte count, and a marker for the section's honest-empty component (`ReportUnavailable`
+renders "Data unavailable"). Write to a TSV; do not stream 61 pages into the conversation.
+
+Use `curl -sL` — without `-L` a 307 to a hand-built page reads as a failure. Expect this to take
+30–60 minutes on a dev server, because each route compiles on first hit. Run it in the background.
+
+### 4. Attribute failures to pages FROM THE LOG — this is the step that matters
+
+```bash
+grep "query failed" <scratchpad>/dev.log | sort | uniq -c | sort -rn
+grep -B 8 "query failed" <scratchpad>/dev.log | grep -E "Compiled /|GET /|query failed"
+```
+
+The `-B 8` window is what ties a failed query to the route that ran it. Without it you have a list
+of errors and no idea which page owns them.
+
+### 5. Separate real failures from your own edits
+
+If you edit files mid-sweep, Turbopack serves stale modules and you get 500s that are artefacts,
+not findings: `(0, ...liveReportsEnabled) is not a function` for a function that exists and
+typechecks. **Restart the server and re-fetch anything that failed** before reporting it. Two of
+three 500s in the 2026-08-20 sweep were this.
+
+### 6. Report in four buckets, not two
+
+| bucket | meaning |
+|---|---|
+| **broken** | non-200, or 200 with an exception in the log |
+| **silently partial** | 200, but the log shows failed queries — the confident-zero case |
+| **blank** | 200, no errors, no data — is that honest or a defect? |
+| **slow** | statement timeouts; they will behave differently under production load |
+
+State the count you swept and the count you skipped. A sweep that quietly omits dynamic routes
+reads as "everything is fine".
+
+## What NOT to conclude
+
+- **A 200 is not a pass.** Check the log for every route, not just the failures.
+- **A blank page is not necessarily broken.** It may be honest — CLAUDE.md's rule is that a
+  confident zero must be disclosed, not that it must be filled.
+- **Do not fix everything you find mid-sweep.** Collect, then decide. Fixing a crash that blocks
+  a flag flip is in scope; rewriting a page against the correct matview is its own PR.
+
+## Definition of done
+
+- [ ] Every static route in the section fetched; dynamic routes tested with real ids or explicitly
+      listed as skipped
+- [ ] Each failure attributed to a route from the server log, not inferred
+- [ ] Stale-module artefacts eliminated by a clean restart and re-fetch
+- [ ] Results in four buckets, with the swept and skipped counts stated
+- [ ] Anything that blocks a pending change fixed; everything else written up, not silently carried

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,11 @@ not within them.
 `political_donations` was checked for the same defect and is clean — no aggregate-shaped donor
 names. Filter 2 is specific to `justice_funding`.
 
+**Run `/money-audit` before shipping any surface that renders a dollar figure.** It enumerates
+every summing site, classifies each as grant-lane or expenditure-lane, and refuses to call a
+filter applied without measuring the delta. It exists because `topicFilter()` mixed the two lanes
+for months and published $31.66bn where the grant figure was $0.92bn.
+
 Use `isRealRecipient()` / `themeMoney()` from `apps/web/src/lib/justice-money.ts` rather than
 rewriting the predicate. Two further traps are handled there:
 
@@ -277,8 +282,14 @@ SELECT remoteness, COUNT(*) FROM gs_entities WHERE is_community_controlled = tru
 
 1. **Start:** Run `/preflight` to check database, env, git, and types
 2. **Work:** Build features, fix bugs, run agents
-3. **Ship:** Run `/ship-merge` — do NOT hand-roll push/PR/merge (see Landing Policy below)
-4. **Close:** Run `/close` to verify, commit, and update handoff
+3. **Before shipping a money surface:** `/money-audit` — figures are the product
+4. **Before flipping a flag that changes what many pages read:** `/surface-sweep` — 200 is not working
+5. **Ship:** Run `/ship-merge` — do NOT hand-roll push/PR/merge (see Landing Policy below)
+6. **Close:** Run `/close` to verify, commit, and update handoff
+
+**`/config-truth` when a feature is configured but inert.** `/preflight` checks env vars are
+*present*; `/config-truth` checks their deployed values can satisfy the comparisons the code makes
+on them. That gap hid a trailing newline that blanked 61 public pages for four months.
 
 ## Cutting scope: sweep the periphery (learned the hard way, 2026-08-18)
 


### PR DESCRIPTION
Classified VISIBLE only because `.claude/skills/` is an unrecognised path. **No code, no rendered surface** — three skill files, a CLAUDE.md section and a preflight note. Merge whenever.

Each of these encodes a procedure I ran ad-hoc today that found a real defect. All three took most of an hour and follow the same steps every time.

## `/money-audit`

Enumerate every money-summing site on a surface, classify each as **grant-lane** or **expenditure-lane**, **measure the delta in SQL before changing anything**, then apply the canonical predicate from `justice-money.ts`.

Its central rule: **a filter applied without a before-and-after is indistinguishable from a filter that did nothing.** Every finding ends in a number that changed, or it isn't a finding.

Found `topicFilter()` publishing **$31.66bn where the grant figure is $0.92bn**.

Carries the warning that made this a judgement call rather than a sweep: six functions are expenditure **by design** — 17 of 18 `%-budget-sds` rows are `is_aggregate = true` and that *is* the measurement. Sweeping replaces one silent error with another.

## `/config-truth`

Compare **deployed** env values against what the code can accept — not whether the var is set.

Found `CIVICGRAPH_LIVE_REPORTS` stored as `"true\n"` against a `=== 'true'` check, which had blanked 61 public pages since April. Includes:

- the precise grep — `\n"$`, **not** `n"$`, which also matches any value ending in the letter n
- the four-private-copies trap (fixing the shared helper alone would have left four pages broken; one used `!==`, which a grep for `=== '` misses)
- the same failure shape in CSS custom properties — an undefined `var()` is silent exactly like a failed `===`

## `/surface-sweep`

Render every route against the live DB and attribute failures to pages **from the server log**.

Its point: **three of the four broken report routes return HTTP 200.** A status-code sweep passes them all. `/reports/influence-network` returns 200 while every one of its queries fails.

Includes the stale-Turbopack-module artefact that produced two false 500s in the real sweep, and the rule to restart and re-fetch before reporting a failure you may have caused.

## Wired so they fire

They sit unused otherwise:

- **CLAUDE.md** — the mandatory-filters section now points at `/money-audit`; Daily Workflow names all three at their decision points.
- **`/preflight`** — a new "what preflight does NOT check" section: it verifies vars are *present*, and a var can be set, non-empty and still wrong. Points at `/config-truth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)