### PR TITLE
/reports/influence-network renders a fabricated zero about political influence

### DIFF
--- a/apps/web/src/app/reports/influence-network/page.tsx
+++ b/apps/web/src/app/reports/influence-network/page.tsx
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { ReportUnavailable } from '../_components/report-unavailable';
 import type { Metadata } from 'next';
 import { getServiceSupabase } from '@/lib/report-supabase';
 import { safe } from '@/lib/services/utils';
@@ -210,7 +211,34 @@ const getDataCached = unstable_cache(getData, ['reports-influence-network'], { r
 
 export default async function InfluenceNetworkReport() {
   const d = await getDataCached();
-  if (!d) return <div className="p-8 text-bauhaus-muted">No data available.</div>;
+  if (!d) return <ReportUnavailable title="The Influence Network" />;
+
+  // EVERY figure on this page comes from a column that does not exist.
+  //
+  // The queries below select `in_procurement`, `in_political_donations`, `in_foundation`,
+  // `system_count`, `power_score`, `procurement_dollars`, `donation_dollars`,
+  // `distinct_govt_buyers`, `distinct_parties_funded` and `total_dollar_flow` from
+  // `mv_revolving_door`. That view has none of them — they belong to `mv_entity_power_index`.
+  // The page was written against one view's shape and points at another's.
+  //
+  // So the select errors, `safe()` returns null, `|| []` makes it an empty list, and 62 sites
+  // below coerce with `|| 0`. The page then renders a complete, confident, entirely fabricated
+  // zero — about political influence, on a public URL. That is worse than rendering nothing,
+  // and it is the exact failure `ReportUnavailable` exists for (#331).
+  //
+  // This guard is a STOPGAP, not the fix. The fix is to rewrite the data layer against the
+  // columns that exist (`contracts`, `donates`, `influence_vectors`, `total_contracts`,
+  // `total_donated`, `distinct_buyers`, `parties_funded`) — 62 sites across 608 lines, its own
+  // PR. The party-aggregate query also sums `political_donations.amount` with no
+  // `receipt_type` filter, which nationally is the difference between $240.8bn and $25.3bn.
+  if (d.allEntities.length === 0) {
+    return (
+      <ReportUnavailable
+        title="The Influence Network"
+        detail="This report reads columns that its source view does not have, so it has no figures to show. Rendering zeros here would be a claim about who holds influence in Australia, and we do not have one."
+      />
+    );
+  }
 
   const s = d.stats;
 


### PR DESCRIPTION
**VISIBLE.** Urgent-ish: #339 merged minutes ago, which is what turns this from an invisible bug into a published claim.

## What it does today

Every figure on the page comes from a column that does not exist.

It selects `in_procurement`, `in_political_donations`, `in_foundation`, `system_count`, `power_score`, `procurement_dollars`, `donation_dollars`, `distinct_govt_buyers`, `distinct_parties_funded` and `total_dollar_flow` from **`mv_revolving_door`**. That view has **none of them** — they belong to `mv_entity_power_index`. The page was written against one view's shape and points at another's.

The chain: select errors → `safe()` returns null → `|| []` makes an empty list → **62 sites coerce with `|| 0`** → the page renders a complete, confident, entirely fabricated zero. About who holds political influence in Australia. On a public URL. With no error, no empty state, and nothing telling a reader that none of it was measured.

## Why now

It has been doing this unnoticed because report pages have read an empty stub since April. **#339 merged today** — now they read the live database, and this page is the one that turns four months of blankness into a published claim.

## This is a stopgap, not the fix

The fix is to rewrite the data layer against the columns that actually exist:

| page expects | real column |
|---|---|
| `in_procurement` | `contracts` |
| `in_political_donations` | `donates` |
| `system_count` | `influence_vectors` |
| `procurement_dollars` | `total_contracts` |
| `donation_dollars` | `total_donated` |
| `distinct_govt_buyers` | `distinct_buyers` |
| `distinct_parties_funded` | `parties_funded` (text[]) |
| `total_dollar_flow` | sum of the three |
| `in_foundation` | **no equivalent** |

62 sites across 608 lines — its own PR, its own review.

**Also waiting there:** the party-aggregate query sums `political_donations.amount` with **no `receipt_type` filter**. Nationally that is the difference between $240.8bn and $25.3bn.

## The change

Uses `ReportUnavailable` — the component #331 added for exactly this. Saying nothing loaded is honest and costs the reader a refresh. A zero is a claim about Australia.

The reasoning is in a comment at the guard, so whoever picks up the rewrite finds the column map rather than rediscovering it.

## Verified

`./scripts/precheck.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)