### PR TITLE
Disclose dollar concentration: the worst-capturing places have one big grant (#300)

### DIFF
--- a/apps/web/src/lib/grant-place-capture.test.ts
+++ b/apps/web/src/lib/grant-place-capture.test.ts
@@ -190,6 +190,7 @@ describe('ranked lists are thresholded', () => {
     place: 'Somewhere',
     state: 'QLD',
     remoteness: null,
+    biggestAwardShare: null,
     ...tallyCapture([]),
     ...over,
   });
@@ -219,6 +220,27 @@ describe('ranked lists are thresholded', () => {
       resolvedDollars: CAPTURE_MIN_DOLLARS * 10,
     });
     expect(rankWorstCapturing([justUnder])).toEqual([]);
+  });
+
+  // Measured 2026-08-20: every one of the twelve worst dollar-capturing councils passes both
+  // thresholds AND has one award carrying 38-96% of its money. Gladstone reads 0.3% of dollars
+  // kept against 70.4% of awards because a few hydrogen grants went to head offices in Sydney and
+  // Perth. The threshold cannot catch that, so the row must carry the concentration and callers
+  // must show it. Filtering these places out would hide a real finding.
+  it('a concentrated place still ranks, and carries the concentration that explains it', () => {
+    const gladstone = place({
+      place: 'Gladstone',
+      resolvedAwards: 27,
+      resolvedDollars: 120_000_000,
+      pctDollarsLocal: 0.3,
+      pctAwardsLocal: 70.4,
+      biggestAwardShare: 38.1,
+    });
+    const ranked = rankWorstCapturing([gladstone]);
+    expect(ranked.map(p => p.place)).toEqual(['Gladstone']);
+    expect(ranked[0].biggestAwardShare).toBe(38.1);
+    // The award share is the other half of the story and must survive alongside it.
+    expect(ranked[0].pctAwardsLocal).toBe(70.4);
   });
 
   it('ranks by awards when asked', () => {

--- a/apps/web/src/lib/grant-place-capture.ts
+++ b/apps/web/src/lib/grant-place-capture.ts
@@ -218,6 +218,18 @@ export interface CapturePlace extends CaptureTally {
   place: string;
   state: string | null;
   remoteness: string | null;
+  /**
+   * Share of this place's delivered dollars sitting in its single largest award, one decimal.
+   *
+   * The confounder that the award/dollar thresholds do NOT catch. Measured 2026-08-20: EVERY one
+   * of the twelve worst dollar-capturing councils has high award capture (47.6%-96.0%) and one
+   * award carrying 38%-96% of its money. Armidale reads 96.0% of awards local and 4.4% of
+   * dollars because a single grant is 95.6% of the total. A "places that keep the least" table
+   * ranked on dollars is substantially a table of "places with one big externally-received
+   * grant", and a surface that ranks without showing this is telling the reader something untrue
+   * about the place.
+   */
+  biggestAwardShare: number | null;
 }
 
 export interface CaptureResult {
@@ -263,6 +275,7 @@ interface RawPlaceRow {
   local_dollars: string | number;
   cross_state_awards: string | number;
   cross_state_dollars: string | number;
+  biggest_award_share: string | number | null;
 }
 
 const n = (v: unknown) => Number(v ?? 0) || 0;
@@ -361,7 +374,8 @@ export async function captureByState(): Promise<CaptureResult> {
            count(*) FILTER (WHERE recipient_state = delivery_state)::bigint AS local_awards,
            COALESCE(sum(value_aud) FILTER (WHERE recipient_state = delivery_state),0)::numeric AS local_dollars,
            count(*) FILTER (WHERE recipient_state IN (${states}) AND recipient_state <> delivery_state)::bigint AS cross_state_awards,
-           COALESCE(sum(value_aud) FILTER (WHERE recipient_state IN (${states}) AND recipient_state <> delivery_state),0)::numeric AS cross_state_dollars
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_state IN (${states}) AND recipient_state <> delivery_state),0)::numeric AS cross_state_dollars,
+           ROUND(100.0 * max(value_aud) / NULLIF(sum(value_aud), 0), 1) AS biggest_award_share
       FROM base
      GROUP BY delivery_state
      ORDER BY delivery_state`);
@@ -370,6 +384,7 @@ export async function captureByState(): Promise<CaptureResult> {
     place: r.place,
     state: r.state,
     remoteness: null,
+    biggestAwardShare: r.biggest_award_share === null ? null : n(r.biggest_award_share),
     ...tallyFromRow(r),
   }));
   const national = sumTallies(places);
@@ -403,7 +418,8 @@ export async function captureByLga(): Promise<CaptureResult> {
            count(*) FILTER (WHERE captured_locally)::bigint AS local_awards,
            COALESCE(sum(value_aud) FILTER (WHERE captured_locally),0)::numeric AS local_dollars,
            count(*) FILTER (WHERE recipient_lga IS NOT NULL AND recipient_state <> delivery_state)::bigint AS cross_state_awards,
-           COALESCE(sum(value_aud) FILTER (WHERE recipient_lga IS NOT NULL AND recipient_state <> delivery_state),0)::numeric AS cross_state_dollars
+           COALESCE(sum(value_aud) FILTER (WHERE recipient_lga IS NOT NULL AND recipient_state <> delivery_state),0)::numeric AS cross_state_dollars,
+           ROUND(100.0 * max(value_aud) / NULLIF(sum(value_aud), 0), 1) AS biggest_award_share
       FROM v_grant_place_capture
      GROUP BY delivery_lga, delivery_state`);
   const totals = await runSql<{ awards: string; dollars: string }>(TOTALS_SQL);
@@ -411,6 +427,7 @@ export async function captureByLga(): Promise<CaptureResult> {
     place: r.place,
     state: r.state,
     remoteness: r.remoteness,
+    biggestAwardShare: r.biggest_award_share === null ? null : n(r.biggest_award_share),
     ...tallyFromRow(r),
   }));
   const national = sumTallies(places);
@@ -427,9 +444,18 @@ export async function captureByLga(): Promise<CaptureResult> {
 }
 
 /**
- * Places that keep the least, thresholded so a single large grant in a tiny council cannot lead
- * the table. Ranked on the resolved base, because a place whose recipients simply do not resolve
- * has not been shown to leak anything.
+ * Places that keep the least, thresholded so a tiny council cannot lead the table on a handful of
+ * awards. Ranked on the resolved base, because a place whose recipients simply do not resolve has
+ * not been shown to leak anything.
+ *
+ * THE THRESHOLDS ARE NOT ENOUGH ON THEIR OWN, and this is deliberate rather than an oversight.
+ * They catch small-N noise; they do not catch DOLLAR CONCENTRATION, which is the failure mode the
+ * data actually has. Gladstone passes both thresholds comfortably — 27 resolved awards, $120m —
+ * and reads 0.3% of dollars kept, but the money is a handful of hydrogen and critical-minerals
+ * grants received by corporate head offices in Sydney and Perth, while 70.4% of its awards stay
+ * local. Filtering those places out would hide a real finding, so per disclose-don't-hide every
+ * row carries `biggestAwardShare` instead. **A caller that ranks on dollars without rendering it
+ * is publishing a misleading table.**
  */
 export function rankWorstCapturing(
   places: readonly CapturePlace[],

--- a/thoughts/shared/analysis/2026-08-20-gladstone-capture-concentration.md
+++ b/thoughts/shared/analysis/2026-08-20-gladstone-capture-concentration.md
@@ -1,0 +1,84 @@
+# The worst-capturing places are mostly places with one big grant
+
+Measured 2026-08-20 against production, after the #301 repair widened
+`v_grant_place_capture` to 110,267 awards / $42.37bn.
+
+## The lead
+
+Widening coverage put **Gladstone** at the bottom of the dollar-capture table: of $200.0m of grant
+money delivered into the council, **$0.36m — 0.3% — was received by an organisation based there.**
+
+That reads like extraction. It is more specific than that, and the specifics matter.
+
+## What the money actually is
+
+| recipient | received in | $m |
+|---|---|---:|
+| Stanwell Corporation Limited | *unresolved* | 76.12 |
+| Alpha HPA Limited | Sydney NSW | 49.50 |
+| **Gladstone** Fortescue Future Industries Pty Ltd | Perth WA | 49.44 |
+| Alpha HPA Limited | Sydney NSW | 17.05 |
+| Vena Energy Services (Australia) Pty Ltd | Brisbane QLD | 3.30 |
+| Northern Oil Refineries Pty Ltd | *unresolved* | 2.04 |
+| Gladstone Regional Council | *unresolved* | 1.72 |
+
+Hydrogen and critical-minerals decarbonisation grants. The projects are in Gladstone; the
+companies are registered at head offices in Sydney and Perth. One recipient is literally named
+**Gladstone** Fortescue Future Industries and is received in Perth — a Gladstone-named subsidiary
+registered at the parent's address, which is the mechanism in a single row.
+
+Meanwhile **70.4% of Gladstone's awards stay local.** The many small grants are local; the few
+enormous ones are not.
+
+## The pattern generalises, and it breaks the ranked list
+
+Every one of the twelve worst dollar-capturing councils shows the same shape — high award capture,
+and one award carrying most of the money:
+
+| council | resolved awards | $m | awards local | dollars local | biggest award |
+|---|---:|---:|---:|---:|---:|
+| Gladstone QLD | 27 | 120 | 70.4% | **0.3%** | 38.1% |
+| Armidale NSW | 25 | 100 | **96.0%** | 4.4% | **95.6%** |
+| Unincorporated SA | 63 | 26 | 60.3% | 6.3% | 47.4% |
+| Kentish TAS | 36 | 62 | 88.9% | 6.8% | 93.1% |
+| Snowy Monaro NSW | 31 | 6 | 64.5% | 9.4% | 40.1% |
+| Albury NSW | 114 | 19 | 79.8% | 12.5% | 50.8% |
+| Ashburton WA | 21 | 5 | 47.6% | 13.3% | 56.3% |
+| Tasman TAS | 28 | 9 | 82.1% | 13.5% | 38.6% |
+| Glenelg VIC | 51 | 99 | 82.4% | 14.7% | 85.1% |
+| Wollondilly NSW | 122 | 85 | 90.2% | 18.4% | 49.1% |
+| Port Adelaide Enfield SA | 227 | 41 | 93.4% | 23.5% | 70.2% |
+| Burdekin QLD | 99 | 24 | 72.7% | 26.7% | 66.7% |
+
+Armidale is the clearest: **96.0% of awards stay local and 4.4% of dollars do, because one grant is
+95.6% of the money.**
+
+**So a "places that keep the least" table ranked on dollars is substantially a table of "places
+with one big externally-received grant".** That is a real finding about how large industrial and
+research grants are administered. It is not the finding a reader assumes they are looking at.
+
+## What this cost, and what changed
+
+The thresholds shipped this morning — `CAPTURE_MIN_AWARDS = 20`, `CAPTURE_MIN_DOLLARS = 5m` —
+guard against small-N noise. **They do not catch dollar concentration**, and concentration is the
+failure mode this data actually has: every council in the table above clears both thresholds
+comfortably.
+
+Filtering concentrated places out would hide something true, so per disclose-don't-hide every
+`CapturePlace` now carries `biggestAwardShare`, and `rankWorstCapturing()` documents that a caller
+ranking on dollars without rendering it is publishing a misleading table.
+
+## The caution on Gladstone specifically
+
+Stanwell Corporation, the single largest award at $76.12m, is **unresolved** — its recipient
+postcode does not map to one trustworthy council, so it sits in neither the local nor the
+elsewhere bucket. Stanwell is a Queensland government-owned generator, so a resolved Stanwell would
+very likely land in Brisbane rather than Gladstone and would deepen the gap rather than close it.
+But that is an inference, not a measurement, and the figure above does not depend on it.
+
+## What this does not say
+
+It does not say Gladstone is being short-changed. Grant money delivered to a place through a
+company headquartered elsewhere still builds the thing in the place. What the measure shows is
+**where the money is administered from**, which is a question about local capability and
+contracting capacity, not about whether the project happens.


### PR DESCRIPTION
Follow-up to #374, which widened coverage and surfaced this. Analysis: `thoughts/shared/analysis/2026-08-20-gladstone-capture-concentration.md`.

## The lead

Widening coverage put **Gladstone** at the bottom of the dollar-capture table: **$0.36m of $200.0m delivered — 0.3% kept.** That reads like extraction. The specifics are more interesting.

| recipient | received in | $m |
|---|---|---:|
| Stanwell Corporation Limited | *unresolved* | 76.12 |
| Alpha HPA Limited | Sydney NSW | 49.50 |
| **Gladstone** Fortescue Future Industries Pty Ltd | Perth WA | 49.44 |
| Alpha HPA Limited | Sydney NSW | 17.05 |

Hydrogen and critical-minerals grants. The projects are in Gladstone; the companies are registered at head offices elsewhere. One recipient is literally named *Gladstone* Fortescue Future Industries and is received in **Perth** — the mechanism in a single row. Meanwhile **70.4% of Gladstone's awards stay local**: the many small grants are local, the few enormous ones are not.

## It generalises, and it breaks the ranked list

Every one of the twelve worst dollar-capturing councils has high award capture (47.6%–96.0%) **and** one award carrying 38%–96% of its money. Armidale: **96.0% of awards local, 4.4% of dollars, one grant = 95.6% of the total.**

So a "places that keep the least" table ranked on dollars is substantially a table of *"places with one big externally-received grant"*. Real finding; not the one a reader assumes.

## What changed

`CAPTURE_MIN_AWARDS`/`CAPTURE_MIN_DOLLARS` guard against small-N noise. **They do not catch dollar concentration**, and every council above clears both thresholds comfortably. Filtering concentrated places out would hide something true, so per disclose-don't-hide every `CapturePlace` now carries **`biggestAwardShare`**, and `rankWorstCapturing()` documents that a caller ranking on dollars without rendering it is publishing a misleading table.

## Caution recorded in the doc

Stanwell — the single largest award at $76.12m — is **unresolved**, so it sits in neither bucket. A resolved Stanwell would likely land in Brisbane and *deepen* the gap, but that is an inference, not a measurement, and the headline does not depend on it.

`./scripts/precheck.sh` green (801 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)