### PR TITLE
/reports/education/[state] logged 13 query failures in one production build

### DIFF
--- a/apps/web/src/app/reports/education/[state]/page.tsx
+++ b/apps/web/src/app/reports/education/[state]/page.tsx
@@ -62,17 +62,28 @@ async function getStateReport(stateCode: string) {
     q(`SELECT entity_type, COUNT(*) as count
       FROM gs_entities WHERE state = '${sc}' AND sector ILIKE '%education%'
       GROUP BY entity_type ORDER BY count DESC`),
-    q(`SELECT COUNT(*) as contracts, SUM(contract_value)::bigint as total_value
-      FROM austender_contracts
-      WHERE (category ILIKE '%education%' OR category ILIKE '%training%'
-        OR title ILIKE '%school%' OR title ILIKE '%education%')
-        AND (supplier_state = '${sc}' OR buyer_state = '${sc}')`),
+    // austender_contracts has NO geographic column at all — not supplier_state, not buyer_state,
+    // not postcode or address. This query asked it for one, so it failed on every state and the
+    // page rendered its contract figures blank. Eight of the thirteen query failures this page
+    // logged in a single production build were this one line, once per state.
+    // Scope through the graph instead: join gs_entities on supplier_abn and use ITS state, which
+    // is how every other state-scoped contract query in the codebase does it.
+    q(`SELECT COUNT(*) as contracts, SUM(ac.contract_value)::bigint as total_value
+      FROM austender_contracts ac
+      JOIN gs_entities e ON e.abn = ac.supplier_abn
+      WHERE (ac.category ILIKE '%education%' OR ac.category ILIKE '%training%'
+        OR ac.title ILIKE '%school%' OR ac.title ILIKE '%education%')
+        AND e.state = '${sc}'`),
+    // `LEFT JOIN gs_relationships r ON r.source_entity_id = ge.id OR r.target_entity_id = ge.id`
+    // cannot use either index — an OR across two join keys forces a scan of 3.43M rows, and this
+    // timed out on five of the eight states in one production build. Two indexed counts instead:
+    // 2.9s and the same answer (QUT and Griffith top the list, as they should).
     q(`SELECT ge.canonical_name, ge.gs_id, ge.entity_type,
-        COUNT(DISTINCT r.id) as connections
+        (SELECT COUNT(*) FROM gs_relationships r WHERE r.source_entity_id = ge.id)
+        + (SELECT COUNT(*) FROM gs_relationships r WHERE r.target_entity_id = ge.id)
+        AS connections
       FROM gs_entities ge
-      LEFT JOIN gs_relationships r ON r.source_entity_id = ge.id OR r.target_entity_id = ge.id
       WHERE ge.state = '${sc}' AND ge.sector ILIKE '%education%'
-      GROUP BY ge.id, ge.canonical_name, ge.gs_id, ge.entity_type
       ORDER BY connections DESC LIMIT 15`),
     getOutcomesMetrics(sc, 'education'),
     q(`SELECT COUNT(*) as total_schools,


### PR DESCRIPTION
**VISIBLE.** Two defects, each multiplied by the eight states this page is generated for.

Both were invisible until #354 made `safe()` name the surface. Before that the build log said `[report-service] query failed` seventeen times and identified nothing.

## 1. `austender_contracts` has no geographic column

Not `supplier_state`, not `buyer_state`, not postcode or address. The contracts query filtered on:

```sql
AND (supplier_state = '${sc}' OR buyer_state = '${sc}')
```

So it **failed on every state**, and the page rendered its contract figures blank. That's **8 of the 13 failures** — one line, once per state.

Scoped through the graph instead — join `gs_entities` on `supplier_abn` and use *its* state, which is how every other state-scoped contract query here works.

**QLD education now returns 341 contracts worth $356m** where the page showed nothing.

## 2. An `OR` across two join keys can't use either index

```sql
LEFT JOIN gs_relationships r ON r.source_entity_id = ge.id OR r.target_entity_id = ge.id
```

Forces a scan of 3.43M rows. **Timed out on five of the eight states.** Replaced with two indexed counts: **2.9s**, same answer — Queensland University of Technology and Griffith top the list, which is what a connections ranking of QLD education entities should look like.

## Why this matters beyond one page

Neither is slowness in the ordinary sense. **The first is a query that can never succeed**, on a public page, failing silently — `safe()` returns null, the caller coerces, and the section renders as though it measured zero contracts.

That's the third distinct instance today of *"query written against a schema that isn't there"*, after `mv_revolving_door.in_procurement` and the `political_donations` receipt filter. The guard in #357 only covers `mv_revolving_door`; `supplier_state` shows the class is wider.

## How it was found

By reading a production build log. The surface-sweep that was impossible this morning took one command this afternoon — which is the return on #354.

## Verified

`./scripts/precheck.sh` green, 746 tests. Both rewritten queries run against production and return sensible results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)