### PR TITLE
Stop ranking universities and service charities as top funders (#390)

### DIFF
--- a/apps/web/src/app/foundation/page.tsx
+++ b/apps/web/src/app/foundation/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { applyGrantmakingFilter } from '@/lib/foundation-giving';
 import { getServiceSupabase } from '@/lib/supabase';
 import Link from 'next/link';
 import { money } from '@/lib/format';
@@ -44,6 +45,15 @@ async function getData(search?: string, sort?: string) {
     : sort === 'need' ? 'need_alignment_score'
     : 'foundation_score';
 
+  // #390: when the question is "who gives the most", total_giving_annual cannot answer it as it
+  // stands. For service_delivery, religious_organisation and education_body it is revenue — the
+  // University of Sydney ($340.7M), Australian Red Cross ($265.7M) and Alice Springs Youth
+  // Accommodation & Support ($196.0M) all led this sort — and 9,217 of 10,190 remaining values are
+  // one of three placeholder round numbers. So THIS SORT ONLY narrows to figures that mean
+  // grantmaking. Those rows are still in the browse under every other sort; they are excluded from
+  // the answer to a question they cannot answer.
+  if (sort === 'giving') query = applyGrantmakingFilter(query);
+
   query = query.order(sortCol, { ascending: false }).limit(200);
 
   const { data, error } = await query;
@@ -86,6 +96,19 @@ export default async function FoundationIndexPage({
           evidence backing, and geographic reach.
         </p>
       </div>
+
+      {/* Sorting by giving narrows the list, and a user who is not told that reads the shorter
+          list as the whole register. #390: total_giving_annual is revenue for universities,
+          service providers and school systems, and a placeholder for 9,217 of 10,190 rows. */}
+      {params.sort === 'giving' && (
+        <p className="mb-6 border-l-4 border-bauhaus-yellow bg-white px-4 py-3 text-sm leading-relaxed">
+          <strong>Sorted by giving shows fewer foundations, on purpose.</strong> For universities,
+          service providers and school systems the recorded figure is revenue rather than
+          grantmaking, and most of the remaining values are a placeholder rather than a
+          measurement. This sort narrows to figures that mean grantmaking; every other sort shows
+          the full list.
+        </p>
+      )}
 
       {/* Search + Sort */}
       <div className="flex flex-wrap gap-3 mb-6 items-center">

--- a/apps/web/src/app/foundations/backlog/page.tsx
+++ b/apps/web/src/app/foundations/backlog/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { measuredGivingOrderSql } from '@/lib/foundation-giving';
 import { getServiceSupabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -255,7 +256,9 @@ function buildBacklogQuery(comparableTypes: string, filter: string) {
           SELECT *
           FROM candidate_rows
           WHERE ${filter}
-          ORDER BY total_giving_annual DESC NULLS LAST
+          -- #390: total_giving_annual is revenue for three types and a placeholder for 90% of
+          -- the rest. Demote rather than exclude, so nothing leaves the backlog.
+          ORDER BY ${measuredGivingOrderSql()}
           LIMIT ${PAGE_QUEUE_SCAN_LIMIT}`;
 }
 

--- a/apps/web/src/lib/foundation-giving.test.ts
+++ b/apps/web/src/lib/foundation-giving.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  givingLabel,
+  measuredGivingOrderSql,
+  grantmakingGivingSql,
+  isGivingMeasured,
+  isPlaceholderGiving,
+} from './foundation-giving';
+
+const fmt = (n: number) => `$${n.toLocaleString()}`;
+
+describe('the four organisations that were ranked as top funders', () => {
+  // Measured live 2026-08-21. Each was in the top seven of "foundations by giving".
+  it.each([
+    ['The University of Sydney', 'university', 340_674_255],
+    ['Monash University', 'university', 273_722_000],
+    ['Catholic Education Centre', 'religious_organisation', 281_472_122],
+    ['Australian Red Cross Society', 'service_delivery', 265_670_000],
+    ['Alice Springs Youth Accommodation & Support', 'service_delivery', 196_035_900],
+  ])('%s is not a grantmaking figure', (_name, type, value) => {
+    expect(isGivingMeasured(type, value)).toBe(false);
+    expect(givingLabel(type, value, fmt)).toBe('Not a grantmaking figure');
+  });
+
+  // The first version of this module was a DENYLIST of three receiving types and it failed open:
+  // `university` was not on it, so Sydney stayed top of the ranking at $340.7M while the Red Cross
+  // was correctly removed. foundations.type has 27 values including legal_aid, hospital,
+  // research_body and peak_body. An allowlist fails closed instead.
+  it.each(['university', 'legal_aid', 'hospital', 'research_body', 'peak_body', 'a_type_nobody_has_added_yet'])(
+    '%s counts as nothing until a human adds it',
+    type => {
+      expect(isGivingMeasured(type, 100_000_000)).toBe(false);
+    },
+  );
+
+  // The control: a real grantmaker of comparable size must survive.
+  it('Minderoo, a genuine grantmaker, survives', () => {
+    expect(isGivingMeasured('trust', 273_817_719)).toBe(true);
+    expect(givingLabel('trust', 273_817_719, fmt)).toBe('$273,817,719');
+  });
+});
+
+describe('the placeholder floor', () => {
+  // 9,217 of 10,190 non-null values sit on these three numbers.
+  it.each([25_000, 100_000, 500_000])('%d is a placeholder, not a measurement', v => {
+    expect(isPlaceholderGiving(v)).toBe(true);
+    expect(isGivingMeasured('trust', v)).toBe(false);
+    expect(givingLabel('trust', v, fmt)).toContain('placeholder');
+  });
+
+  // Deliberate: a foundation that genuinely gives $25,000 is treated as unmeasured rather than
+  // guessed at. Understating certainty is the safe direction.
+  it('a near-miss value is treated as real', () => {
+    expect(isPlaceholderGiving(25_001)).toBe(false);
+    expect(isGivingMeasured('trust', 25_001)).toBe(true);
+  });
+});
+
+describe('absent figures', () => {
+  it.each([null, undefined, 0])('%s renders as not recorded, never as zero giving', v => {
+    expect(isGivingMeasured('trust', v as number | null)).toBe(false);
+    expect(givingLabel('trust', v as number | null, fmt)).toBe('Giving not recorded');
+  });
+});
+
+describe('the SQL predicate', () => {
+  it('allowlists the grantmaking types and excludes all three placeholders', () => {
+    const sql = grantmakingGivingSql('f');
+    for (const t of ['grantmaker', 'private_ancillary_fund', 'trust']) {
+      expect(sql).toContain(`'${t}'`);
+    }
+    expect(sql).not.toContain('university');
+    for (const v of [25000, 100000, 500000]) expect(sql).toContain(String(v));
+    expect(sql).toContain('f.total_giving_annual');
+  });
+
+  // A null type is not evidence of grantmaking. 316 foundations carry no type and NONE of them
+  // holds a figure above $50M, so failing closed here costs nothing measurable and prevents the
+  // next untyped ingest from ranking as a major funder.
+  it('a missing type counts as nothing', () => {
+    expect(isGivingMeasured(null, 4_000_000)).toBe(false);
+    expect(givingLabel(null, 4_000_000, fmt)).toBe('Not a grantmaking figure');
+  });
+});
+
+describe('the ordering expression demotes rather than excludes', () => {
+  // Filtering a browse would drop a university foundation entirely, which is a second silent
+  // error on top of the first. Every row stays; the unmeasured ones go last.
+  it('nulls the unmeasured cases so they sort last, and keeps the row', () => {
+    const sql = measuredGivingOrderSql('f');
+    expect(sql).toContain('DESC NULLS LAST');
+    expect(sql).toContain("'grantmaker'");
+    expect(sql).toContain('25000');
+    expect(sql).not.toContain('WHERE');
+  });
+});

--- a/apps/web/src/lib/foundation-giving.ts
+++ b/apps/web/src/lib/foundation-giving.ts
@@ -1,0 +1,134 @@
+/**
+ * `foundations.total_giving_annual`, filtered honestly.
+ *
+ * The column does NOT mean "money this organisation gives away". Two separate defects, and six
+ * surfaces ranked on it before this module existed (#390).
+ *
+ * 1. IT IS WRONG IN KIND FOR SOME TYPES. For service providers, school systems and universities it
+ *    carries revenue or expenditure. Measured 2026-08-21, the top of "foundations by giving" was:
+ *
+ *      The University of Sydney                     $340.7M   a university
+ *      Catholic Education Centre                    $281.5M   a school system
+ *      Australian Red Cross Society                 $265.7M   a service charity
+ *      Alice Springs Youth Accommodation & Support  $196.0M   a service provider
+ *
+ *    Alice Springs Youth Accommodation & Support Service ranked among Australia's largest
+ *    philanthropic funders is the clearest tell: it is an organisation this project exists to show
+ *    RECEIVING money.
+ *
+ * 2. NINETY PERCENT OF IT IS A PLACEHOLDER. Of 10,190 non-null values, 6,942 are exactly $25,000,
+ *    1,474 are exactly $100,000 and 801 are exactly $500,000 — 9,217 of 10,190 on three round
+ *    numbers, with only 964 distinct values in the whole column. A descending sort therefore
+ *    returns a few miscategorised giants and then ~6,942 foundations tied at $25,000 in arbitrary
+ *    order.
+ *
+ * So: rank only over types whose figure means grantmaking, and never render a placeholder as
+ * though it were a measurement.
+ */
+
+/**
+ * The types whose `total_giving_annual` plausibly means GRANTMAKING. An allowlist, not a denylist.
+ *
+ * The first version of this was a denylist of three receiving types, and it FAILED OPEN: `university`
+ * was not on it, so The University of Sydney stayed at the top of the giving ranking at $340.7M
+ * while the Red Cross and Alice Springs Youth Accommodation were correctly removed. `foundations.type`
+ * has 27 values including `legal_aid`, `hospital`, `research_body`, `peak_body`, `sport_recreation`
+ * and `emergency_relief` — all organisations that receive.
+ *
+ * A denylist means every type someone adds later counts as giving until a human notices. An
+ * allowlist means a new type counts as nothing until a human decides. Given the failure mode here
+ * is publishing a service provider as a major philanthropist, it fails closed.
+ */
+export const GRANTMAKING_TYPES: ReadonlySet<string> = new Set([
+  'grantmaker',
+  'philanthropic_foundation',
+  'private_ancillary_fund',
+  'public_ancillary_fund',
+  'community_foundation',
+  'corporate_foundation',
+  'giving_circle',
+  'trust',
+  'trustee',
+]);
+
+export const PLACEHOLDER_GIVING: readonly number[] = [25_000, 100_000, 500_000];
+
+export function isPlaceholderGiving(value: number | null | undefined): boolean {
+  if (value === null || value === undefined) return false;
+  return PLACEHOLDER_GIVING.includes(Number(value));
+}
+
+/** Whether this row's giving figure means grantmaking AND is not a placeholder. */
+export function isGivingMeasured(
+  type: string | null | undefined,
+  value: number | null | undefined,
+): boolean {
+  if (value === null || value === undefined) return false;
+  if (!(Number(value) > 0)) return false;
+  // Fails closed: an unrecognised or missing type is not evidence of grantmaking.
+  if (!type || !GRANTMAKING_TYPES.has(type)) return false;
+  return !isPlaceholderGiving(value);
+}
+
+/**
+ * What to print beside a foundation's giving figure. Never a bare number for an unmeasured row —
+ * the point of #390 is that a bare number is exactly what misled.
+ */
+export function givingLabel(
+  type: string | null | undefined,
+  value: number | null | undefined,
+  format: (n: number) => string,
+): string {
+  if (value === null || value === undefined || !(Number(value) > 0)) return 'Giving not recorded';
+  if (!type || !GRANTMAKING_TYPES.has(type)) return 'Not a grantmaking figure';
+  if (isPlaceholderGiving(Number(value))) return `${format(Number(value))} — placeholder`;
+  return format(Number(value));
+}
+
+/**
+ * SQL predicate for ranking. Use wherever a query orders by giving.
+ *
+ * `alias` must match the table alias in the query. Taken as an argument rather than left to
+ * hand-editing, for the same reason `grantFilterSql()` does it in justice-money.ts.
+ */
+export function grantmakingGivingSql(alias?: string): string {
+  const p = alias ? `${alias}.` : '';
+  const types = [...GRANTMAKING_TYPES].map(t => `'${t}'`).join(',');
+  const placeholders = PLACEHOLDER_GIVING.join(',');
+  return `${p}total_giving_annual IS NOT NULL
+    AND ${p}total_giving_annual > 0
+    AND ${p}type = ANY (ARRAY[${types}])
+    AND ${p}total_giving_annual <> ALL (ARRAY[${placeholders}]::numeric[])`;
+}
+
+/** PostgREST builder form, for `.from('foundations')` call sites. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function applyGrantmakingFilter<T extends { not: any; gt: any; in: any }>(query: T): T {
+  let q = query.gt('total_giving_annual', 0).in('type', [...GRANTMAKING_TYPES]);
+  for (const v of PLACEHOLDER_GIVING) q = q.not('total_giving_annual', 'eq', v);
+  return q as T;
+}
+
+/**
+ * ORDER BY expression that DEMOTES rather than excludes.
+ *
+ * Filtering is wrong for a browse or a sort: a university foundation is still worth finding, and
+ * dropping it would be a second silent error on top of the first. This keeps every row and sends
+ * the unmeasured ones to the bottom, so a revenue figure can never lead a giving ranking.
+ *
+ * Use `applyGrantmakingFilter` / `grantmakingGivingSql` only where the question genuinely is
+ * "which foundations give the most" and a wrong-in-kind row would be an answer, not a listing.
+ */
+export function measuredGivingOrderSql(alias?: string): string {
+  const p = alias ? `${alias}.` : '';
+  const types = [...GRANTMAKING_TYPES].map(t => `'${t}'`).join(',');
+  const placeholders = PLACEHOLDER_GIVING.join(',');
+  return `CASE
+      WHEN ${p}total_giving_annual IS NULL THEN NULL
+      WHEN ${p}total_giving_annual <= 0 THEN NULL
+      WHEN ${p}type IS NULL THEN NULL
+      WHEN ${p}type <> ALL (ARRAY[${types}]) THEN NULL
+      WHEN ${p}total_giving_annual = ANY (ARRAY[${placeholders}]::numeric[]) THEN NULL
+      ELSE ${p}total_giving_annual
+    END DESC NULLS LAST`;
+}

--- a/migrations/2026-08-21-soft-reference-repoint.sql
+++ b/migrations/2026-08-21-soft-reference-repoint.sql
@@ -1,0 +1,108 @@
+-- Repair 4 rows my own merge broke, and record why it broke them. #324 follow-up.
+--
+-- NOT YET APPLIED.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \
+--     -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres \
+--     -v ON_ERROR_STOP=1 -f migrations/2026-08-21-soft-reference-repoint.sql
+--
+-- THE MISTAKE, AND IT WAS MINE.
+--
+-- 2026-08-21-gov-entity-merge.sql re-pointed every foreign key by GENERATING the update list from
+-- pg_constraint at run time, specifically so a hand-written list could not miss one. Its header
+-- says so, approvingly. That was the right instinct against the wrong failure mode.
+--
+-- **A catalogue-driven sweep sees declared foreign keys. It does not see SOFT REFERENCES** --
+-- columns that hold a gs_entities.id without any FK constraint declared. This database has plenty:
+-- `organizations.gs_entity_id` (104,139 rows, the GrantScope <-> JusticeHub bridge),
+-- `justice_funding.gs_entity_id`, `state_tenders.gs_entity_id`, `community_directory_orgs`,
+-- `acnc_programs` and more. None of them were re-pointed, because none of them are foreign keys.
+--
+-- Found by accident while measuring product coupling for #306: `organizations` reported 104,139
+-- rows carrying a gs_entity_id but only 104,136 resolving. Two of those three were already
+-- dangling before today. One was not.
+--
+-- MEASURED BLAST RADIUS: 4 rows, in 3 tables.
+--
+--     community_directory_orgs.gs_entity_id    2
+--     acnc_programs.gs_entity_id               1
+--     organizations.gs_entity_id               1
+--
+-- Small, and only small by luck -- justice_funding.gs_entity_id is a soft reference over 157K rows
+-- and simply happened to hold none of the 151 merged-away ids. The same merge against a different
+-- 151 entities could have silently orphaned money rows.
+--
+-- WHY IT IS REPAIRABLE AT ALL: gs_entity_merge_map_20260821 was written as a PERMANENT TABLE
+-- rather than a CTE, on the reasoning that it is "the only record of what merged into what, and
+-- the thing anyone reversing this would need". That decision is what makes this fix possible
+-- rather than a forensic exercise.
+--
+-- THE RULE FOR NEXT TIME. When merging or deleting entities, sweep BOTH:
+--   1. declared foreign keys, from pg_constraint  (what the merge did)
+--   2. soft references -- uuid columns named gs_entity_id / entity_id / canonical_entity_id with
+--      no FK to the target, from information_schema  (what it missed)
+-- Neither list is a superset of the other, which is the same shape as the measure_kind /
+-- is_aggregate trap already documented in CLAUDE.md.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS _backup_soft_reference_repoint_20260821 (
+  tbl text, col text, row_id text, old_entity_id uuid, new_entity_id uuid
+);
+
+INSERT INTO _backup_soft_reference_repoint_20260821
+SELECT 'organizations', 'gs_entity_id', o.id::text, o.gs_entity_id, m.winner_id
+  FROM organizations o JOIN gs_entity_merge_map_20260821 m ON m.loser_id = o.gs_entity_id;
+
+INSERT INTO _backup_soft_reference_repoint_20260821
+SELECT 'community_directory_orgs', 'gs_entity_id', c.id::text, c.gs_entity_id, m.winner_id
+  FROM community_directory_orgs c JOIN gs_entity_merge_map_20260821 m ON m.loser_id = c.gs_entity_id;
+
+INSERT INTO _backup_soft_reference_repoint_20260821
+SELECT 'acnc_programs', 'gs_entity_id', a.id::text, a.gs_entity_id, m.winner_id
+  FROM acnc_programs a JOIN gs_entity_merge_map_20260821 m ON m.loser_id = a.gs_entity_id;
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM _backup_soft_reference_repoint_20260821;
+  RAISE NOTICE 're-pointing % soft references broken by the merge', n;
+  IF n NOT BETWEEN 1 AND 50 THEN
+    RAISE EXCEPTION 'expected ~4 broken soft references, found % -- re-measure before repairing', n;
+  END IF;
+END $$;
+
+UPDATE organizations o SET gs_entity_id = m.winner_id
+  FROM gs_entity_merge_map_20260821 m WHERE m.loser_id = o.gs_entity_id;
+
+UPDATE community_directory_orgs c SET gs_entity_id = m.winner_id
+  FROM gs_entity_merge_map_20260821 m WHERE m.loser_id = c.gs_entity_id;
+
+UPDATE acnc_programs a SET gs_entity_id = m.winner_id
+  FROM gs_entity_merge_map_20260821 m WHERE m.loser_id = a.gs_entity_id;
+
+-- Nothing may still point at a merged-away entity through these three columns.
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT (SELECT count(*) FROM organizations o JOIN gs_entity_merge_map_20260821 m ON m.loser_id = o.gs_entity_id)
+       + (SELECT count(*) FROM community_directory_orgs c JOIN gs_entity_merge_map_20260821 m ON m.loser_id = c.gs_entity_id)
+       + (SELECT count(*) FROM acnc_programs a JOIN gs_entity_merge_map_20260821 m ON m.loser_id = a.gs_entity_id)
+    INTO n;
+  IF n <> 0 THEN
+    RAISE EXCEPTION '% soft references still point at merged-away entities', n;
+  END IF;
+END $$;
+
+COMMIT;
+
+-- NOT repaired here, because it predates today and is a different question: 2 rows in
+-- community_directory_orgs, 2 in organizations and 313 in acnc_programs were ALREADY dangling
+-- before the merge, along with 88 in state_tenders. Those are older breakage and deserve their own
+-- measurement rather than being swept into a repair of my own mistake.
+--
+-- Also NOT dangling despite appearing so to a naive heuristic: entity_identifiers.entity_id
+-- (31,509) and ghl_contacts.canonical_entity_id (1,822) point at `canonical_entities`, a different
+-- table entirely -- see the CLAUDE.md note that entity_identifiers is a CRM store and NOT the
+-- graph crosswalk.

--- a/migrations/2026-08-21-soft-reference-repoint.sql
+++ b/migrations/2026-08-21-soft-reference-repoint.sql
@@ -1,6 +1,9 @@
 -- Repair 4 rows my own merge broke, and record why it broke them. #324 follow-up.
 --
--- NOT YET APPLIED.
+-- APPLIED 2026-08-21 to tednluwflfhxyucgwigh, on Ben's explicit authorization.
+--   UPDATE 1 (organizations) / 2 (community_directory_orgs) / 1 (acnc_programs).
+--   Verified after: organizations resolving 104,136 -> 104,137, and ZERO rows in any of the three
+--   still point at a merged-away entity.
 --
 -- Apply:
 --   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com \


### PR DESCRIPTION
Closes #390.

## The defect

`total_giving_annual` does not mean "money this organisation gives away". The top of *foundations by giving* was:

| | | |
|---|---:|---|
| The University of Sydney | $340.7M | a university |
| Catholic Education Centre | $281.5M | a school system |
| Australian Red Cross Society | $265.7M | a service charity |
| **Alice Springs Youth Accommodation & Support** | **$196.0M** | **a service provider** |

An organisation this project exists to show *receiving* money, published as a major philanthropist. Beneath them, **9,217 of 10,190 values are one of three placeholder round numbers**.

## My first fix was a denylist and it failed open

I excluded three receiving types. `university` wasn't one of them — so **Sydney and Monash stayed at the top** while the Red Cross was correctly removed. `foundations.type` has 27 values including `legal_aid`, `hospital`, `research_body`, `peak_body`, `sport_recreation`.

So it is now an **allowlist** of the nine types whose figure plausibly means grantmaking. A denylist means every type added later counts as giving until a human notices; an allowlist means a new type counts as nothing until a human decides. It fails closed, including for a missing type — 316 rows carry none, and none holds a figure above $50M.

## Applied per site, not everywhere

- **`/foundation?sort=giving`** narrows to grantmaking figures (1,753 → 306) **and says so on the page** — a shorter list with no explanation reads as the whole register.
- **Backlog ranking demotes rather than excludes**, so nothing leaves a work queue.
- **Fixed-set orderings** (`review-set`, `prf`) untouched — filtering there would drop rows from a set someone chose.

22 tests, each named for a real organisation that was misranked. Verified live: all six receiving organisations gone from `sort=giving`, Minderoo still present.