### PR TITLE
'donation' was a claim the graph made about 1.13M rows and 184K satisfied

### DIFF
--- a/apps/web/src/app/api/ask/route.ts
+++ b/apps/web/src/app/api/ask/route.ts
@@ -13,7 +13,7 @@ You have access to these PostgreSQL tables:
 Columns: id (uuid), entity_type (text: charity, company, foundation, indigenous_corp, social_enterprise, government_body, political_party), canonical_name (text), abn (text), gs_id (text), state (text), postcode (text), sector (text), remoteness (text: 'Major Cities of Australia', 'Inner Regional Australia', 'Outer Regional Australia', 'Remote Australia', 'Very Remote Australia'), seifa_irsd_decile (smallint 1-10, 1=most disadvantaged), is_community_controlled (boolean), lga_name (text), lga_code (text), latest_revenue (numeric), latest_assets (numeric)
 
 ## gs_relationships (~3.43M rows) — links between entities
-Columns: id, source_entity_id (uuid->gs_entities.id), target_entity_id (uuid->gs_entities.id), relationship_type (text: 'contract', 'donation', 'grant', 'subsidiary_of', 'lobbies_for'), amount (numeric), year (integer), dataset (text)
+Columns: id, source_entity_id (uuid->gs_entities.id), target_entity_id (uuid->gs_entities.id), relationship_type (text: 'contract', 'donation', 'party_receipt', 'grant', 'subsidiary_of', 'lobbies_for'). 'donation' is a real political donation; 'party_receipt' is other party income from the same AEC returns — fundraising, transfers, levies, subscriptions. Never add them together and call the result donations., amount (numeric), year (integer), dataset (text)
 
 ## austender_contracts (~824K rows) — federal government contracts
 Columns: id, title, contract_value (numeric), buyer_name, supplier_name, supplier_abn, contract_start (date), contract_end (date), category, procurement_method

--- a/apps/web/src/app/api/query/route.ts
+++ b/apps/web/src/app/api/query/route.ts
@@ -10,7 +10,7 @@ You have access to these PostgreSQL tables:
 Columns: id (uuid), entity_type (text: charity, company, foundation, indigenous_corp, social_enterprise, government_body, political_party), canonical_name (text), abn (text), gs_id (text), state (text), postcode (text), sector (text), remoteness (text: 'Major Cities of Australia', 'Inner Regional Australia', 'Outer Regional Australia', 'Remote Australia', 'Very Remote Australia'), seifa_irsd_decile (smallint 1-10, 1=most disadvantaged), is_community_controlled (boolean), lga_name (text), lga_code (text), latest_revenue (numeric), latest_assets (numeric)
 
 ## gs_relationships (~200K rows) — links between entities
-Columns: id, source_entity_id (uuid→gs_entities.id), target_entity_id (uuid→gs_entities.id), relationship_type (text: 'contract', 'donation', 'grant', 'subsidiary_of'), amount (numeric), year (integer), dataset (text)
+Columns: id, source_entity_id (uuid→gs_entities.id), target_entity_id (uuid→gs_entities.id), relationship_type (text: 'contract', 'donation', 'party_receipt', 'grant', 'subsidiary_of'). 'donation' is a real political donation; 'party_receipt' is other party income from the same AEC returns — fundraising, transfers, levies. Never add them together and call the result donations., amount (numeric), year (integer), dataset (text)
 
 ## austender_contracts (~670K rows) — federal government contracts
 Columns: id, title, contract_value (numeric), buyer_name, supplier_name, supplier_abn, contract_start (date), contract_end (date), category, procurement_method

--- a/scripts/check-graph-completeness.mjs
+++ b/scripts/check-graph-completeness.mjs
@@ -123,8 +123,13 @@ async function checkDataset(def) {
     `${pre}SELECT count(*) FROM (SELECT DISTINCT ${EDGE_KEY_COLS} FROM (${def.selectSql}) _q) _d;`));
 
   // ACTUAL: edges currently in gs_relationships for this dataset + type.
+  // A dataset may emit MORE THAN ONE relationship type. aec_donations splits on receipt_type into
+  // 'donation' and 'party_receipt', so counting only `relationshipType` would compare every
+  // expected row against the donations alone and report 87% drift on a healthy graph.
+  const types = def.relationshipTypes ?? [def.relationshipType];
+  const typeList = types.map((t) => `'${t}'`).join(', ');
   const actual = Number(await psqlScalar(`actual:${def.dataset}`,
-    `SELECT count(*) FROM gs_relationships WHERE dataset = '${def.dataset}' AND relationship_type = '${def.relationshipType}';`));
+    `SELECT count(*) FROM gs_relationships WHERE dataset = '${def.dataset}' AND relationship_type IN (${typeList});`));
 
   // SOURCE rows: coverage denominator (the trend line).
   const sourceRows = Number(await psqlScalar(`source:${def.dataset}`,
@@ -142,7 +147,7 @@ async function checkDataset(def) {
 
   return {
     dataset: def.dataset,
-    relationship_type: def.relationshipType,
+    relationship_type: (def.relationshipTypes ?? [def.relationshipType]).join('+'),
     expected_edges: expected,
     actual_edges: actual,
     source_rows: sourceRows,

--- a/scripts/lib/graph-edge-datasets.mjs
+++ b/scripts/lib/graph-edge-datasets.mjs
@@ -27,7 +27,11 @@ export const EDGE_KEY_COLS = "source_entity_id, target_entity_id, relationship_t
 export const GRAPH_EDGE_DATASETS = [
   {
     dataset: 'aec_donations',
+    // TWO types out of one source, split on receipt_type. See the CASE in selectSql below.
+    // `relationshipType` stays for the reporting label; `relationshipTypes` is what the
+    // completeness gate counts, or it would expect every row and find only the donations.
     relationshipType: 'donation',
+    relationshipTypes: ['donation', 'party_receipt'],
     label: 'Donation relationships',
     sourceTable: 'political_donations',
     cols: '(source_entity_id, target_entity_id, relationship_type, amount, year, dataset, source_record_id, confidence, properties)',
@@ -45,7 +49,30 @@ export const GRAPH_EDGE_DATASETS = [
      CREATE INDEX ON donor_map(key);
      ANALYZE donor_map;`,
     selectSql: `SELECT
-       donor.id AS source_entity_id, party.id AS target_entity_id, 'donation' AS relationship_type, d.amount,
+       donor.id AS source_entity_id, party.id AS target_entity_id,
+       -- relationship_type = 'donation' is a CLAIM about a row, and until 2026-08-20 this
+       -- builder made it about every row of political_donations. Measured on the edges:
+       --
+       --   other receipt        797,404 edges   108.62 bn   <- fundraising income, transfers, levies
+       --   donation received    184,078 edges    17.32 bn   <- the actual donations
+       --   (null)               103,887 edges     6.85 bn
+       --   subscription          17,813 edges     1.20 bn
+       --   unspecified           27,237 edges     0.94 bn
+       --   public funding         1,435 edges     0.35 bn
+       --
+       -- 87% of the dollars were not donations, and /reports/donor-contractors published the
+       -- inflated total as "they donated 31.3 bn to 1073 political parties".
+       --
+       -- The fix is NOT a WHERE clause. Filtering here would delete 950K rows of real, useful
+       -- data — party fundraising income is how parties are funded, and worth being able to ask
+       -- about. It is also not a filter at each read site: seven matviews read this type, and
+       -- asking every future consumer to remember properties->>'receipt_type' is precisely how
+       -- the justice_funding filters came to be missing from 98 of 100 files.
+       --
+       -- So the rows stay and the LABEL stops lying. Everything that already filters
+       -- relationship_type = 'donation' becomes correct with no change to it.
+       CASE WHEN d.receipt_type = 'donation received' THEN 'donation'
+            ELSE 'party_receipt' END AS relationship_type, d.amount,
        NULLIF(split_part(d.financial_year, '-', 1), '')::int,
        'aec_donations', d.id::text AS source_record_id, 'registry',
        jsonb_build_object(

--- a/scripts/resolve-donor-entities.mjs
+++ b/scripts/resolve-donor-entities.mjs
@@ -248,7 +248,11 @@ async function main() {
       relationships.push({
         source_entity_id: donorEntityId,
         target_entity_id: partyEntityId,
-        relationship_type: 'donation',
+        // Same split as scripts/lib/graph-edge-datasets.mjs. THIS SCRIPT IS A SECOND WRITER of
+        // aec_donations edges — 110,402 of them, 6.13 bn — and fixing only the set-based builder
+        // would look correct until the next run of this one silently re-injected 'donation' edges
+        // for rows that are party fundraising income, transfers and levies.
+        relationship_type: d.receipt_type === 'donation received' ? 'donation' : 'party_receipt',
         amount: d.amount,
         year,
         dataset: 'aec_donations',


### PR DESCRIPTION
Code only. **The rebuild is not run** — commands below, both Tier 3.

## The bug

`relationship_type = 'donation'` says a row is a political donation. Both writers applied it to every row of `political_donations`:

| `receipt_type` | edges | $bn |
|---|---|---|
| other receipt | 797,404 | **108.62** |
| **donation received** | **184,078** | **17.32** |
| *(null)* | 103,887 | 6.85 |
| subscription | 17,813 | 1.20 |
| unspecified | 27,237 | 0.94 |
| public funding | 1,435 | 0.35 |

87% of the dollars were not donations. `/reports/donor-contractors` published the total as *"they donated $31.3B to 1073 political parties"*. Measured: **556 entities, $0.86bn**.

## The fix is not a WHERE clause, and that's the point

**Filtering in the builder** would delete 950K rows of real data. Party fundraising income is *how parties are funded* — worth being able to ask about, not worth destroying.

**Filtering at each read site** is worse. Seven matviews read this type, and asking every future consumer to remember `properties->>'receipt_type'` is exactly how the `justice_funding` filters came to be missing from 98 of 100 files. **This repo already learned that lesson — `measure_kind` exists for it.**

So the rows stay and the **label** stops lying:

```sql
CASE WHEN d.receipt_type = 'donation received' THEN 'donation'
     ELSE 'party_receipt' END
```

**All seven matviews become correct with no change to any of them.** `mv_revolving_door`, `mv_entity_power_index`, `mv_gs_donor_contractors`, the place views — they already filter `relationship_type = 'donation'`; that filter starts meaning what it says.

## Four sites, because three would have made this look done

1. **`graph-edge-datasets.mjs`** — the CASE. 1,021,452 edges.
2. **`resolve-donor-entities.mjs`** — **a second writer**, 110,402 edges / $6.13bn. Found by grepping consumers rather than assuming there was one. Fixing only (1) would look correct until the next run of this re-injected mislabelled edges.
3. **`check-graph-completeness.mjs`** — the gate counts by `relationship_type`, so a split dataset would compare every expected row against the donations alone and **report 87% drift on a healthy graph**. Datasets may now declare `relationshipTypes`.
4. **`/api/ask` and `/api/query`** — both hardcode the valid types in their LLM prompt. Without this the new type is invisible to the natural-language surfaces: correct data, unreachable. Both now also instruct never to add the two together.

## To apply (Tier 3, yours)

```bash
node scripts/build-entity-graph.mjs --phase=donations
# then refresh the dependent matviews
```

## Heads up — external contract

`/api/data/graph` filters `relationship_type = 'donation'`. Per `docs/integrations/`, that's the Giving Data Commons API and **Empathy Ledger consumes it**. Its donation figures will drop ~87% after the rebuild. That's a **correction** — it has been serving inflated numbers — but it should be told, not discovered.

## Relationship to #347

#347 filters `mv_gs_donor_contractors` on `properties->>'receipt_type'` downstream. Still worth applying now: it fixes the live page today without a rebuild. Once this lands and the graph is rebuilt, that predicate becomes redundant but harmless.

## Verified

`./scripts/precheck.sh` green. Module parses; gate confirmed to emit `relationship_type IN ('donation', 'party_receipt')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)