### PR TITLE
Place capture: what share of grant money delivered into a place stays there (#300)

### DIFF
--- a/apps/web/src/app/api/data/map/route.ts
+++ b/apps/web/src/app/api/data/map/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/supabase';
 import { whitelist } from '@/lib/sql';
 import { rateLimit } from '@/lib/rate-limit';
+import { NON_RECIPIENT_SQL_ARRAY, STATE_CODES_SQL } from '@/lib/grant-place-capture';
 
 export const dynamic = 'force-dynamic';
 
@@ -134,6 +135,50 @@ export async function GET(request: Request) {
         WHERE e.lga_name IS NOT NULL
         GROUP BY 1, 2
       ),
+      capture_lga AS MATERIALIZED (
+        -- Place capture at council grain, from v_grant_place_capture. The view holds
+        -- the four exclusions (see migrations/2026-08-19-grant-place-capture.sql and
+        -- lib/grant-place-capture.ts); do not restate them here.
+        --
+        -- Denominator is the RESOLVED base — awards whose recipient postcode also
+        -- resolves to a single trustworthy council. 6,259 covered awards ($10.69bn)
+        -- do not, and counting those as delivered off-site is what turns an 87.3%
+        -- national dollar share into 59.6%. Unresolved is not off-site.
+        --
+        -- Councils under 20 resolved awards report NULL rather than a confident
+        -- percentage on noise, which the layer paints as "not measured".
+        SELECT delivery_lga AS lga_name, delivery_state AS state,
+               count(*)::int AS capture_awards,
+               sum(value_aud)::numeric AS capture_dollars,
+               CASE WHEN count(*) FILTER (WHERE recipient_lga IS NOT NULL) >= 20
+                    THEN ROUND(100.0 * sum(value_aud) FILTER (WHERE captured_locally)
+                         / NULLIF(sum(value_aud) FILTER (WHERE recipient_lga IS NOT NULL), 0), 1)
+               END AS capture_pct_dollars,
+               CASE WHEN count(*) FILTER (WHERE recipient_lga IS NOT NULL) >= 20
+                    THEN ROUND(100.0 * count(*) FILTER (WHERE captured_locally)
+                         / NULLIF(count(*) FILTER (WHERE recipient_lga IS NOT NULL), 0), 1)
+               END AS capture_pct_awards
+        FROM v_grant_place_capture
+        GROUP BY 1, 2
+      ),
+      capture_state AS MATERIALIZED (
+        -- The same measure at state grain, across nearly the whole register: states
+        -- are recorded directly, so none of the postcode exclusions apply. Only the
+        -- multi-state, 'National' and 'Overseas' delivery strings drop out, which is
+        -- why this covers $200bn where the council path covers $33.75bn.
+        SELECT delivery_state AS state,
+               ROUND(100.0 * sum(value_aud) FILTER (WHERE recipient_state = delivery_state)
+                    / NULLIF(sum(value_aud) FILTER (WHERE recipient_state IN (${STATE_CODES_SQL})), 0), 1)
+                 AS state_capture_pct_dollars,
+               ROUND(100.0 * count(*) FILTER (WHERE recipient_state = delivery_state)
+                    / NULLIF(count(*) FILTER (WHERE recipient_state IN (${STATE_CODES_SQL})), 0), 1)
+                 AS state_capture_pct_awards
+        FROM grantconnect_awards
+        WHERE value_aud > 0
+          AND delivery_state IN (${STATE_CODES_SQL})
+          AND lower(btrim(recipient_name)) <> ALL (${NON_RECIPIENT_SQL_ARRAY})
+        GROUP BY 1
+      ),
       alma AS MATERIALIZED (
         SELECT e.lga_name, UPPER(e.state) AS state,
                COUNT(*)::int AS alma_linked
@@ -150,6 +195,9 @@ export async function GET(request: Request) {
              jt.justice_total AS justice_funding_total,
              gr.grants_total AS grants_awarded_total,
              COALESCE(al.alma_linked, 0) AS alma_linked_count,
+             cl.capture_pct_dollars, cl.capture_pct_awards,
+             cl.capture_awards, cl.capture_dollars,
+             cs.state_capture_pct_dollars, cs.state_capture_pct_awards,
              COALESCE(un.unplaced, 0) AS unplaced_count,
              un.unplaced_reasons,
              COALESCE(pl.placed, 0) AS placed_count,
@@ -165,6 +213,8 @@ export async function GET(request: Request) {
       LEFT JOIN justice jt ON jt.lga_name = lc.lga_name AND jt.state = lc.state
       LEFT JOIN grants gr ON gr.lga_name = lc.lga_name AND gr.state = lc.state
       LEFT JOIN alma al ON al.lga_name = lc.lga_name AND al.state = lc.state
+      LEFT JOIN capture_lga cl ON cl.lga_name = lc.lga_name AND cl.state = lc.state
+      LEFT JOIN capture_state cs ON cs.state = lc.state
       WHERE dd.desert_score IS NOT NULL OR COALESCE(un.unplaced, 0) > 0
       ORDER BY dd.desert_score DESC NULLS LAST`,
       }),
@@ -192,6 +242,15 @@ export async function GET(request: Request) {
       // join ran for every council here — zero is a real answer for it.
       grants_awarded_total: number | null;
       alma_linked_count: number;
+      // Null on capture means not measured — no covered awards, or too few
+      // resolved ones to report a share. Never coerce it to zero: a blank
+      // council has not been shown to keep nothing.
+      capture_pct_dollars: number | null;
+      capture_pct_awards: number | null;
+      capture_awards: number | null;
+      capture_dollars: number | null;
+      state_capture_pct_dollars: number | null;
+      state_capture_pct_awards: number | null;
       unplaced_reasons: Record<string, number> | null;
     }>;
 

--- a/apps/web/src/lib/atlas/layers.test.ts
+++ b/apps/web/src/lib/atlas/layers.test.ts
@@ -38,6 +38,51 @@ function feature(overrides: Partial<AtlasFeature> = {}): AtlasFeature {
   };
 }
 
+describe('the place-capture layers', () => {
+  it('both are registered, public, and painted from the dollar share', () => {
+    const lga = getAtlasLayer('grant-capture-lga') as AtlasLiveLayer | null;
+    const state = getAtlasLayer('grant-capture-state') as AtlasLiveLayer | null;
+    expect(lga).not.toBeNull();
+    expect(state).not.toBeNull();
+    expect(lga!.consent).toBe('public');
+    expect(state!.consent).toBe('public');
+    expect(lga!.value(feature({ capture_pct_dollars: 8.3 }))).toBe(8.3);
+    expect(state!.value(feature({ state_capture_pct_dollars: 97.3 }))).toBe(97.3);
+  });
+
+  // A council with no covered awards has not been shown to keep nothing: it has
+  // not been measured. Coercing that to zero would paint it the worst red on the
+  // map for having no data.
+  it('an unmeasured council reads as no data, never as zero capture', () => {
+    const lga = getAtlasLayer('grant-capture-lga') as AtlasLiveLayer;
+    expect(lga.value(feature({ capture_pct_dollars: null }))).toBeNull();
+    expect(atlasStyleFor(lga, lga.value(feature({ capture_pct_dollars: null })))).toEqual(
+      ATLAS_NO_DATA_STYLE,
+    );
+    expect(lga.noDataLabel.toLowerCase()).not.toContain('0');
+  });
+
+  // Both layers describe the same measure at different coverage. The council
+  // layer must state its minority coverage on the surface so nobody quotes
+  // $33.75bn as if it were the whole $230bn register.
+  it('the council layer states its coverage and the state layer states its grain', () => {
+    const lga = getAtlasLayer('grant-capture-lga')!;
+    const state = getAtlasLayer('grant-capture-state')!;
+    expect(lga.caveat).toContain('$33.75bn');
+    expect(lga.caveat).toContain('$230bn');
+    expect(lga.honestAt).toBe('council');
+    expect(state.honestAt).toBe('state');
+  });
+
+  // 85.1% of awards against 59.6% of dollars: a layer that painted dollars
+  // without saying so would read as "remote Australia keeps more".
+  it('the council caveat says the award share moves differently', () => {
+    const lga = getAtlasLayer('grant-capture-lga')!;
+    expect(lga.caveat).toContain('85.1%');
+    expect(lga.caveat).toContain('59.6%');
+  });
+});
+
 describe('the registry contract', () => {
   it('every layer carries a real caveat, not a placeholder', () => {
     for (const layer of ATLAS_LAYERS) {
@@ -137,6 +182,8 @@ describe('consent tiers gate surfaces', () => {
     expect(visibleAtlasLayers('public').map(l => l.key)).toEqual([
       'funding-deserts',
       'grants-awarded',
+      'grant-capture-lga',
+      'grant-capture-state',
       'money-recorded',
       'justice-funding',
       'renewal-cliff',

--- a/apps/web/src/lib/atlas/layers.ts
+++ b/apps/web/src/lib/atlas/layers.ts
@@ -52,6 +52,22 @@ export interface AtlasFeature {
    * organisation placed in this council. Zero is a real answer (the join ran
    * and found none); null/absent means the payload predates the field. */
   alma_linked_count?: number | null;
+  /** Share of grant DOLLARS delivered into this council that were received by an
+   * organisation placed here, of the awards whose recipient location also resolves.
+   * Null means not measured — either no covered awards, or too few to report.
+   * Optional for the same cached-payload reason as unplaced_reasons. */
+  capture_pct_dollars?: number | null;
+  /** The same share counted as AWARDS rather than dollars. It moves differently and
+   * both belong on screen: nationally 85.1% of awards but 59.6% of dollars stay put. */
+  capture_pct_awards?: number | null;
+  /** Awards and dollars behind this council's capture figures — the covered minority,
+   * never the whole grant record. */
+  capture_awards?: number | null;
+  capture_dollars?: number | null;
+  /** Capture at STATE grain for the state this council sits in, repeated on every
+   * council of that state. Near-complete coverage, unlike the council figures. */
+  state_capture_pct_dollars?: number | null;
+  state_capture_pct_awards?: number | null;
   /** Null when the council has no point coordinates; it still renders where a
    * boundary matches its name. Coordinates only drive bounds-fitting. */
   lat: number | null;
@@ -465,6 +481,80 @@ const whatsWorking: AtlasLiveLayer = {
   format: v => (v === 0 ? 'None yet' : `${v.toFixed(0)} linked`),
 };
 
+// Place capture: of the money delivered into a place, how much does the place
+// keep? Two layers, two geographies, two very different coverage stories — see
+// lib/grant-place-capture.ts for the four exclusions and their measured cost.
+//
+// Both paint the DOLLAR share. The award share moves differently (nationally
+// 85.1% of awards against 59.6% of dollars) and rides in the payload for the
+// place panel; the caveats say so, because either number alone misleads.
+const captureScale: AtlasScaleStop[] = [
+  { min: 90, color: '#1040C0', fillOpacity: 0.3, label: '90% or more stays' },
+  { min: 75, color: '#4CB876', fillOpacity: 0.4, label: '75–90%' },
+  { min: 50, color: '#F0C020', fillOpacity: 0.5, label: '50–75%' },
+  { min: 25, color: '#E06C18', fillOpacity: 0.6, label: '25–50%' },
+  { min: 0, color: '#D02020', fillOpacity: 0.7, label: 'Under 25% stays' },
+];
+
+const grantCaptureLga: AtlasLiveLayer = {
+  key: 'grant-capture-lga',
+  status: 'live',
+  kind: 'choropleth',
+  group: 'money',
+  name: 'Money the council keeps',
+  unit: '% of delivered grant dollars received by an organisation here',
+  caveat:
+    'Of the grant money GrantConnect records as delivered INTO this council, the share ' +
+    'received by an organisation based here. It covers a well-measured minority of the ' +
+    'register — 85,898 awards and $33.75bn of 291,264 awards and $230bn — because both ' +
+    'the delivery and the recipient postcode must resolve to a single trustworthy ' +
+    'council, and multi-site grants are excluded rather than counted as delivered away. ' +
+    'Counted as dollars; the share of separate awards kept locally runs far higher ' +
+    '(85.1% against 59.6% nationally), so this layer shows where the money goes, not ' +
+    'how many opportunities a place holds. Blank means not measured, never zero.',
+  honestAt: 'council',
+  honestAtNote:
+    'Council level, and only for awards where both ends resolve to one council. Councils ' +
+    'with fewer than 20 resolved awards are left blank rather than painted on noise.',
+  consent: 'public',
+  scale: captureScale,
+  scaleNote:
+    'Bands are plain quarters of the share, not quantiles: a place keeping under a ' +
+    'quarter of what is delivered into it reads red wherever it sits.',
+  noDataLabel: 'Not measured here',
+  value: f => num(f.capture_pct_dollars),
+  format: v => `${v.toFixed(0)}% stays`,
+};
+
+const grantCaptureState: AtlasLiveLayer = {
+  key: 'grant-capture-state',
+  status: 'live',
+  kind: 'choropleth',
+  group: 'money',
+  name: 'Money the state keeps',
+  unit: '% of delivered grant dollars received in the same state',
+  caveat:
+    'Of the grant money delivered into this state, the share received by an organisation ' +
+    'based in the same state. Unlike the council layer this covers nearly the whole ' +
+    'register — 281,016 awards and $200bn — because states are recorded directly and need ' +
+    'no postcode lookup; only multi-state, National and Overseas delivery strings drop out. ' +
+    'Every council of a state is painted the same, because the number is about the state. ' +
+    'State borders are a coarse test: money can cross the country inside one state and ' +
+    'still count as kept.',
+  honestAt: 'state',
+  honestAtNote:
+    'State grain repeated across the state, not a council figure. It says nothing about ' +
+    'which places within a state receive the money.',
+  consent: 'public',
+  scale: captureScale,
+  scaleNote:
+    'Same bands as the council layer so the two can be read against each other. Most ' +
+    'states sit high: the interesting question is which council keeps it, not which state.',
+  noDataLabel: 'Not measured here',
+  value: f => num(f.state_capture_pct_dollars),
+  format: v => `${v.toFixed(0)}% stays`,
+};
+
 /** Communities whose in-person consent to appear on the PUBLIC Goods layer
  * has been gathered and recorded. Adding a community name here is the whole
  * flip: the layer's consent tier derives from this list, and the server feed
@@ -522,6 +612,8 @@ const goodsDelivered: AtlasPointLayer = {
 export const ATLAS_LAYERS: readonly AtlasLayer[] = [
   fundingDeserts,
   grantsAwarded,
+  grantCaptureLga,
+  grantCaptureState,
   moneyRecorded,
   justiceFunding,
   renewalCliff,

--- a/apps/web/src/lib/atlas/share.test.ts
+++ b/apps/web/src/lib/atlas/share.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AtlasFeature } from './layers';
+import { getAtlasLayer } from './layers';
 import {
   buildAtlasUrl,
   councilCsv,
@@ -172,8 +173,15 @@ describe('taking the data with its caveats', () => {
     expect(json.place.council).toBe('Ceduna');
     for (const layer of json.layers) {
       expect(String(layer.contains).length).toBeGreaterThan(80);
-      expect(layer.honest_at).toBe('council');
+      // Every layer ships the grain it is honest at, and it is not always
+      // 'council': the state capture layer repeats a state figure on every
+      // council of that state, so the export must say 'state' beside it
+      // rather than let a council row imply a council-grain number.
+      expect(layer.honest_at).toBe(getAtlasLayer(String(layer.key))!.honestAt);
+      expect(String(layer.honest_at_note).length).toBeGreaterThan(20);
     }
+    expect(json.layers.find(l => l.key === 'grant-capture-state')?.honest_at).toBe('state');
+    expect(json.layers.find(l => l.key === 'grant-capture-lga')?.honest_at).toBe('council');
     const deserts = json.layers.find(l => l.key === 'funding-deserts');
     expect(deserts?.formatted).toBe('180');
   });

--- a/apps/web/src/lib/grant-place-capture.test.ts
+++ b/apps/web/src/lib/grant-place-capture.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CAPTURE_MIN_AWARDS,
+  CAPTURE_MIN_DOLLARS,
+  MULTI_SITE_SENTINEL,
+  buildPostcodeLgaIndex,
+  isCapturableAward,
+  isTrustworthyLocality,
+  rankWorstCapturing,
+  tallyCapture,
+  type CaptureAward,
+  type CapturePlace,
+} from './grant-place-capture';
+
+const award = (over: Partial<Parameters<typeof isCapturableAward>[0]> = {}) => ({
+  delivery_postcode: '4816',
+  value_aud: 100_000,
+  recipient_name: 'Real Org Inc',
+  ...over,
+});
+
+describe('exclusion 1 — multi-site grants are not a place', () => {
+  it("refuses the literal string 'Multiple'", () => {
+    expect(isCapturableAward(award({ delivery_postcode: MULTI_SITE_SENTINEL }))).toBe(false);
+  });
+
+  it('refuses it with surrounding whitespace too', () => {
+    expect(isCapturableAward(award({ delivery_postcode: ' Multiple ' }))).toBe(false);
+  });
+
+  // The 4.5x error: admitted, 'Multiple' equals no recipient postcode, so every one of the
+  // 5,978 rows counts as delivered off-site and cross-state leakage reads $17.79bn
+  // instead of $3.95bn.
+  it('excluded rows are not counted as delivered off-site', () => {
+    const multi: CaptureAward = {
+      value: 19_550_000_000,
+      deliveryPlace: MULTI_SITE_SENTINEL,
+      deliveryState: null,
+      recipientPlace: 'Sydney',
+      recipientState: 'NSW',
+    };
+    const admitted = tallyCapture([multi]);
+    expect(admitted.localDollars).toBe(0);
+
+    const excluded = tallyCapture([multi].filter(a => a.deliveryPlace !== MULTI_SITE_SENTINEL));
+    expect(excluded.dollars).toBe(0);
+    expect(excluded.pctDollarsLocal).toBe(0);
+  });
+
+  it('a real postcode is admitted', () => {
+    expect(isCapturableAward(award())).toBe(true);
+  });
+});
+
+describe('exclusion 2 — aggregates and non-positive values', () => {
+  it.each(['Total', 'TOTALS', 'various', 'n/a', '(blank)', '   '])(
+    'refuses the aggregate-shaped recipient name %j',
+    name => {
+      expect(isCapturableAward(award({ recipient_name: name }))).toBe(false);
+    },
+  );
+
+  it.each([0, -1, null])('refuses a non-positive value %j', value_aud => {
+    expect(isCapturableAward(award({ value_aud }))).toBe(false);
+  });
+
+  it('refuses an award with no delivery postcode at all', () => {
+    expect(isCapturableAward(award({ delivery_postcode: null }))).toBe(false);
+  });
+});
+
+describe('exclusion 3 — a postcode touching two councils resolves to none', () => {
+  it('refuses rather than picking one', () => {
+    const index = buildPostcodeLgaIndex([
+      { postcode: '2620', locality: 'Queanbeyan', lga_name: 'Queanbeyan-Palerang' },
+      { postcode: '2620', locality: 'Hume', lga_name: 'Snowy Monaro' },
+    ]);
+    expect(index.has('2620')).toBe(false);
+  });
+
+  it('keeps a postcode whose rows all name one council', () => {
+    const index = buildPostcodeLgaIndex([
+      { postcode: '4680', locality: 'Gladstone', lga_name: 'Gladstone' },
+      { postcode: '4680', locality: 'Barney Point', lga_name: 'Gladstone' },
+    ]);
+    expect(index.get('4680')).toBe('Gladstone');
+  });
+});
+
+describe('exclusion 4 — SA3-shaped postcode_geo rows carry wrong councils', () => {
+  it('refuses the Croydon artefact', () => {
+    // 4816 is Palm Island money. postcode_geo records it as locality
+    // 'Townsville - South' with lga_name 'Croydon', ~900km away, which made
+    // Croydon QLD the worst-capturing council in the country on $72.9M.
+    expect(isTrustworthyLocality('Townsville - South')).toBe(false);
+    const index = buildPostcodeLgaIndex([
+      { postcode: '4816', locality: 'Townsville - South', lga_name: 'Croydon' },
+      { postcode: '4816', locality: 'Palm Island', lga_name: 'Palm Island' },
+    ]);
+    // The bad row is refused BEFORE the single-council test, so the postcode
+    // still resolves — and resolves to the right council.
+    expect(index.get('4816')).toBe('Palm Island');
+  });
+
+  it('keeps ordinary locality names', () => {
+    expect(isTrustworthyLocality('Alice Springs')).toBe(true);
+    expect(isTrustworthyLocality(null)).toBe(false);
+  });
+
+  it('a postcode left with no trustworthy row resolves to nothing', () => {
+    const index = buildPostcodeLgaIndex([
+      { postcode: '4816', locality: 'Townsville - South', lga_name: 'Croydon' },
+    ]);
+    expect(index.size).toBe(0);
+  });
+});
+
+describe('the measure', () => {
+  const here = (value: number): CaptureAward => ({
+    value,
+    deliveryPlace: 'Palm Island',
+    deliveryState: 'QLD',
+    recipientPlace: 'Palm Island',
+    recipientState: 'QLD',
+  });
+  const sameState = (value: number): CaptureAward => ({
+    value,
+    deliveryPlace: 'Palm Island',
+    deliveryState: 'QLD',
+    recipientPlace: 'Brisbane',
+    recipientState: 'QLD',
+  });
+  const interstate = (value: number): CaptureAward => ({
+    value,
+    deliveryPlace: 'Palm Island',
+    deliveryState: 'QLD',
+    recipientPlace: 'Sydney',
+    recipientState: 'NSW',
+  });
+  const unresolved = (value: number): CaptureAward => ({
+    value,
+    deliveryPlace: 'Palm Island',
+    deliveryState: 'QLD',
+    recipientPlace: null,
+    recipientState: null,
+  });
+
+  it('counts same-council as captured and different-council as not', () => {
+    const t = tallyCapture([here(10), sameState(10)]);
+    expect(t.localAwards).toBe(1);
+    expect(t.pctAwardsLocal).toBe(50);
+  });
+
+  it('separates regional centralisation from interstate extraction', () => {
+    const t = tallyCapture([sameState(100), interstate(300)]);
+    expect(t.sameStateElsewhereDollars).toBe(100);
+    expect(t.crossStateDollars).toBe(300);
+  });
+
+  // The finding the whole module exists to carry: nationally 85.1% of awards
+  // but 59.6% of dollars stay local. A surface showing one measure misleads.
+  it('the two measures are computed independently and can diverge', () => {
+    const t = tallyCapture([here(1), here(1), here(1), sameState(97)]);
+    expect(t.pctAwardsLocal).toBe(75);
+    expect(t.pctDollarsLocal).toBe(3);
+  });
+
+  it('unresolved recipients are their own bucket, not off-site', () => {
+    const t = tallyCapture([here(50), unresolved(50)]);
+    expect(t.unresolvedDollars).toBe(50);
+    expect(t.sameStateElsewhereDollars).toBe(0);
+    expect(t.crossStateDollars).toBe(0);
+    // Resolved base says everything measured stayed put...
+    expect(t.pctDollarsLocal).toBe(100);
+    // ...the wider base says half the money left, which is the gloomier
+    // reading and the source of the headline 59.6%.
+    expect(t.pctDollarsLocalOfBase).toBe(50);
+  });
+
+  it('an empty set reports zeroes rather than dividing by zero', () => {
+    const t = tallyCapture([]);
+    expect(t.pctAwardsLocal).toBe(0);
+    expect(t.pctDollarsLocal).toBe(0);
+    expect(Number.isFinite(t.pctDollarsLocalOfBase)).toBe(true);
+  });
+});
+
+describe('ranked lists are thresholded', () => {
+  const place = (over: Partial<CapturePlace>): CapturePlace => ({
+    place: 'Somewhere',
+    state: 'QLD',
+    remoteness: null,
+    ...tallyCapture([]),
+    ...over,
+  });
+
+  it('a single large grant in a tiny council cannot top the table', () => {
+    const noise = place({
+      place: 'Tiny Shire',
+      resolvedAwards: 1,
+      resolvedDollars: 300_000_000,
+      pctDollarsLocal: 0,
+    });
+    const real = place({
+      place: 'Wangaratta',
+      resolvedAwards: 400,
+      resolvedDollars: 258_000_000,
+      pctDollarsLocal: 8.3,
+    });
+    const ranked = rankWorstCapturing([noise, real]);
+    expect(ranked.map(p => p.place)).toEqual(['Wangaratta']);
+  });
+
+  it('thresholds default from the module, not the caller', () => {
+    expect(CAPTURE_MIN_AWARDS).toBeGreaterThan(1);
+    expect(CAPTURE_MIN_DOLLARS).toBeGreaterThan(0);
+    const justUnder = place({
+      resolvedAwards: CAPTURE_MIN_AWARDS - 1,
+      resolvedDollars: CAPTURE_MIN_DOLLARS * 10,
+    });
+    expect(rankWorstCapturing([justUnder])).toEqual([]);
+  });
+
+  it('ranks by awards when asked', () => {
+    const common = { resolvedAwards: 100, resolvedDollars: CAPTURE_MIN_DOLLARS * 2 };
+    const a = place({ place: 'A', ...common, pctAwardsLocal: 20, pctDollarsLocal: 90 });
+    const b = place({ place: 'B', ...common, pctAwardsLocal: 90, pctDollarsLocal: 20 });
+    expect(rankWorstCapturing([a, b], { by: 'awards' })[0].place).toBe('A');
+    expect(rankWorstCapturing([a, b], { by: 'dollars' })[0].place).toBe('B');
+  });
+});

--- a/apps/web/src/lib/grant-place-capture.ts
+++ b/apps/web/src/lib/grant-place-capture.ts
@@ -1,0 +1,442 @@
+import { getDirectServiceSupabase } from '@/lib/supabase';
+import { NON_RECIPIENT_NAMES, isRealRecipient } from '@/lib/justice-money';
+
+/**
+ * Place capture: of the grant money delivered into a place, how much does the place keep?
+ *
+ * `grantconnect_awards` carries `delivery_postcode`/`delivery_state` as columns SEPARATE from
+ * `recipient_postcode`/`recipient_state`. Nothing in the codebase read them until 2026-08-19.
+ * This module owns the measure and its exclusions so the next query cannot rewrite them from
+ * memory — the same reason `justice-money.ts` exists.
+ *
+ * FOUR EXCLUSIONS, each with a measured cost. Do not relax one to widen coverage without
+ * re-reading what it bought:
+ *
+ * 1. `delivery_postcode = 'Multiple'` — a literal string on 5,978 rows worth $19.55bn. These are
+ *    multi-site grants; they are not a place. Because 'Multiple' never equals a recipient
+ *    postcode, leaving them in counted every one as delivered off-site: $42.46bn away from the
+ *    recipient instead of $22.91bn, and $17.79bn crossing state lines instead of $3.95bn. The
+ *    cross-state figure was wrong by 4.5x.
+ *
+ * 2. Aggregate-shaped recipient names (2,663 rows) and `value_aud <= 0` (195 rows). The name list
+ *    is `NON_RECIPIENT_NAMES` from `justice-money.ts`, reused rather than restated.
+ *
+ * 3. Single-LGA postcodes only. 521 of 2,859 postcodes touch more than one council; attributing
+ *    them by picking one is how you get a wrong answer that looks right. Same discipline as the
+ *    LGA attribution rebuild: unplaced beats confidently wrong.
+ *
+ * 4. `postcode_geo` rows whose `locality` is an SA3 name, not a locality — 443 of them, carrying
+ *    WRONG councils. Postcode 4816 is recorded as locality 'Townsville - South' with
+ *    `lga_name = 'Croydon'`, a council ~900km away. Left in, Croydon QLD ranked as the
+ *    worst-capturing council in Australia on $72.9M that is really Palm Island money. Those rows
+ *    are wrong for every consumer of `postcode_geo` and their repair is a separate issue; this
+ *    module only refuses them; the repair is issue #301 and
+ *    `migrations/2026-08-19-sa3-locality-lga-repair.sql`.
+ *
+ * TWO MEASURES, NEVER ONE. Every result carries both `pctAwardsLocal` and `pctDollarsLocal`, and
+ * the module deliberately offers no single "capture rate", because the two disagree and the
+ * disagreement is the finding. Nationally (measured 2026-08-20) 85.1% of awards but 59.6% of
+ * dollars stay in the delivery council. Award share falls monotonically with remoteness; dollar
+ * share does not fall at all. A surface showing only dollars would report that remote Australia
+ * captures MORE than the cities — true, and deeply misleading alone.
+ *
+ * THE DENOMINATOR TRAP, found while implementing this (2026-08-20). 6,259 of the 85,898 covered
+ * awards, worth $10.69bn — 31.7% of the covered dollars — have a delivery council but a recipient
+ * postcode that does NOT resolve to a single trustworthy council. They are unresolved, not
+ * off-site. Counting them as off-site is where the headline 59.6% comes from; on the resolved base
+ * the dollar figure is 87.3%. Both are true of different questions, so both are returned:
+ * `pctDollarsLocal` uses the resolved base and `pctDollarsLocalOfBase` uses the wider one. Any
+ * surface must say which it is showing.
+ *
+ * COVERAGE. The council path is a well-measured MINORITY: 85,898 awards and $33.75bn of 291,264
+ * awards and $230bn. The state path is near-complete: 281,016 awards and $200.22bn, losing only
+ * the multi-state, National and Overseas delivery strings. Coverage counts ride on every result
+ * so no caller recomputes them.
+ */
+
+/** Exclusion 1. A literal string in `delivery_postcode`, not a null and not a code. */
+export const MULTI_SITE_SENTINEL = 'Multiple';
+
+/**
+ * Exclusion 4. `postcode_geo.locality` values shaped like an ABS SA3 name — `'Townsville - South'`
+ * — rather than a locality. Matched on the ` - ` separator, which no real Australian locality name
+ * in the table contains.
+ */
+export const SA3_LOCALITY_SEPARATOR = ' - ';
+
+/** The eight state and territory codes. Anything else in `delivery_state` is multi-site,
+ * 'National' or 'Overseas' and is not a place. */
+export const STATE_CODES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'ACT', 'TAS', 'NT'] as const;
+export type StateCode = (typeof STATE_CODES)[number];
+
+/** Defaults for any ranked list, set here rather than per caller so one large grant in a tiny
+ * council cannot top the table as noise. */
+export const CAPTURE_MIN_AWARDS = 20;
+export const CAPTURE_MIN_DOLLARS = 5_000_000;
+
+/** Exclusion 1 + 2, as a predicate over one award. */
+export function isCapturableAward(award: {
+  delivery_postcode?: string | null;
+  value_aud?: number | null;
+  recipient_name?: string | null;
+}): boolean {
+  if (!award.delivery_postcode) return false;
+  if (award.delivery_postcode.trim() === MULTI_SITE_SENTINEL) return false;
+  if (!(Number(award.value_aud) > 0)) return false;
+  return isRealRecipient(award.recipient_name);
+}
+
+/** Exclusion 4, as a predicate over one `postcode_geo` row. */
+export function isTrustworthyLocality(locality: string | null | undefined): boolean {
+  if (!locality) return false;
+  return !locality.includes(SA3_LOCALITY_SEPARATOR);
+}
+
+/**
+ * Exclusions 3 + 4 together: postcode → council, for postcodes that resolve to exactly one
+ * trustworthy council. A postcode touching two councils resolves to none.
+ */
+export function buildPostcodeLgaIndex(
+  rows: readonly { postcode: string; locality: string | null; lga_name: string | null }[],
+): Map<string, string> {
+  const candidates = new Map<string, Set<string>>();
+  for (const row of rows) {
+    if (!row.lga_name) continue;
+    if (!isTrustworthyLocality(row.locality)) continue;
+    const set = candidates.get(row.postcode) ?? new Set<string>();
+    set.add(row.lga_name);
+    candidates.set(row.postcode, set);
+  }
+  const index = new Map<string, string>();
+  for (const [postcode, lgas] of candidates) {
+    if (lgas.size === 1) index.set(postcode, [...lgas][0]);
+  }
+  return index;
+}
+
+export interface CaptureTally {
+  /** Awards and dollars after the exclusions — the base this row measures. */
+  awards: number;
+  dollars: number;
+  /** Of the base, those whose recipient location also resolves. The honest denominator. */
+  resolvedAwards: number;
+  resolvedDollars: number;
+  /** Delivery and recipient in the same place. */
+  localAwards: number;
+  localDollars: number;
+  /** Resolved elsewhere, but inside the same state — regional centralisation. */
+  sameStateElsewhereAwards: number;
+  sameStateElsewhereDollars: number;
+  /** Resolved elsewhere, across a state border — interstate extraction. */
+  crossStateAwards: number;
+  crossStateDollars: number;
+  /** Recipient location does not resolve. NOT off-site: unmeasured. */
+  unresolvedAwards: number;
+  unresolvedDollars: number;
+  /** Local share of the RESOLVED base, one decimal. */
+  pctAwardsLocal: number;
+  pctDollarsLocal: number;
+  /** Local share of the WHOLE base, counting unresolved as not-local. The wider, gloomier
+   * reading; correct only for a question that treats "we cannot tell" as "not here". */
+  pctAwardsLocalOfBase: number;
+  pctDollarsLocalOfBase: number;
+}
+
+/** One award as the tally sees it. Places are councils on the council path and state codes on
+ * the state path — the tally does not care which, only whether they match. */
+export interface CaptureAward {
+  value: number;
+  deliveryPlace: string;
+  deliveryState: string | null;
+  recipientPlace: string | null;
+  recipientState: string | null;
+}
+
+function pct(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 1000) / 10;
+}
+
+/**
+ * The measure itself, pure. Both percentages are computed independently and may legitimately
+ * diverge — that divergence is the finding, not a rounding artefact.
+ */
+export function tallyCapture(awards: readonly CaptureAward[]): CaptureTally {
+  const t = {
+    awards: 0,
+    dollars: 0,
+    resolvedAwards: 0,
+    resolvedDollars: 0,
+    localAwards: 0,
+    localDollars: 0,
+    sameStateElsewhereAwards: 0,
+    sameStateElsewhereDollars: 0,
+    crossStateAwards: 0,
+    crossStateDollars: 0,
+    unresolvedAwards: 0,
+    unresolvedDollars: 0,
+  };
+  for (const a of awards) {
+    const v = Number(a.value) || 0;
+    t.awards += 1;
+    t.dollars += v;
+    if (!a.recipientPlace) {
+      t.unresolvedAwards += 1;
+      t.unresolvedDollars += v;
+      continue;
+    }
+    t.resolvedAwards += 1;
+    t.resolvedDollars += v;
+    if (a.recipientPlace === a.deliveryPlace) {
+      t.localAwards += 1;
+      t.localDollars += v;
+    } else if (a.recipientState && a.deliveryState && a.recipientState !== a.deliveryState) {
+      t.crossStateAwards += 1;
+      t.crossStateDollars += v;
+    } else {
+      t.sameStateElsewhereAwards += 1;
+      t.sameStateElsewhereDollars += v;
+    }
+  }
+  return {
+    ...t,
+    pctAwardsLocal: pct(t.localAwards, t.resolvedAwards),
+    pctDollarsLocal: pct(t.localDollars, t.resolvedDollars),
+    pctAwardsLocalOfBase: pct(t.localAwards, t.awards),
+    pctDollarsLocalOfBase: pct(t.localDollars, t.dollars),
+  };
+}
+
+export interface CapturePlace extends CaptureTally {
+  place: string;
+  state: string | null;
+  remoteness: string | null;
+}
+
+export interface CaptureResult {
+  places: CapturePlace[];
+  national: CaptureTally;
+  coverage: {
+    /** Awards and dollars this path measures. */
+    measuredAwards: number;
+    measuredDollars: number;
+    /** The whole GrantConnect register, so a surface can state the share without a second query. */
+    totalAwards: number;
+    totalDollars: number;
+  };
+}
+
+/** `NON_RECIPIENT_NAMES` as a SQL array literal, so the list exists once in TypeScript and every
+ * query is generated from it rather than retyped beside it. Exported because the Atlas map route
+ * needs the same list, and a second hand-typed copy there is exactly how a filter drifts. */
+export const NON_RECIPIENT_SQL_ARRAY = `ARRAY[${[...NON_RECIPIENT_NAMES]
+  .map(n => `'${n.replace(/'/g, "''")}'`)
+  .join(',')}]`;
+
+/** The state-code whitelist as a SQL list, for the same reason. */
+export const STATE_CODES_SQL = STATE_CODES.map(s => `'${s}'`).join(',');
+
+function nonRecipientSql(): string {
+  return NON_RECIPIENT_SQL_ARRAY;
+}
+
+/** The whole register, for the coverage denominator both paths report. */
+const TOTALS_SQL = `SELECT count(*)::bigint AS awards, COALESCE(sum(value_aud),0)::numeric AS dollars
+   FROM grantconnect_awards`;
+
+interface RawPlaceRow {
+  place: string;
+  state: string | null;
+  remoteness: string | null;
+  awards: string | number;
+  dollars: string | number;
+  resolved_awards: string | number;
+  resolved_dollars: string | number;
+  local_awards: string | number;
+  local_dollars: string | number;
+  cross_state_awards: string | number;
+  cross_state_dollars: string | number;
+}
+
+const n = (v: unknown) => Number(v ?? 0) || 0;
+
+/** Rebuild a tally from the SQL group row. The arithmetic that derives the percentages lives in
+ * `tallyCapture`; this only restates the group as awards so there is one implementation. */
+function tallyFromRow(row: RawPlaceRow): CaptureTally {
+  const awards = n(row.awards);
+  const dollars = n(row.dollars);
+  const resolvedAwards = n(row.resolved_awards);
+  const resolvedDollars = n(row.resolved_dollars);
+  const localAwards = n(row.local_awards);
+  const localDollars = n(row.local_dollars);
+  const crossStateAwards = n(row.cross_state_awards);
+  const crossStateDollars = n(row.cross_state_dollars);
+  const t = {
+    awards,
+    dollars,
+    resolvedAwards,
+    resolvedDollars,
+    localAwards,
+    localDollars,
+    crossStateAwards,
+    crossStateDollars,
+    sameStateElsewhereAwards: resolvedAwards - localAwards - crossStateAwards,
+    sameStateElsewhereDollars: resolvedDollars - localDollars - crossStateDollars,
+    unresolvedAwards: awards - resolvedAwards,
+    unresolvedDollars: dollars - resolvedDollars,
+  };
+  return {
+    ...t,
+    pctAwardsLocal: pct(localAwards, resolvedAwards),
+    pctDollarsLocal: pct(localDollars, resolvedDollars),
+    pctAwardsLocalOfBase: pct(localAwards, awards),
+    pctDollarsLocalOfBase: pct(localDollars, dollars),
+  };
+}
+
+function sumTallies(places: readonly CapturePlace[]): CaptureTally {
+  const zero: CaptureAward[] = [];
+  const base = tallyCapture(zero);
+  const acc = { ...base };
+  for (const p of places) {
+    acc.awards += p.awards;
+    acc.dollars += p.dollars;
+    acc.resolvedAwards += p.resolvedAwards;
+    acc.resolvedDollars += p.resolvedDollars;
+    acc.localAwards += p.localAwards;
+    acc.localDollars += p.localDollars;
+    acc.sameStateElsewhereAwards += p.sameStateElsewhereAwards;
+    acc.sameStateElsewhereDollars += p.sameStateElsewhereDollars;
+    acc.crossStateAwards += p.crossStateAwards;
+    acc.crossStateDollars += p.crossStateDollars;
+    acc.unresolvedAwards += p.unresolvedAwards;
+    acc.unresolvedDollars += p.unresolvedDollars;
+  }
+  acc.pctAwardsLocal = pct(acc.localAwards, acc.resolvedAwards);
+  acc.pctDollarsLocal = pct(acc.localDollars, acc.resolvedDollars);
+  acc.pctAwardsLocalOfBase = pct(acc.localAwards, acc.awards);
+  acc.pctDollarsLocalOfBase = pct(acc.localDollars, acc.dollars);
+  return acc;
+}
+
+async function runSql<T>(query: string): Promise<T[]> {
+  const supabase = getDirectServiceSupabase();
+  const { data, error } = await supabase.rpc('exec_sql', { query });
+  if (error) throw new Error(`grant place capture query failed: ${error.message}`);
+  return (data ?? []) as T[];
+}
+
+/**
+ * Capture at state grain, across the near-whole register.
+ *
+ * Applies only exclusion 1 (via the state-code whitelist, which also drops 'National', 'Overseas'
+ * and comma-joined multi-state strings) and exclusion 2. The council-only exclusions 3 and 4 do
+ * NOT apply: `delivery_state` and `recipient_state` are recorded directly and need no postcode
+ * lookup, which is why this path measures $200.22bn where the council path measures $33.75bn.
+ */
+export async function captureByState(): Promise<CaptureResult> {
+  const states = STATE_CODES.map(s => `'${s}'`).join(',');
+  const rows = await runSql<RawPlaceRow>(`
+    WITH base AS (
+      SELECT delivery_state, recipient_state, value_aud
+        FROM grantconnect_awards
+       WHERE value_aud > 0
+         AND delivery_state IN (${states})
+         AND lower(btrim(recipient_name)) <> ALL (${nonRecipientSql()})
+    )
+    SELECT delivery_state AS place,
+           delivery_state AS state,
+           NULL::text     AS remoteness,
+           count(*)::bigint AS awards,
+           sum(value_aud)::numeric AS dollars,
+           count(*) FILTER (WHERE recipient_state IN (${states}))::bigint AS resolved_awards,
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_state IN (${states})),0)::numeric AS resolved_dollars,
+           count(*) FILTER (WHERE recipient_state = delivery_state)::bigint AS local_awards,
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_state = delivery_state),0)::numeric AS local_dollars,
+           count(*) FILTER (WHERE recipient_state IN (${states}) AND recipient_state <> delivery_state)::bigint AS cross_state_awards,
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_state IN (${states}) AND recipient_state <> delivery_state),0)::numeric AS cross_state_dollars
+      FROM base
+     GROUP BY delivery_state
+     ORDER BY delivery_state`);
+  const totals = await runSql<{ awards: string; dollars: string }>(TOTALS_SQL);
+  const places: CapturePlace[] = rows.map(r => ({
+    place: r.place,
+    state: r.state,
+    remoteness: null,
+    ...tallyFromRow(r),
+  }));
+  const national = sumTallies(places);
+  return {
+    places,
+    national,
+    coverage: {
+      measuredAwards: national.awards,
+      measuredDollars: national.dollars,
+      totalAwards: n(totals[0]?.awards),
+      totalDollars: n(totals[0]?.dollars),
+    },
+  };
+}
+
+/**
+ * Capture at council grain, reading `v_grant_place_capture`.
+ *
+ * The view holds all four exclusions (see `migrations/2026-08-19-grant-place-capture.sql`), so ad
+ * hoc SQL and this module agree by construction. It is not reimplemented here.
+ */
+export async function captureByLga(): Promise<CaptureResult> {
+  const rows = await runSql<RawPlaceRow>(`
+    SELECT delivery_lga AS place,
+           delivery_state AS state,
+           max(delivery_remoteness) AS remoteness,
+           count(*)::bigint AS awards,
+           sum(value_aud)::numeric AS dollars,
+           count(*) FILTER (WHERE recipient_lga IS NOT NULL)::bigint AS resolved_awards,
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_lga IS NOT NULL),0)::numeric AS resolved_dollars,
+           count(*) FILTER (WHERE captured_locally)::bigint AS local_awards,
+           COALESCE(sum(value_aud) FILTER (WHERE captured_locally),0)::numeric AS local_dollars,
+           count(*) FILTER (WHERE recipient_lga IS NOT NULL AND recipient_state <> delivery_state)::bigint AS cross_state_awards,
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_lga IS NOT NULL AND recipient_state <> delivery_state),0)::numeric AS cross_state_dollars
+      FROM v_grant_place_capture
+     GROUP BY delivery_lga, delivery_state`);
+  const totals = await runSql<{ awards: string; dollars: string }>(TOTALS_SQL);
+  const places: CapturePlace[] = rows.map(r => ({
+    place: r.place,
+    state: r.state,
+    remoteness: r.remoteness,
+    ...tallyFromRow(r),
+  }));
+  const national = sumTallies(places);
+  return {
+    places,
+    national,
+    coverage: {
+      measuredAwards: national.awards,
+      measuredDollars: national.dollars,
+      totalAwards: n(totals[0]?.awards),
+      totalDollars: n(totals[0]?.dollars),
+    },
+  };
+}
+
+/**
+ * Places that keep the least, thresholded so a single large grant in a tiny council cannot lead
+ * the table. Ranked on the resolved base, because a place whose recipients simply do not resolve
+ * has not been shown to leak anything.
+ */
+export function rankWorstCapturing(
+  places: readonly CapturePlace[],
+  opts: { by?: 'dollars' | 'awards'; minAwards?: number; minDollars?: number; limit?: number } = {},
+): CapturePlace[] {
+  const by = opts.by ?? 'dollars';
+  const minAwards = opts.minAwards ?? CAPTURE_MIN_AWARDS;
+  const minDollars = opts.minDollars ?? CAPTURE_MIN_DOLLARS;
+  return places
+    .filter(p => p.resolvedAwards >= minAwards && p.resolvedDollars >= minDollars)
+    .sort((a, b) =>
+      by === 'dollars'
+        ? a.pctDollarsLocal - b.pctDollarsLocal
+        : a.pctAwardsLocal - b.pctAwardsLocal,
+    )
+    .slice(0, opts.limit ?? 20);
+}


### PR DESCRIPTION
Closes #300.

`grantconnect_awards` has carried `delivery_postcode`/`delivery_state` separate from the recipient columns since ingest and nothing read them. This adds the measure as a typed module over the already-applied `v_grant_place_capture` view, plus two Atlas layers and the payload fields behind them. No new routes, no new pages.

## What landed

- `lib/grant-place-capture.ts` — the four exclusions as typed constants and predicates, a pure `tallyCapture()`, `captureByState()` / `captureByLga()`, and `rankWorstCapturing()` with module-level thresholds. 27 tests, one per error actually made while measuring.
- Two Atlas layers, both `public`: `grant-capture-lga` (council grain, 85,898 awards / $33.75bn of 291,264 / $230bn, coverage stated in the caveat) and `grant-capture-state` (state grain, 281,016 awards / $200bn).
- `/api/data/map` carries `capture_pct_dollars`, `capture_pct_awards`, `capture_awards`, `capture_dollars` and the two state figures.

## The correction the spec did not have

6,259 covered awards worth **$10.69bn — 31.7% of covered dollars** — have a delivery council but a recipient postcode that does not resolve to a single trustworthy council. They are **unresolved, not off-site**. Counting them as off-site is the entire gap between the issue's 59.6% headline dollar share and the 87.3% resolved one. Both are returned and named (`pctDollarsLocal` vs `pctDollarsLocalOfBase`); the layers paint the resolved base, and a council with under 20 resolved awards paints "not measured" rather than zero.

## Verified

`./scripts/precheck.sh` green (783 tests). Against the live DB through the dev server, `/api/data/map?state=QLD`: 69 councils, 43 measured, worst is Mackay at 30.5% dollars / 91.7% awards, Croydon absent, state capture 97.3%.

**Public-surface note:** classify-changes says SAFE (lib + api only), but this does add two layers to the Atlas picker. Worth an eyeball on the preview at `/atlas` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)