### PR TITLE
Make matview staleness visible, and correct what #314 assumed (#314)

### DIFF
--- a/apps/web/src/app/api/ops/health/route.ts
+++ b/apps/web/src/app/api/ops/health/route.ts
@@ -3,6 +3,7 @@ import { requireAdminApi } from '@/lib/admin-auth';
 import { getServiceSupabase } from '@/lib/supabase';
 import { classifySourceHealth, type SourceRun } from '@grant-engine/source-health';
 import { classifyPipelineHealth } from '@grant-engine/pipeline-health';
+import { getAllMvFreshness, summariseFreshness } from '@/lib/mv-freshness';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
@@ -366,6 +367,21 @@ export async function GET() {
       communityControlled: Number(ec.community_controlled ?? 0),
     };
 
+    // Read last: a freshness failure must not cost the rest of the health payload.
+
+    let matviews: ReturnType<typeof summariseFreshness> | null = null;
+
+    try {
+
+      matviews = summariseFreshness(await getAllMvFreshness());
+
+    } catch (err) {
+
+      console.error('[ops/health] matview freshness unreadable', err);
+
+    }
+
+
     const response = NextResponse.json({
       stats: {
         // Admin audit A13: these were `count ?? 0`. safe() returns count:null when a query blows
@@ -436,6 +452,11 @@ export async function GET() {
         return { lastRunAt: at, hoursSince: Math.round(hours * 10) / 10, stale: hours > 6, unknown: false };
       })(),
       discoveryRuns: recentDiscoveryRuns.data ?? [],
+      // Matview freshness (#314). `actionable` is the count worth going red on; `unknown` counts
+      // the on_demand matviews owned by paths that do not write to mv_refresh_log, which are a
+      // known unknown rather than a fault. A failed lookup reports null — unreadable is NOT
+      // healthy, and the tile must not render it as zero faults.
+      matviews,
       sourceHealth,
       pipelineHealth,
       lastUpdated: new Date().toISOString(),

--- a/apps/web/src/components/as-of.tsx
+++ b/apps/web/src/components/as-of.tsx
@@ -1,0 +1,50 @@
+import {
+  freshnessLabel,
+  getMvFreshness,
+  shouldWarnReader,
+  type MvFreshnessRow,
+} from '@/lib/mv-freshness';
+
+/**
+ * The as-of stamp that belongs beside any figure read from a matview.
+ *
+ * #314 step 4: a surface whose matview is stale currently serves the number silently, and that is
+ * the wrong behaviour. Per disclose-don't-hide, say the as-of date rather than hide the lag — and
+ * say it WITH the number, not on a help page, the same rule the Atlas layer registry enforces for
+ * caveats.
+ *
+ * A missing verdict renders as "date unknown", never as nothing. Rendering nothing is the one
+ * failure mode that reads as "this number is current".
+ */
+export function AsOf({ row, className = '' }: { row: MvFreshnessRow | null; className?: string }) {
+  const warn = row ? shouldWarnReader(row.freshness) : false;
+  const label = row ? freshnessLabel(row) : 'Refresh date unknown';
+  return (
+    <p
+      className={`font-mono text-[11px] uppercase tracking-widest ${
+        warn ? 'text-bauhaus-red' : 'text-bauhaus-black/60'
+      } ${className}`}
+      // The date is part of the claim, so it is announced with it rather than left to a title
+      // attribute a screen reader may never reach.
+      data-freshness={row?.freshness ?? 'unknown'}
+    >
+      {label}
+    </p>
+  );
+}
+
+/**
+ * Server-component form: fetches the verdict for one matview and renders it.
+ *
+ * A freshness lookup must never take down the surface it is annotating — an unreadable verdict is
+ * "date unknown", which is exactly what `AsOf` renders for a null row.
+ */
+export async function AsOfMatview({ mvName, className }: { mvName: string; className?: string }) {
+  let row: MvFreshnessRow | null = null;
+  try {
+    row = await getMvFreshness(mvName);
+  } catch {
+    row = null;
+  }
+  return <AsOf row={row} className={className} />;
+}

--- a/apps/web/src/lib/mv-freshness.test.ts
+++ b/apps/web/src/lib/mv-freshness.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  freshnessLabel,
+  isActionable,
+  shouldWarnReader,
+  summariseFreshness,
+  type MvFreshness,
+  type MvFreshnessRow,
+} from './mv-freshness';
+
+const row = (over: Partial<MvFreshnessRow> = {}): MvFreshnessRow => ({
+  mv_name: 'mv_thing',
+  tier: 'nightly',
+  freshness: 'fresh',
+  age_hours: 8,
+  max_age_hours: 36,
+  last_success_at: '2026-08-20T01:30:00Z',
+  last_attempt_status: 'success',
+  notes: null,
+  ...over,
+});
+
+describe('what counts as a fault', () => {
+  it.each<MvFreshness>(['stale', 'never', 'orphan', 'unregistered'])(
+    '%s is actionable',
+    f => expect(isActionable(f)).toBe(true),
+  );
+
+  it.each<MvFreshness>(['fresh', 'unmanaged', 'retired', 'disabled'])(
+    '%s is not',
+    f => expect(isActionable(f)).toBe(false),
+  );
+
+  // The whole point of the 'unlogged' verdict. 16 on_demand matviews are refreshed by paths that
+  // do not write to mv_refresh_log — refresh_alma_dashboards(), the youth-justice report scripts —
+  // and each names its owner in notes. Alerting on them would cry wolf 16 times a night until
+  // nobody read the alert, which is worse than the staleness it was meant to catch.
+  it('unlogged is a known unknown, not a fault', () => {
+    expect(isActionable('unlogged')).toBe(false);
+    expect(freshnessLabel(row({ freshness: 'unlogged', last_success_at: null }))).toBe(
+      'Refreshed outside the schedule — date not recorded',
+    );
+  });
+
+  // A visitor reading a number needs to know it is old. They do not need to know the registry
+  // has an orphaned row — that is an ops problem, not a caveat on the figure.
+  it('the reader is warned about age, not about registry bookkeeping', () => {
+    expect(shouldWarnReader('stale')).toBe(true);
+    expect(shouldWarnReader('never')).toBe(true);
+    expect(shouldWarnReader('orphan')).toBe(false);
+    expect(shouldWarnReader('unregistered')).toBe(false);
+    expect(shouldWarnReader('fresh')).toBe(false);
+  });
+});
+
+describe('the words beside the figure', () => {
+  it('dates a fresh figure', () => {
+    expect(freshnessLabel(row())).toBe('As at 20 Aug 2026');
+  });
+
+  it('says overdue as well as the date, so the number is still traceable', () => {
+    expect(freshnessLabel(row({ freshness: 'stale', last_success_at: '2026-08-01T01:30:00Z' }))).toBe(
+      'As at 1 Aug 2026 — overdue a refresh',
+    );
+  });
+
+  // Never invent freshness the log cannot support. Omitting the date entirely would read as
+  // "current"; saying it is not recorded is the honest form.
+  it('says the date is missing rather than omitting it', () => {
+    expect(freshnessLabel(row({ freshness: 'fresh', last_success_at: null }))).toBe(
+      'Last refresh not recorded',
+    );
+  });
+
+  it('a retired matview is frozen, not broken', () => {
+    expect(freshnessLabel(row({ freshness: 'retired', last_success_at: '2026-08-15T03:55:00Z' }))).toBe(
+      'Retired, frozen at 15 Aug 2026',
+    );
+  });
+
+  it('every verdict produces words — no silent empty label', () => {
+    const all: MvFreshness[] = [
+      'fresh', 'unmanaged', 'unlogged', 'retired', 'disabled', 'stale', 'never', 'orphan', 'unregistered',
+    ];
+    for (const f of all) {
+      expect(freshnessLabel(row({ freshness: f })).length, f).toBeGreaterThan(8);
+    }
+  });
+});
+
+describe('the ops summary', () => {
+  // Measured against production 2026-08-20 immediately after the view shipped: 76 fresh,
+  // 16 unlogged, 9 retired, 3 unmanaged, and nothing stale, never, orphaned or unregistered.
+  it('counts faults and known-unknowns separately', () => {
+    const rows = [
+      ...Array.from({ length: 76 }, (_, i) => row({ mv_name: `f${i}` })),
+      ...Array.from({ length: 16 }, (_, i) => row({ mv_name: `u${i}`, freshness: 'unlogged', last_success_at: null, age_hours: null })),
+      ...Array.from({ length: 9 }, (_, i) => row({ mv_name: `r${i}`, freshness: 'retired' })),
+      ...Array.from({ length: 3 }, (_, i) => row({ mv_name: `m${i}`, freshness: 'unmanaged' })),
+    ];
+    const s = summariseFreshness(rows);
+    expect(s.total).toBe(104);
+    expect(s.fresh).toBe(76);
+    expect(s.actionable).toBe(0);
+    expect(s.unknown).toBe(19);
+    expect(s.worst).toEqual([]);
+  });
+
+  it('puts the oldest fault first, and a never-refreshed one ahead of a merely stale one', () => {
+    const s = summariseFreshness([
+      row({ mv_name: 'mv_stale', freshness: 'stale', age_hours: 200 }),
+      row({ mv_name: 'mv_never', freshness: 'never', age_hours: null, last_success_at: null }),
+      row({ mv_name: 'mv_ok' }),
+    ]);
+    expect(s.actionable).toBe(2);
+    // A null age sorts as infinitely old: never-refreshed is the worst case, not the mildest.
+    expect(s.worst.map(r => r.mv_name)).toEqual(['mv_never', 'mv_stale']);
+  });
+});

--- a/apps/web/src/lib/mv-freshness.ts
+++ b/apps/web/src/lib/mv-freshness.ts
@@ -1,0 +1,166 @@
+import { getDirectServiceSupabase } from '@/lib/supabase';
+
+/**
+ * Matview freshness, as something a surface can say out loud.
+ *
+ * A stale matview does not error. It serves a confidently wrong number to whatever reads it, and
+ * a confident non-zero is harder to spot than a confident zero. Until 2026-08-20 the only way to
+ * discover staleness here was to refresh a matview by hand during unrelated work and watch the
+ * counts move — which is exactly how it was found (#314).
+ *
+ * WHAT #314 FEARED AND WHAT WAS TRUE. The ticket reported that the nightly refresh had not run on
+ * the night of 18→19 August. It ran, and succeeded, as it did every other night that week; the one
+ * failure in the window was 2026-08-11, `server restarted`. The cluster of matviews reporting a
+ * last success of 15–16 August were tier `weekly` (cron `0 15 * * 0`) and tier `retire`. They were
+ * exactly as fresh as configured.
+ *
+ * That misreading is the reason this module exists. The raw log could not distinguish:
+ *   - "fresh for its tier" from "overdue"
+ *   - "refreshed by a path that does not log" from "never refreshed at all"
+ * Both were reconstructible only by knowing the cron schedules by heart. Now `v_mv_refresh_drift`
+ * carries a one-word verdict and this module gives it to callers with the words to print.
+ *
+ * THE TRAP THAT WAS ALSO FIXED. The drift view used to compute the last refresh from the last log
+ * row OF ANY STATUS, so a failed refresh reset the staleness clock and a matview failing for a week
+ * read as fresh. It now counts successes only, and reports the last attempt separately.
+ * Always filter `mv_refresh_log` on `status IN ('success','success-fallback')` for the same reason.
+ */
+
+/** The verdict `v_mv_refresh_drift` assigns. Ordered here from best to worst. */
+export type MvFreshness =
+  | 'fresh'
+  | 'unmanaged'
+  | 'unlogged'
+  | 'retired'
+  | 'disabled'
+  | 'stale'
+  | 'never'
+  | 'orphan'
+  | 'unregistered';
+
+export interface MvFreshnessRow {
+  mv_name: string;
+  tier: string | null;
+  freshness: MvFreshness;
+  age_hours: number | null;
+  max_age_hours: number | null;
+  last_success_at: string | null;
+  last_attempt_status: string | null;
+  notes: string | null;
+}
+
+/**
+ * Verdicts that mean something is wrong and someone should act.
+ *
+ * `unlogged` is deliberately NOT here. Sixteen `on_demand` matviews are refreshed by paths that do
+ * not write to the log — `refresh_alma_dashboards()`, the youth-justice report scripts — and each
+ * names its owner in `notes`. Treating them as failures would cry wolf sixteen times a night and
+ * the real alert would stop being read. It is an honest unknown, not a fault.
+ */
+const ACTIONABLE: ReadonlySet<MvFreshness> = new Set<MvFreshness>([
+  'stale',
+  'never',
+  'orphan',
+  'unregistered',
+]);
+
+export function isActionable(freshness: MvFreshness): boolean {
+  return ACTIONABLE.has(freshness);
+}
+
+/**
+ * Whether a surface reading this matview should warn the reader rather than just date the figure.
+ * Narrower than `isActionable`: an orphaned registry row is an ops problem, not something a
+ * visitor looking at a number needs to be told about.
+ */
+export function shouldWarnReader(freshness: MvFreshness): boolean {
+  return freshness === 'stale' || freshness === 'never';
+}
+
+/**
+ * The words a surface puts beside a figure. Never invent freshness the log cannot support: where
+ * the as-of date is unknown the label says so instead of quietly omitting it.
+ */
+export function freshnessLabel(row: Pick<MvFreshnessRow, 'freshness' | 'last_success_at'>): string {
+  const asOf = row.last_success_at ? formatAsOf(row.last_success_at) : null;
+  switch (row.freshness) {
+    case 'fresh':
+    case 'unmanaged':
+      return asOf ? `As at ${asOf}` : 'Last refresh not recorded';
+    case 'stale':
+      return asOf ? `As at ${asOf} — overdue a refresh` : 'Overdue a refresh';
+    case 'never':
+      return 'Never refreshed since records began';
+    case 'unlogged':
+      // The distinction #314 asked for: refreshed by another path, so the log cannot date it.
+      return 'Refreshed outside the schedule — date not recorded';
+    case 'retired':
+      return asOf ? `Retired, frozen at ${asOf}` : 'Retired, no longer refreshed';
+    case 'disabled':
+      return asOf ? `Refresh disabled, frozen at ${asOf}` : 'Refresh disabled';
+    case 'orphan':
+      return 'Registry row for a matview that no longer exists';
+    case 'unregistered':
+      return 'Not on the refresh registry — nothing schedules it';
+  }
+}
+
+/** Date only. A time-of-day on a nightly aggregate implies a precision the number does not have. */
+export function formatAsOf(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-AU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export interface MvFreshnessSummary {
+  total: number;
+  fresh: number;
+  /** Verdicts in ACTIONABLE — the count an ops tile should turn red on. */
+  actionable: number;
+  /** Known unknowns: owned elsewhere, or run without a schedule. Not faults. */
+  unknown: number;
+  worst: MvFreshnessRow[];
+}
+
+export function summariseFreshness(rows: readonly MvFreshnessRow[]): MvFreshnessSummary {
+  const actionable = rows.filter(r => isActionable(r.freshness));
+  return {
+    total: rows.length,
+    fresh: rows.filter(r => r.freshness === 'fresh').length,
+    actionable: actionable.length,
+    unknown: rows.filter(r => r.freshness === 'unlogged' || r.freshness === 'unmanaged').length,
+    worst: [...actionable].sort((a, b) => (b.age_hours ?? Infinity) - (a.age_hours ?? Infinity)),
+  };
+}
+
+const SELECT =
+  'mv_name,tier,freshness,age_hours,max_age_hours,last_success_at,last_attempt_status,notes';
+
+/** Every matview's verdict. Reads the live database, never the snapshot: a snapshot's refresh log
+ * would date the snapshot, not production. */
+export async function getAllMvFreshness(): Promise<MvFreshnessRow[]> {
+  const { data, error } = await getDirectServiceSupabase()
+    .from('v_mv_refresh_drift')
+    .select(SELECT);
+  if (error) throw new Error(`mv freshness query failed: ${error.message}`);
+  return (data ?? []) as unknown as MvFreshnessRow[];
+}
+
+/**
+ * One matview's verdict, for a surface that wants to date its own figure.
+ *
+ * Returns null when the view holds no row for that name, and callers must render that as "date
+ * unknown" rather than as fresh — a missing verdict is the one case where saying nothing is the
+ * same as claiming the number is current.
+ */
+export async function getMvFreshness(mvName: string): Promise<MvFreshnessRow | null> {
+  const { data, error } = await getDirectServiceSupabase()
+    .from('v_mv_refresh_drift')
+    .select(SELECT)
+    .eq('mv_name', mvName)
+    .maybeSingle();
+  if (error) throw new Error(`mv freshness query failed: ${error.message}`);
+  return (data as unknown as MvFreshnessRow) ?? null;
+}

--- a/migrations/2026-08-20-mv-staleness-visible.sql
+++ b/migrations/2026-08-20-mv-staleness-visible.sql
@@ -1,0 +1,117 @@
+-- Make matview staleness visible rather than inferable. #314 steps 3 and 4.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -f migrations/2026-08-20-mv-staleness-visible.sql
+--
+-- WHAT #314 ASSUMED, AND WHAT IS ACTUALLY TRUE (measured 2026-08-20):
+--
+--   The ticket reported that "nothing ran on the night of 18->19 August". It ran.
+--   cron.job_run_details for the nightly job (jobid 4) shows succeeded on 16, 17, 18, 19 and 20
+--   August, 11-13 minutes each. The only failure in the window is 2026-08-11, 'server restarted'.
+--
+--   The "15-16 August" cluster the ticket read as staleness is TIER BEHAVIOUR. Four of its five
+--   matviews are tier 'weekly' (cron '0 15 * * 0' -- last Sunday was the 16th) and the fifth,
+--   mv_foundation_landscape_top_foundations, is tier 'retire'. They were exactly as fresh as
+--   configured. Nothing was wrong with them.
+--
+--   Of the 23 never-logged entries, 19 are tier 'on_demand' and 16 have no success row. Every one
+--   of those 16 carries a `notes` value naming its owner -- refresh_alma_dashboards(),
+--   refresh_sentiment_analytics(), scripts/refresh-youth-justice-report-*. They are
+--   REFRESHED-BUT-UNLOGGED, which is the second of the ticket's "two very different problems".
+--
+-- THE DEFECT THAT SURVIVES, and what this migration fixes:
+--
+--   1. The log could not express any of the above. A reader could not tell "fresh for its tier"
+--      from "overdue", or "refreshed by another path" from "never refreshed at all". Both
+--      distinctions were reconstructible only by knowing the cron schedules by heart, which is
+--      how a weekly matview got mistaken for a four-day-stale one.
+--
+--   2. v_mv_refresh_drift computed last_refresh_at from the LAST LOG ROW OF ANY STATUS. A failed
+--      refresh therefore read as a refresh, and staleness reset itself on failure. It is now
+--      computed from successful rows only, with the last attempt reported separately so a
+--      failing matview is visible as failing rather than as fresh.
+
+ALTER TABLE mv_refresh_registry ADD COLUMN IF NOT EXISTS max_age_hours integer;
+
+COMMENT ON COLUMN mv_refresh_registry.max_age_hours IS
+  'Hours after which this matview is overdue. NULL means no schedule owns it, so it cannot be '
+  'overdue -- only unknown. Set from the tier''s cron cadence plus slack, not from taste.';
+
+-- Cadence plus slack, so a normal late run is not an alert:
+--   nightly  cron '0 17 * * *'  -> 24h + 12h
+--   weekly   cron '0 15 * * 0'  -> 168h + 24h
+--   on_demand / retire          -> NULL, nothing schedules them
+UPDATE mv_refresh_registry SET max_age_hours = 36  WHERE tier = 'nightly'   AND max_age_hours IS NULL;
+UPDATE mv_refresh_registry SET max_age_hours = 192 WHERE tier = 'weekly'    AND max_age_hours IS NULL;
+UPDATE mv_refresh_registry SET max_age_hours = NULL WHERE tier IN ('on_demand','retire');
+
+-- DROP, not CREATE OR REPLACE: replace cannot insert columns into the middle of the column list
+-- ("cannot change name of view column bytes to max_age_hours"). Nothing in the application reads
+-- this view -- checked 2026-08-20, zero references under apps/web/src -- so dropping it is safe.
+DROP VIEW IF EXISTS v_mv_refresh_drift;
+
+CREATE VIEW v_mv_refresh_drift AS
+WITH cat AS (
+  SELECT c.relname AS mv_name,
+         pg_total_relation_size(c.oid::regclass) AS bytes,
+         EXISTS (SELECT 1 FROM pg_index i
+                  WHERE i.indrelid = c.oid AND i.indisunique
+                    AND i.indpred IS NULL AND i.indexprs IS NULL) AS has_unique_idx
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relkind = 'm'
+),
+-- SUCCESS ONLY. The previous definition took the last row of any status, so a failed refresh
+-- reset the clock and a matview that had been failing for a week read as fresh.
+last_success AS (
+  SELECT DISTINCT ON (mv_name) mv_name, finished_at, started_at
+    FROM mv_refresh_log
+   WHERE status IN ('success','success-fallback')
+   ORDER BY mv_name, finished_at DESC
+),
+-- The last attempt regardless of outcome, so failure is visible AS failure.
+last_attempt AS (
+  SELECT DISTINCT ON (mv_name) mv_name, started_at, status
+    FROM mv_refresh_log ORDER BY mv_name, started_at DESC
+)
+SELECT COALESCE(cat.mv_name, r.mv_name::name) AS mv_name,
+       CASE
+         WHEN r.mv_name IS NULL   THEN 'UNREGISTERED'
+         WHEN cat.mv_name IS NULL THEN 'ORPHAN_ROW'
+         ELSE 'ok'
+       END AS drift,
+       r.tier, r.enabled, r.health, r.max_age_hours, r.notes,
+       cat.bytes, cat.has_unique_idx,
+       ls.finished_at AS last_success_at,
+       la.started_at  AS last_attempt_at,
+       la.status      AS last_attempt_status,
+       now() - ls.finished_at AS staleness,
+       ROUND(EXTRACT(epoch FROM now() - ls.finished_at) / 3600.0, 1) AS age_hours,
+       -- One word a human or a surface can act on. Ordered so the structural problems win.
+       CASE
+         WHEN r.mv_name IS NULL   THEN 'unregistered'   -- exists in the DB, nothing owns it
+         WHEN cat.mv_name IS NULL THEN 'orphan'         -- registry row for a matview that is gone
+         WHEN r.tier = 'retire'   THEN 'retired'        -- deliberately not refreshed
+         WHEN r.enabled IS NOT TRUE THEN 'disabled'
+         WHEN ls.finished_at IS NULL AND r.max_age_hours IS NULL THEN 'unlogged'
+             -- owned by a path that does not write to mv_refresh_log; see notes. NOT "never
+             -- refreshed" -- the log simply cannot tell you, and saying so is the honest answer.
+         WHEN ls.finished_at IS NULL THEN 'never'       -- scheduled, and has never succeeded
+         WHEN r.max_age_hours IS NULL THEN 'unmanaged'  -- has run, but nothing schedules it
+         WHEN now() - ls.finished_at > make_interval(hours => r.max_age_hours) THEN 'stale'
+         ELSE 'fresh'
+       END AS freshness
+  FROM cat
+  FULL JOIN mv_refresh_registry r ON r.mv_name = cat.mv_name
+  LEFT JOIN last_success ls ON ls.mv_name = COALESCE(cat.mv_name, r.mv_name::name)
+  LEFT JOIN last_attempt la ON la.mv_name = COALESCE(cat.mv_name, r.mv_name::name);
+
+COMMENT ON VIEW v_mv_refresh_drift IS
+  'Every matview with the freshness verdict a surface should disclose. last_success_at counts '
+  'SUCCESSFUL refreshes only -- the earlier definition used the last row of any status, so a '
+  'failed refresh read as a refresh. freshness ''unlogged'' means an on_demand matview owned by a '
+  'path that does not write to mv_refresh_log (see notes); it is an honest unknown, not a zero. '
+  'See migrations/2026-08-20-mv-staleness-visible.sql and #314.';
+
+GRANT SELECT ON v_mv_refresh_drift TO anon, authenticated, service_role;


### PR DESCRIPTION
Closes #314 steps 1–3 and implements the decision in step 4.

## The ticket's premise was wrong, and that is the finding

- **The non-run never happened.** `cron.job_run_details` for the nightly job shows *succeeded* on 16, 17, 18, **19** and 20 August, 11–13 minutes each. The only failure in the window is 2026-08-11, `server restarted`.
- **The "15–16 August" cluster is tier behaviour.** Four of the five matviews in the ticket's table are tier `weekly` (cron `0 15 * * 0` — last Sunday was the 16th); the fifth is tier `retire`. Exactly as fresh as configured.
- **The 23 never-logged resolve to 16**, all tier `on_demand`, and every one names its owner in `notes`. Refreshed-but-unlogged — the second of the ticket's "two very different problems".

The real defect: the log could not express any of that. "Fresh for its tier" was indistinguishable from "overdue", and "refreshed elsewhere" from "never refreshed", unless you knew the cron schedules by heart. That is how a weekly matview got read as four days stale.

## What changed

- `max_age_hours` per registry entry, from each tier's cadence plus slack (nightly 36h, weekly 192h, `on_demand`/`retire` NULL — nothing schedules them, so they cannot be *overdue*, only *unknown*).
- **`v_mv_refresh_drift` now counts successes only.** It previously took the last log row of *any* status, so a failed refresh reset the staleness clock and a matview failing for a week read as fresh. Last attempt is reported separately so failure is visible as failure.
- A one-word `freshness` verdict: `fresh · stale · never · unlogged · unmanaged · retired · disabled · orphan · unregistered`.
- `lib/mv-freshness.ts` (17 tests) turns a verdict into the words a surface prints. **`unlogged` is deliberately not actionable** — alerting nightly on 16 externally-owned matviews is how an alert stops being read.
- `/api/ops/health` carries the summary; a failed lookup reports `null`, not zero faults, matching that route's existing rule that a question we failed to ask is not a measurement of zero.
- `components/as-of.tsx` is step 4's disclosure: a null verdict renders "date unknown", never nothing, because nothing reads as "current".

## Verified

Migration **applied**. Against production: 104 matviews — 76 fresh, 16 unlogged, 9 retired, 3 unmanaged, and **nothing stale, never-refreshed, orphaned or unregistered**. `/api/ops/health` locally returns `{"total":104,"fresh":76,"actionable":0,"unknown":19,"worst":[]}`. `./scripts/precheck.sh` green (800 tests).

## Note on the VISIBLE flag

`classify-changes.sh` marks this VISIBLE because of the new component under `src/components/`. **No page imports it yet**, so nothing on any surface changes — there is nothing to eyeball on the preview. Rolling `AsOf` out across the ~60 surfaces that read matviews is deliberately a separate piece of work, since each placement is a visual decision. Flagging rather than auto-merging per the landing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)