### PR TITLE
Migration Parity: fail only on applied-without-file; drafts warn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,13 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # Fails when the database holds a post-baseline migration with no committed file, and (strict, on main)
-      # when a committed file was never applied. Needs the two repo secrets above; until Ben adds them this
+      # Fails when the database holds a post-baseline migration with no committed file. Committed files not yet
+      # applied are drafts awaiting Ben's verb and only warn (they sit on main legitimately; --strict would make
+      # every main push red until he says apply). Needs the two repo secrets above; until Ben adds them this
       # step reports "skipped" rather than pretending to have checked.
       - name: Parity (folder vs supabase_migrations.schema_migrations)
         if: ${{ env.SUPABASE_SERVICE_ROLE_KEY != '' }}
-        run: node scripts/check-migration-parity.mjs ${{ github.ref == 'refs/heads/main' && '--strict' || '' }}
+        run: node scripts/check-migration-parity.mjs
       - name: Parity skipped (no SUPABASE_SERVICE_ROLE_KEY secret)
         if: ${{ env.SUPABASE_SERVICE_ROLE_KEY == '' }}
         run: echo "::warning::migration parity not checked; add SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY as repo secrets"

--- a/scripts/check-migration-parity.mjs
+++ b/scripts/check-migration-parity.mjs
@@ -36,12 +36,15 @@ const localOnly = [...local.keys()].filter((v) => v >= BASELINE && !remote.has(v
 
 console.log(`tracker: ${remote.size} versions (${preBaseline.length} pre-baseline history) · folder: ${local.size} files`);
 if (remoteOnly.length) {
+  if (process.env.GITHUB_ACTIONS) console.log(`::error title=Migrations applied without a committed file::${remoteOnly.map((v) => `${v} ${remote.get(v)}`).join(', ')}`);
   console.log(`\n✗ ${remoteOnly.length} version(s) applied to the database with NO file in supabase/migrations/:`);
   for (const v of remoteOnly) console.log(`   ${v}  ${remote.get(v)}   ← commit the SQL here with this version, or it is lost`);
 }
 if (localOnly.length) {
   console.log(`\n${STRICT ? '✗' : '·'} ${localOnly.length} file(s) in supabase/migrations/ not yet applied (pending Ben's verb, or applied without db-apply.sh):`);
   for (const v of localOnly) console.log(`   ${local.get(v)}`);
+  // In GitHub Actions, surface pending drafts as annotations so they are visible on the run without failing it.
+  if (process.env.GITHUB_ACTIONS && !STRICT) console.log(`::warning title=Migration drafts pending::${localOnly.map((v) => local.get(v)).join(', ')} committed but not applied; apply with /db-apply`);
 }
 if (!remoteOnly.length && (!localOnly.length || !STRICT)) { console.log(localOnly.length ? '✓ parity: nothing applied is uncommitted (drafts pending)' : '✓ parity: folder and tracker agree on every post-baseline version'); process.exit(0); }
 process.exit(1);


### PR DESCRIPTION
## What

The CI job no longer passes `--strict` on main. Strict fails on committed-but-unapplied files, which is the normal state of a migration waiting for Ben's verb, so every main push would have gone red. The job still fails on the dangerous direction (a version applied to the database with no committed file), now with a GitHub error annotation naming the versions; pending drafts surface as a warning annotation.

## Verification

This PR's own CI run is the first Migration Parity check with the two repo secrets present: expect the job green with a warning listing the two pending drafts (`20260905150000`, `20260905151000`). `scripts/precheck.sh` green locally.