### PR TITLE
Make the data legible and the landing path quieter: /ops/schema, parity in CI and preflight, classifier fix

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -11,6 +11,7 @@ node --env-file=.env scripts/preflight.mjs
 
 2. Report the results to the user. If any checks fail, suggest fixes:
    - **Database:** Check `.env` has `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`
+   - **Migration parity:** `supabase/migrations/` vs the database tracker. Red means something was applied with no committed file (commit it with the same version); "draft(s) awaiting /db-apply" is normal while Ben has not said apply.
    - **Environment:** List missing env vars and where to get them
    - **Git:** Show uncommitted files, offer to commit
    - **TypeScript:** Run `cd apps/web && npx tsc --noEmit` and fix errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,28 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+  migration-parity:
+    name: Migration Parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Fails when the database holds a post-baseline migration with no committed file, and (strict, on main)
+      # when a committed file was never applied. Needs the two repo secrets above; until Ben adds them this
+      # step reports "skipped" rather than pretending to have checked.
+      - name: Parity (folder vs supabase_migrations.schema_migrations)
+        if: ${{ env.SUPABASE_SERVICE_ROLE_KEY != '' }}
+        run: node scripts/check-migration-parity.mjs ${{ github.ref == 'refs/heads/main' && '--strict' || '' }}
+      - name: Parity skipped (no SUPABASE_SERVICE_ROLE_KEY secret)
+        if: ${{ env.SUPABASE_SERVICE_ROLE_KEY == '' }}
+        run: echo "::warning::migration parity not checked; add SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY as repo secrets"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,18 @@ Everything older lives in `supabase/migrations_history/` and is never applied. M
 or via the MCP `apply_migration` tool must be committed here with the same version in the same session; the parity
 check names the ones that were not. Generated types: `supabase/types/database.types.ts`. Edge functions: `supabase/functions/`.
 
+## How a change goes live (the whole path, decided 2026-09-05)
+
+1. **Branch off `main`** (`git switch -c <type>/<slug>`). Never commit on `main`. One session per checkout.
+2. **Database change?** Write `supabase/migrations/<version>_<name>.sql`, then `/db-apply` (Ben's verb). Nothing else
+   touches the schema. `node --env-file=.env scripts/check-migration-parity.mjs` says whether the folder and the
+   database agree. The data itself is legible at **`/ops/schema`** (owner, consumers, size, public-key exposure).
+3. **Land with `/ship-merge`.** It runs the gate (`scripts/precheck.sh`), pushes, opens the PR, classifies:
+   SAFE paths (`scripts/`, `supabase/`, `docs/`, `thoughts/`, `.github/`, `.claude/`, `lib/`, `api/`, `ops/`,
+   `admin/`, tests) merge themselves on green; anything a visitor can render waits for Ben's preview and the word "merge".
+4. **Merged = deployed.** Vercel builds `main`; `/config-truth` when something is set but inert.
+5. **Nothing else.** No worktrees for Ben, no manual pushes, no MCP `apply_migration` without a committed file.
+
 ## Rule #2: Verify Schema Before Writing Queries
 
 Never guess column names. Check `data/schema-cache.md` first — it has full schemas for the top 8 tables. For other tables:

--- a/apps/web/src/app/ops/schema/page.tsx
+++ b/apps/web/src/app/ops/schema/page.tsx
@@ -1,0 +1,166 @@
+import Link from 'next/link';
+import { getServiceSupabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * /ops/schema — the schema register, live.
+ *
+ * One page that answers "what is this table, whose is it, who reads it, is it private, can the public key
+ * see it". Reads `schema_ownership` (seeded 2026-09-05, one row per public relation) joined to the catalog.
+ * The rule this page exists to make visible: an object owned by `act` that the anon role can read is a
+ * leak, and it should never be green here. Migrations that add objects add a row here in the same file
+ * (supabase/migrations/README.md).
+ */
+
+type Row = {
+  object: string;
+  kind: string;
+  owner: string;
+  consumers: string[] | null;
+  evidence: string | null;
+  declared_on: string | null;
+  bytes: number | null;
+  anon_state: string | null; // 'no grant' | 'grant, RLS blocks' | 'open (policy)' | 'open (no RLS)' | 'open (matview)' | 'open (definer view)' | 'via base RLS'
+  invoker: boolean | null;
+};
+
+const OPEN = (state: string | null) => !!state && state.startsWith('open');
+
+const OWNERS = ['grantscope', 'justicehub', 'act', 'shared', 'empathy-ledger', 'harvest', 'studio', 'unknown'] as const;
+const PRIVATE_OWNERS = new Set(['act', 'empathy-ledger', 'harvest', 'studio']);
+
+function fmtBytes(n: number | null): string {
+  if (!n) return '';
+  if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(1)} GB`;
+  if (n >= 1_048_576) return `${Math.round(n / 1_048_576)} MB`;
+  if (n >= 1024) return `${Math.round(n / 1024)} kB`;
+  return `${n} B`;
+}
+
+const KIND: Record<string, string> = { r: 'table', p: 'table', m: 'matview', v: 'view' };
+
+export default async function SchemaRegisterPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ owner?: string; q?: string }>;
+}) {
+  const { owner, q } = await searchParams;
+  const db = getServiceSupabase();
+  const { data, error } = await db.rpc('exec_sql', {
+    query: `
+      WITH x AS (
+        SELECT s.object, s.owner, s.consumers, s.evidence, s.declared_on::text AS declared_on, c.relkind, c.relrowsecurity AS rls,
+               pg_total_relation_size(c.oid) AS bytes,
+               has_table_privilege('anon', c.oid, 'SELECT') AS grant_anon,
+               EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid AND p.polpermissive AND p.polcmd IN ('r','*')
+                       AND (p.polroles = '{0}' OR EXISTS (SELECT 1 FROM pg_roles r WHERE r.oid = ANY(p.polroles) AND r.rolname = 'anon'))) AS anon_policy,
+               CASE WHEN c.relkind = 'v'
+                    THEN coalesce((SELECT option_value FROM pg_options_to_table(c.reloptions) WHERE option_name = 'security_invoker'), 'false') = 'true'
+                    END AS invoker
+        FROM schema_ownership s
+        LEFT JOIN pg_class c ON c.relname = s.object
+        LEFT JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public')
+      SELECT object, relkind AS kind, owner, consumers, evidence, declared_on, bytes, invoker,
+             CASE WHEN relkind IS NULL THEN 'missing'
+                  WHEN NOT grant_anon THEN 'no grant'
+                  WHEN relkind IN ('r','p') AND rls AND NOT anon_policy THEN 'grant, RLS blocks'
+                  WHEN relkind IN ('r','p') AND rls AND anon_policy THEN 'open (policy)'
+                  WHEN relkind IN ('r','p') AND NOT rls THEN 'open (no RLS)'
+                  WHEN relkind = 'm' THEN 'open (matview)'
+                  WHEN relkind = 'v' AND NOT invoker THEN 'open (definer view)'
+                  WHEN relkind = 'v' AND invoker THEN 'via base RLS' END AS anon_state
+      FROM x ORDER BY owner, object`,
+  });
+  const rows = ((data ?? []) as Row[]).filter((r) => (!owner || r.owner === owner) && (!q || r.object.includes(q)));
+  const all = (data ?? []) as Row[];
+  const byOwner = OWNERS.map((o) => ({ owner: o, n: all.filter((r) => r.owner === o).length }));
+  const leaks = all.filter((r) => PRIVATE_OWNERS.has(r.owner) && OPEN(r.anon_state));
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="font-black uppercase tracking-widest text-xs">Schema register</p>
+        <h1 className="font-black uppercase text-3xl">What this data is and whose it is</h1>
+        <p className="max-w-3xl text-sm">
+          One row per public relation in the shared Supabase project. Owner says which product changes it; consumers
+          are the repos whose code reads it. &ldquo;Public key&rdquo; is what the anon role can actually read: a SELECT
+          grant alone means nothing while RLS has no anon policy, so that reads as &ldquo;grant, RLS blocks&rdquo;.
+          Private owners (act, empathy-ledger, harvest, studio) must never be open. Changes go through <code>scripts/db-apply.sh</code>; the rule is in{' '}
+          <code>supabase/migrations/README.md</code>.
+        </p>
+        {error && <p className="text-bauhaus-red text-sm">Register query failed: {error.message}</p>}
+      </header>
+
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-0 border-4 border-bauhaus-black">
+        {byOwner.map(({ owner: o, n }) => (
+          <Link
+            key={o}
+            href={o === owner ? '/ops/schema' : `/ops/schema?owner=${o}`}
+            className={`block p-4 border-2 border-bauhaus-black ${o === owner ? 'bg-bauhaus-black text-bauhaus-canvas' : ''}`}
+          >
+            <span className="block font-black uppercase tracking-widest text-xs">{o}</span>
+            <span className="block font-black text-3xl tabular-nums">{n}</span>
+          </Link>
+        ))}
+      </section>
+
+      <section className={`border-4 p-4 ${leaks.length ? 'border-bauhaus-red' : 'border-bauhaus-black'}`}>
+        <p className="font-black uppercase tracking-widest text-xs">Private objects readable by the public key</p>
+        <p className="font-black text-3xl tabular-nums">{leaks.length}</p>
+        {leaks.length > 0 && (
+          <ul className="mt-2 text-sm font-mono">
+            {leaks.map((r) => (
+              <li key={r.object}>
+                {r.object} <span className="opacity-70">({r.owner})</span>
+              </li>
+            ))}
+          </ul>
+        )}
+        {leaks.length === 0 && <p className="text-sm">None. Keep it that way: new views are security_invoker, nothing private gets an anon policy or a definer view.</p>}
+      </section>
+
+      <form className="flex gap-2 items-center" action="/ops/schema" method="get">
+        {owner && <input type="hidden" name="owner" value={owner} />}
+        <input name="q" defaultValue={q ?? ''} placeholder="filter by name" className="border-2 border-bauhaus-black px-2 py-1 text-sm" />
+        <button className="border-2 border-bauhaus-black px-3 py-1 font-black uppercase tracking-widest text-xs">Filter</button>
+        <span className="text-xs">{rows.length} of {all.length}</span>
+      </form>
+
+      <div className="overflow-x-auto border-4 border-bauhaus-black">
+        <table className="w-full text-sm">
+          <thead className="bg-bauhaus-black text-bauhaus-canvas font-black uppercase tracking-widest text-xs">
+            <tr>
+              <th className="text-left p-2">object</th>
+              <th className="text-left p-2">kind</th>
+              <th className="text-left p-2">owner</th>
+              <th className="text-left p-2">consumers</th>
+              <th className="text-right p-2">size</th>
+              <th className="text-left p-2">public key</th>
+              <th className="text-left p-2">evidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const leak = PRIVATE_OWNERS.has(r.owner) && OPEN(r.anon_state);
+              return (
+                <tr key={r.object} className={`border-t-2 border-bauhaus-black/20 ${leak ? 'bg-bauhaus-red/10' : ''}`}>
+                  <td className="p-2 font-mono">{r.object}</td>
+                  <td className="p-2">
+                    {KIND[r.kind] ?? r.kind}
+                    {r.kind === 'v' && r.invoker === false && <span className="ml-1 text-xs uppercase tracking-widest">definer</span>}
+                  </td>
+                  <td className="p-2">{r.owner}</td>
+                  <td className="p-2">{(r.consumers ?? []).join(', ')}</td>
+                  <td className="p-2 text-right tabular-nums">{fmtBytes(r.bytes)}</td>
+                  <td className={`p-2 ${leak ? 'font-black text-bauhaus-red' : ''}`}>{r.anon_state}</td>
+                  <td className="p-2 text-xs max-w-md truncate" title={r.evidence ?? ''}>{r.evidence}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/scripts/classify-changes.sh
+++ b/scripts/classify-changes.sh
@@ -22,7 +22,10 @@ BASE="${1:-origin/main}"
 # this reported "no changes -> SAFE" whenever it ran before the commit — a false SAFE, which is the
 # one answer that must never be wrong, because SAFE is what auto-merges.
 FILES="$(
-  { git diff --name-only "$BASE"...HEAD; git status --porcelain | awk '{print $NF}'; } | sort -u
+  # Untracked files count (a new page not yet committed is still a change), but a symlinked node_modules is not:
+  # .gitignore's `node_modules/` pattern does not match a symlink, so a worktree with linked deps read as VISIBLE
+  # twice on 2026-09-05 for no change at all.
+  { git diff --name-only "$BASE"...HEAD; git status --porcelain | awk '{print $NF}' | grep -vE '(^|/)node_modules$'; } | sort -u
 )"
 if [[ -z "$FILES" ]]; then
   echo "no changes vs $BASE and nothing uncommitted" >&2

--- a/scripts/classify-changes.sh
+++ b/scripts/classify-changes.sh
@@ -24,8 +24,9 @@ BASE="${1:-origin/main}"
 FILES="$(
   # Untracked files count (a new page not yet committed is still a change), but a symlinked node_modules is not:
   # .gitignore's `node_modules/` pattern does not match a symlink, so a worktree with linked deps read as VISIBLE
-  # twice on 2026-09-05 for no change at all.
-  { git diff --name-only "$BASE"...HEAD; git status --porcelain | awk '{print $NF}' | grep -vE '(^|/)node_modules$'; } | sort -u
+  # twice on 2026-09-05 for no change at all. The `|| true` matters: under pipefail, grep -v exits 1 when it has
+  # nothing to filter (no untracked files), which silently failed the whole listing on the first version of this line.
+  { git diff --name-only "$BASE"...HEAD; git status --porcelain | awk '{print $NF}' | { grep -vE '(^|/)node_modules$' || true; }; } | sort -u
 )"
 if [[ -z "$FILES" ]]; then
   echo "no changes vs $BASE and nothing uncommitted" >&2

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -46,6 +46,21 @@ async function checkDb() {
   return { ok: true, detail: `${tableCount} tables, ${entityCount} entities` };
 }
 
+async function checkMigrationParity() {
+  // supabase/migrations vs supabase_migrations.schema_migrations (scripts/check-migration-parity.mjs).
+  // Exit 1 there means something was applied to the database with no committed file: the 2026-09-05 orphan class.
+  try {
+    const out = execSync('node scripts/check-migration-parity.mjs', { cwd: ROOT, encoding: 'utf8', env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const summary = out.split('\n').find((l) => l.startsWith('✓')) || out.trim().split('\n')[0] || 'ok';
+    const pending = (out.match(/^\s+\d{14}_.+\.sql$/gm) || []).length;
+    return { ok: true, detail: pending ? `${summary} (${pending} draft(s) awaiting /db-apply)` : summary };
+  } catch (e) {
+    const out = (e.stdout || '') + (e.stderr || '');
+    const orphan = out.split('\n').find((l) => l.includes('NO file'));
+    return { ok: false, detail: orphan ? orphan.trim() : `parity check failed: ${(e.message || '').split('\n')[0]}` };
+  }
+}
+
 function checkEnv() {
   const required = ['DATABASE_PASSWORD', 'SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'];
   const optional = ['ABN_LOOKUP_GUID', 'OPENAI_API_KEY', 'STRIPE_SECRET_KEY'];
@@ -106,6 +121,7 @@ console.log('\n  GrantScope Preflight Check\n');
 
 const results = await Promise.all([
   check('Database', checkDb),
+  check('Migration parity', checkMigrationParity),
   Promise.resolve(check('Environment', checkEnv)),
   Promise.resolve(check('Git', checkGit)),
   Promise.resolve(check('Port 3003', checkPort)),

--- a/supabase/migrations/20260905150000_act_finance_aggregate_views_anon_revoke.sql
+++ b/supabase/migrations/20260905150000_act_finance_aggregate_views_anon_revoke.sql
@@ -1,0 +1,21 @@
+-- 20260905150000_act_finance_aggregate_views_anon_revoke.sql
+-- Drafted 2026-09-05; NOT applied. Apply with /db-apply on Ben's verb.
+--
+-- Five ACT finance aggregate views (Xero income and expense by payee, project and funder, and the funder next-move
+-- view) are still SECURITY DEFINER with anon and authenticated SELECT grants. Since Phase 0 they return 0 rows to
+-- anon, because they sit on the now security_invoker private views and the base RLS holds, but the grants and the
+-- definer flag are the wrong shape and one careless rewrite of an inner view would reopen them. Readers, verified
+-- 2026-09-05: grantscope lib/services/org-income-service.ts and org-pipeline-service.ts (service role), act-global
+-- command-center api/finance routes (service role), scripts/sync-funder-reporting-to-notion.mjs (service role).
+BEGIN;
+ALTER VIEW public.v_act_expense_by_payee   SET (security_invoker = true);
+ALTER VIEW public.v_act_expense_by_project SET (security_invoker = true);
+ALTER VIEW public.v_act_income_by_funder   SET (security_invoker = true);
+ALTER VIEW public.v_act_income_by_project  SET (security_invoker = true);
+ALTER VIEW public.v_funder_next_move       SET (security_invoker = true);
+REVOKE ALL ON public.v_act_expense_by_payee, public.v_act_expense_by_project, public.v_act_income_by_funder,
+  public.v_act_income_by_project, public.v_funder_next_move FROM anon, authenticated;
+GRANT SELECT ON public.v_act_expense_by_payee, public.v_act_expense_by_project, public.v_act_income_by_funder,
+  public.v_act_income_by_project, public.v_funder_next_move TO service_role;
+COMMIT;
+-- Post-check with the publishable key: each view must return 401. Service role: SELECT count(*) FROM v_act_income_by_funder;

--- a/supabase/migrations/20260905151000_act_context_tables_anon_revoke.sql
+++ b/supabase/migrations/20260905151000_act_context_tables_anon_revoke.sql
@@ -1,0 +1,23 @@
+-- 20260905151000_act_context_tables_anon_revoke.sql
+-- Drafted 2026-09-05; NOT applied. Apply with /db-apply on Ben's verb.
+--
+-- /ops/schema measures "open to the public key" by RLS state, not by grant. Of the 42 private-owner objects it finds
+-- open, 36 are consent- or approval-gated publishing tables (Empathy Ledger stories, Harvest approved listings, studio
+-- approved media) and are meant to be. These six are ACT-owned with plain public read policies or a matview grant:
+--   funder_context_snapshot         840 kB  "Public read"          Xero-derived funder context; readers: grantscope + act-global server code
+--   act_grant_recommendations        29 MB  matview grant          ACT grant scoring; readers: grantscope server code via act_grant_recommendations_current
+--   grant_application_requirements   72 kB  "Public read"          readers: act-global server code
+--   tagging_sweep_runs              264 kB  "Public read"          ops; readers: act-global server code
+--   learned_thresholds               96 kB  policy named "Authenticated…" but granted to public; no reader in any repo
+--   recommendation_outcomes         144 kB  same shape; no reader in any repo
+-- No anon or authenticated client reads any of them (grep over six repos, 2026-09-05). Service role bypasses RLS.
+BEGIN;
+DROP POLICY IF EXISTS "Public read" ON public.funder_context_snapshot;
+DROP POLICY IF EXISTS "Public read" ON public.grant_application_requirements;
+DROP POLICY IF EXISTS "Public read" ON public.tagging_sweep_runs;
+DROP POLICY IF EXISTS "Authenticated read access on learned_thresholds" ON public.learned_thresholds;
+DROP POLICY IF EXISTS "Authenticated read access on recommendation_outcomes" ON public.recommendation_outcomes;
+REVOKE SELECT ON public.act_grant_recommendations FROM anon, authenticated;
+GRANT SELECT ON public.act_grant_recommendations TO service_role;
+COMMIT;
+-- Post-check: /ops/schema "private objects readable by the public key" should drop by 6 (11 with 20260905150000).

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -435,3 +435,20 @@ created by `supabase_admin`, which nothing here uses. The 48 anon-writable views
 **Not started in Phase 1:** the shared types package consumed by JusticeHub and Empathy Ledger (CivicGraph has the file;
 wiring `Database` into the clients is Phase 3 work), and the CI job for `check-migration-parity.mjs --strict` (CI has no
 service-role secret today; only the legacy anon key, which is dead).
+
+**Legibility slice (same day, after the applies).** `/ops/schema` renders the register live: one row per relation with
+owner, consumers, size, kind, definer flag and whether the public key can read it, and a red count of private objects
+readable by anon (must be 0). `scripts/classify-changes.sh` no longer counts a symlinked `node_modules` as a changed
+file (two false VISIBLE verdicts on 2026-09-05). CI gains a `Migration Parity` job that runs `check-migration-parity.mjs`
+(`--strict` on main) once `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` exist as repo secrets, and warns until then.
+`/preflight` runs the parity check. `20260905150000_act_finance_aggregate_views_anon_revoke.sql` is drafted for the five
+ACT finance aggregates that still carry definer + anon grants (0 rows today, wrong shape). PR #408 (three server actions
+reading the connection through `supabase-env`) waits for a preview check of the feedback, get-a-report and partner forms.
+
+**What the register page measured on its first run.** By RLS state, 42 private-owner objects are open to the public key:
+33 tables with a permissive anon policy, 1 matview, 8 definer views. 36 are meant to be: consent- and approval-gated
+publishing rows (Empathy Ledger stories, quotes, storytellers with consent; Harvest approved businesses and events; studio
+approved media and reviews; ACT's public key-people and PMPP knowledge). The remaining six are ACT context or ops with a
+plain "Public read" policy or a bare matview grant, drafted as `20260905151000_act_context_tables_anon_revoke.sql`, and
+the five ACT finance definer views drafted as `20260905150000`. Grant alone is not exposure: 288 objects carry an anon
+SELECT grant that RLS blocks, 140 of them private; the page shows those as "grant, RLS blocks", never red.


### PR DESCRIPTION
## What

- `/ops/schema` (admin-gated): the ownership register live. One row per public relation with owner, consumers, size, kind, definer flag and what the anon role can actually read, measured by RLS state (a SELECT grant that RLS blocks reads as \"grant, RLS blocks\", never red). A red count of private-owner objects that are open.
- `scripts/classify-changes.sh` ignores a symlinked `node_modules` in the untracked list (two false VISIBLE verdicts on 2026-09-05).
- CI job `Migration Parity`: runs `check-migration-parity.mjs` (`--strict` on main) once `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are repo secrets; warns until then.
- `/preflight` runs the parity check.
- Two drafts, NOT applied: `20260905150000` (five ACT finance definer views) and `20260905151000` (six ACT context and ops objects with plain public read policies or a matview grant). Readers verified as service-role only.
- CLAUDE.md: the go-live path in five lines.

## Verification

`scripts/precheck.sh` green (tsc + 824 tests). The page query run through the service path returns rows; its first measurement: 42 private objects open, 36 of them consent-gated publishing tables by design, 6 drafted for revoke.