### PR TITLE
Two API endpoints have been returning nothing, including the public one

### DIFF
--- a/apps/web/src/app/api/data/political-money/route.ts
+++ b/apps/web/src/app/api/data/political-money/route.ts
@@ -115,16 +115,25 @@ export async function GET() {
       }),
 
       // 5. Pay-to-play: entities that both donate and hold contracts
-      // Use mv_revolving_door which already has this cross-reference
-      supabase
-        .from('mv_revolving_door')
-        .select('gs_id, canonical_name, entity_type, abn, state, donation_dollars, procurement_dollars, distinct_parties_funded, contract_count, revolving_door_score')
-        .eq('in_political_donations', true)
-        .eq('in_procurement', true)
-        .gt('donation_dollars', 0)
-        .gt('procurement_dollars', 0)
-        .order('procurement_dollars', { ascending: false })
-        .limit(100),
+      // WAS selecting donation_dollars, procurement_dollars, distinct_parties_funded,
+      // in_political_donations and in_procurement from mv_revolving_door. That view has none of
+      // them — they are all on mv_entity_power_index. The select errored, so this endpoint has
+      // been returning an empty donor-contractor list to every caller, including the Giving Data
+      // Commons consumers documented in docs/integrations/.
+      //
+      // The two views are complementary: the power index holds the measurements, mv_revolving_door
+      // holds revolving_door_score. Joined rather than swapped, so the score survives.
+      supabase.rpc('exec_sql', {
+        query: `SELECT p.gs_id, p.canonical_name, p.entity_type, p.abn, p.state,
+                  p.donation_dollars, p.procurement_dollars, p.distinct_parties_funded,
+                  p.contract_count, COALESCE(rd.revolving_door_score, 0) AS revolving_door_score
+             FROM mv_entity_power_index p
+             LEFT JOIN mv_revolving_door rd ON rd.gs_id = p.gs_id
+            WHERE p.in_political_donations = 1 AND p.in_procurement = 1
+              AND p.donation_dollars > 0 AND p.procurement_dollars > 0
+            ORDER BY p.procurement_dollars DESC
+            LIMIT 100`,
+      }),
     ]);
 
     // Parse results

--- a/apps/web/src/app/api/power/accountability/route.ts
+++ b/apps/web/src/app/api/power/accountability/route.ts
@@ -52,12 +52,27 @@ export async function GET() {
       // Revolving door: entities in 2+ influence systems
       safe(
         supabase
-          .from('mv_revolving_door')
-          .select(
-            'gs_id, canonical_name, entity_type, state, is_community_controlled, system_count, procurement_dollars, donation_dollars, contract_count, distinct_govt_buyers, distinct_parties_funded, total_dollar_flow, revolving_door_score'
-          )
-          .order('revolving_door_score', { ascending: false })
-          .limit(20)
+          // system_count, procurement_dollars, donation_dollars, distinct_govt_buyers,
+          // distinct_parties_funded and total_dollar_flow are NOT on mv_revolving_door — they are
+          // on mv_entity_power_index. This select errored and the endpoint returned nothing.
+          // Base on mv_revolving_door (the subject: entities with 2+ influence vectors, and the
+          // only home of revolving_door_score) and join the power index for the measurements.
+          .rpc('exec_sql', {
+            query: `SELECT rd.gs_id, rd.canonical_name, rd.entity_type, rd.state,
+                      rd.is_community_controlled,
+                      COALESCE(p.system_count, 0)            AS system_count,
+                      COALESCE(p.procurement_dollars, 0)     AS procurement_dollars,
+                      COALESCE(p.donation_dollars, 0)        AS donation_dollars,
+                      COALESCE(p.contract_count, 0)          AS contract_count,
+                      COALESCE(p.distinct_govt_buyers, 0)    AS distinct_govt_buyers,
+                      COALESCE(p.distinct_parties_funded, 0) AS distinct_parties_funded,
+                      COALESCE(p.total_dollar_flow, 0)       AS total_dollar_flow,
+                      rd.revolving_door_score
+                 FROM mv_revolving_door rd
+                 LEFT JOIN mv_entity_power_index p ON p.gs_id = rd.gs_id
+                ORDER BY rd.revolving_door_score DESC NULLS LAST
+                LIMIT 20`,
+          })
       ),
 
       // Summary stats


### PR DESCRIPTION
SAFE — two API routes. The systematic pass you asked for.

## Method

Scripted audit of **all 20 files** that query `mv_revolving_door`, checking every referenced column against the view's actual 22. Not a read-through — a diff.

**Four surfaces were asking for columns it doesn't have.** Two are fixed on other branches (#353 influence-network, #355 political-money page). These are the other two, and neither had been noticed because **both fail silently**.

## `/api/data/political-money` — the public one

Selected `donation_dollars`, `procurement_dollars`, `distinct_parties_funded`, filtered on `in_political_donations` / `in_procurement`. **None exist on that view.**

The select errored, so this endpoint has been returning an **empty donor-contractor list to every caller**. Per `docs/integrations/`, that's the Giving Data Commons API.

## `/api/power/accountability`

Selected `system_count`, `procurement_dollars`, `donation_dollars`, `distinct_govt_buyers`, `distinct_parties_funded`, `total_dollar_flow`. Same story, same result.

## The fix

All ten missing columns live on `mv_entity_power_index`. **Joined, not switched** — `revolving_door_score` exists only on `mv_revolving_door`, and swapping views would lose it.

The two are complementary: the power index holds measurements for 185,393 entities; `mv_revolving_door` holds the 3,586-entity subject.

Verified the join returns **865 rows**, matching what the political-money page now publishes.

## Why this class hides so well

PostgREST returns an error object the caller swallows. SQL against a missing column fails inside `exec_sql`, where the page turns it into an empty array. **Nothing throws.** The endpoint answers 200 with nothing in it — which is indistinguishable from "there is nothing to report".

## A guard exists, deliberately not in this PR

I wrote a test that walks every file touching `mv_revolving_door` and fails on any phantom column. It **correctly fails right now**, because #353 and #355 are unmerged and those two pages are still broken on `main`. It lands the moment they do — merging them first, then this, then the guard, closes the class permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)