### PR TITLE
Community dossier: health and housing setting section

### DIFF
--- a/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
+++ b/apps/web/src/app/org/[slug]/goods/community/[communityId]/page.tsx
@@ -8,6 +8,8 @@ import {
   type CommunityRelationshipPerson,
   type LocalEntity,
 } from '@/lib/services/goods-community-detail';
+import { getRhdSignalForLga, ratePerHundred } from '@/lib/services/rhd-signal';
+import { getOvercrowdingForRemoteness, overcrowdedPct } from '@/lib/services/overcrowding-signal';
 import { RecordDeploymentButton } from './record-deployment';
 import { PushToGhlButton } from './push-to-ghl-button';
 import { ghlLocationId } from '@/lib/ghl-links';
@@ -37,6 +39,7 @@ export default async function GoodsCommunityPage({
 
   const {
     community,
+    healthSetting,
     mappedBuyers,
     localEntities,
     signals,
@@ -53,6 +56,21 @@ export default async function GoodsCommunityPage({
   const totalDemand = community.demand_beds + community.demand_washers;
   const activeSignals = signals.filter((signal) => ['new', 'reviewing'].includes(signal.status));
   const authorityIds = new Set(operatingModel.authority.candidates.map((entity) => entity.id));
+  const rhd = getRhdSignalForLga(community.lga_name);
+  const remotenessOvercrowding = getOvercrowdingForRemoteness(community.remoteness);
+  const iloc = healthSetting.iloc;
+  const pph = healthSetting.phidu.find((row) => row.indicator === 'pph_admissions_total') ?? null;
+  const medianAgeDeath = healthSetting.phidu.find((row) => row.indicator === 'median_age_death_persons') ?? null;
+  const ilocConditions: Array<[string, number | null]> = iloc
+    ? [
+        ['Mental health condition', iloc.mental_health],
+        ['Asthma', iloc.asthma],
+        ['Diabetes', iloc.diabetes],
+        ['Heart disease', iloc.heart_disease],
+        ['Arthritis', iloc.arthritis],
+        ['Kidney disease', iloc.kidney_disease],
+      ]
+    : [];
   const adjacentEntities = localEntities.filter((entity) => !authorityIds.has(entity.id)).slice(0, 12);
 
   return (
@@ -176,6 +194,110 @@ export default async function GoodsCommunityPage({
                 <RecordDeploymentButton communityId={community.id} communityName={community.community_name} />
                 <Link href={`/org/${slug}/goods`} className="inline-flex min-h-10 items-center rounded-md border border-[var(--ws-border)] px-3 text-xs font-semibold hover:bg-[var(--ws-surface-2)]">Open Goods record</Link>
               </div>
+            </Section>
+
+            <Section title="Health and housing setting" eyebrow="Setting, not outcome" testId="community-health-setting">
+              <p className="mb-4 max-w-3xl text-xs leading-5 text-[var(--ws-text-secondary)]">
+                These figures describe the conditions a bed or washer goes into. They are never a measure of Goods
+                impact, never demand, and dividing anything here by anything else does not produce coverage.
+              </p>
+
+              <div className="grid gap-2 sm:grid-cols-3">
+                {community.overcrowded_pct != null ? (
+                  <CompactFact
+                    label={`Households needing more bedrooms · measured, ILOC${community.overcrowding_as_at ? ` · Census ${new Date(community.overcrowding_as_at).getFullYear()}` : ''}`}
+                    value={`${community.overcrowded_pct}%`}
+                  />
+                ) : remotenessOvercrowding ? (
+                  <CompactFact
+                    label="Households needing more bedrooms · remoteness class, not this community"
+                    value={`${overcrowdedPct(remotenessOvercrowding, 'firstNations')}%`}
+                  />
+                ) : (
+                  <CompactFact label="Households needing more bedrooms" value="Not measured" />
+                )}
+                <CompactFact
+                  label="People per dwelling · derived, approximate"
+                  value={community.persons_per_dwelling != null ? community.persons_per_dwelling.toLocaleString('en-AU') : 'Not measured'}
+                />
+                <CompactFact
+                  label="Occupied dwellings in the ILOC"
+                  value={community.occupied_dwellings != null ? community.occupied_dwellings.toLocaleString('en-AU') : 'No matched ILOC'}
+                />
+              </div>
+              {community.overcrowding_source ? (
+                <p className="mt-2 text-[10px] leading-4 text-[var(--ws-text-tertiary)]">{community.overcrowding_source}</p>
+              ) : (
+                <p className="mt-2 text-[10px] leading-4 text-[var(--ws-text-tertiary)]">
+                  No ABS Indigenous Location maps one-to-one onto this community, so no measured overcrowding figure is
+                  claimed for it — deliberately unmatched rather than confidently wrong.
+                </p>
+              )}
+
+              {iloc ? (
+                <div className="mt-4">
+                  <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[var(--ws-text-tertiary)]">
+                    Self-reported long-term conditions · {iloc.indigenous_persons_counted?.toLocaleString('en-AU') ?? '—'} First Nations people counted, ILOC {iloc.iloc_name}
+                  </div>
+                  <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    {ilocConditions.map(([label, count]) => (
+                      <CompactFact key={label} label={label} value={count != null ? count.toLocaleString('en-AU') : '—'} />
+                    ))}
+                  </div>
+                  <p className="mt-2 text-[10px] leading-4 text-[var(--ws-text-tertiary)]">
+                    ABS Census 2021 Indigenous Profile I12. Self-reported and small-cell randomised: read as a burden
+                    signal, never as clinical prevalence. People can report more than one condition.
+                  </p>
+                </div>
+              ) : null}
+
+              {(pph || medianAgeDeath || rhd) ? (
+                <dl className="mt-4 divide-y divide-[var(--ws-border)] border-t border-[var(--ws-border)]">
+                  {pph?.rate != null ? (
+                    <FactRow
+                      label={`Potentially preventable hospital admissions, whole LGA (${community.lga_name}), ${pph.year}`}
+                      value={`${pph.rate.toLocaleString('en-AU')} ${pph.rate_unit || 'per 100,000'}`}
+                    />
+                  ) : null}
+                  {medianAgeDeath?.number != null ? (
+                    <FactRow
+                      label={`Median age at death, whole LGA (${community.lga_name}), ${medianAgeDeath.year}`}
+                      value={`${medianAgeDeath.number} years`}
+                    />
+                  ) : null}
+                  {rhd ? (
+                    <FactRow
+                      label={`Rheumatic heart disease, ${rhd.region} health region, at ${rhd.asAt}`}
+                      value={`${ratePerHundred(rhd.firstNationsRatePer100k)} in every 100 First Nations people`}
+                    />
+                  ) : null}
+                </dl>
+              ) : null}
+              {(pph || medianAgeDeath) ? (
+                <p className="mt-2 text-[10px] leading-4 text-[var(--ws-text-tertiary)]">
+                  LGA rows cover the whole council area, not this community. Source: PHIDU Social Health Atlas, Torrens
+                  University (CC BY-NC-SA).
+                </p>
+              ) : null}
+              {rhd ? (
+                <p className="mt-1 text-[10px] leading-4 text-[var(--ws-text-tertiary)]">
+                  RHD belongs to the register region, never to this community or council. AIHW table {rhd.sourceTable} (CC BY 4.0).
+                </p>
+              ) : null}
+
+              {(community.dss_health_care_cards != null || community.dss_disability_pension != null || community.dss_jobseeker != null) ? (
+                <div className="mt-4">
+                  <div className="font-mono text-[9px] font-semibold uppercase tracking-widest text-[var(--ws-text-tertiary)]">
+                    Income support, whole postcode {community.postcode}
+                  </div>
+                  <div className="mt-2 grid grid-cols-3 gap-2">
+                    <CompactFact label="Health Care Cards" value={community.dss_health_care_cards?.toLocaleString('en-AU') ?? '—'} />
+                    <CompactFact label="Disability Support Pension" value={community.dss_disability_pension?.toLocaleString('en-AU') ?? '—'} />
+                    <CompactFact label="JobSeeker" value={community.dss_jobseeker?.toLocaleString('en-AU') ?? '—'} />
+                  </div>
+                  {community.dss_source ? <p className="mt-2 text-[10px] leading-4 text-[var(--ws-text-tertiary)]">{community.dss_source}.</p> : null}
+                </div>
+              ) : null}
             </Section>
 
             <Section title="Adjacent organisations and activity" eyebrow="Useful context, not a lead list" testId="community-adjacent">

--- a/apps/web/src/lib/services/goods-community-detail.test.ts
+++ b/apps/web/src/lib/services/goods-community-detail.test.ts
@@ -36,6 +36,18 @@ const community: CommunityDetail = {
   data_quality_score: null,
   last_profiled_at: null,
   data_sources: null,
+  lga_code: '70420',
+  abs_iloc_code: null,
+  occupied_dwellings: null,
+  overcrowded_dwellings: null,
+  overcrowded_pct: null,
+  persons_per_dwelling: null,
+  overcrowding_source: null,
+  overcrowding_as_at: null,
+  dss_health_care_cards: null,
+  dss_disability_pension: null,
+  dss_jobseeker: null,
+  dss_source: null,
 };
 
 const authorityCandidate: LocalEntity = {

--- a/apps/web/src/lib/services/goods-community-detail.ts
+++ b/apps/web/src/lib/services/goods-community-detail.ts
@@ -29,6 +29,54 @@ export type CommunityDetail = {
   data_quality_score: number | null;
   last_profiled_at: string | null;
   data_sources: string[] | null;
+  lga_code: string | null;
+  abs_iloc_code: string | null;
+  occupied_dwellings: number | null;
+  overcrowded_dwellings: number | null;
+  overcrowded_pct: number | null;
+  persons_per_dwelling: number | null;
+  /** Full provenance travels with the figure — ILOC code, name, caveats. */
+  overcrowding_source: string | null;
+  overcrowding_as_at: string | null;
+  dss_health_care_cards: number | null;
+  dss_disability_pension: number | null;
+  dss_jobseeker: number | null;
+  dss_source: string | null;
+};
+
+/** ABS Census 2021 long-term conditions for this community's ILOC.
+ * Self-reported and small-cell randomised: a burden signal, never clinical
+ * prevalence. Null when the community has no matched ILOC. */
+export type IlocHealthRow = {
+  iloc_code: string;
+  iloc_name: string;
+  indigenous_persons_counted: number | null;
+  kidney_disease: number | null;
+  heart_disease: number | null;
+  diabetes: number | null;
+  asthma: number | null;
+  mental_health: number | null;
+  arthritis: number | null;
+  no_long_term_condition: number | null;
+  median_age: number | null;
+  median_hh_income_wk: number | null;
+};
+
+/** PHIDU Social Health Atlas rows for this community's LGA. LGA grain — the
+ * whole council area, not the community. CC BY-NC-SA: attribution rendered. */
+export type PhiduHealthRow = {
+  indicator: string;
+  year: string;
+  number: number | null;
+  rate: number | null;
+  rate_unit: string | null;
+  sr: number | null;
+  suppression: string | null;
+};
+
+export type CommunityHealthSetting = {
+  iloc: IlocHealthRow | null;
+  phidu: PhiduHealthRow[];
 };
 
 export type MappedBuyer = {
@@ -197,6 +245,7 @@ export type TimelineEvent = {
 
 export type GoodsCommunityDetail = {
   community: CommunityDetail;
+  healthSetting: CommunityHealthSetting;
   mappedBuyers: MappedBuyer[];
   localEntities: LocalEntity[];
   signals: SignalSummary[];
@@ -307,10 +356,33 @@ export async function getGoodsCommunityDetail(communityId: string, orgProfileId?
 
   const { data: community, error } = await db
     .from('goods_communities')
-    .select('id, community_name, state, postcode, region_label, service_region, remoteness, lga_name, priority, demand_beds, demand_washers, assets_deployed, land_council, local_government, main_language, estimated_population, estimated_households, nearest_staging_hub, freight_corridor, last_mile_method, total_govt_contract_value, total_justice_funding, total_foundation_grants, proof_line, story, data_quality_score, last_profiled_at, data_sources')
+    .select('id, community_name, state, postcode, region_label, service_region, remoteness, lga_name, priority, demand_beds, demand_washers, assets_deployed, land_council, local_government, main_language, estimated_population, estimated_households, nearest_staging_hub, freight_corridor, last_mile_method, total_govt_contract_value, total_justice_funding, total_foundation_grants, proof_line, story, data_quality_score, last_profiled_at, data_sources, lga_code, abs_iloc_code, occupied_dwellings, overcrowded_dwellings, overcrowded_pct, persons_per_dwelling, overcrowding_source, overcrowding_as_at, dss_health_care_cards, dss_disability_pension, dss_jobseeker, dss_source')
     .eq('id', communityId)
     .maybeSingle();
   if (error || !community) return null;
+
+  // Health setting: the community's own ILOC conditions plus its LGA's PHIDU
+  // rows. Both optional — no match means the section says so, not a zero.
+  const [ilocHealthRes, phiduRes] = await Promise.all([
+    community.abs_iloc_code
+      ? db
+          .from('abs_iloc_health')
+          .select('iloc_code, iloc_name, indigenous_persons_counted, kidney_disease, heart_disease, diabetes, asthma, mental_health, arthritis, no_long_term_condition, median_age, median_hh_income_wk')
+          .eq('iloc_code', community.abs_iloc_code)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    community.lga_code
+      ? db
+          .from('phidu_lga_health')
+          .select('indicator, year, number, rate, rate_unit, sr, suppression')
+          .eq('lga_code', community.lga_code)
+          .in('indicator', ['pph_admissions_total', 'median_age_death_persons'])
+      : Promise.resolve({ data: null }),
+  ]);
+  const healthSetting: CommunityHealthSetting = {
+    iloc: (ilocHealthRes.data as IlocHealthRow | null) ?? null,
+    phidu: (phiduRes.data as PhiduHealthRow[] | null) ?? [],
+  };
 
   // Mapped procurement entities at this community
   const { data: mappedBuyersRaw } = await db
@@ -636,6 +708,7 @@ export async function getGoodsCommunityDetail(communityId: string, orgProfileId?
 
   return {
     community: typedCommunity,
+    healthSetting,
     mappedBuyers,
     localEntities,
     signals,

--- a/apps/web/src/lib/services/rhd-signal.test.ts
+++ b/apps/web/src/lib/services/rhd-signal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { PLACE_REGIONS } from './place-intelligence';
-import { RHD_BY_PLACE_REGION, RHD_REGIONS, getRhdSignalForRegion, ratePerHundred } from './rhd-signal';
+import { RHD_BY_PLACE_REGION, RHD_REGIONS, getRhdSignalForLga, getRhdSignalForRegion, ratePerHundred } from './rhd-signal';
 
 /**
  * These figures are transcribed by hand from a published workbook and shown to
@@ -71,6 +71,14 @@ describe('RHD_REGIONS', () => {
     // caveat is ever dropped the page overstates its own coverage.
     const note = RHD_REGIONS['nt-central-australia'].boundaryNote;
     expect(note).toContain('APY');
+  });
+
+  it('resolves an NT council to its register region, and nothing else', () => {
+    expect(getRhdSignalForLga('Barkly')?.region).toBe('Central Australia');
+    expect(getRhdSignalForLga('west arnhem')?.region).toBe('Northern Territory Top End');
+    // A non-NT council or an unknown one never inherits a register number.
+    expect(getRhdSignalForLga('Ceduna')).toBeNull();
+    expect(getRhdSignalForLga(null)).toBeNull();
   });
 
   it('converts a rate per 100,000 into people per 100', () => {

--- a/apps/web/src/lib/services/rhd-signal.ts
+++ b/apps/web/src/lib/services/rhd-signal.ts
@@ -116,6 +116,21 @@ export function getRhdSignalForRegion(regionKey: string): RhdRegionSignal | null
 }
 
 /**
+ * The register region an NT council belongs to, resolved through the same
+ * proxy-LGA membership the Atlas draws. Non-NT councils, and NT places whose
+ * council is unknown, get null — the register number never stretches past the
+ * geography it was reported for.
+ */
+export function getRhdSignalForLga(lgaName: string | null): RhdRegionSignal | null {
+  if (!lgaName) return null;
+  const wanted = lgaName.trim().toLowerCase();
+  for (const region of Object.values(RHD_REGIONS)) {
+    if (region.proxyLgas.some(lga => lga.toLowerCase() === wanted)) return region;
+  }
+  return null;
+}
+
+/**
  * The prevalence rate as a share of population, which is how a person reads it.
  * 2,902.7 per 100,000 is 2.9 in every 100.
  */

--- a/migrations/2026-08-25-grant-health-reference-tables.sql
+++ b/migrations/2026-08-25-grant-health-reference-tables.sql
@@ -1,0 +1,23 @@
+-- API-role grants for the psql-created health reference tables. Same missing-
+-- GRANT class as v_goods_relationship_* (2026-08): anything created via psql
+-- has no grants to the Supabase API roles, so the app client reads silently
+-- return nothing. All three are open reference data (ABS Census, PHIDU CC
+-- BY-NC-SA) — read-only for every API role.
+--
+-- Apply:
+--   source .env && PGPASSWORD="$DATABASE_PASSWORD" psql -h aws-0-ap-southeast-2.pooler.supabase.com -p 5432 -U "postgres.tednluwflfhxyucgwigh" -d postgres -f migrations/2026-08-25-grant-health-reference-tables.sql
+
+GRANT SELECT ON abs_iloc_overcrowding, abs_iloc_health, phidu_lga_health
+  TO anon, authenticated, service_role;
+
+DO $$
+DECLARE n integer;
+BEGIN
+  SELECT count(*) INTO n FROM information_schema.table_privileges
+  WHERE table_name IN ('abs_iloc_health', 'abs_iloc_overcrowding', 'phidu_lga_health')
+    AND grantee IN ('service_role', 'anon', 'authenticated')
+    AND privilege_type = 'SELECT';
+  IF n <> 9 THEN
+    RAISE EXCEPTION 'expected 9 SELECT grants (3 tables x 3 roles), got %', n;
+  END IF;
+END $$;


### PR DESCRIPTION
The per-community decision-read surface (the parked goods-data-alignment item): wires the verified health/need reference tables into `/org/[slug]/goods/community/[id]`.

- **Measured ILOC overcrowding** with the full provenance string (incl. hand-match caveats like "ILOC includes Tjurma Homelands"); the remoteness-class figure appears only as a labelled fallback, and unmatched communities say "deliberately unmatched rather than confidently wrong".
- **Self-reported long-term conditions** (ABS I12, burden-signal caveat), **PHIDU LGA rows** (PPH admissions, median age at death; CC BY-NC-SA attribution, whole-LGA labelling), **NT RHD** via new `getRhdSignalForLga` (proxy-LGA membership; null outside the two register regions — tested), and **DSS postcode cards** with the never-sum caveat.
- Claim ceiling printed at the top of the section: setting, never outcome, never coverage.

**Blocked on a Tier-3 grant**: the psql-created tables (`abs_iloc_*`, `phidu_lga_health`) have zero API-role grants, so app reads silently return nothing. `migrations/2026-08-25-grant-health-reference-tables.sql` (read-only SELECT to the three API roles, self-verifying) is in this PR, NOT YET APPLIED.

Verified on :3013 (Amata): overcrowding 35.6% with source string, DSS cards render; conditions/PHIDU blocks await the grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m2P2H1KAKgpi9kzw7FLHi