### PR TITLE
Phase 2 option C: private-data exposure gate in preflight and CI, plus the measured plan

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -11,6 +11,7 @@ node --env-file=.env scripts/preflight.mjs
 
 2. Report the results to the user. If any checks fail, suggest fixes:
    - **Database:** Check `.env` has `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`
+   - **Private exposure:** `scripts/check-private-exposure.mjs`. Red names an ACT-owned object the public key can read that is not on the allowlist; close it through `/db-apply` the same day.
    - **Migration parity:** `supabase/migrations/` vs the database tracker. Red means something was applied with no committed file (commit it with the same version); "draft(s) awaiting /db-apply" is normal while Ben has not said apply.
    - **Environment:** List missing env vars and where to get them
    - **Git:** Show uncommitted files, offer to commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Parity (folder vs supabase_migrations.schema_migrations)
         if: ${{ env.SUPABASE_SERVICE_ROLE_KEY != '' }}
         run: node scripts/check-migration-parity.mjs
+      - name: Private exposure (no ACT-owned object open to the public key beyond the allowlist)
+        if: ${{ env.SUPABASE_SERVICE_ROLE_KEY != '' }}
+        run: node scripts/check-private-exposure.mjs
       - name: Parity skipped (no SUPABASE_SERVICE_ROLE_KEY secret)
         if: ${{ env.SUPABASE_SERVICE_ROLE_KEY == '' }}
         run: echo "::warning::migration parity not checked; add SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY as repo secrets"

--- a/scripts/check-private-exposure.mjs
+++ b/scripts/check-private-exposure.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Is anything ACT-private open to the public key?
+ *
+ *   node --env-file=.env scripts/check-private-exposure.mjs
+ *
+ * "Open" is measured by RLS state, the same way /ops/schema measures it, never by grant alone:
+ *   table  : anon has SELECT and (RLS is off, or a PERMISSIVE read policy names anon or public)
+ *   matview: anon has SELECT (matviews have no RLS)
+ *   view   : anon has SELECT and the view is SECURITY DEFINER (runs as postgres, bypasses base RLS)
+ * Scope: objects whose schema_ownership.owner is 'act'. Exit 1 and name anything open that is not in ALLOWLIST.
+ *
+ * Phase 2 option C of the platform review (thoughts/shared/plans/phase2-private-data-boundary.md): the boundary is a gate
+ * until the schema move (option B) makes it structural. A new ACT object is not done until it has a register row; an
+ * object with no row is invisible here, which is why supabase/migrations/README.md requires the row in the same migration.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+// Open on purpose. Each entry carries the policy that opens it and why that is acceptable. Adding here is a decision.
+const ALLOWLIST = {
+  coe_key_people: 'consent-filtered public key-people ("Public can view key people", qual filters rows)',
+  partner_storytellers: 'consent-filtered ("Public can view public storytellers")',
+  pmpp_knowledge: 'published knowledge only ("Active PMPP is viewable by everyone")',
+  newsletter_subscriptions: 'admin-filtered ("Admins can read newsletter subscriptions"); anon sees no rows',
+};
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) { console.error('need SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (run with --env-file=.env)'); process.exit(2); }
+
+const sb = createClient(url, key);
+const { data, error } = await sb.rpc('exec_sql', { query: `
+  SELECT s.object, c.relkind::text AS kind,
+    CASE WHEN c.relkind = 'v' THEN 'definer view' WHEN c.relkind = 'm' THEN 'matview grant' WHEN NOT c.relrowsecurity THEN 'no RLS'
+         ELSE (SELECT string_agg(p.polname, '; ') FROM pg_policy p WHERE p.polrelid = c.oid AND p.polpermissive AND p.polcmd IN ('r','*')
+               AND (p.polroles = '{0}' OR EXISTS (SELECT 1 FROM pg_roles r WHERE r.oid = ANY(p.polroles) AND r.rolname = 'anon'))) END AS why
+  FROM schema_ownership s JOIN pg_class c ON c.relname = s.object JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+  WHERE s.owner = 'act' AND has_table_privilege('anon', c.oid, 'SELECT')
+    AND ( (c.relkind IN ('r','p') AND (NOT c.relrowsecurity OR EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid AND p.polpermissive AND p.polcmd IN ('r','*')
+            AND (p.polroles = '{0}' OR EXISTS (SELECT 1 FROM pg_roles r WHERE r.oid = ANY(p.polroles) AND r.rolname = 'anon')))))
+       OR c.relkind = 'm'
+       OR (c.relkind = 'v' AND coalesce((SELECT option_value FROM pg_options_to_table(c.reloptions) WHERE option_name = 'security_invoker'), 'false') <> 'true') )
+  ORDER BY s.object` });
+if (error) { console.error('exposure query failed:', error.message); process.exit(2); }
+
+const open = data || [];
+const unexpected = open.filter((r) => !(r.object in ALLOWLIST));
+const stale = Object.keys(ALLOWLIST).filter((o) => !open.some((r) => r.object === o));
+console.log(`ACT-owned objects open to the public key: ${open.length} (allowlisted ${open.length - unexpected.length})`);
+if (stale.length) console.log(`· allowlist entries no longer open (prune them): ${stale.join(', ')}`);
+if (unexpected.length) {
+  console.log(`\n✗ ${unexpected.length} ACT-private object(s) open to the public key and NOT allowlisted:`);
+  for (const r of unexpected) console.log(`   ${r.object} (${r.kind}) via ${r.why}`);
+  if (process.env.GITHUB_ACTIONS) console.log(`::error title=ACT-private data open to the public key::${unexpected.map((r) => r.object).join(', ')}`);
+  console.log('\n   close it with a migration through /db-apply (REVOKE from anon, security_invoker, or drop the policy), or add it to ALLOWLIST with a reason.');
+  process.exit(1);
+}
+console.log('✓ nothing ACT-private is open to the public key beyond the allowlist');

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -61,6 +61,18 @@ async function checkMigrationParity() {
   }
 }
 
+async function checkPrivateExposure() {
+  // scripts/check-private-exposure.mjs: no ACT-owned object may be open to the public key beyond its allowlist.
+  try {
+    const out = execSync('node scripts/check-private-exposure.mjs', { cwd: ROOT, encoding: 'utf8', env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    return { ok: true, detail: (out.split('\n').find((l) => l.startsWith('✓')) || out.trim().split('\n')[0] || 'ok').replace(/^✓ /, '') };
+  } catch (e) {
+    const out = (e.stdout || '') + (e.stderr || '');
+    const first = out.split('\n').find((l) => l.trim().startsWith('✗') || l.includes('failed')) || (e.message || '').split('\n')[0];
+    return { ok: false, detail: first.trim() };
+  }
+}
+
 function checkEnv() {
   const required = ['DATABASE_PASSWORD', 'SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'];
   const optional = ['ABN_LOOKUP_GUID', 'OPENAI_API_KEY', 'STRIPE_SECRET_KEY'];
@@ -122,6 +134,7 @@ console.log('\n  GrantScope Preflight Check\n');
 const results = await Promise.all([
   check('Database', checkDb),
   check('Migration parity', checkMigrationParity),
+  check('Private exposure', checkPrivateExposure),
   Promise.resolve(check('Environment', checkEnv)),
   Promise.resolve(check('Git', checkGit)),
   Promise.resolve(check('Port 3003', checkPort)),

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -44,5 +44,6 @@ pre-baseline versions, and resetting those would erase the only record of what t
 - Nothing under `xero_*`, `ghl_*`, `linkedin_*`, `communications_*`, `email_*`, `receipt*`,
   `project_funding_*`, `project_pipelines`, `goods_relationships` is ever granted to `anon`.
 - Functions set `search_path = public, extensions, pg_temp`.
-- `schema_ownership` gets a row for every new object (owner, consumers, evidence) in the same migration.
+- `schema_ownership` gets a row for every new object (owner, consumers, evidence) in the same migration. An ACT-owned object
+  with no row is invisible to `scripts/check-private-exposure.mjs`, which is the gate that keeps private data off the public key.
 - Money surfaces run `/money-audit` before shipping; that is unchanged.

--- a/thoughts/shared/plans/phase2-private-data-boundary.md
+++ b/thoughts/shared/plans/phase2-private-data-boundary.md
@@ -1,0 +1,100 @@
+---
+date: 2026-09-05
+topic: Phase 2 of the Supabase platform review, the private-data boundary
+status: plan, measured; recommendation at the end; nothing applied
+depends_on: thoughts/shared/findings/supabase-platform-review-2026-09-05.md (sections 1, 2, 10)
+---
+
+# Phase 2: put a boundary around ACT's private data
+
+**The question.** The review found ACT's CRM, accounts mirror and inbox living in the same Supabase project as the public
+civic graph, and found them readable with the public key through definer views. Phase 0 and Phase 1 closed every such
+object found (register red count 42 → 31, all 31 consent-gated publishing rows by design). The remaining risk is
+structural: the private data is still one careless view or policy away from the public key. This plan measures what a
+boundary costs in three shapes and recommends one.
+
+All figures measured 2026-09-05 against the live project with `schema_ownership` seeded `[V]`.
+
+## What "ACT private" is, measured
+
+| measure | value |
+|---|---|
+| ACT-owned objects | 235: 170 tables, 64 views, 1 matview, 345 MB |
+| foreign keys from ACT tables into civic tables | 39 (`org_profiles`, `users`, `gs_entities`, `grant_opportunities`, `foundations`, `organizations`, `alma_funding_opportunities`, `public_profiles`, `person_identity_map`, `justicehub_nodes`, …) |
+| foreign keys from civic tables into ACT tables | 0 |
+| ACT views that join civic tables | 13 of 64 (`v_act_organisations`, `v_act_people`, `v_act_pipeline_unified`, `v_act_procurement_buyers`, the seven `v_goods_*`, `v_grant_readiness`, `act_funding_opportunity_current_status`, `task_queue_dashboard`) |
+| code naming ACT objects via `.from()` | grantscope 271 call sites in 84 files; act-global 1,803 call sites in 527 files |
+| `exec_sql` strings naming ACT tables in grantscope | 1,211 mentions |
+| schemas the API exposes | `public` only (`drizzle` holds one Harvest migrations table) |
+| ACT objects open to the public key today | 4, all by design: `coe_key_people`, `partner_storytellers`, `pmpp_knowledge` (consent or approval filtered), `newsletter_subscriptions` (admin-filtered) |
+
+The FKs are the tell: ACT's work-truth tables (Obligations, Communities, Asks' mirrors) reference CivicGraph's tenancy
+(`org_profiles`, `users`) and spine (`gs_entities`, `grant_opportunities`, `foundations`) by design, per ADRs 0003 and 0004.
+The desk is not a separate product bolted onto the civic graph; it is a private lens on it.
+
+## Three shapes, costed
+
+### A. Separate Supabase project (the review's original Phase 2)
+
+Move the 235 objects to their own project. The public project then has one rule, "public read, service-role write".
+
+- **Breaks** all 39 FKs (cross-database FKs do not exist) and the 13 cross views; each becomes an application-side join or a
+  `postgres_fdw` foreign table. Auth splits too: the desk's `org_profiles`/`users` references need either a second auth
+  pool or plain uuids with no referential integrity.
+- **Re-points** ~2,000 call sites across two repos to a second client, plus the 13 edge functions that write ACT tables.
+- **Effort:** a quarter, as estimated in the review, with a dual-running window and a parity check between projects.
+- **Gains:** physical separation; a leak in the civic project cannot reach accounts data; independent compute and backups.
+
+### B. Separate schema inside the same project
+
+Move the 235 objects to a schema `act`. PostgREST exposes only `public` today, so an unexposed `act` schema is unreachable
+through the public key at any URL, and a new schema starts with zero grants to `anon` and `authenticated` (the default
+privileges that hand `public` objects to those roles do not apply elsewhere). FKs and cross views keep working: same database.
+
+- **Keeps** all 39 FKs and the 13 views (views in `public` may read `act` tables; they must be `security_invoker` or the
+  boundary is undone, which the register page already flags).
+- **Re-points** the same ~2,000 `.from()` call sites to `.schema('act')`, or exposes `act` to the API for the service role
+  only (exposure is per schema, not per role, so exposing it re-opens the grant question; prefer `.schema()` on the
+  service client plus RPCs). `exec_sql` strings keep working if its `search_path` gains `act` after `public`.
+- **Effort:** two to three weeks, table family by table family (xero, ghl, comms, receipts, project knowledge, goods), each
+  move a migration through `/db-apply` with the parity check; the desk's reads move with each family.
+- **Gains:** private by default, no auth split, no FK rework. Loses: none of the physical-separation benefits of A.
+
+### C. Guardrail only, no move
+
+Keep the tables where they are; make the boundary a check that fails the build: no ACT-owned object may be open to the
+public key beyond a named allowlist (the four above). Run it in `/preflight` and in CI next to Migration Parity, off the same
+query `/ops/schema` renders.
+
+- **Breaks** nothing, re-points nothing. **Effort:** a day. **Gains:** the class of leak found on 2026-09-05 is caught the
+  day it is reintroduced instead of months later. Loses: the data is still one revoked check away from exposure, and every
+  new ACT table needs a register row for the check to see it (the migrations README already requires that).
+
+## Recommendation
+
+**C now, B folded into Phase 3, A not unless a compliance or blast-radius reason appears.**
+
+- C is cheap, honest and enforceable this week, and it turns the register from a page into a gate.
+- B is the right end state for one project shared by six repos: private by default instead of private by vigilance. Its
+  cost is dominated by re-pointing call sites, which Phase 3 (named SQL instead of `exec_sql` strings, typed RPCs) touches
+  anyway; doing the schema move family by family inside that work costs little extra and removes the vigilance dependency.
+- A's benefits (separate compute, backups, physical isolation) are real but nothing in the review needed them, and its
+  cost lands on the FKs that encode ADRs 0003 and 0004. Revisit if ACT's accounts data needs its own retention or access
+  regime, or if a funder or auditor asks where the data lives.
+
+## What C needs (the next slice)
+
+1. `scripts/check-private-exposure.mjs`: the `/ops/schema` state query filtered to `owner = 'act'` and open, minus the
+   allowlist; exit 1 with the names on anything new. Allowlist lives in the script with the reason for each entry.
+2. Run it in `/preflight` and as a step in the CI `Migration Parity` job (same secrets).
+3. One line in `supabase/migrations/README.md`: a new ACT table or view is not done until the register has its row and the
+   check is green.
+
+## What B needs when Phase 3 starts
+
+1. `CREATE SCHEMA act;` with no grants beyond `service_role`; `exec_sql` search_path `public, act, extensions, pg_temp`.
+2. Per family: `ALTER TABLE ... SET SCHEMA act;` (FKs and views follow automatically), re-point that family's `.from()`
+   calls to `.schema('act')`, run parity and the exposure check, ship.
+3. Views in `public` that read `act` tables stay `security_invoker`; the register page shows any definer view over `act`
+   as red.
+4. Edge functions `ghl-webhook` and `intake` write ACT tables and move with the ghl and intake families.


### PR DESCRIPTION
## What

- `scripts/check-private-exposure.mjs`: fails when any ACT-owned object is open to the public key (measured by RLS state, as `/ops/schema` does) beyond a four-entry allowlist that names the policy and reason for each. Runs in `/preflight` and as a step in the CI `Migration Parity` job.
- `thoughts/shared/plans/phase2-private-data-boundary.md`: three shapes for the boundary, costed with live measurements (235 ACT objects, 39 FKs into the civic spine, 13 cross views, ~2,000 call sites). Recommends the gate now, a schema move folded into Phase 3, a project split only on a compliance reason.
- README and preflight skill lines.

## Verification

Guardrail against live: 4 open, 4 allowlisted, exit 0. `scripts/precheck.sh` green.