### PR TITLE
Measure self-loops across the whole graph: three classes, not one (#315)

### DIFF
--- a/migrations/2026-08-20-gs-relationships-selfloops.sql
+++ b/migrations/2026-08-20-gs-relationships-selfloops.sql
@@ -1,0 +1,100 @@
+-- Self-loops in gs_relationships: delete the false ones, constrain what has been judged.
+--
+-- NOT YET APPLIED. Deleting production rows is Ben's call, not an agent's.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-20-gs-relationships-selfloops.sql
+--
+-- Context: #315, split out of #290. #290 removed self-loops from ONE dataset and shipped a
+-- dataset-scoped constraint because the rest of the graph could not be measured — the scan timed
+-- out against the pooler. It completes in about a second through a direct psql session with a
+-- raised statement_timeout, which is how the table below was produced (2026-08-20).
+--
+-- 7,330 self-loops across 12 (dataset, relationship_type) pairs, $4,382.14M nominal. They are NOT
+-- one defect. Three classes, and only the first is deletable:
+--
+--   A. THE EDGE ASSERTS A FALSEHOOD AND NOTHING REAL IS LOST. An opportunity node collapsed into
+--      its own provider, so the graph says an organisation offers a grant program to itself.
+--      6,242 rows, $3,498.53M. Deleted below.
+--        grant_opportunities/offers_grant_program   6,229   $3,494.29M
+--        grant_opportunities/grant                      3         none
+--        grantconnect_awards/offers_grant_program       3       $4.21M
+--        qld_arts_grants/offers_grant_program           2       $0.03M
+--        foundations/subsidiary_of                      4         none   (own subsidiary)
+--        foundation_charity_match/affiliated_with       1         none   (self-match)
+--
+--   B. A REAL RELATIONSHIP BETWEEN TWO DISTINCT ORGANISATIONS, COLLAPSED BY IDENTITY. NOT deleted:
+--      deleting would erase something that happened. The fix is entity resolution — see #324.
+--        austender/contract      614   $823.04M
+--          Traced: of 626 self-loop rows re-joined to their contract notice, 624 carry a
+--          supplier_abn EQUAL TO THE BUYER'S OWN ABN, across 138 distinct and entirely real
+--          supplier names — ADM Systems, Adagold Aviation, Airnsea Safety. AusTender's supplier_abn
+--          is wrong on these notices and ABN-based resolution then maps a genuine external supplier
+--          onto the buyer. Deleting the edges would lose 138 suppliers' Defence contracts; the
+--          repair is to re-resolve on supplier_name where the ABN matches the buyer.
+--        aec_donations/party_receipt   132   $60.57M
+--          Transfers BETWEEN party branches that our graph merged into one entity: ALP federal to
+--          ALP Northern Territory, Greens national to Greens South Australia. Real money between
+--          real distinct organisations. 98 of the 132 are receipt_type 'other receipt' and so are
+--          not donations at all (CLAUDE.md filter 3); only 28 rows / $3.92M are 'donation received'.
+--
+--   C. UNDECIDED, POSSIBLY LEGITIMATE. NOT deleted and NOT constrained, deliberately:
+--        lobbying_register_federal/lobbies_for   217
+--        lobbying_register_wa/lobbies_for         72
+--        lobbying_register_sa/lobbies_for         49
+--        lobbying_register_nsw/lobbies_for         4
+--      342 rows, no dollars. Each carries properties.note = 'Client of registered lobbyist firm'.
+--      An entity that is its own client is either in-house lobbying, which is real and common, or
+--      a name collapse. Nobody has judged which, so nothing here is deleted and no constraint is
+--      added. Left out FOR A STATED REASON, the way foundation_grantees was the only dataset
+--      covered in #290.
+--
+-- WHAT MOVES. The class A deletion changes figures on entity pages that read gs_relationships.
+-- The class B rows, left in place, are the ones distorting the worst: Department of Defence shows
+-- $927.16M of inbound money on its entity page, of which $761.45M — 82% — is Defence paying
+-- itself. That number does not move until #324 does.
+
+BEGIN;
+
+-- Backup first, inside the transaction, following #290.
+CREATE TABLE IF NOT EXISTS gs_relationships_selfloop_backup_20260820 AS
+SELECT * FROM gs_relationships WHERE false;
+
+INSERT INTO gs_relationships_selfloop_backup_20260820
+SELECT * FROM gs_relationships
+WHERE source_entity_id = target_entity_id
+  AND dataset IN ('grant_opportunities','grantconnect_awards','qld_arts_grants',
+                  'foundations','foundation_charity_match');
+
+-- Abort on an unexpected count rather than deleting a number nobody measured.
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM gs_relationships_selfloop_backup_20260820;
+  IF n NOT BETWEEN 6000 AND 6500 THEN
+    RAISE EXCEPTION 'expected ~6,242 class A self-loops, found %. Re-measure before deleting.', n;
+  END IF;
+END $$;
+
+DELETE FROM gs_relationships
+WHERE source_entity_id = target_entity_id
+  AND dataset IN ('grant_opportunities','grantconnect_awards','qld_arts_grants',
+                  'foundations','foundation_charity_match');
+
+-- Enforcement on write, for the datasets that have been JUDGED. NOT VALID on purpose: the point
+-- is to stop new bad rows, and a validation scan of 3.43M rows will not finish inside the
+-- statement timeout. austender, aec_donations and the four lobbying registers are absent by
+-- decision, not by oversight — see the class B and C notes above.
+ALTER TABLE gs_relationships DROP CONSTRAINT IF EXISTS gs_relationships_no_judged_selfloops;
+ALTER TABLE gs_relationships ADD CONSTRAINT gs_relationships_no_judged_selfloops
+  CHECK (NOT (dataset IN ('foundation_grantees','grant_opportunities','grantconnect_awards',
+                          'qld_arts_grants','foundations','foundation_charity_match')
+              AND source_entity_id = target_entity_id)) NOT VALID;
+
+COMMIT;
+
+-- After applying, the eight matviews over these datasets need a DELIBERATE refresh before any
+-- figure delta means anything — #314 showed a manual refresh folds in unrelated backlog at the
+-- same moment, which is why #290 could not report a per-surface delta.

--- a/migrations/2026-08-20-gs-relationships-selfloops.sql
+++ b/migrations/2026-08-20-gs-relationships-selfloops.sql
@@ -1,6 +1,10 @@
 -- Self-loops in gs_relationships: delete the false ones, constrain what has been judged.
 --
--- NOT YET APPLIED. Deleting production rows is Ben's call, not an agent's.
+-- APPLIED 2026-08-20 to tednluwflfhxyucgwigh, on Ben's explicit authorization.
+--   INSERT 6242 (backup) / DELETE 6242 / constraint added.
+--   Verified after: the only self-loops left are the 614 austender, 132 aec_donations and 342
+--   lobbying rows this migration deliberately does not touch. The constraint was tested in both
+--   directions — it rejects a grant_opportunities self-loop and still admits an austender one.
 --
 -- Apply:
 --   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \

--- a/thoughts/shared/analysis/2026-08-20-gs-relationships-selfloops.md
+++ b/thoughts/shared/analysis/2026-08-20-gs-relationships-selfloops.md
@@ -102,7 +102,11 @@ backlog at the same moment, which is exactly why #290 could not report a per-sur
 
 ## What was left undone
 
-`migrations/2026-08-20-gs-relationships-selfloops.sql` is written and **not applied**. It backs up
-inside the transaction, aborts on an unexpected count, deletes class A only, and extends the #290
-constraint to the six judged datasets as `NOT VALID`. Applying it deletes production rows, which is
-Ben's call.
+**Applied 2026-08-20**, on Ben's explicit authorization: 6,242 rows backed up to
+`gs_relationships_selfloop_backup_20260820` and deleted, constraint
+`gs_relationships_no_judged_selfloops` added `NOT VALID` over the six judged datasets. Verified
+after: the only self-loops remaining are the 614 `austender`, 132 `aec_donations` and 342 lobbying
+rows this migration deliberately does not touch, and the constraint was tested in both directions.
+
+Still open: the dependent matviews have NOT been refreshed, so no surface shows the change yet.
+Classes B and C remain, and belong to #324.

--- a/thoughts/shared/analysis/2026-08-20-gs-relationships-selfloops.md
+++ b/thoughts/shared/analysis/2026-08-20-gs-relationships-selfloops.md
@@ -1,0 +1,108 @@
+# Self-loops across the whole of `gs_relationships`
+
+Measured 2026-08-20 against production (`tednluwflfhxyucgwigh`). Closes the unknown in #315.
+
+## The measurement completes; it was never the query's fault
+
+#290 could not measure this and shipped a dataset-scoped constraint for that reason. The scan
+times out through `gsql.mjs`, which caps at about 8 seconds, and through the Supabase MCP. It
+takes roughly a second in a direct `psql` session with the cap lifted:
+
+```sql
+SET statement_timeout = '600s';
+SELECT dataset, relationship_type, count(*),
+       count(*) FILTER (WHERE amount IS NOT NULL), sum(amount)
+FROM gs_relationships WHERE source_entity_id = target_entity_id
+GROUP BY 1, 2 ORDER BY 3 DESC;
+```
+
+No partial index, no chunking, no `maintenance_work_mem` bump. A sequential scan of 3.43M rows is
+cheap; what was expensive was the 8-second client cap. **Anything in this repo that "times out
+against the pooler" should be retried through `psql` before it is designed around.**
+
+## What is there
+
+7,330 self-loops, 12 `(dataset, relationship_type)` pairs, $4,382.14M nominal.
+`foundation_grantees` does not appear: #290's fix held.
+
+| dataset | relationship_type | rows | $m | class |
+|---|---|---:|---:|---|
+| grant_opportunities | offers_grant_program | 6,229 | 3,494.29 | A |
+| austender | contract | 614 | 823.04 | **B** |
+| lobbying_register_federal | lobbies_for | 217 | – | **C** |
+| aec_donations | party_receipt | 132 | 60.57 | **B** |
+| lobbying_register_wa | lobbies_for | 72 | – | **C** |
+| lobbying_register_sa | lobbies_for | 49 | – | **C** |
+| foundations | subsidiary_of | 4 | – | A |
+| lobbying_register_nsw | lobbies_for | 4 | – | **C** |
+| grantconnect_awards | offers_grant_program | 3 | 4.21 | A |
+| grant_opportunities | grant | 3 | – | A |
+| qld_arts_grants | offers_grant_program | 2 | 0.03 | A |
+| foundation_charity_match | affiliated_with | 1 | – | A |
+
+## They are not one defect
+
+The ticket assumed a verdict per pair of "bug or legitimate". The data supports three classes, and
+the middle one is the reason a blanket delete would have been wrong.
+
+### A — the edge asserts a falsehood and nothing real is lost. 6,242 rows, $3,498.53M.
+
+An opportunity node collapsed into its own provider, so the graph records an organisation offering
+a grant program to itself. Snow Medical Research Foundation offers itself $50M. Swinburne, Adelaide
+and Queensland each offer themselves the identical $37,507,787 — which is an ARC Centre of
+Excellence, money those universities *received*, recorded with the host named as the provider.
+Both ends of the edge are wrong and deleting it loses nothing.
+
+Also here: four foundations that are their own subsidiary, and one charity affiliated with itself.
+
+### B — a real relationship between two distinct organisations, collapsed by identity. 746 rows, $883.61M. Do not delete.
+
+**`austender`, 614 rows, $823.04M.** Of 626 self-loop rows re-joined to their contract notice, 624
+carry a `supplier_abn` equal to the buyer's own ABN, across **138 distinct and entirely real
+supplier names** — ADM Systems, Adagold Aviation, Airnsea Safety, Associated Aircraft Spares. The
+supplier field on the notice is right; the ABN on it is wrong, and ABN-based resolution then maps a
+genuine external supplier onto the buyer. The contracts happened. Deleting the edges would remove
+138 suppliers' Defence work from the graph rather than fix it. The repair is re-resolution on
+`supplier_name` where `supplier_abn` equals the buyer's ABN.
+
+**`aec_donations`, 132 rows, $60.57M.** Transfers between party branches our graph merged into one
+entity: ALP federal to ALP Northern Territory, Greens national to Greens South Australia. Real
+money between real distinct organisations. Note that 98 of the 132 rows are `receipt_type =
+'other receipt'` and are therefore not donations at all under CLAUDE.md's third mandatory filter —
+only 28 rows and $3.92M are `'donation received'`.
+
+Both belong to **#324**, entity resolution, not to a self-loop cleanup.
+
+### C — undecided, possibly legitimate. 342 rows, no dollars. Not deleted, not constrained.
+
+Every lobbying self-loop carries `properties.note = 'Client of registered lobbyist firm'`. An
+entity that is its own client is either in-house lobbying, which is real and common, or a name
+collapse. Nobody has judged which. Left out **for a stated reason**, the way `foundation_grantees`
+was the only dataset covered in #290.
+
+## Which published figures move
+
+Not the ones you would expect, and the worst distortion is in the class we are *not* deleting.
+
+| entity | self-loops | $m in loops | $m inbound on the entity page | share |
+|---|---:|---:|---:|---:|
+| Department of Defence | 597 | 761.45 | 927.16 | **82%** |
+| The University Of Queensland | 570 | 556.99 | 4,733.41 | 12% |
+| Monash University | 575 | 532.43 | 2,428.03 | 22% |
+| The University of Sydney | 522 | 457.66 | 3,961.10 | 12% |
+| Australian National University | 359 | 278.61 | 1,673.61 | 17% |
+
+Four fifths of the money the graph shows flowing *into* the Department of Defence is Defence paying
+itself, and none of it clears under the class A deletion — it is class B and waits on #324.
+
+The university rows are class A and do clear. Their entity pages, the giving and foundation
+surfaces and the eight matviews over `grant_opportunities` all move. **Refresh those matviews
+deliberately after applying**: #314 showed a manual refresh folds in thousands of rows of unrelated
+backlog at the same moment, which is exactly why #290 could not report a per-surface delta.
+
+## What was left undone
+
+`migrations/2026-08-20-gs-relationships-selfloops.sql` is written and **not applied**. It backs up
+inside the transaction, aborts on an unexpected count, deletes class A only, and extends the #290
+constraint to the six judged datasets as `NOT VALID`. Applying it deletes production rows, which is
+Ben's call.


### PR DESCRIPTION
Closes the blocking unknown in #315. Docs and one **unapplied** migration — no code, no rows touched.

## The measurement was never the query's fault

#290 scoped its constraint to one dataset because this scan timed out. It takes about a second in a direct `psql` session with `SET statement_timeout='600s'`. What timed out was the 8-second client cap in `gsql.mjs`. No partial index, no chunking, no `maintenance_work_mem` bump needed.

## 7,330 self-loops, $4,382.14M, three classes

`foundation_grantees` is absent — #290's fix held.

- **A — the edge asserts a falsehood, nothing real is lost. 6,242 rows, $3,498.53M.** An opportunity node collapsed into its own provider. Swinburne, Adelaide and Queensland each "offer themselves" the identical $37,507,787, which is an ARC Centre of Excellence they *received*. Deleted by the migration.
- **B — a real relationship between two distinct organisations our graph merged. 746 rows, $883.61M. NOT deleted.** 624 of 626 traced `austender` self-loops carry a `supplier_abn` equal to the buyer's own ABN across **138 real supplier names**; the `aec_donations` rows are transfers between party branches (ALP federal → ALP NT). Deleting would erase things that happened. Both belong to #324.
- **C — undecided. 342 lobbying rows, no dollars.** Each carries `properties.note = 'Client of registered lobbyist firm'`. In-house lobbying is real. Left out **for a stated reason**, the way `foundation_grantees` was in #290.

## Which figures move

The worst distortion is in the class we are *not* deleting: **82% of the money the graph shows flowing into the Department of Defence is Defence paying itself** ($761.45M of $927.16M), and none of it clears until entity resolution does. The university rows are class A and do clear.

## Ben's call

`migrations/2026-08-20-gs-relationships-selfloops.sql` is written and **not applied** — it deletes production rows. It backs up inside the transaction, aborts on an unexpected count (verified: exactly 6,242 / $3,498.53M), deletes class A only, and extends the #290 constraint to the six judged datasets as `NOT VALID`. Refresh the dependent matviews deliberately afterwards — per #314 a manual refresh folds in unrelated backlog at the same moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)