### PR TITLE
Two report pages take longer to prerender than Vercel's 60s cap allows

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,6 +12,27 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // Report pages query the live database while prerendering, and the default 60s cap is not
+  // enough for the slowest of them. Measured 2026-08-20 with CIVICGRAPH_LIVE_REPORTS on:
+  //
+  //     /reports/community-efficiency   59.6s   ← failed the build 3 attempts running
+  //     /reports/board-interlocks       56.4s   ← would be next
+  //     /reports/youth-justice/qld/crime-prevention-schools  28.0s
+  //     /reports/tax-transparency       27.7s
+  //     /reports/philanthropy-power     23.1s
+  //
+  // Nobody had seen these numbers before, because the flag that makes these pages query anything
+  // has been inert since April (#339) — so every build until now prerendered them against an
+  // empty stub in milliseconds.
+  //
+  // Raising the cap rather than marking the slow pages `force-dynamic`: ISR keeps them instant
+  // for readers and costs one slow render an hour, where force-dynamic would put the query on
+  // every request. The real fix for the two worst is a precomputed matview — `charity_browse`
+  // went 10.4s to 92ms that way — and that is tracked separately, not papered over here.
+  //
+  // Cost: roughly 3 extra minutes of build, against the 45-minute cap noted above. `cpus: 2`
+  // already bounds how many of these run at once, which also keeps them off the shared pooler.
+  staticPageGenerationTimeout: 180,
   experimental: {
     externalDir: true,
     // Vercel's 4-core/8GB builder OOM-SIGKILLs this build repeatedly. Fewer


### PR DESCRIPTION
Classified VISIBLE because it touches `next.config.ts`. **Nothing rendered changes** — it's a build-time cap.

## What happened

`/reports/community-efficiency` failed a preview build three attempts running — *"took more than 60 seconds"* — and took the whole build down with it, failing #341 on a rebase that was otherwise clean.

**Nobody had seen this before**, because the flag that makes report pages query anything has been inert since April (#339). Every build for four months prerendered 58 report pages against an empty stub, in milliseconds. Setting `CIVICGRAPH_LIVE_REPORTS` in the Preview environment today was the first time any build had run them against the real database.

## Measured, with the flag on

```
/reports/community-efficiency                         59.6s   ← the one that failed
/reports/board-interlocks                             56.4s   ← would have been next
/reports/youth-justice/qld/crime-prevention-schools   28.0s
/reports/tax-transparency                             27.7s
/reports/philanthropy-power                           23.1s
```

Then a cliff — everything else is under 20s.

## Why raise the cap rather than mark them `force-dynamic`

ISR keeps these pages **instant for readers** and costs one slow render an hour. `force-dynamic` would put a 59-second query on **every request**.

Cost: roughly 3 extra minutes of build against the 45-minute cap already noted in the config. `cpus: 2` bounds how many run at once, which also keeps them off the shared Supabase pooler.

## This unblocks #339 as much as #341

Production has the flag too. Once #339 makes the code honour it, **production builds hit exactly this.** Landing #339 without this would have failed the production build on the first deploy — safe in itself (Vercel keeps the last good deploy) but nothing would ship, and it would look like the flag broke the site.

## Verified by the thing that failed

A full local `next build` with `CIVICGRAPH_LIVE_REPORTS=true` — the exact condition. **Exit 0, no timeouts.**

## Follow-up, deliberately not papered over here

A 59-second page wants a **precomputed matview**, not a longer timeout. `charity_browse` went 10.4s → 92ms that way. The two worst pages are named in the config comment so this stays findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)