### PR TITLE
Stop trying to read Vercel previews; verify locally and hand Ben the link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,3 +458,38 @@ This repo's cluster: see brand alignment map. The map says:
 **Rule**: read the map before designing. Update the map BEFORE shipping a new design. Never re-decide what's already decided.
 
 <!-- END ACT-CONTEXT -->
+
+## Verifying a change: local first, previews for Ben (decided 2026-08-20)
+
+A whole session went on trying to read Vercel previews. They are protected by SSO, an agent
+cannot sign in, and every attempt cost an 8–11 minute build and ended at a login page. Meanwhile
+everything that was actually found that day came from local:
+
+| found by | what |
+|---|---|
+| `npm run dev` on 3013 | the 61-route sweep, the donor-contractors crash, the state-disclosure render, the influence-network zeros |
+| a local production build | the 60s static-generation limit that failed a preview build (#344) |
+| a Vercel preview | nothing |
+
+**So: local for the agent's verification, previews for Ben's review. The agent does not try to
+read previews.** Hand Ben the URL with the specific thing to look at, and say plainly what was
+verified locally.
+
+### `npm run dev` is not enough on its own
+
+Dev mode is not a production build. The 60-second prerender cap only exists at build time, so no
+amount of clicking around a dev server would ever have surfaced it. Before claiming a
+public-surface change is verified:
+
+```bash
+cd apps/web && npm run preview     # production build + start on :3015, live reports on
+```
+
+It shares `.next` with the dev server, so stop dev first — `scripts/precheck.sh` says the same
+thing and for the same reason.
+
+### What local genuinely cannot tell you
+
+Vercel build-machine limits, deployment protection behaviour, and the values of production env
+vars. The first is mostly covered by `npm run preview`; for the third use `/config-truth`, because
+a var can be set, non-empty and still wrong.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "palette": "node scripts/palette-scan.mjs",
-    "palette:baseline": "node scripts/palette-scan.mjs --write"
+    "palette:baseline": "node scripts/palette-scan.mjs --write",
+    "preview": "CIVICGRAPH_LIVE_REPORTS=true next build && CIVICGRAPH_LIVE_REPORTS=true next start -p 3015"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.50",


### PR DESCRIPTION
SAFE — `package.json` script + a CLAUDE.md section. Nothing rendered changes.

## The problem this closes

A large part of today went on preview mechanics. Previews are SSO-protected, an agent cannot sign in, and every attempt cost an 8–11 minute build and ended on a login page. Three `vercel redeploy` calls were cancelled by the ignored-build step in under 12 seconds each, and an empty commit does not trigger a rebuild because zero files changed — correct behaviour, and it also means **an env-var change can never trigger a rebuild**.

Meanwhile, everything actually found today came from local:

| found by | what |
|---|---|
| `npm run dev` on 3013 | the 61-route sweep, the `donor-contractors` crash, the state-disclosure render, the influence-network zeros |
| a local production build | the 60s static-generation cap that failed a preview build (#344) |
| **a Vercel preview** | **nothing** |

## The decision

**Local for the agent's verification, previews for Ben's review, and the agent does not try to read previews at all.**

That removes the friction rather than tooling around it. A Vercel protection-bypass token — free, two minutes in the dashboard — would have made the slow path work while the fast path sat unused. Recommended against, and the reasoning is in CLAUDE.md so it doesn't get re-litigated.

## `npm run dev` is not enough on its own

Dev mode is not a production build. The prerender cap only exists at build time, so no amount of clicking a dev server would have surfaced #344.

```bash
cd apps/web && npm run preview   # production build + next start on :3015, live reports on
```

That's what "verified" should mean before a public-surface claim. It shares `.next` with dev, so stop dev first — `precheck.sh` already says so for the same reason.

## What local genuinely cannot tell you

Vercel build-machine limits, deployment protection behaviour, and production env values. The first is mostly covered by `npm run preview`; the third points at `/config-truth`, because a var can be set, non-empty and still wrong.

## Verified

Full `./scripts/precheck.sh` including the production build. (I pushed the first commit after a `--fast` run, which the script tells you not to do; re-ran it properly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)