### PR TITLE
Re-derive the remoteness shift, and reverse this morning's correction (#311)

### DIFF
--- a/thoughts/shared/analysis/2026-08-21-remoteness-shift-rederived.md
+++ b/thoughts/shared/analysis/2026-08-21-remoteness-shift-rederived.md
@@ -1,0 +1,59 @@
+# The remoteness shift, re-derived on a like-for-like base
+
+Measured 2026-08-21. Restores the table withdrawn from the #311 brief earlier the same day, and
+corrects the brief's own correction.
+
+## Why the earlier numbers could not be trusted
+
+The table has now been derived three ways and only the third is sound.
+
+| method | Outer Regional | problem |
+|---|---:|---|
+| original (in #311, pre-repair) | -26.6% | measured on the old $23.06bn base, before #301 widened coverage |
+| by recipient **council** | **+2.1%** | picks one remoteness class for councils spanning several — a sign flip from an arbitrary choice |
+| by recipient **postcode**, unmapped kept | -28.3% | $16.2bn falls into "postcode unmapped" on the address side against $3.6bn on the delivery side, so the comparison is not like-for-like |
+| **by postcode, both ends mapped** | **-25.2%** | the base is stated and the comparison is symmetric |
+
+The third is the one to use. It restricts to awards where **both** the delivery postcode and the
+recipient postcode map to exactly one remoteness class, so there is no "unmapped" bucket to absorb
+the difference asymmetrically.
+
+**Base: 139,472 awards, $34.69bn**, of the $51.29bn where both postcodes are present. The
+$16.6bn difference is awards with at least one end in a postcode spanning two remoteness classes;
+it is excluded by construction rather than dumped in a residual category.
+
+## The result
+
+| remoteness | by delivery | by registered address | shift |
+|---|---:|---:|---:|
+| Major Cities | $22,659m | $25,013m | **+10.4%** |
+| Inner Regional | $5,525m | $4,995m | -9.6% |
+| Outer Regional | $4,317m | $3,230m | **-25.2%** |
+| Remote | $1,010m | $636m | **-37.1%** |
+| Very Remote | $1,180m | $819m | **-30.6%** |
+
+**$3,672m crosses a remoteness boundary, and $2,669m of it — 72.7% — lands in Major Cities.**
+
+## This corrects the brief's own correction
+
+The #311 brief flagged that the ticket's phrase "into the cities" was wrong, on the grounds that
+of the $878m that shifted, only $383m landed in Major Cities and $497m landed in "postcode
+unmapped".
+
+**That correction was itself an artefact of the unmapped bucket.** Once both ends are required to
+map, there is no unmapped bucket, and the money that leaves regional and remote Australia does
+overwhelmingly land in the cities — 72.7% of it. The net gain of $2,354m in Major Cities almost
+exactly equals the net loss across the four non-city classes.
+
+So **"into the cities" is defensible after all**, on a stated base. The sentence for the room:
+
+> Attribute the money by registered address instead of by where the work happens, and Remote
+> Australia's recorded total falls 37 per cent, Very Remote 31, Outer Regional 25. Nearly three
+> quarters of what moves lands in the major cities. That is measured on 35 billion dollars of
+> federal grants where we can place both ends.
+
+## The caution that stands
+
+The gradient is not perfectly monotonic — Remote (-37.1%) falls further than Very Remote (-30.6%).
+Do not describe it as "the more remote the worse", because the data does not say that. It says the
+non-city classes all lose and the cities gain.

--- a/thoughts/shared/briefs/311-intermediary-conversations.md
+++ b/thoughts/shared/briefs/311-intermediary-conversations.md
@@ -6,8 +6,9 @@ today's figures are enough. Every figure below was re-verified against the live 
 
 > **Updated 2026-08-21.** The capture figures changed materially after #301's `postcode_geo`
 > repair let the SA3 exclusion be narrowed: coverage rose 28% and the headline dollar share moved
-> a long way. **Do not use any printout of this brief dated 2026-08-20.** One table has been
-> WITHDRAWN rather than restated — see "The table you cannot use yet".
+> a long way. **Do not use any printout of this brief dated 2026-08-20.** The remoteness shift
+> table was withdrawn and has since been re-derived on a sound base — and it reverses the
+> "into the cities" correction this brief made that morning.
 
 ## The four figures you can say
 
@@ -28,30 +29,40 @@ the cities". **Two separate problems: the wording, and now the numbers themselve
 Cities at all — it lands in postcodes we cannot map. Say "into the cities" and you overstate the
 city-ward flow by more than half.
 
-## The table you cannot use yet
+## The remoteness shift, re-derived 2026-08-21
 
-**WITHDRAWN 2026-08-21. Do not quote the remoteness shift percentages.**
+Withdrawn earlier today, now restored on a base that holds up. Full working:
+`thoughts/shared/analysis/2026-08-21-remoteness-shift-rederived.md`.
 
-The 26.6 / 35.6 / 22.5 figures were measured on the old $23.06bn resolved base. That base is now
-larger, and re-deriving the table produced **two different answers that disagree with each other
-and with the original**, because resolving a recipient's remoteness is genuinely hard:
+Restricted to awards where **both** the delivery postcode and the recipient postcode map to
+exactly one remoteness class, so no "unmapped" bucket absorbs the difference asymmetrically.
+**Base: 139,472 awards, $34.69bn.**
 
-- resolving via the recipient's COUNCIL means picking one remoteness class for councils that span
-  several — arbitrary, and it flipped Outer Regional from -26.6% to **+2.1%**, a sign change;
-- resolving via the recipient's POSTCODE drops every postcode spanning two classes, which pushed
-  **$16.2bn into "postcode unmapped"** on the address side against $3.6bn on the delivery side.
+| remoteness | by delivery | by registered address | shift |
+|---|---:|---:|---:|
+| Major Cities | $22,659m | $25,013m | **+10.4%** |
+| Inner Regional | $5,525m | $4,995m | -9.6% |
+| Outer Regional | $4,317m | $3,230m | **-25.2%** |
+| Remote | $1,010m | $636m | **-37.1%** |
+| Very Remote | $1,180m | $819m | **-30.6%** |
 
-Neither is trustworthy. A third number invented in an afternoon, quoted to a council, and later
-corrected is worse than not having the number.
+**$3,672m crosses a remoteness boundary and $2,669m of it — 72.7% — lands in Major Cities.**
 
-**What to say instead, which is still true and still lands:**
+**This reverses what this brief said this morning.** It flagged "into the cities" as wrong,
+because only $383m of $878m landed in Major Cities. That was an artefact of the unmapped bucket.
+Require both ends to map and the phrase is right: nearly three quarters of what moves goes to the
+cities.
 
-> Money is recorded where the organisation is registered, not where the work happens. In remote
-> Australia those are routinely different places, and the gap runs against the remote end. We
-> measure it per council rather than nationally, because the national average hides it.
+**The sentence for the room:**
 
-If they press for the national number, say it is being re-derived and you will send it. Then
-re-derive it properly.
+> Attribute the money by registered address instead of by where the work happens, and Remote
+> Australia's recorded total falls 37 per cent, Very Remote 31, Outer Regional 25. Nearly three
+> quarters of what moves lands in the major cities. That is measured on 35 billion dollars of
+> federal grants where we can place both ends.
+
+**Do not say "the more remote the worse."** Remote (-37.1%) falls further than Very Remote
+(-30.6%). The data says the non-city classes all lose and the cities gain, not that it worsens
+monotonically.
 
 ## Say this before they ask
 


### PR DESCRIPTION
Docs only. Restores the table I withdrew from the #311 brief a few hours ago.

## Three derivations, one sound

| method | Outer Regional | problem |
|---|---:|---|
| original (in #311) | -26.6% | measured before #301 widened coverage |
| by recipient **council** | **+2.1%** | picks one remoteness class for councils spanning several — a sign flip from an arbitrary choice |
| by postcode, unmapped kept | -28.3% | $16.2bn falls into "unmapped" on the address side vs $3.6bn on the delivery side — not like-for-like |
| **by postcode, both ends mapped** | **-25.2%** | base stated, comparison symmetric |

The last one requires **both** the delivery and recipient postcode to map to exactly one remoteness class, so there is no residual bucket to absorb the difference asymmetrically. **Base: 139,472 awards, $34.69bn** of the $51.29bn where both postcodes exist.

## Result

| remoteness | by delivery | by registered address | shift |
|---|---:|---:|---:|
| Major Cities | $22,659m | $25,013m | **+10.4%** |
| Inner Regional | $5,525m | $4,995m | -9.6% |
| Outer Regional | $4,317m | $3,230m | **-25.2%** |
| Remote | $1,010m | $636m | **-37.1%** |
| Very Remote | $1,180m | $819m | **-30.6%** |

**$3,672m crosses a remoteness boundary and $2,669m of it — 72.7% — lands in Major Cities.** The net gain in Major Cities almost exactly equals the net loss across the four non-city classes.

## It reverses the correction the brief made this morning

The brief flagged the ticket's phrase *"into the cities"* as wrong, because only $383m of $878m landed in Major Cities and $497m landed in "postcode unmapped".

**That correction was itself an artefact of the unmapped bucket.** Require both ends to map and the phrase is right: nearly three quarters of what moves goes to the cities. The brief now says so, and points at the working.

## One caution kept

The gradient is **not monotonic** — Remote (-37.1%) falls further than Very Remote (-30.6%). Do not say "the more remote the worse". The data says the non-city classes all lose and the cities gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)