### PR TITLE
Playwright is the way to verify production — not curl, not the Chrome extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,6 +503,24 @@ worth a build on its own.
 `npm run preview` shares `.next` with the dev server, so stop dev first — `scripts/precheck.sh`
 says the same thing for the same reason.
 
+### Verifying PRODUCTION: Playwright, not curl, not the extension
+
+`curl` against civicgraph.app returns **429** — Vercel's Security Checkpoint is a JS challenge no
+HTTP client can solve, so every curl check yields a plausible-looking failure that means nothing.
+The Chrome extension works but disconnects; on 2026-08-20 it was down for hours while five merged
+PRs sat unverified.
+
+**`mcp__playwright__browser_navigate` + `browser_evaluate` is the reliable path.** It drives a
+real browser, passes the challenge, and needs no extension. It reads JSON API responses as easily
+as pages.
+
+Two traps when checking content this way, both hit on 2026-08-20:
+- **Match case-insensitively.** CSS `text-transform` means `innerText` gives "NOT PUBLISHED" where
+  the source says "Not published". Two changes were reported as "not deployed" when they were live.
+- **Check the code path, not just the route.** `/api/data/graph` returned zero LGA nodes and looked
+  broken; that layer only renders under `?mode=ndis`. A wrong probe reads exactly like a real
+  regression.
+
 ### What local genuinely cannot tell you
 
 Vercel build-machine limits, deployment protection behaviour, and the values of production env


### PR DESCRIPTION
SAFE — CLAUDE.md plus the `/land` skill (global).

## What happened

Five merged PRs sat unverified for hours today: the Chrome extension disconnected, and `curl` against `civicgraph.app` returns **429** — Vercel's Security Checkpoint is a JS challenge no HTTP client can solve.

**Playwright drives a real browser, passes the challenge, needs no extension, and reads JSON API responses as easily as pages.** All five were verified in about two minutes once I tried it.

## The correction worth recording

I concluded *"an agent cannot read a preview"* and wrote that into `/land`. What today actually established is narrower:

- the **Chrome extension** could not
- **Vercel previews** are SSO-protected and remain unreadable
- **production is public and always was readable** — I just never reached for the right tool

## Two traps that make a working change look broken

Both hit while verifying, both now documented:

**Match case-insensitively.** CSS `text-transform` means `innerText` returns "NOT PUBLISHED" where the source says "Not published". That produced two false "not deployed" readings on changes that were live.

**Check the code path, not just the route.** `/api/data/graph` returned zero LGA nodes and looked like #364 had failed. That layer only renders under `?mode=ndis`. **A wrong probe reads exactly like a real regression**, and I nearly reported one.

## Verified with it

| merge | evidence |
|---|---|
| #360 | `/reports/education/qld` — "341 contracts", $355.8M, QUT present |
| #361 | `/reports/picc` — Oonchiumpa, Brodie Germaine, Aboriginal Legal Service |
| #364 | `?mode=ndis` — Brisbane 29,711 participants / 2,099 entities / SEIFA 8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
