### PR TITLE
Server actions read the Supabase connection through supabase-env

### DIFF
--- a/apps/web/src/app/feedback/actions.ts
+++ b/apps/web/src/app/feedback/actions.ts
@@ -1,10 +1,14 @@
 'use server';
 
 import { createClient } from '@supabase/supabase-js';
+import { getSupabaseSecretKey, getSupabaseUrl } from '@/lib/supabase-env';
 import { pushFeedbackToGHL } from '@/lib/services/feedback-ghl';
 
-const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+// One read site for the connection (lib/supabase-env): prefers the clean NEXT_PUBLIC_* URL and the new secret key,
+// and trims. This file used to read SUPABASE_URL first, which in production carried a trailing newline (/config-truth,
+// 2026-09-05); URL parsing happened to strip it, so nothing broke, but the pattern is the one that blanked 61 report pages.
+const SUPABASE_URL = getSupabaseUrl().trim();
+const SUPABASE_KEY = getSupabaseSecretKey().trim();
 
 export type FeedbackResult = { ok: boolean; id?: string; error?: string };
 

--- a/apps/web/src/app/get-a-report/actions.ts
+++ b/apps/web/src/app/get-a-report/actions.ts
@@ -1,9 +1,13 @@
 'use server';
 
 import { createClient } from '@supabase/supabase-js';
+import { getSupabaseSecretKey, getSupabaseUrl } from '@/lib/supabase-env';
 
-const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+// One read site for the connection (lib/supabase-env): prefers the clean NEXT_PUBLIC_* URL and the new secret key,
+// and trims. This file used to read SUPABASE_URL first, which in production carried a trailing newline (/config-truth,
+// 2026-09-05); URL parsing happened to strip it, so nothing broke, but the pattern is the one that blanked 61 report pages.
+const SUPABASE_URL = getSupabaseUrl().trim();
+const SUPABASE_KEY = getSupabaseSecretKey().trim();
 
 export type SubmissionResult = {
   ok: boolean;

--- a/apps/web/src/app/share/partner/actions.ts
+++ b/apps/web/src/app/share/partner/actions.ts
@@ -1,10 +1,14 @@
 'use server';
 
 import { createClient } from '@supabase/supabase-js';
+import { getSupabaseSecretKey, getSupabaseUrl } from '@/lib/supabase-env';
 import { pushPartnershipToGHL } from '@/lib/services/partnership-ghl';
 
-const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+// One read site for the connection (lib/supabase-env): prefers the clean NEXT_PUBLIC_* URL and the new secret key,
+// and trims. This file used to read SUPABASE_URL first, which in production carried a trailing newline (/config-truth,
+// 2026-09-05); URL parsing happened to strip it, so nothing broke, but the pattern is the one that blanked 61 report pages.
+const SUPABASE_URL = getSupabaseUrl().trim();
+const SUPABASE_KEY = getSupabaseSecretKey().trim();
 
 export type PartnershipResult = { ok: boolean; id?: string; error?: string };
 


### PR DESCRIPTION
## What

`app/feedback`, `app/get-a-report` and `app/share/partner` server actions now take the URL and secret key from `lib/supabase-env` (`getSupabaseUrl()`, `getSupabaseSecretKey()`, trimmed) instead of reading `SUPABASE_URL` first and `SUPABASE_SERVICE_ROLE_KEY` directly.

## Why

`/config-truth` on 2026-09-05 found production `SUPABASE_URL` carried a trailing newline (since re-entered clean). URL parsing strips newlines so these forms never broke, but it is the exact pattern that blanked 61 report pages for four months. One read site, whitespace-tolerant, new key names first.

## Verification

`scripts/precheck.sh` green (tsc + full vitest). Behaviour change: none intended. VISIBLE paths, so this waits for a preview check: submit the feedback form, the get-a-report form and the partner share form on the preview and confirm each returns ok.