### PR TITLE
/api/data/graph returned nothing for its LGA layer — six columns did not exist

### DIFF
--- a/apps/web/src/app/api/data/graph/route.ts
+++ b/apps/web/src/app/api/data/graph/route.ts
@@ -384,15 +384,29 @@ export async function GET(request: Request) {
         ndis_participants: number; ndis_entities: number;
         ndis_avg_utilisation: number | null;
         seifa_decile: number | null; desert_score: number | null;
-        procurement_entities: number; justice_entities: number;
         total_entities: number;
       }>(supabase,
+        // SIX of these columns did not exist on mv_disability_landscape, so this endpoint —
+        // /api/data/graph, a PUBLIC API — returned nothing for the LGA layer. Real names:
+        //   ndis_entities        -> disability_entities
+        //   ndis_avg_utilisation -> state_avg_utilisation
+        //   seifa_decile         -> avg_irsd_decile
+        //   procurement_entities -> cross_system_procurement   (was selected and never read)
+        //   justice_entities     -> cross_system_justice       (was selected and never read)
+        //   total_entities       -> no equivalent; see the sum below
+        // Aliased back to the names the response mapping already uses, so the API contract is
+        // unchanged — it just starts returning data.
         `SELECT dl.lga_name, dl.state, dl.remoteness,
-                dl.ndis_participants, dl.ndis_entities,
-                dl.ndis_avg_utilisation,
-                dl.seifa_decile, dl.desert_score,
-                dl.procurement_entities, dl.justice_entities,
-                dl.total_entities
+                dl.ndis_participants,
+                dl.disability_entities   AS ndis_entities,
+                dl.state_avg_utilisation AS ndis_avg_utilisation,
+                dl.avg_irsd_decile       AS seifa_decile,
+                dl.desert_score,
+                -- The response field is cross_system_entities and the view has no distinct count,
+                -- only the two lanes. This sum is an UPPER BOUND: an entity present in both
+                -- procurement and justice is counted twice. Stated rather than smoothed over.
+                (COALESCE(dl.cross_system_procurement, 0)
+                 + COALESCE(dl.cross_system_justice, 0)) AS total_entities
          FROM mv_disability_landscape dl
          WHERE dl.ndis_participants > 0 ${stateFilter}
          ORDER BY dl.ndis_participants DESC

--- a/apps/web/src/lib/column-manifest.test.ts
+++ b/apps/web/src/lib/column-manifest.test.ts
@@ -43,17 +43,7 @@ const ALLOWED = new Set<string>([
   // REAL BUGS, found by this guard on the day it was written. Left failing rather than fixed in
   // the same PR so the guard could land immediately and stop new instances; each is its own fix.
   //
-  // /api/data/graph — a PUBLIC endpoint. Six columns that do not exist on mv_disability_landscape.
-  // The view has disability_entities (not ndis_entities), state_avg_utilisation (not
-  // ndis_avg_utilisation), avg_irsd_decile (not seifa_decile), cross_system_procurement and
-  // cross_system_justice (not *_entities), and no total_entities at all.
-  'mv_disability_landscape.ndis_entities',
-  'mv_disability_landscape.ndis_avg_utilisation',
-  'mv_disability_landscape.seifa_decile',
-  'mv_disability_landscape.procurement_entities',
-  'mv_disability_landscape.justice_entities',
-  'mv_disability_landscape.total_entities',
-  //
+
   // /reports/community-efficiency — mv_entity_power_index has total_dollar_flow, not
   // total_dollars, and id, not entity_id. That page has a THIRD defect this guard cannot see:
   // both its exec_sql calls pass `{ sql: ... }` where the parameter is `query`, so


### PR DESCRIPTION
SAFE — one API route plus a shrunk guard baseline.

The first of the eight bugs #363's guard found on its first run, and the most exposed: **this is a public endpoint.**

## What was wrong

Six of the columns it selected are not on `mv_disability_landscape`:

| selected | actual |
|---|---|
| `ndis_entities` | `disability_entities` |
| `ndis_avg_utilisation` | `state_avg_utilisation` |
| `seifa_decile` | `avg_irsd_decile` |
| `procurement_entities` | `cross_system_procurement` — **selected and never read** |
| `justice_entities` | `cross_system_justice` — **selected and never read** |
| `total_entities` | **no equivalent at all** |

So the whole `SELECT` errored and the LGA layer came back empty, silently, for every caller.

## The fix

Aliased back to the names the response mapping already uses, so **the API contract is unchanged** — it just starts returning data:

```
Brisbane      29,711 participants   2,099 disability entities
Moreton Bay   18,774                  701
Gold Coast    16,827                1,307
```

The two never-read columns are dropped rather than renamed.

## The one honest compromise

`total_entities` has no counterpart. The response field is `cross_system_entities` and the view offers only the two lanes, so it's now their **sum — an upper bound**, because an entity present in both procurement and justice is counted twice.

The comment says so. A derived number presented as a measured one is the thing this codebase has spent the day removing.

## Baseline shrunk in the same commit

The six entries are removed from the guard's `ALLOWED` list. **A baseline that keeps entries for bugs already fixed is a baseline that hides the regression when they come back.**

Two grandfathered groups remain: `/reports/community-efficiency` (two wrong names plus two queries that pass `{ sql: … }` where the parameter is `query`, so neither has ever run), and the four `person_roles` parser false-positives.

## Verified

Corrected query run against production. `./scripts/precheck.sh` green, 752 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)