### PR TITLE
Three queries that could never succeed, each rendering a panel empty

### DIFF
--- a/apps/web/src/app/reports/youth-justice/trackers/page.tsx
+++ b/apps/web/src/app/reports/youth-justice/trackers/page.tsx
@@ -183,7 +183,10 @@ async function getData() {
       r.status AS run_status,
       r.completed_at AS run_completed_at,
       r.duration_ms AS run_duration_ms
-    FROM agent_schedules
+    -- The alias. Every column above and in the WHERE is s.-prefixed, so without it this failed
+    -- with 'missing FROM-clause entry for table "s"' on every build, and the automations panel
+    -- rendered empty. agent_schedules has all five columns; only the two characters were missing.
+    FROM agent_schedules s
     LEFT JOIN latest_runs r
       ON r.agent_id = s.agent_id
      AND r.rn = 1

--- a/apps/web/src/lib/exec-sql-readonly.test.ts
+++ b/apps/web/src/lib/exec-sql-readonly.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The exec_sql read-only guard, exercised directly.
+ *
+ * It is not exported (it is an internal of the runtime client proxy), so this test re-evaluates
+ * the same predicate from source. That is deliberate: the alternative is exporting a security
+ * check purely to test it, and a copy that drifts would be caught by the first case below, which
+ * is taken verbatim from the query that exposed the bug.
+ *
+ * WHY IT CHANGED. The stacked-statement rule was `/;\s*\S/` against the whole query, so a
+ * semicolon inside a STRING LITERAL read as a statement separator:
+ *
+ *     STRING_AGG(DISTINCT location, '; ' ORDER BY location)
+ *
+ * /reports/youth-justice/qld/crime-prevention-schools uses exactly that, so its target-regions
+ * panel failed on every build and rendered empty. Literals are now removed before the check.
+ *
+ * The cases below exist so that loosening cannot go further by accident: everything the guard
+ * blocked before, it must still block.
+ */
+const SRC = readFileSync(join(process.cwd(), 'src/lib/supabase.ts'), 'utf8');
+const BODY = SRC.slice(SRC.indexOf('function isReadOnlyExecSql'));
+const isReadOnly = new Function(
+  'query',
+  BODY.slice(BODY.indexOf('{') + 1, BODY.indexOf('\n}')) .replace(/^\s*function[^\n]*\n/, ''),
+) as (q: string | undefined) => boolean;
+
+describe('exec_sql read-only guard', () => {
+  it('allows a semicolon inside a string literal — the case that broke a live page', () => {
+    expect(isReadOnly(
+      `WITH x AS (SELECT STRING_AGG(DISTINCT location, '; ' ORDER BY location) AS l FROM t) SELECT * FROM x`,
+    )).toBe(true);
+  });
+
+  it('allows ordinary reads', () => {
+    expect(isReadOnly('SELECT 1')).toBe(true);
+    expect(isReadOnly('  \n WITH a AS (SELECT 1) SELECT * FROM a')).toBe(true);
+    expect(isReadOnly('SELECT * FROM t; ')).toBe(true); // single trailing semicolon
+  });
+
+  it('STILL BLOCKS a genuinely stacked statement', () => {
+    expect(isReadOnly('SELECT 1; DROP TABLE users')).toBe(false);
+    expect(isReadOnly("SELECT 'a'; DELETE FROM users")).toBe(false);
+  });
+
+  it('STILL BLOCKS writes, including inside a CTE', () => {
+    for (const q of [
+      'DELETE FROM users',
+      'UPDATE users SET x = 1',
+      'INSERT INTO users VALUES (1)',
+      'WITH d AS (DELETE FROM users RETURNING *) SELECT * FROM d',
+      'WITH u AS (UPDATE users SET x = 1 RETURNING *) SELECT * FROM u',
+    ]) {
+      expect(isReadOnly(q), q).toBe(false);
+    }
+  });
+
+  it('STILL BLOCKS non-select entry points and empties', () => {
+    expect(isReadOnly('DROP TABLE users')).toBe(false);
+    expect(isReadOnly('')).toBe(false);
+    expect(isReadOnly(undefined)).toBe(false);
+    expect(isReadOnly('-- just a comment')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/services/report-service.ts
+++ b/apps/web/src/lib/services/report-service.ts
@@ -1326,7 +1326,12 @@ export async function getPiccPeerOrgs() {
               COUNT(DISTINCT a.id)::int as alma_programs,
               STRING_AGG(DISTINCT a.type, ', ') as program_types
        FROM gs_entities e
-       JOIN alma_interventions a ON a.gs_entity_id = e.gs_id
+       -- e.id, NOT e.gs_id. alma_interventions.gs_entity_id is a uuid and gs_entities.gs_id is
+       -- text, so this failed with "operator does not exist: uuid = text" on every build and the
+       -- PICC peer-organisations panel rendered empty. The name is the trap: gs_entity_id reads
+       -- as if it pairs with gs_id, and it pairs with id.
+       -- (No backticks in this comment: it lives inside a JS template literal.)
+       JOIN alma_interventions a ON a.gs_entity_id = e.id
        WHERE a.type IN ('Cultural Connection', 'Community-Led', 'Wraparound Support', 'Diversion', 'Family Strengthening')
          AND e.is_community_controlled = true
          AND e.abn != '14640793728'

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -24,7 +24,14 @@ function isReadOnlyExecSql(query: string | undefined): boolean {
     .trim();
   if (!stripped) return false;
   if (!/^(select|with)\b/i.test(stripped)) return false; // top-level read only
-  if (/;\s*\S/.test(stripped.replace(/;\s*$/, ''))) return false; // no stacked statements
+  // Stacked-statement check runs on the query with STRING LITERALS REMOVED. A semicolon inside a
+  // quoted literal is not a statement separator, and treating it as one rejected valid read-only
+  // SQL: `STRING_AGG(DISTINCT location, '; ' ORDER BY location)` on
+  // /reports/youth-justice/qld/crime-prevention-schools failed on every build, and the page
+  // rendered its target-regions panel empty. Doubled quotes ('') are handled so an escaped quote
+  // inside a literal does not end it early.
+  const withoutLiterals = stripped.replace(/'(?:[^']|'')*'/g, "''");
+  if (/;\s*\S/.test(withoutLiterals.replace(/;\s*$/, ''))) return false; // no stacked statements
   if (/\b(insert\s+into|update\s+[\w".]+\s+set|delete\s+from|merge\s+into)\b/i.test(stripped)) {
     return false; // no data-modifying CTE
   }


### PR DESCRIPTION
**VISIBLE.** All three surfaced from one production build log — readable only because #354 made `safe()` name the failing surface.

None is slowness. Each fails **every time, on every build, silently**: `safe()` returns null, the caller coerces, the panel renders as though it measured nothing.

## 1. Missing two characters

`/reports/youth-justice/trackers` selected `s.agent_id`, `s.interval_hours`, `s.enabled`, `s.last_run_at`, `s.priority` — `FROM agent_schedules`, with **no alias**.

```
missing FROM-clause entry for table "s"
```

`agent_schedules` has all five columns. Added `s`.

## 2. The security guard was wrong, not the query

`isReadOnlyExecSql` rejected `/reports/youth-justice/qld/crime-prevention-schools` with *"exec_sql only accepts read-only queries"*. The query is an ordinary `WITH … SELECT`.

The stacked-statement rule tested `/;\s*\S/` against the whole string, and the query contains:

```sql
STRING_AGG(DISTINCT location, '; ' ORDER BY location)
```

**A semicolon inside a string literal is not a statement separator.** The check now runs with literals removed — doubled quotes handled, so an escaped quote doesn't end a literal early.

**Loosening a security guard needs proof it didn't get weaker.** `exec-sql-readonly.test.ts` exercises the predicate directly and confirms it still blocks:

- stacked statements — `SELECT 1; DROP TABLE users`
- `DELETE` / `UPDATE` / `INSERT`
- **writes inside a CTE** — `WITH d AS (DELETE FROM users RETURNING *) SELECT * FROM d`
- non-select entry points, empty string, `undefined`, comment-only

Everything it blocked before, it still blocks.

## 3. A name that lies

`getPiccPeerOrgs` joined `alma_interventions.gs_entity_id` (**uuid**) to `gs_entities.gs_id` (**text**):

```
operator does not exist: uuid = text
```

`gs_entity_id` reads as if it pairs with `gs_id`. It pairs with `id`. Corrected join returns real peers — Oonchiumpa Consultancy & Services (7 programs), Brodie Germaine Fitness Aboriginal Corporation (4), Aboriginal Legal Service NSW/ACT (4).

## Why batched

One class, not three features: **queries written against a schema or a guard that doesn't match them, failing invisibly on public pages.** The repo's policy is to batch related fixes rather than pay the pipeline three times.

## Verified

`./scripts/precheck.sh` green — 751 tests (5 new). All three corrected queries run against production and return sensible results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)