### PR TITLE
The public API reported Westpac as donating $3.5bn. It donated $82m.

### DIFF
--- a/apps/web/src/app/api/data/entity/[identifier]/route.ts
+++ b/apps/web/src/app/api/data/entity/[identifier]/route.ts
@@ -117,9 +117,16 @@ export async function GET(
       e.abn
         ? safe(
             supabase.rpc('exec_sql', {
+              // 'other receipt' is 72% of rows and 85% of dollars in political_donations and
+              // is NOT donations — it is party fundraising income, transfers and levies. Without
+              // this filter THIS ENDPOINT reported Westpac as donating $3,478.6m against a real
+              // $82.0m, and Sino Iron Pty Ltd & Korean Steel Pty Ltd as donating $8,108m when
+              // they donated nothing. 1,880 entities were overstated by more than 10x, on a
+              // public API, about named organisations.
               query: `SELECT COALESCE(SUM(amount), 0)::bigint as total,
                              COUNT(*)::int as count
-                        FROM political_donations WHERE donor_abn = '${esc(e.abn)}'`,
+                        FROM political_donations WHERE donor_abn = '${esc(e.abn)}'
+                          AND receipt_type = 'donation received'`,
             })
           )
         : Promise.resolve(null),

--- a/apps/web/src/app/entities/[gsId]/page.tsx
+++ b/apps/web/src/app/entities/[gsId]/page.tsx
@@ -340,6 +340,7 @@ export default async function EntityDossierPage({
       query: `SELECT donation_to, SUM(amount)::bigint as total, COUNT(*)::int as count,
                      array_agg(DISTINCT financial_year ORDER BY financial_year) as years
               FROM political_donations WHERE donor_abn = '${e.abn}'
+                AND receipt_type = 'donation received'
               GROUP BY donation_to ORDER BY total DESC LIMIT 20`,
     });
     politicalDonations = (donData || []) as DonationRow[];

--- a/apps/web/src/app/entity/[gsId]/print/page.tsx
+++ b/apps/web/src/app/entity/[gsId]/print/page.tsx
@@ -43,6 +43,7 @@ export default async function PrintEntityPage({ params }: { params: Promise<{ gs
     e.abn ? safe(supabase.rpc('exec_sql', {
       query: `SELECT donation_to, SUM(amount)::bigint as total, COUNT(*)::int as count
          FROM political_donations WHERE donor_abn = '${e.abn}'
+           AND receipt_type = 'donation received'
          GROUP BY donation_to ORDER BY total DESC LIMIT 10`,
     })) : null,
     e.abn ? safe(supabase.rpc('exec_sql', {


### PR DESCRIPTION
**VISIBLE and urgent.** A public API making dollar claims about named organisations, some of which donated nothing.

## The defect

`/api/data/entity/{identifier}` summed `political_donations.amount` with **no `receipt_type` filter**. 'other receipt' is 72% of rows and 85% of the dollars — party fundraising income, transfers and levies. Not donations.

Measured on production:

| entity | API reported | actually donated |
|---|---|---|
| **Sino Iron Pty Ltd & Korean Steel Pty Ltd** | **$8,108m** | **$0** |
| **Westpac** | $3,478.6m | $82.0m |
| **Greaton Development Pty Ltd** | **$3,201.6m** | **$0** |

**1,880 entities are overstated by more than 10x.**

## How it was found

I was writing a note to the Empathy Ledger maintainers about a *different* endpoint. `docs/integrations/empathy-ledger-anchor-card.md` says they consume `/api/data/entity/{abn}`, so I checked what that endpoint actually returns before describing it — and it was wrong.

I had also told Ben earlier that Empathy Ledger consumes `/api/data/political-money`. **That was wrong**; I'd generalised from "`/api/data` is the Commons API". The doc names the entity endpoint.

## The fix

`AND receipt_type = 'donation received'`, applied to the three surfaces that make per-organisation dollar claims:

- `/api/data/entity/{identifier}` — the public API
- `/entity/{gsId}/print`
- `/entities/{gsId}`

**`/entity/{gsId}` already had it.** Its comment is where the 72%/85% figures come from — the fix existed and had simply not been carried across to its siblings.

Verified: `/api/data/entity/33007457141` now returns **81,993,922** across 1,355 receipts.

## Deliberately not swept

Eighteen other files read `political_donations` without the filter. Several are **legitimate** — row counts for health checks, and "all receipts" is a real measure when labelled as such. They need reading one at a time rather than a regex, and none makes per-entity dollar claims:

```
app/insights/page.tsx                          app/api/data/health/route.ts
app/api/insights/route.ts                      app/api/data/graph/route.ts
app/api/ops/health/route.ts                    app/api/data/power-index/route.ts
app/api/mission-control/route.ts               app/api/data/entity/top/route.ts
app/api/query/route.ts                         app/reports/consulting-class/page.tsx
app/reports/multicultural-sector/fecca-eccv/page.tsx
app/reports/power-concentration/page.tsx       app/reports/political-money/page.tsx
app/reports/procurement-oligopoly/page.tsx     app/reports/youth-justice/qld/sector/page.tsx
lib/services/org-dashboard-service.ts          lib/services/report-service.ts
```

## Note on the gate

A test failed once during this work and passed on re-run with no code change — pooler contention after a day of heavy querying. Recording it rather than ignoring it. The gate is green on a clean run: 745 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)