### PR TITLE
Atlas health-need layers: overcrowding + RHD regions; org-only map counts

### DIFF
--- a/apps/web/src/app/api/data/map/route.ts
+++ b/apps/web/src/app/api/data/map/route.ts
@@ -11,6 +11,7 @@ const limiter = rateLimit();
 
 const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'ACT', 'NT'] as const;
 const METRICS = ['desert_score', 'unplaced_share'] as const;
+const ORG_ENTITY_FILTER_SQL = "entity_type NOT IN ('person', 'program')";
 
 const schema = z.object({
   state: z.string().optional(),
@@ -95,6 +96,7 @@ export async function GET(request: Request) {
         SELECT postcode, COALESCE(lga_source, 'unstamped') AS reason, COUNT(*) AS n
         FROM gs_entities
         WHERE lga_name IS NULL AND postcode IS NOT NULL
+          AND ${ORG_ENTITY_FILTER_SQL}
         GROUP BY 1, 2
       ),
       council_pc AS MATERIALIZED (
@@ -117,6 +119,7 @@ export async function GET(request: Request) {
         SELECT lga_name, UPPER(state) AS state, COUNT(*)::int AS placed
         FROM gs_entities
         WHERE lga_name IS NOT NULL
+          AND ${ORG_ENTITY_FILTER_SQL}
         GROUP BY 1, 2
       ),
       justice AS MATERIALIZED (
@@ -224,6 +227,7 @@ export async function GET(request: Request) {
                COUNT(*)::int AS n
         FROM gs_entities
         WHERE lga_name IS NULL
+          AND ${ORG_ENTITY_FILTER_SQL}
         GROUP BY 1, 2`,
       }),
     ]);
@@ -255,7 +259,7 @@ export async function GET(request: Request) {
     }>;
 
     // The live why-tally rides the summary: (state, reason, n) rows the
-    // client scopes to its state filter. ~40 rows, six reason codes.
+    // client scopes to its state filter.
     const unplacedReasons = (reasonResult.data || []) as Array<{
       state: string | null; reason: string; n: number;
     }>;

--- a/apps/web/src/app/api/data/place/[code]/route.ts
+++ b/apps/web/src/app/api/data/place/[code]/route.ts
@@ -20,6 +20,7 @@ const limiter = rateLimit();
 // ran and found none, which each layer's caveat knows how to say.
 
 const LGA_CODE = /^\d{4,5}$/;
+const ORG_ENTITY_FILTER_SQL = "entity_type NOT IN ('person', 'program')";
 
 interface MoneyBlock {
   records: number;
@@ -60,6 +61,7 @@ export async function GET(
         SELECT id, gs_id, canonical_name, entity_type, is_community_controlled, lga_source, abn
         FROM gs_entities
         WHERE lga_code = '${code}' AND lga_name IS NOT NULL
+          AND ${ORG_ENTITY_FILTER_SQL}
       ),
       justice AS (
         SELECT COUNT(*)::int AS records, COALESCE(SUM(jf.amount_dollars), 0)::numeric AS total

--- a/apps/web/src/app/atlas/atlas-client.tsx
+++ b/apps/web/src/app/atlas/atlas-client.tsx
@@ -12,12 +12,14 @@ import {
   isChoroplethLayer,
   isLiveLayer,
   isPointLayer,
+  isRegionLayer,
   visibleAtlasLayers,
   type AtlasFeature,
   type AtlasLiveLayer,
   type AtlasPoint,
   type AtlasSurface,
 } from '@/lib/atlas/layers';
+import { RHD_REGIONS } from '@/lib/services/rhd-signal';
 import {
   buildAtlasUrl,
   councilCsv,
@@ -129,6 +131,7 @@ export default function AtlasClient({
   const [failed, setFailed] = useState(false);
   const [stateFilter, setStateFilter] = useState('ALL');
   const [selected, setSelected] = useState<AtlasFeature | null>(null);
+  const [selectedRegionKey, setSelectedRegionKey] = useState<string | null>(null);
   // The layer being read (caveat card) can be declared or point-grain; the
   // layer painting the choropleth is always the last choropleth pick.
   const [activeKey, setActiveKey] = useState(() => {
@@ -177,6 +180,13 @@ export default function AtlasClient({
     setActiveKey(key);
     const layer = getAtlasLayer(key);
     if (layer && isChoroplethLayer(layer)) setMapKey(key);
+    if (layer && isRegionLayer(layer)) {
+      setStateFilter('NT');
+      setSelected(null);
+      setSelectedRegionKey(selectedRegionKey ?? Object.keys(RHD_REGIONS)[0] ?? null);
+    } else {
+      setSelectedRegionKey(null);
+    }
   }
 
   function selectPlace(f: AtlasFeature) {
@@ -343,6 +353,8 @@ export default function AtlasClient({
   // The active layer's points, when it is point-grain and this surface holds
   // data for it. A public instance passes no points, so nothing renders.
   const activePointLayer = isPointLayer(activeLayer) ? activeLayer : null;
+  const activeRegionLayer = isRegionLayer(activeLayer) ? activeLayer : null;
+  const selectedRegion = selectedRegionKey ? RHD_REGIONS[selectedRegionKey] ?? null : null;
   const activePoints = useMemo(
     () => (activePointLayer ? pointsByLayer?.[activePointLayer.key] ?? [] : []),
     [activePointLayer, pointsByLayer]
@@ -425,6 +437,9 @@ export default function AtlasClient({
             onSelect={selectPlace}
             pointLayer={activePointLayer}
             points={activePoints}
+            regionLayer={activeRegionLayer}
+            selectedRegionKey={selectedRegionKey}
+            onSelectRegion={setSelectedRegionKey}
           />
         )}
       </div>
@@ -566,6 +581,39 @@ export default function AtlasClient({
             </p>
           )}
 
+          {activeRegionLayer && selectedRegion && (
+            <div className="mt-3 border-2 border-bauhaus-black bg-white p-3">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-red">
+                Selected health region
+              </p>
+              <h3 className="mt-1 text-sm font-black uppercase tracking-wider">
+                {selectedRegion.region}
+              </h3>
+              <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+                <div>
+                  <p className="text-[9px] uppercase tracking-widest text-bauhaus-muted">First Nations cases</p>
+                  <p className="text-lg font-black tabular-nums">{selectedRegion.firstNationsCases.toLocaleString('en-AU')}</p>
+                </div>
+                <div>
+                  <p className="text-[9px] uppercase tracking-widest text-bauhaus-muted">Prevalence</p>
+                  <p className="text-lg font-black tabular-nums">{activeRegionLayer.format(selectedRegion.firstNationsRatePer100k)}</p>
+                </div>
+                <div>
+                  <p className="text-[9px] uppercase tracking-widest text-bauhaus-muted">Non-Indigenous cases</p>
+                  <p className="font-black tabular-nums">{selectedRegion.nonIndigenousCases.toLocaleString('en-AU')}</p>
+                </div>
+                <div>
+                  <p className="text-[9px] uppercase tracking-widest text-bauhaus-muted">Rate disparity</p>
+                  <p className="font-black tabular-nums">{selectedRegion.rateRatio}×</p>
+                </div>
+              </div>
+              <p className="mt-2 text-[10px] leading-snug text-bauhaus-muted">{selectedRegion.boundaryNote}</p>
+              <p className="mt-2 text-[9px] uppercase tracking-widest text-bauhaus-muted">
+                As at {selectedRegion.asAt} · AIHW table {selectedRegion.sourceTable}
+              </p>
+            </div>
+          )}
+
           {/* The colour scale lives WITH the caveat: what the number contains
               and what the colours mean are one explanation. */}
           {(() => {
@@ -599,7 +647,9 @@ export default function AtlasClient({
                   </p>
                 )}
                 <p className="text-[10px] text-gray-400 mt-1.5 leading-snug">
-                  {filtered.length} councils{undrawn > 0 ? `; ${undrawn} hold no coordinates and render only where a boundary name matches` : ''}.
+                  {activeRegionLayer
+                    ? `${Object.keys(RHD_REGIONS).length} health regions with held observations.`
+                    : `${filtered.length} councils${undrawn > 0 ? `; ${undrawn} hold no coordinates and render only where a boundary name matches` : ''}.`}
                 </p>
               </div>
             );
@@ -999,6 +1049,35 @@ export default function AtlasClient({
             </div>
           ) : (
             <div>
+              {activeRegionLayer ? (
+                <>
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-bauhaus-muted mb-2">
+                    Health regions held
+                  </p>
+                  <div className="space-y-2">
+                    {Object.entries(RHD_REGIONS).map(([key, region]) => (
+                      <button
+                        key={key}
+                        onClick={() => setSelectedRegionKey(key)}
+                        className={`w-full border-2 px-3 py-2 text-left transition-colors cursor-pointer ${
+                          selectedRegionKey === key
+                            ? 'border-bauhaus-red bg-bauhaus-red text-white'
+                            : 'border-bauhaus-black bg-white hover:bg-bauhaus-black hover:text-white'
+                        }`}
+                      >
+                        <span className="block text-[11px] font-black uppercase tracking-wider">{region.region}</span>
+                        <span className="mt-1 block text-xs tabular-nums">
+                          {activeRegionLayer.format(region.firstNationsRatePer100k)}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <p className="mt-3 text-[10px] leading-snug text-bauhaus-muted">
+                    These are health-service observations. Council search and rankings return when you choose a council layer.
+                  </p>
+                </>
+              ) : (
+                <>
               <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">Find a place</p>
               <input
                 type="text"
@@ -1048,6 +1127,8 @@ export default function AtlasClient({
                   ))}
                 </div>
               </div>
+                </>
+              )}
             </div>
           )}
         </aside>

--- a/apps/web/src/app/atlas/atlas-map.tsx
+++ b/apps/web/src/app/atlas/atlas-map.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useEffect, useState } from 'react';
-import { MapContainer, TileLayer, GeoJSON, CircleMarker, Tooltip, ZoomControl, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, GeoJSON, CircleMarker, Marker, Tooltip, ZoomControl, useMap } from 'react-leaflet';
 import type { FeatureCollection, Feature, Geometry } from 'geojson';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -12,7 +12,9 @@ import {
   type AtlasLiveLayer,
   type AtlasPoint,
   type AtlasPointLayer,
+  type AtlasRegionLayer,
 } from '@/lib/atlas/layers';
+import { RHD_REGIONS } from '@/lib/services/rhd-signal';
 
 interface AtlasMapProps {
   features: AtlasFeature[];
@@ -23,6 +25,9 @@ interface AtlasMapProps {
    * the surface that is allowed to hold it; this component just draws. */
   pointLayer?: AtlasPointLayer | null;
   points?: AtlasPoint[];
+  regionLayer?: AtlasRegionLayer | null;
+  selectedRegionKey?: string | null;
+  onSelectRegion?: (key: string) => void;
 }
 
 const STATE_ABBREV: Record<string, string> = {
@@ -82,7 +87,31 @@ function FitBounds({ features }: { features: AtlasFeature[] }) {
   return null;
 }
 
-export default function AtlasMap({ features, layer, selected, onSelect, pointLayer, points }: AtlasMapProps) {
+function FocusRegions({ active }: { active: boolean }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!active) return;
+    map.fitBounds(
+      L.latLngBounds(
+        Object.values(RHD_REGIONS).map(region => region.labelAt)
+      ),
+      { padding: [70, 70], maxZoom: 5 }
+    );
+  }, [active, map]);
+  return null;
+}
+
+export default function AtlasMap({
+  features,
+  layer,
+  selected,
+  onSelect,
+  pointLayer,
+  points,
+  regionLayer,
+  selectedRegionKey,
+  onSelectRegion,
+}: AtlasMapProps) {
   const [geoData, setGeoData] = useState<FeatureCollection | null>(null);
   const [geoLoading, setGeoLoading] = useState(true);
 
@@ -197,6 +226,46 @@ export default function AtlasMap({ features, layer, selected, onSelect, pointLay
     [selected, features, layer]
   );
 
+  const regionByLga = useMemo(() => {
+    const lookup = new Map<string, string>();
+    for (const [key, region] of Object.entries(RHD_REGIONS)) {
+      for (const lga of region.proxyLgas) lookup.set(lga, key);
+    }
+    return lookup;
+  }, []);
+
+  const regionStyle = useMemo(() => {
+    return (feature: Feature<Geometry, { lga_name: string; state: string }> | undefined) => {
+      const key = feature?.properties ? regionByLga.get(feature.properties.lga_name) : null;
+      const region = key ? RHD_REGIONS[key] : null;
+      if (!key || !region || feature?.properties.state !== 'Northern Territory') {
+        return { fillOpacity: 0, opacity: 0, weight: 0 };
+      }
+      const paint = atlasStyleFor(regionLayer!, region.firstNationsRatePer100k);
+      const selected = key === selectedRegionKey;
+      return {
+        fillColor: paint.color,
+        fillOpacity: selected ? 0.86 : paint.fillOpacity,
+        color: selected ? '#121212' : '#fff',
+        weight: selected ? 1.4 : 0.7,
+        opacity: selected ? 1 : 0.45,
+      };
+    };
+  }, [regionByLga, regionLayer, selectedRegionKey]);
+
+  const onEachRegionFeature = useMemo(() => {
+    return (feature: Feature<Geometry, { lga_name: string; state: string }>, mapLayer: L.Layer) => {
+      const key = regionByLga.get(feature.properties.lga_name);
+      const region = key ? RHD_REGIONS[key] : null;
+      if (!key || !region || feature.properties.state !== 'Northern Territory') return;
+      mapLayer.on('click', () => onSelectRegion?.(key));
+      (mapLayer as L.Path).bindTooltip(
+        `<div class="text-xs"><strong>${region.region}</strong><br/>First Nations RHD prevalence: <strong>${regionLayer!.format(region.firstNationsRatePer100k)}</strong><br/>${region.firstNationsCases.toLocaleString('en-AU')} people on the register</div>`,
+        { sticky: true }
+      );
+    };
+  }, [onSelectRegion, regionByLga, regionLayer]);
+
   return (
     <MapContainer
       center={center}
@@ -222,6 +291,29 @@ export default function AtlasMap({ features, layer, selected, onSelect, pointLay
           onEachFeature={onEachFeature}
         />
       )}
+
+      {regionLayer && geoData && !geoLoading && (
+        <GeoJSON
+          key={`regions-${selectedRegionKey ?? 'none'}`}
+          data={geoData}
+          style={regionStyle}
+          onEachFeature={onEachRegionFeature}
+        />
+      )}
+
+      {regionLayer && Object.entries(RHD_REGIONS).map(([key, region]) => (
+        <Marker
+          key={`region-label-${key}`}
+          position={region.labelAt}
+          icon={L.divIcon({
+            className: '',
+            html: `<button class="border-2 border-black bg-white px-2 py-1 text-[10px] font-black uppercase shadow-[3px_3px_0_0_#121212] whitespace-nowrap">${region.region}</button>`,
+            iconSize: [190, 28],
+            iconAnchor: [95, 14],
+          })}
+          eventHandlers={{ click: () => onSelectRegion?.(key) }}
+        />
+      ))}
 
       {/* Labels tile layer on top of polygons */}
       <TileLayer
@@ -295,7 +387,8 @@ export default function AtlasMap({ features, layer, selected, onSelect, pointLay
         );
       })}
 
-      <FitBounds features={features} />
+      {!regionLayer && <FitBounds features={features} />}
+      <FocusRegions active={Boolean(regionLayer)} />
       <InvalidateOnResize />
     </MapContainer>
   );

--- a/apps/web/src/app/org/[slug]/goods/communities/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/communities/page.tsx
@@ -4,13 +4,16 @@ import { ACT_FAST_PROFILE, isActSlug, shouldUseFastLocalOrg } from '@/lib/servic
 import { getOrgProfileBySlug } from '@/lib/services/org-dashboard-service';
 import { getGoodsCommunitiesHub, type CommunityHubRow } from '@/lib/services/goods-communities-hub';
 
-export const revalidate = 300;
+// This is a live operational register. Caching the route can leave the initial
+// HTML on an older component shape than the streamed RSC tree during local
+// development, which produces a hydration mismatch as well as stale counts.
+export const dynamic = 'force-dynamic';
 
-function relAgo(iso: string | null): string {
+function relAgo(iso: string | null, nowMs: number): string {
   if (!iso) return '—';
   const t = new Date(iso).getTime();
   if (isNaN(t)) return '—';
-  const days = Math.round((Date.now() - t) / 86_400_000);
+  const days = Math.round((nowMs - t) / 86_400_000);
   if (days < 1) return 'today';
   if (days < 30) return `${days}d ago`;
   if (days < 365) return `${Math.round(days / 30)}mo ago`;
@@ -43,6 +46,7 @@ export default async function GoodsCommunitiesHubPage({
     search: sp.q,
     sort,
   });
+  const renderedAtMs = Date.now();
 
   // Sort toggle hrefs that preserve scope / state / search.
   const baseParams = new URLSearchParams();
@@ -91,7 +95,7 @@ export default async function GoodsCommunitiesHubPage({
           <Pill href={`/org/${slug}/goods/communities`} active={scope === 'active'} label={`Active (lead+active+warm)`} />
           <Pill href={`/org/${slug}/goods/communities?scope=lead`} active={scope === 'lead'} label="Lead only" />
           <Pill href={`/org/${slug}/goods/communities?scope=with_deployments`} active={scope === 'with_deployments'} label="With deployments" />
-          <Pill href={`/org/${slug}/goods/communities?scope=all`} active={scope === 'all'} label="All 1546" />
+          <Pill href={`/org/${slug}/goods/communities?scope=all`} active={scope === 'all'} label="All communities" />
 
           <span className="ml-4 font-black uppercase tracking-wider">State:</span>
           <Pill href={`/org/${slug}/goods/communities${scope !== 'active' ? `?scope=${scope}` : ''}`} active={!sp.state} label="All" />
@@ -133,7 +137,7 @@ export default async function GoodsCommunitiesHubPage({
               {communities.length === 0 ? (
                 <tr><td colSpan={10} className="px-3 py-6 text-center text-gray-500">No communities match this filter.</td></tr>
               ) : (
-                communities.map((c, i) => <Row key={c.id} c={c} alt={i % 2 === 1} orgSlug={slug} />)
+                communities.map((c, i) => <Row key={c.id} c={c} alt={i % 2 === 1} orgSlug={slug} renderedAtMs={renderedAtMs} />)
               )}
             </tbody>
           </table>
@@ -156,7 +160,7 @@ export default async function GoodsCommunitiesHubPage({
 function Cell({ label, value, accent }: { label: string; value: number; accent?: boolean }) {
   return (
     <div className={`border-4 border-bauhaus-black ${accent ? 'bg-bauhaus-yellow' : 'bg-white'} p-3`}>
-      <div className="text-2xl font-black">{value.toLocaleString()}</div>
+      <div className="text-2xl font-black">{value.toLocaleString('en-AU')}</div>
       <div className="mt-1 text-[10px] font-black uppercase tracking-widest text-gray-700">{label}</div>
     </div>
   );
@@ -177,7 +181,7 @@ function Th({ children, align }: { children: React.ReactNode; align?: 'left' | '
   return <th className={`border-b-2 border-bauhaus-black px-2 py-1.5 text-left font-black uppercase tracking-wider text-[10px] ${align === 'right' ? 'text-right' : ''}`}>{children}</th>;
 }
 
-function Row({ c, alt, orgSlug }: { c: CommunityHubRow; alt: boolean; orgSlug: string }) {
+function Row({ c, alt, orgSlug, renderedAtMs }: { c: CommunityHubRow; alt: boolean; orgSlug: string; renderedAtMs: number }) {
   const pBg = c.priority === 'lead' ? 'bg-bauhaus-red text-white' :
     c.priority === 'active' ? 'bg-bauhaus-yellow' :
     c.priority === 'warm' ? 'bg-bauhaus-canvas' : 'bg-gray-200';
@@ -243,7 +247,7 @@ function Row({ c, alt, orgSlug }: { c: CommunityHubRow; alt: boolean; orgSlug: s
         <span className="font-black">{c.mapped_buyer_count}</span>
         {c.ghl_linked_buyer_count > 0 && <span className="text-bauhaus-yellow bg-bauhaus-black px-1 ml-1 font-mono text-[9px]">{c.ghl_linked_buyer_count}↗</span>}
       </td>
-      <td className="border-b border-gray-300 px-2 py-1.5 align-top">{relAgo(c.last_action_at)}</td>
+      <td className="border-b border-gray-300 px-2 py-1.5 align-top">{relAgo(c.last_action_at, renderedAtMs)}</td>
     </tr>
   );
 }

--- a/apps/web/src/lib/atlas/layers.test.ts
+++ b/apps/web/src/lib/atlas/layers.test.ts
@@ -12,8 +12,10 @@ import {
   isPointLayer,
   visibleAtlasLayers,
   type AtlasFeature,
+  type AtlasDeclaredLayer,
   type AtlasLayer,
   type AtlasLiveLayer,
+  type AtlasRegionLayer,
 } from './layers';
 
 function feature(overrides: Partial<AtlasFeature> = {}): AtlasFeature {
@@ -188,6 +190,8 @@ describe('consent tiers gate surfaces', () => {
       'justice-funding',
       'renewal-cliff',
       'seifa-disadvantage',
+      'household-overcrowding',
+      'health-outcomes',
       'whats-working',
       ...(GOODS_PUBLIC_PLACES.length > 0 ? ['goods-delivered'] : []),
       'unplaced-orgs',
@@ -202,6 +206,27 @@ describe('consent tiers gate surfaces', () => {
     expect(getAtlasLayer('unplaced-orgs')!.group).toBe('data-quality');
     // data-quality is the LAST group the picker renders.
     expect(ATLAS_GROUP_ORDER[ATLAS_GROUP_ORDER.length - 1]).toBe('data-quality');
+  });
+});
+
+describe('Goods health need layers', () => {
+  it('maps overcrowding from remoteness rather than pretending it is council-grain', () => {
+    const layer = getAtlasLayer('household-overcrowding') as AtlasLiveLayer | null;
+    expect(layer).not.toBeNull();
+    expect(layer!.group).toBe('need');
+    expect(layer!.consent).toBe('public');
+    expect(layer!.value(feature({ remoteness: 'Very Remote Australia' }))).toBe(31.3);
+    expect(layer!.value(feature({ remoteness: null }))).toBeNull();
+    expect(layer!.honestAtNote).toContain('Remoteness class only');
+  });
+
+  it('maps RHD at health-region grain without reading a council value', () => {
+    const layer = getAtlasLayer('health-outcomes') as AtlasRegionLayer | null;
+    expect(layer).not.toBeNull();
+    expect(layer!.status).toBe('live');
+    expect(layer!.kind).toBe('regions');
+    expect(layer!.honestAt).toBe('health-region');
+    expect(layer!.caveat).toContain('never to an individual council');
   });
 });
 

--- a/apps/web/src/lib/atlas/layers.ts
+++ b/apps/web/src/lib/atlas/layers.ts
@@ -25,6 +25,11 @@
 // client-side. The registry itself holds no figures, only the contract.
 
 import { money } from '@/lib/format';
+import {
+  getOvercrowdingForRemoteness,
+  overcrowdedPct,
+} from '@/lib/services/overcrowding-signal';
+import { RHD_REGIONS } from '@/lib/services/rhd-signal';
 
 /** One row of the /api/data/map payload. */
 export interface AtlasFeature {
@@ -80,7 +85,13 @@ export type AtlasConsentTier = 'public' | 'org' | 'withheld';
 /** The geography a layer's number is honest at — not the finest grain the
  * data could be sliced to, but the coarsest one at which the claim survives
  * its own caveat. */
-export type AtlasGeography = 'national' | 'state' | 'council' | 'postcode' | 'community';
+export type AtlasGeography =
+  | 'national'
+  | 'state'
+  | 'health-region'
+  | 'council'
+  | 'postcode'
+  | 'community';
 
 /** Picker groups. Substantive layers lead; the map's own error bars sit
  * last under "How sure are we" — uncertainty qualifies the other layers,
@@ -151,6 +162,17 @@ export interface AtlasPointLayer extends AtlasLayerCommon {
   format(value: number): string;
 }
 
+/** A layer whose observation and selection grain is a named administrative
+ * region rather than a council. Geometry membership lives with the source
+ * signal so the map cannot accidentally read these values from council rows. */
+export interface AtlasRegionLayer extends AtlasLayerCommon {
+  status: 'live';
+  kind: 'regions';
+  scale: AtlasScaleStop[];
+  noDataLabel: string;
+  format(value: number): string;
+}
+
 /** One point of an AtlasPointLayer, produced server-side by the surface that
  * is allowed to see it. */
 export interface AtlasPoint {
@@ -168,9 +190,11 @@ export interface AtlasDeclaredLayer extends AtlasLayerCommon {
   waitingOn: string;
 }
 
-export type AtlasLayer = AtlasLiveLayer | AtlasPointLayer | AtlasDeclaredLayer;
+export type AtlasLayer = AtlasLiveLayer | AtlasPointLayer | AtlasRegionLayer | AtlasDeclaredLayer;
 
-export function isLiveLayer(layer: AtlasLayer): layer is AtlasLiveLayer | AtlasPointLayer {
+export function isLiveLayer(
+  layer: AtlasLayer
+): layer is AtlasLiveLayer | AtlasPointLayer | AtlasRegionLayer {
   return layer.status === 'live';
 }
 
@@ -183,6 +207,10 @@ export function isChoroplethLayer(layer: AtlasLayer): layer is AtlasLiveLayer {
 
 export function isPointLayer(layer: AtlasLayer): layer is AtlasPointLayer {
   return layer.status === 'live' && layer.kind === 'points';
+}
+
+export function isRegionLayer(layer: AtlasLayer): layer is AtlasRegionLayer {
+  return layer.status === 'live' && layer.kind === 'regions';
 }
 
 /** Style painted for places a live layer holds nothing about. */
@@ -381,6 +409,69 @@ const seifaDisadvantage: AtlasLiveLayer = {
   // One decimal, trailing zero trimmed: Ceduna's 2.52 must read "decile 2.5",
   // not round up to a softer "decile 3" (Ben, 2026-08-10).
   format: v => `decile ${v.toFixed(1).replace(/\.0$/, '')}`,
+};
+
+const householdOvercrowding: AtlasLiveLayer = {
+  key: 'household-overcrowding',
+  status: 'live',
+  kind: 'choropleth',
+  group: 'need',
+  name: 'Household overcrowding',
+  unit: '% of First Nations households overcrowded',
+  caveat:
+    'First Nations households needing one or more additional bedrooms under the ' +
+    "Canadian National Occupancy Standard, from the Health Performance Framework's " +
+    '2021 Census table by remoteness. Every council in the same remoteness class ' +
+    'gets the same value: this is a need signal a bed responds to, not a measured ' +
+    'council overcrowding rate. CNOS also does not fully account for extended ' +
+    'family obligations in First Nations households, so read the figure as a floor.',
+  honestAt: 'national',
+  honestAtNote:
+    'Remoteness class only. It can distinguish major city, regional, remote and very ' +
+    'remote councils, but it cannot say which community or council has the higher local rate.',
+  consent: 'public',
+  scale: [
+    { min: 30, color: '#D02020', fillOpacity: 0.7, label: '30% or more' },
+    { min: 15, color: '#E06C18', fillOpacity: 0.6, label: '15–30%' },
+    { min: 10, color: '#F0C020', fillOpacity: 0.5, label: '10–15%' },
+    { min: 8, color: '#4CB876', fillOpacity: 0.4, label: '8–10%' },
+    { min: 0, color: '#1040C0', fillOpacity: 0.3, label: 'Under 8%' },
+  ],
+  scaleNote:
+    'Bands follow the published remoteness rates: very remote Australia is the only class above 30%.',
+  noDataLabel: 'No remoteness class held',
+  value: f => {
+    const signal = getOvercrowdingForRemoteness(f.remoteness);
+    return signal ? overcrowdedPct(signal, 'firstNations') : null;
+  },
+  format: v => `${v.toFixed(1).replace(/\.0$/, '')}%`,
+};
+
+const healthOutcomes: AtlasRegionLayer = {
+  key: 'health-outcomes',
+  status: 'live',
+  kind: 'regions',
+  group: 'need',
+  name: 'Rheumatic heart disease',
+  unit: 'First Nations prevalence per 100,000 people',
+  caveat:
+    'People living with rheumatic heart disease on the NT register at 31 December 2021. ' +
+    'The number belongs to the health service region, never to an individual council. ' +
+    'The overlay assembles council polygons as a visual proxy for the two service regions; ' +
+    'unincorporated NT is left unpainted where it cannot be assigned safely.',
+  honestAt: 'health-region',
+  honestAtNote:
+    'Honest for the two 2021 NT register regions held here: Central Australia and Top End. ' +
+    'Region boundaries are a labelled council-polygon proxy, not an official boundary file.',
+  consent: 'public',
+  scale: [
+    { min: 3100, color: '#D02020', fillOpacity: 0.72, label: '3,100 or more per 100,000' },
+    { min: 2800, color: '#E06C18', fillOpacity: 0.62, label: '2,800–3,099 per 100,000' },
+    { min: 0, color: '#1040C0', fillOpacity: 0.35, label: 'Under 2,800 per 100,000' },
+  ],
+  scaleNote: `${Object.keys(RHD_REGIONS).length} NT register regions held; no colour means no region-level observation held.`,
+  noDataLabel: 'No regional RHD observation held',
+  format: v => `${v.toLocaleString('en-AU', { maximumFractionDigits: 1 })} per 100,000`,
 };
 
 const unplacedOrgs: AtlasLiveLayer = {
@@ -618,6 +709,8 @@ export const ATLAS_LAYERS: readonly AtlasLayer[] = [
   justiceFunding,
   renewalCliff,
   seifaDisadvantage,
+  householdOvercrowding,
+  healthOutcomes,
   whatsWorking,
   goodsDelivered,
   unplacedOrgs,

--- a/apps/web/src/lib/atlas/reasons.test.ts
+++ b/apps/web/src/lib/atlas/reasons.test.ts
@@ -1,6 +1,5 @@
-// The reason registry is a contract with the database: the six codes here
-// are exactly the lga_source stamps the 2026-08 placement migrations wrote.
-// A code drifting out of sync fails loudly here, not silently on the map.
+// The reason registry is a contract with the database: the stamped codes plus
+// the explicit unstamped repair bucket must render loudly, not silently vanish.
 
 import { describe, expect, it } from 'vitest';
 import {
@@ -15,7 +14,7 @@ import {
 } from './reasons';
 
 describe('the reason registry', () => {
-  it('pins the six lga_source codes the migrations stamp', () => {
+  it('pins the lga_source codes and the unstamped repair bucket', () => {
     expect(UNPLACED_REASONS.map(r => r.code).sort()).toEqual([
       'no_postcode',
       'no_state',
@@ -23,6 +22,7 @@ describe('the reason registry', () => {
       'state_conflict',
       'unknown_postcode',
       'unresolved_multi_lga_postcode',
+      'unstamped',
     ]);
   });
 
@@ -51,10 +51,11 @@ describe('per-council rows', () => {
     const rows = reasonRows({
       unresolved_multi_lga_postcode: 312,
       state_conflict: 40,
+      unstamped: 2,
       postcode_unmapped_in_abs: 0,
       no_state: Number.NaN,
     });
-    expect(rows.map(r => r.code)).toEqual(['unresolved_multi_lga_postcode', 'state_conflict']);
+    expect(rows.map(r => r.code)).toEqual(['unresolved_multi_lga_postcode', 'state_conflict', 'unstamped']);
     expect(rows[0].label).toBe('postcode spans several councils');
   });
 
@@ -102,6 +103,7 @@ describe('export columns', () => {
       'unplaced_postcode_unmapped_in_abs',
       'unplaced_state_conflict',
       'unplaced_no_state',
+      'unplaced_unstamped',
     ]);
   });
 });

--- a/apps/web/src/lib/atlas/reasons.ts
+++ b/apps/web/src/lib/atlas/reasons.ts
@@ -1,10 +1,9 @@
 // Why an organisation sits on no council's count — the reason codes.
 //
-// Every gs_entities row without a council carries exactly one lga_source
-// reason code (stamped by the 2026-08 placement migrations; zero unstamped
-// rows, verified live). The Atlas reads them live so "cannot place" is never
-// one opaque percentage: the caveat card and the place panel both say WHY,
-// with counts.
+// Every organisation-like gs_entities row without a council should carry one
+// lga_source reason code. New imports can still arrive unstamped between
+// placement passes, so the Atlas treats "unstamped" as an explicit repair
+// bucket instead of hiding it behind a fallback label.
 //
 // Two kinds of reason:
 //  - councilPossible: the organisation's postcode ties it to candidate
@@ -32,6 +31,7 @@ export const UNPLACED_REASONS: readonly UnplacedReason[] = [
   { code: 'unknown_postcode', label: 'postcode we do not recognise', councilPossible: false },
   { code: 'state_conflict', label: 'recorded state disagrees with the postcode', councilPossible: true },
   { code: 'no_state', label: 'no state on the record', councilPossible: true },
+  { code: 'unstamped', label: 'unstamped', councilPossible: true },
 ];
 
 /** Label for a code, including codes this registry has not met — a new stamp

--- a/apps/web/src/lib/services/goods-communities-hub.test.ts
+++ b/apps/web/src/lib/services/goods-communities-hub.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { fetchGoodsCommunityRows } from './goods-communities-hub';
+
+function pagedDb(rows: Array<{ id: string }>) {
+  const ranges: Array<[number, number]> = [];
+  const query: any = {
+    select: () => query,
+    order: () => query,
+    in: () => query,
+    eq: () => query,
+    gt: () => query,
+    range: async (from: number, to: number) => {
+      ranges.push([from, to]);
+      return { data: rows.slice(from, to + 1), error: null };
+    },
+  };
+  return { db: { from: () => query }, ranges };
+}
+
+describe('fetchGoodsCommunityRows', () => {
+  it('continues beyond the Supabase 1,000-row response cap', async () => {
+    const source = Array.from({ length: 1546 }, (_, i) => ({ id: `community-${i}` }));
+    const { db, ranges } = pagedDb(source);
+
+    const rows = await fetchGoodsCommunityRows(db, { scope: 'all' });
+
+    expect(rows).toHaveLength(1546);
+    expect(ranges).toEqual([[0, 999], [1000, 1999]]);
+    expect(new Set(rows.map(row => row.id)).size).toBe(1546);
+  });
+});

--- a/apps/web/src/lib/services/goods-communities-hub.ts
+++ b/apps/web/src/lib/services/goods-communities-hub.ts
@@ -45,6 +45,7 @@ export type CommunitiesHubResult = {
 };
 
 const ACTIVE_PRIORITIES = ['lead', 'active', 'warm'];
+const COMMUNITY_PAGE_SIZE = 1000;
 
 async function fetchChunked(db: any, table: string, columns: string, ids: string[], chunkSize = 100, optional = false): Promise<any[]> {
   if (ids.length === 0) return [];
@@ -61,6 +62,30 @@ async function fetchChunked(db: any, table: string, columns: string, ids: string
   return results.flat();
 }
 
+export async function fetchGoodsCommunityRows(
+  db: any,
+  filters: { scope: 'active' | 'lead' | 'all' | 'with_deployments'; state?: string }
+): Promise<any[]> {
+  const rows: any[] = [];
+  for (let from = 0; ; from += COMMUNITY_PAGE_SIZE) {
+    let page = db
+      .from('goods_communities')
+      .select('id, community_name, state, postcode, region_label, priority, demand_beds, demand_washers, assets_deployed, land_council')
+      .order('id', { ascending: true });
+
+    if (filters.scope === 'active') page = page.in('priority', ACTIVE_PRIORITIES);
+    else if (filters.scope === 'lead') page = page.eq('priority', 'lead');
+    else if (filters.scope === 'with_deployments') page = page.gt('assets_deployed', 0);
+    if (filters.state) page = page.eq('state', filters.state);
+
+    const { data, error } = await page.range(from, from + COMMUNITY_PAGE_SIZE - 1);
+    if (error) throw new Error(`communities fetch: ${error.message}`);
+    const batch = Array.isArray(data) ? data : [];
+    rows.push(...batch);
+    if (batch.length < COMMUNITY_PAGE_SIZE) return rows;
+  }
+}
+
 export async function getGoodsCommunitiesHub({
   scope = 'active',
   state,
@@ -74,22 +99,7 @@ export async function getGoodsCommunitiesHub({
 } = {}): Promise<CommunitiesHubResult> {
   const db = getServiceSupabase();
 
-  let q = db
-    .from('goods_communities')
-    .select('id, community_name, state, postcode, region_label, priority, demand_beds, demand_washers, assets_deployed, land_council')
-    .limit(2000);
-
-  if (scope === 'active') q = q.in('priority', ACTIVE_PRIORITIES);
-  else if (scope === 'lead') q = q.eq('priority', 'lead');
-  else if (scope === 'with_deployments') q = q.gt('assets_deployed', 0);
-  // 'all' = no filter
-
-  if (state) q = q.eq('state', state);
-
-  const { data: rawCommunities, error } = await q;
-  if (error) throw new Error(`communities fetch: ${error.message}`);
-
-  let communities = (rawCommunities || []) as any[];
+  let communities = await fetchGoodsCommunityRows(db, { scope, state });
   if (search) {
     const s = search.toLowerCase();
     communities = communities.filter(c =>

--- a/apps/web/src/lib/services/rhd-signal.test.ts
+++ b/apps/web/src/lib/services/rhd-signal.test.ts
@@ -36,6 +36,18 @@ describe('RHD_REGIONS', () => {
     }
   });
 
+  it('carries non-overlapping council proxies and label positions for the Atlas', () => {
+    const seen = new Set<string>();
+    for (const [key, signal] of regions) {
+      expect(signal.proxyLgas.length, key).toBeGreaterThan(0);
+      expect(signal.labelAt, key).toHaveLength(2);
+      for (const lga of signal.proxyLgas) {
+        expect(seen.has(lga), `${lga} belongs to more than one region proxy`).toBe(false);
+        seen.add(lga);
+      }
+    }
+  });
+
   it('only maps place regions that actually exist', () => {
     for (const [placeKey, rhdKey] of Object.entries(RHD_BY_PLACE_REGION)) {
       expect(PLACE_REGIONS[placeKey], `${placeKey} is not a place region`).toBeDefined();

--- a/apps/web/src/lib/services/rhd-signal.ts
+++ b/apps/web/src/lib/services/rhd-signal.ts
@@ -37,6 +37,10 @@ export interface RhdRegionSignal {
   sourceTable: string;
   /** What this region does and does not cover, relative to ours. */
   boundaryNote: string;
+  /** Council polygons used only to draw a transparent visual proxy for the
+   * register region. The observation remains regional. */
+  proxyLgas: string[];
+  labelAt: [number, number];
 }
 
 /**
@@ -59,6 +63,8 @@ export const RHD_REGIONS: Record<string, RhdRegionSignal> = {
     sourceTable: 'D1.06.12',
     boundaryNote:
       'The NT Rheumatic Heart Disease Register reports Central Australia as a health service region. It covers Mparntwe (Alice Springs), the Barkly and the surrounding communities, but not the APY Lands, which are in South Australia and appear on a separate register.',
+    proxyLgas: ['Alice Springs', 'Barkly', 'Central Desert', 'MacDonnell'],
+    labelAt: [-21.5, 133.4],
   },
   'nt-top-end': {
     region: 'Northern Territory Top End',
@@ -71,6 +77,24 @@ export const RHD_REGIONS: Record<string, RhdRegionSignal> = {
     asAt: '31 December 2021',
     sourceTable: 'D1.06.12',
     boundaryNote: 'The northern half of the Northern Territory, as the register defines it.',
+    proxyLgas: [
+      'Belyuen',
+      'Coomalie',
+      'Darwin',
+      'Darwin Waterfront Precinct',
+      'East Arnhem',
+      'Groote Archipelago',
+      'Katherine',
+      'Litchfield',
+      'Palmerston',
+      'Roper Gulf',
+      'Tiwi Islands',
+      'Victoria Daly',
+      'Wagait',
+      'West Arnhem',
+      'West Daly',
+    ],
+    labelAt: [-14.7, 132.2],
   },
 };
 

--- a/supabase/migrations/20260824111000_stamp_unplaced_org_reason_backlog.sql
+++ b/supabase/migrations/20260824111000_stamp_unplaced_org_reason_backlog.sql
@@ -1,0 +1,59 @@
+-- Stamp the remaining unplaced organisation-like rows that arrived without an
+-- lga_source reason after the August placement passes.
+--
+-- This deliberately does not place any entity. It only moves null lga_source
+-- rows into the same reason buckets the Atlas already explains.
+
+BEGIN;
+
+WITH target AS (
+  SELECT e.id,
+         CASE
+           WHEN e.postcode IS NULL THEN 'no_postcode'
+           WHEN NOT EXISTS (
+             SELECT 1
+             FROM postcode_geo pg
+             WHERE pg.postcode = e.postcode
+           ) THEN 'unknown_postcode'
+           WHEN e.state IS NULL THEN 'no_state'
+           WHEN NOT EXISTS (
+             SELECT 1
+             FROM postcode_geo pg
+             WHERE pg.postcode = e.postcode
+               AND upper(pg.state) = upper(e.state)
+           ) THEN 'state_conflict'
+           WHEN NOT EXISTS (
+             SELECT 1
+             FROM postcode_geo pg
+             WHERE pg.postcode = e.postcode
+               AND pg.lga_name IS NOT NULL
+           ) THEN 'postcode_unmapped_in_abs'
+           ELSE 'unresolved_multi_lga_postcode'
+         END AS reason
+  FROM gs_entities e
+  WHERE e.lga_name IS NULL
+    AND e.lga_source IS NULL
+    AND e.entity_type NOT IN ('person', 'program')
+)
+UPDATE gs_entities e
+   SET lga_source = target.reason,
+       updated_at = now()
+  FROM target
+ WHERE e.id = target.id;
+
+DO $$
+DECLARE
+  remaining integer;
+BEGIN
+  SELECT count(*) INTO remaining
+  FROM gs_entities
+  WHERE lga_name IS NULL
+    AND lga_source IS NULL
+    AND entity_type NOT IN ('person', 'program');
+
+  IF remaining <> 0 THEN
+    RAISE EXCEPTION 'unplaced organisation-like rows still unstamped: %', remaining;
+  END IF;
+END $$;
+
+COMMIT;

--- a/thoughts/shared/handoffs/goods-data-alignment/current.md
+++ b/thoughts/shared/handoffs/goods-data-alignment/current.md
@@ -1,0 +1,74 @@
+---
+date: 2026-08-25T03:19:46Z
+session_name: goods-data-alignment
+branch: main
+status: active
+---
+
+# Work Stream: goods-data-alignment
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-08-25T03:19:46Z
+**Goal:** Goods x CivicGraph data alignment: verified supply/need/health facts, typed + guarded in the Goods repo, backfilled + source-stamped in CivicGraph, rendered on goodsoncountry.com/data. Done when the last PR (Goods #232) merges.
+**Branch:** main (all work lands via short-lived branches; never commit to main)
+**Test:** Goods: cd v2 && npx vitest run src/lib/data && npx tsc --noEmit · grantscope: bash scripts/precheck.sh
+
+### Now
+[->] Waiting on Ben to merge Goods PR #232 (Utopia health row, VISIBLE). Nothing else in flight.
+
+### This Session
+- [x] Ruling T (Goods DECISIONS.md): 20kg HDPE/Stretch Bed; conflict swept; 45kg/800t/109,600 family banned in check-retired-figures (21 figures guarded)
+- [x] NT waste + ABS overcrowding figures verified against primary sources (research/nt-plastics-overcrowding-facts-2026-08-24.md); CDS corrected ~800t -> ~530t
+- [x] supply-context.ts + guards; `supply:` figure namespace in deck guards; road integration (gap + Maningrida stops); Maningrida run corrected 60 -> 40 (register-verified)
+- [x] Material traceability tables live on Goods Supabase (cwsyhpiuepvdjtxaozwf), RLS-locked; design doc docs/material_traceability_schema.sql
+- [x] goodsoncountry.com/data built and LIVE (prod-verified): map + panels, overcrowding bars, health setting, supply facts, method; route-audience registered
+- [x] CivicGraph: goods_communities extended (waste/overcrowding/identifier/DSS cols); ABS ILOC backfill NT+QLD+WA = 161 communities measured; abs_iloc_overcrowding + abs_iloc_health (613 ILOCs); phidu_lga_health (7,176 rows); dss cols on 1,517 rows
+- [x] LGA fixes: Palm Island was Douglas-QLD (fixed 35790); Maningrida/Wadeye set; Utopia RULED Barkly 70420 (3 convergent sources); Kununurra row created (had assets, no row)
+- [x] Merged: Goods #225-231; grantscope #394-398. All migrations applied + committed.
+
+### Next
+- [ ] Ben merges Goods PR #232 (then delete remote branches feat/data-page-v2, fix/utopia-health-row — Tier 3, Ben's verb)
+- [ ] CivicGraph per-community decision-read surface — PARKED: another session is mid-flight in goods-communities-hub.ts / rhd-signal.ts / atlas (uncommitted in this tree); their work wants these new tables
+- [ ] Waste-supply columns (est_plastic_waste_tpa etc.) stay NULL — needs fieldwork, not ingest
+- [ ] Optional: SA/NSW/VIC ILOC packs; PHIDU deeper sheets (risk factors are suppressed for remote LGAs — Census/PPH lanes only)
+
+### Decisions
+- 20kg/bed (ruling T, workpaper until measured run weighs it); 1t clean HDPE ≈ 50 leg-sets; never derive beds-possible from supply
+- Health/need = SETTING, never outcome/demand; claim ceiling printed on surfaces; beds÷households never becomes "coverage"
+- One-community-one-ILOC-or-nothing; caveats (exc. town camps, whole-town) travel in source strings; NULL over guessed
+- PHIDU licence CC BY-NC-SA: attribute, check before paid-tier use
+- Utopia LGA = Barkly (council page + Wikipedia + Urapuntja Health)
+
+### Open Questions
+- UNCONFIRMED: whether the rhd-signal session wants to consume abs_iloc_health / phidu_lga_health (they're its natural raw material)
+- UNCONFIRMED: PR #232 merge state (was OPEN, checks green, awaiting Ben)
+
+### Workflow State
+pattern: sequential ship-loop (build -> gates -> PR -> Ben merges VISIBLE / auto-merge SAFE)
+phase: done pending #232
+total_phases: n/a
+retries: 0
+max_retries: 3
+
+#### Resolved
+- goal: "align CivicGraph data with Goods for presentations, pitches, website"
+- resource_allocation: balanced
+
+#### Unknowns
+- (none blocking)
+
+#### Last Failure
+(none open; note for future: classifier blocks psql DDL and gh branch-delete in auto-mode; \copy needs pstdin under -f; Turbopack AND webpack refuse symlinked node_modules — APFS `cp -Rc` clone works)
+
+---
+
+## Context
+
+Full detail lives in: memory/project_goods_supply_context.md (the standing facts),
+research/nt-plastics-overcrowding-facts-2026-08-24.md (Goods repo, sourced figures),
+Goods DECISIONS.md ruling T, and migrations/2026-08-2[45]-*.sql (each self-documenting
+with apply commands). The /data page modules: supply-context.ts, community-need.ts,
+community-health.ts — all guarded (measured-or-explained for every canon community).
+Cross-session note: this grantscope tree carries ANOTHER session's uncommitted work
+(atlas, goods-communities-hub, rhd-signal) — do not touch or commit those files.


### PR DESCRIPTION
Takes over and lands the rhd-signal session's uncommitted work (left in the main tree 2026-08-24 evening), plus a palette-ratchet fix.

## What's in it
- **Two new public Atlas need layers**: First Nations household overcrowding (HPF 2021 Census, remoteness-class grain — caveat states every council in a class shares the value) and NT rheumatic heart disease at health-region grain via a new `AtlasRegionLayer` kind (Central Australia / Top End register regions; council polygons are only a visual proxy, labelled as such).
- **Region UI**: region cards + clickable region overlays/labels on the map, sidebar region list replacing council search while a region layer is active.
- **Org-only counts**: `/api/data/map` and `/api/data/place/[code]` now exclude `person`/`program` entity rows.
- **`unstamped` reason bucket** in the unplaced-reason registry, with migration `20260824111000` (already applied — 0 unstamped org rows remain, verified live).
- **Goods communities hub**: paginate past Supabase's 1,000-row cap (the "All" view was silently truncated) + `force-dynamic` to fix a hydration mismatch from cached relative dates.
- **Fix added in this session**: the new region UI used 8 raw `text-gray-*` classes that failed the palette ratchet — swapped for `text-bauhaus-muted`.

## Verification
- `scripts/precheck.sh` green: tsc clean, 832 tests passing (includes new layer, region-proxy and pagination tests).
- Migration verified applied: `SELECT count(*)` of unstamped unplaced org rows = 0.

VISIBLE change — eyeball `/atlas` (pick the two new need layers) and `/org/act/goods/communities` on the preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m2P2H1KAKgpi9kzw7FLHi