### PR TITLE
Search: /api/global-search reads the one index; structured fields and postcode rows

### DIFF
--- a/apps/web/src/app/api/global-search/route.ts
+++ b/apps/web/src/app/api/global-search/route.ts
@@ -1,128 +1,82 @@
-import { getServiceSupabase } from '@/lib/supabase';
-import { NextRequest, NextResponse } from 'next/server';
-import * as EntityService from '@/lib/services/entity-service';
-import * as GrantService from '@/lib/services/grant-service';
-import * as FoundationService from '@/lib/services/foundation-service';
+import { NextResponse, type NextRequest } from 'next/server';
+import { parseSearchQuery, searchIndex, type SearchHit } from '@/lib/search/search-index';
 
 export const dynamic = 'force-dynamic';
 
-const FUNDING_SEARCH_TERMS =
-  /\b(grant|grants|fund|funding|foundation|foundations|program|programs|fellowship|fellowships|award|awards|scholarship|scholarships|philanthropy|philanthropic)\b/i;
+/**
+ * /api/global-search — the live lanes behind the header search and the /search page.
+ *
+ * Until 2026-09-05 this ran five separate lanes (entities, grants, foundations, people via ILIKE on
+ * mv_board_interlocks, places via postcode_geo), each with its own statement-timeout risk. It now makes ONE call to
+ * search_index_query over mv_search_index and sorts the hits into the five shapes the client already renders, so the
+ * page did not change. Council-area rows (kind "place") have no lane in this client yet and are left out here;
+ * /api/search/index serves every kind.
+ *
+ * scope=full is the /search page (every lane). Any other scope is the header box: entities and grants only.
+ */
+const ENTITY_KINDS = new Set(['charity', 'company', 'indigenous_corp', 'government_body', 'program', 'social_enterprise', 'intervention']);
+const LANE_CAP = 8;
 
 export async function GET(req: NextRequest) {
+  const sp = req.nextUrl.searchParams;
+  const fullScope = sp.get('scope') === 'full';
+  const query = parseSearchQuery({ q: sp.get('q'), state: sp.get('state'), limit: '60' });
+  if (!query) return NextResponse.json({ entities: [], foundations: [], grants: [], people: [], places: [] });
 
-  const q = req.nextUrl.searchParams.get('q')?.trim();
-  const limit = Math.min(Number(req.nextUrl.searchParams.get('limit') || 20), 50);
-  // scope=full is the /search page: every live lane runs, no wording heuristics.
-  // The default (typeahead) path keeps its fast-path gating.
-  const fullScope = req.nextUrl.searchParams.get('scope') === 'full';
-
-  if (!q || q.length < 2) {
-    return NextResponse.json({ entities: [], grants: [] });
+  let hits: SearchHit[];
+  try {
+    hits = await searchIndex(query);
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 });
   }
 
-  const db = getServiceSupabase();
+  const take = (pred: (h: SearchHit) => boolean) => hits.filter(pred).slice(0, LANE_CAP);
 
-  // Entity lookup is the homepage typeahead's fast path. Broad ILIKE scans over
-  // grants/foundations can hit database statement timeouts, so only search those
-  // lanes when the wording suggests a funding query.
-  const entityResults = await EntityService.search(db, q, Math.min(limit, 10));
-  const shouldSearchFunding = fullScope || FUNDING_SEARCH_TERMS.test(q);
-  const [grantResults, foundationResults, peopleResults, placeResults] = await Promise.all([
-    shouldSearchFunding ? GrantService.search(db, q, 5) : Promise.resolve({ data: [], error: null }),
-    shouldSearchFunding ? FoundationService.search(db, q, 5) : Promise.resolve({ data: [], error: null }),
-    fullScope ? searchPeople(db, q) : Promise.resolve([]),
-    fullScope ? searchPlaces(db, q) : Promise.resolve([]),
-  ]);
+  const entities = take((h) => ENTITY_KINDS.has(h.kind)).map((h) => ({
+    id: h.id,
+    name: h.name,
+    entityType: h.kind.replace(/_/g, ' '),
+    abn: h.abn,
+    state: h.state,
+    sourceCount: h.source_count ?? 0,
+    revenue: h.money_in,
+    href: h.href ?? `/entity/${encodeURIComponent(h.id)}`,
+  }));
+  const grants = take((h) => h.kind === 'grant_round').map((h) => ({
+    id: h.id,
+    name: h.name,
+    amountMin: h.amount_min,
+    amountMax: h.money_in,
+    closesAt: h.closes_at,
+    programType: h.sector,
+    source: h.meta,
+    href: h.href ?? `/grants/${h.id}`,
+  }));
+  if (!fullScope) return NextResponse.json({ entities, grants });
 
-  const entities = (entityResults.data).map((e, i) => {
-    const sourceWeight = Math.min(e.source_count ?? 0, 5);
-    return {
-      type: 'entity' as const,
-      id: e.gs_id,
-      name: e.canonical_name,
-      entityType: e.entity_type,
-      abn: e.abn,
-      state: e.state,
-      sourceCount: e.source_count,
-      revenue: e.latest_revenue,
-      relationships: 0,
-      systems: [] as string[],
-      href: `/entities/${e.gs_id}`,
-      // Keep the typeahead response lean; detail pages can load relationship stats.
-      _score: (entityResults.data.length - i) + sourceWeight,
-    };
-  });
-
-  // Re-sort: boost entities with more cross-system data to the top
-  entities.sort((a, b) => b._score - a._score);
-
-  // Filter out foundations already represented in entities (by ABN match)
-  const entityAbns = new Set(entities.map(e => e.abn).filter(Boolean));
-  const foundations = (foundationResults.data)
-    .filter(f => !entityAbns.has(f.acnc_abn))
-    .map(f => ({
-      type: 'foundation' as const,
-      id: f.id,
-      name: f.name,
-      foundationType: f.type,
-      abn: f.acnc_abn,
-      totalGiving: f.total_giving_annual,
-      focus: f.thematic_focus,
-      href: `/foundations/${f.id}`,
-    }));
-
-  const grants = (grantResults.data).map(g => ({
-    type: 'grant' as const,
-    id: g.id,
-    name: g.name,
-    amountMin: g.amount_min,
-    amountMax: g.amount_max,
-    closesAt: g.closes_at,
-    programType: g.program_type,
-    source: g.source,
-    href: `/grants/${g.id}`,
+  const foundations = take((h) => h.kind === 'foundation').map((h) => ({
+    id: h.id,
+    name: h.name,
+    abn: h.abn,
+    totalGiving: h.money_out,
+    focus: h.sector ? h.sector.split(', ').filter(Boolean) : null,
+    href: h.href ?? `/foundations/${h.id}`,
+  }));
+  const people = take((h) => h.kind === 'person').map((h) => ({
+    name: h.name,
+    boardCount: h.source_count ?? 0,
+    href: h.href ?? `/person/${encodeURIComponent(h.name)}`,
+  }));
+  const places = take((h) => h.kind === 'postcode').map((h) => ({
+    postcode: h.postcode ?? '',
+    locality: h.place,
+    state: h.state,
+    lga: null as string | null,
+    href: h.href ?? `/places/${h.postcode}`,
   }));
 
-  return NextResponse.json({ entities, foundations, grants, people: peopleResults, places: placeResults });
-}
-
-type Db = ReturnType<typeof getServiceSupabase>;
-
-async function searchPeople(db: Db, q: string) {
-  const { data } = await db
-    .from('mv_board_interlocks')
-    .select('person_name_display, board_count, interlock_score')
-    .ilike('person_name_display', `%${q}%`)
-    .order('interlock_score', { ascending: false, nullsFirst: false })
-    .limit(5);
-  return (data ?? []).map(p => ({
-    type: 'person' as const,
-    name: p.person_name_display,
-    boardCount: p.board_count,
-    // /person/[name] decodes dashes back to spaces before normalising.
-    href: `/person/${encodeURIComponent(p.person_name_display.replace(/\s+/g, '-'))}`,
-  }));
-}
-
-async function searchPlaces(db: Db, q: string) {
-  const isPostcode = /^\d{2,4}$/.test(q);
-  let query = db.from('postcode_geo').select('postcode, locality, state, lga_name').limit(24);
-  query = isPostcode ? query.like('postcode', `${q}%`) : query.ilike('locality', `%${q}%`);
-  const { data } = await query;
-  // postcode_geo is one row per locality; a place result is a postcode. Some rows carry a
-  // junk locality equal to the postcode itself — prefer a real name when one exists.
-  const byPostcode = new Map<string, { postcode: string; locality: string | null; state: string | null; lga: string | null }>();
-  for (const row of data ?? []) {
-    const locality = row.locality && row.locality !== row.postcode ? row.locality : null;
-    const existing = byPostcode.get(row.postcode);
-    if (!existing || (!existing.locality && locality)) {
-      byPostcode.set(row.postcode, { postcode: row.postcode, locality, state: row.state, lga: row.lga_name });
-    }
-  }
-  return Array.from(byPostcode.values()).slice(0, 5).map(p => ({
-    type: 'place' as const,
-    ...p,
-    href: `/places/${p.postcode}`,
-  }));
+  return NextResponse.json(
+    { entities, foundations, grants, people, places },
+    { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600' } },
+  );
 }

--- a/apps/web/src/lib/search/search-index.test.ts
+++ b/apps/web/src/lib/search/search-index.test.ts
@@ -24,6 +24,7 @@ describe('parseSearchQuery — untrusted input into what the RPC accepts', () =>
   it('lists every kind the index carries', () => {
     expect(SEARCH_KINDS).toContain('grant_round');
     expect(SEARCH_KINDS).toContain('place');
-    expect(SEARCH_KINDS.length).toBe(11);
+    expect(SEARCH_KINDS).toContain('postcode');
+    expect(SEARCH_KINDS.length).toBe(12);
   });
 });

--- a/apps/web/src/lib/search/search-index.ts
+++ b/apps/web/src/lib/search/search-index.ts
@@ -17,6 +17,7 @@ export const SEARCH_KINDS = [
   'person',
   'place',
   'intervention',
+  'postcode',
 ] as const;
 export type SearchKind = (typeof SEARCH_KINDS)[number];
 
@@ -32,6 +33,7 @@ export const KIND_LABEL: Record<SearchKind, string> = {
   person: 'Person',
   place: 'Council area',
   intervention: 'Intervention',
+  postcode: 'Postcode',
 };
 
 export type SearchHit = {
@@ -47,6 +49,10 @@ export type SearchHit = {
   tier: string | null;
   meta: string | null;
   href: string | null;
+  source_count: number | null; // organisations: source systems; people: boards; areas and postcodes: organisations
+  closes_at: string | null; // grant rounds only
+  amount_min: number | null; // grant rounds only
+  postcode: string | null; // postcode rows and social enterprises
   score: number;
 };
 

--- a/supabase/migrations/20260905162000_mv_search_index_structured_fields.sql
+++ b/supabase/migrations/20260905162000_mv_search_index_structured_fields.sql
@@ -1,0 +1,151 @@
+-- 20260905162000_mv_search_index_structured_fields.sql
+-- Third build of the index in one afternoon, and the last for a while: the /search client renders entities with a source
+-- count, grant rounds with a close date and amount, and places keyed by postcode. This adds source_count (mv_gs_entity_stats
+-- for organisations, board_count for people, entity_count for areas), closes_at and amount_min for grant rounds, a postcode
+-- column, and a twelfth kind: postcode rows from mv_funding_by_postcode (7,209) linking to /places/{postcode}. The RPC's
+-- return type changes, and CREATE OR REPLACE cannot change a return type, so it is dropped and recreated.
+BEGIN;
+DROP MATERIALIZED VIEW IF EXISTS public.mv_search_index;
+CREATE MATERIALIZED VIEW public.mv_search_index AS
+WITH ent AS (
+  SELECT e.entity_type AS kind, e.gs_id AS id, e.canonical_name AS name, e.abn, e.state, e.lga_name AS place, e.sector,
+         coalesce(f.grants_total, 0) + coalesce(f.contracts_total, 0) AS money_in, NULL::numeric AS money_out,
+         CASE WHEN e.is_community_controlled THEN 'community-controlled' END AS tier,
+         nullif(concat_ws(' · ', nullif(e.remoteness, ''), CASE WHEN f.grand_total_records > 0 THEN f.grand_total_records || ' funding records' END), '') AS meta,
+         '/entity/' || e.gs_id AS href,
+         st.source_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM gs_entities e
+  LEFT JOIN mv_entity_total_funding f ON f.entity_id = e.id
+  -- mv_gs_entity_stats carries 412k rows for 609k entities and is not guaranteed one row per id; take the max per id
+  LEFT JOIN (SELECT id, max(source_count) AS source_count FROM mv_gs_entity_stats GROUP BY id) st ON st.id = e.id
+  WHERE e.entity_type IN ('charity', 'company', 'indigenous_corp', 'government_body', 'program')
+),
+se AS (
+  SELECT 'social_enterprise' AS kind, s.se_id::text AS id, s.name, s.abn, s.state, s.city AS place, s.sectors_text AS sector,
+         coalesce(s.contract_value, 0) AS money_in, NULL::numeric AS money_out, s.verification_tier AS tier,
+         nullif(concat_ws(' · ', CASE WHEN s.contract_count > 0 THEN s.contract_count || ' contracts' END, CASE WHEN s.buyer_count > 0 THEN s.buyer_count || ' buyers' END), '') AS meta,
+         '/social-enterprises/' || s.se_id AS href,
+         NULL::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, s.postcode
+  FROM se_search_index s
+),
+fnd AS (
+  SELECT 'foundation' AS kind, f.id::text AS id, f.name, f.acnc_abn AS abn, NULL::text AS state, NULL::text AS place,
+         array_to_string(f.thematic_focus, ', ') AS sector, NULL::numeric AS money_in, f.total_giving_annual AS money_out,
+         f.profile_confidence AS tier,
+         nullif(concat_ws(' · ', f.type, CASE WHEN f.avg_grant_size > 0 THEN 'avg grant $' || round(f.avg_grant_size)::text END), '') AS meta,
+         '/foundations/' || f.id AS href,
+         NULL::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM foundations f
+),
+grants AS (
+  SELECT 'grant_round' AS kind, g.id::text AS id, g.name, NULL::text AS abn, NULL::text AS state, NULL::text AS place,
+         array_to_string(g.categories, ', ') AS sector, g.amount_max::numeric AS money_in, NULL::numeric AS money_out,
+         g.application_status AS tier,
+         nullif(concat_ws(' · ', g.provider, CASE WHEN g.closes_at IS NOT NULL THEN 'closes ' || to_char(g.closes_at, 'DD Mon YYYY') END), '') AS meta,
+         '/grants/' || g.id AS href,
+         NULL::integer AS source_count, g.closes_at, g.amount_min::numeric AS amount_min, NULL::text AS postcode
+  FROM grant_opportunities g
+  WHERE g.closes_at IS NULL OR g.closes_at >= current_date
+),
+ppl AS (
+  SELECT 'person' AS kind, b.person_name_normalised AS id, b.person_name_display AS name, NULL::text AS abn, NULL::text AS state, NULL::text AS place,
+         array_to_string(b.organisations[1:3], ', ') AS sector,
+         coalesce(b.total_procurement_dollars, 0) + coalesce(b.total_justice_dollars, 0) AS money_in, coalesce(b.total_donation_dollars, 0) AS money_out,
+         CASE WHEN b.connects_community_controlled THEN 'connects community-controlled' END AS tier,
+         b.board_count || ' boards' AS meta,
+         '/person/' || regexp_replace(b.person_name_display, '\s', '%20', 'g') AS href,
+         b.board_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM mv_board_interlocks b
+),
+plc AS (
+  -- mv_funding_by_lga is not one row per council (1,725 rows, 1,030 distinct code+state on 2026-09-05): take the most
+  -- complete row per council name and state rather than summing, which would double-count re-ingested rows.
+  SELECT 'place' AS kind,
+         trim(both '-' from regexp_replace(lower(l.lga_name), '[^a-z0-9]+', '-', 'g')) || '-' || lower(coalesce(l.state, 'xx')) AS id,
+         trim(l.lga_name) AS name, NULL::text AS abn, upper(l.state) AS state, trim(l.lga_name) AS place, NULL::text AS sector,
+         l.total_funding AS money_in, NULL::numeric AS money_out,
+         CASE WHEN l.avg_seifa_decile IS NOT NULL THEN 'SEIFA decile ' || round(l.avg_seifa_decile)::text END AS tier,
+         l.entity_count || ' organisations · ' || l.community_controlled_count || ' community-controlled' AS meta,
+         '/place/council/' || trim(both '-' from regexp_replace(lower(l.lga_name), '[^a-z0-9]+', '-', 'g')) AS href,
+         l.entity_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM (
+    -- keys normalised: the same council appears with case and whitespace variants ("Cardinia" x3 for VIC)
+    SELECT DISTINCT ON (lower(trim(lga_name)), lower(coalesce(state, ''))) * FROM mv_funding_by_lga l0
+    WHERE lga_name IS NOT NULL
+      -- a council row with no state is a duplicate whenever the same name exists with a state (430 of 432 on 2026-09-05)
+      AND (state IS NOT NULL OR NOT EXISTS (SELECT 1 FROM mv_funding_by_lga l1 WHERE l1.state IS NOT NULL AND lower(trim(l1.lga_name)) = lower(trim(l0.lga_name))))
+    ORDER BY lower(trim(lga_name)), lower(coalesce(state, '')), entity_count DESC NULLS LAST, total_funding DESC NULLS LAST
+  ) l
+),
+alma AS (
+  SELECT 'intervention' AS kind, a.id::text AS id, a.name, NULL::text AS abn, NULL::text AS state, array_to_string(a.geography[1:2], ', ') AS place,
+         a.type AS sector, NULL::numeric AS money_in, NULL::numeric AS money_out, a.evidence_level AS tier,
+         nullif(concat_ws(' · ', a.operating_organization, CASE WHEN a.years_operating > 0 THEN a.years_operating || ' years' END), '') AS meta,
+         CASE WHEN a.gs_entity_id IS NOT NULL THEN '/entity/' || e.gs_id END AS href,
+         NULL::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM alma_interventions a LEFT JOIN gs_entities e ON e.id = a.gs_entity_id
+  WHERE a.review_status = 'Published'
+),
+pcd AS (
+  SELECT 'postcode' AS kind, p.postcode || '-' || lower(coalesce(p.state, 'xx')) AS id,
+         p.postcode || CASE WHEN p.locality IS NOT NULL THEN ' ' || initcap(p.locality) ELSE '' END AS name,
+         NULL::text AS abn, upper(p.state) AS state, initcap(p.locality) AS place, NULL::text AS sector,
+         p.total_funding AS money_in, NULL::numeric AS money_out,
+         CASE WHEN p.seifa_irsd_decile IS NOT NULL THEN 'SEIFA decile ' || p.seifa_irsd_decile END AS tier,
+         nullif(concat_ws(' · ', nullif(p.remoteness, ''), p.entity_count || ' organisations'), '') AS meta,
+         '/places/' || p.postcode AS href,
+         p.entity_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, p.postcode
+  FROM (
+    SELECT DISTINCT ON (postcode, lower(coalesce(state, ''))) * FROM mv_funding_by_postcode
+    ORDER BY postcode, lower(coalesce(state, '')), entity_count DESC NULLS LAST
+  ) p
+  WHERE p.postcode ~ '^\d{4}$'
+),
+u AS (
+  SELECT * FROM ent UNION ALL SELECT * FROM se UNION ALL SELECT * FROM fnd UNION ALL SELECT * FROM grants
+  UNION ALL SELECT * FROM ppl UNION ALL SELECT * FROM plc UNION ALL SELECT * FROM alma UNION ALL SELECT * FROM pcd
+)
+SELECT u.kind, u.id, u.name, u.abn, u.state, u.place, u.sector, u.money_in, u.money_out, u.tier, u.meta, u.href,
+       u.source_count, u.closes_at, u.amount_min, u.postcode,
+       to_tsvector('simple', concat_ws(' ', u.name, u.sector, u.place, u.abn, u.meta, u.postcode)) AS tsv,
+       now() AS built_at
+FROM u
+WHERE u.name IS NOT NULL AND length(trim(u.name)) > 1;
+
+CREATE UNIQUE INDEX mv_search_index_kind_id ON public.mv_search_index (kind, id);
+CREATE INDEX mv_search_index_name_trgm ON public.mv_search_index USING gin (name extensions.gin_trgm_ops);
+CREATE INDEX mv_search_index_tsv ON public.mv_search_index USING gin (tsv);
+CREATE INDEX mv_search_index_kind_state ON public.mv_search_index (kind, state);
+CREATE INDEX mv_search_index_abn ON public.mv_search_index (abn) WHERE abn IS NOT NULL;
+
+REVOKE ALL ON public.mv_search_index FROM anon, authenticated;
+GRANT SELECT ON public.mv_search_index TO service_role;
+
+DROP FUNCTION IF EXISTS public.search_index_query(text, text[], text, integer);
+CREATE FUNCTION public.search_index_query(q text, kinds text[] DEFAULT NULL, p_state text DEFAULT NULL, p_limit integer DEFAULT 20)
+RETURNS TABLE (kind text, id text, name text, abn text, state text, place text, sector text, money_in numeric, money_out numeric, tier text, meta text, href text,
+               source_count integer, closes_at date, amount_min numeric, postcode text, score real)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH p AS (
+    SELECT trim(q) AS raw, lower(trim(q)) AS lq, regexp_replace(q, '\s', '', 'g') AS digits,
+           websearch_to_tsquery('simple', q) AS tsq
+  )
+  SELECT s.kind, s.id, s.name, s.abn, s.state, s.place, s.sector, s.money_in, s.money_out, s.tier, s.meta, s.href,
+         s.source_count, s.closes_at, s.amount_min, s.postcode,
+         (CASE WHEN lower(s.name) = p.lq THEN 3.0 WHEN lower(s.name) LIKE p.lq || '%' THEN 2.0
+               WHEN s.abn = p.digits THEN 3.0 WHEN s.postcode = p.digits THEN 3.0 ELSE 0.0 END
+          + similarity(s.name, p.raw) + ts_rank(s.tsv, p.tsq))::real AS score
+  FROM public.mv_search_index s, p
+  WHERE length(p.raw) >= 2
+    AND (kinds IS NULL OR s.kind = ANY (kinds))
+    -- a state filter keeps rows without a state (national grant rounds, foundations, people): they apply everywhere
+    AND (p_state IS NULL OR s.state = p_state OR s.state IS NULL)
+    AND (s.name % p.raw OR s.tsv @@ p.tsq OR (p.digits ~ '^\d{11}$' AND s.abn = p.digits) OR (p.digits ~ '^\d{4}$' AND s.postcode = p.digits))
+  ORDER BY score DESC, s.money_in DESC NULLS LAST, s.name
+  LIMIT greatest(1, least(coalesce(p_limit, 20), 100));
+$$;
+REVOKE ALL ON FUNCTION public.search_index_query(text, text[], text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.search_index_query(text, text[], text, integer) TO anon, authenticated, service_role;
+COMMIT;

--- a/supabase/migrations/20260905163000_search_index_query_rank_postcode.sql
+++ b/supabase/migrations/20260905163000_search_index_query_rank_postcode.sql
@@ -1,0 +1,31 @@
+-- 20260905163000_search_index_query_rank_postcode.sql
+-- Ranking only (same return type, so CREATE OR REPLACE is fine): a four-digit query puts the postcode row itself first,
+-- then the organisations in it; an eleven-digit query puts the ABN owner first. Measured 2026-09-05: '0870' ranked three
+-- social enterprises in 0870 above "0870 Alice Springs".
+BEGIN;
+CREATE OR REPLACE FUNCTION public.search_index_query(q text, kinds text[] DEFAULT NULL, p_state text DEFAULT NULL, p_limit integer DEFAULT 20)
+RETURNS TABLE (kind text, id text, name text, abn text, state text, place text, sector text, money_in numeric, money_out numeric, tier text, meta text, href text,
+               source_count integer, closes_at date, amount_min numeric, postcode text, score real)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH p AS (
+    SELECT trim(q) AS raw, lower(trim(q)) AS lq, regexp_replace(q, '\s', '', 'g') AS digits,
+           websearch_to_tsquery('simple', q) AS tsq
+  )
+  SELECT s.kind, s.id, s.name, s.abn, s.state, s.place, s.sector, s.money_in, s.money_out, s.tier, s.meta, s.href,
+         s.source_count, s.closes_at, s.amount_min, s.postcode,
+         (CASE WHEN lower(s.name) = p.lq THEN 3.0 WHEN lower(s.name) LIKE p.lq || '%' THEN 2.0
+               WHEN s.abn = p.digits THEN 3.0
+               WHEN s.postcode = p.digits AND s.kind = 'postcode' THEN 3.5
+               WHEN s.postcode = p.digits THEN 2.5 ELSE 0.0 END
+          + similarity(s.name, p.raw) + ts_rank(s.tsv, p.tsq))::real AS score
+  FROM public.mv_search_index s, p
+  WHERE length(p.raw) >= 2
+    AND (kinds IS NULL OR s.kind = ANY (kinds))
+    AND (p_state IS NULL OR s.state = p_state OR s.state IS NULL)
+    AND (s.name % p.raw OR s.tsv @@ p.tsq OR (p.digits ~ '^\d{11}$' AND s.abn = p.digits) OR (p.digits ~ '^\d{4}$' AND s.postcode = p.digits))
+  ORDER BY score DESC, s.money_in DESC NULLS LAST, s.name
+  LIMIT greatest(1, least(coalesce(p_limit, 20), 100));
+$$;
+COMMIT;

--- a/supabase/migrations/20260905164000_mv_search_index_postcode_rows_and_rank.sql
+++ b/supabase/migrations/20260905164000_mv_search_index_postcode_rows_and_rank.sql
@@ -1,0 +1,158 @@
+-- 20260905164000_mv_search_index_postcode_rows_and_rank.sql
+-- Fourth and final build for the day. Postcode rows: one per postcode, ABS-style locality label. Ranking: greatest
+-- applicable bonus instead of first-branch-wins. Same RPC return type as 20260905162000, so CREATE OR REPLACE.
+BEGIN;
+DROP MATERIALIZED VIEW IF EXISTS public.mv_search_index;
+CREATE MATERIALIZED VIEW public.mv_search_index AS
+WITH ent AS (
+  SELECT e.entity_type AS kind, e.gs_id AS id, e.canonical_name AS name, e.abn, e.state, e.lga_name AS place, e.sector,
+         coalesce(f.grants_total, 0) + coalesce(f.contracts_total, 0) AS money_in, NULL::numeric AS money_out,
+         CASE WHEN e.is_community_controlled THEN 'community-controlled' END AS tier,
+         nullif(concat_ws(' · ', nullif(e.remoteness, ''), CASE WHEN f.grand_total_records > 0 THEN f.grand_total_records || ' funding records' END), '') AS meta,
+         '/entity/' || e.gs_id AS href,
+         st.source_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM gs_entities e
+  LEFT JOIN mv_entity_total_funding f ON f.entity_id = e.id
+  -- mv_gs_entity_stats carries 412k rows for 609k entities and is not guaranteed one row per id; take the max per id
+  LEFT JOIN (SELECT id, max(source_count) AS source_count FROM mv_gs_entity_stats GROUP BY id) st ON st.id = e.id
+  WHERE e.entity_type IN ('charity', 'company', 'indigenous_corp', 'government_body', 'program')
+),
+se AS (
+  SELECT 'social_enterprise' AS kind, s.se_id::text AS id, s.name, s.abn, s.state, s.city AS place, s.sectors_text AS sector,
+         coalesce(s.contract_value, 0) AS money_in, NULL::numeric AS money_out, s.verification_tier AS tier,
+         nullif(concat_ws(' · ', CASE WHEN s.contract_count > 0 THEN s.contract_count || ' contracts' END, CASE WHEN s.buyer_count > 0 THEN s.buyer_count || ' buyers' END), '') AS meta,
+         '/social-enterprises/' || s.se_id AS href,
+         NULL::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, s.postcode
+  FROM se_search_index s
+),
+fnd AS (
+  SELECT 'foundation' AS kind, f.id::text AS id, f.name, f.acnc_abn AS abn, NULL::text AS state, NULL::text AS place,
+         array_to_string(f.thematic_focus, ', ') AS sector, NULL::numeric AS money_in, f.total_giving_annual AS money_out,
+         f.profile_confidence AS tier,
+         nullif(concat_ws(' · ', f.type, CASE WHEN f.avg_grant_size > 0 THEN 'avg grant $' || round(f.avg_grant_size)::text END), '') AS meta,
+         '/foundations/' || f.id AS href,
+         NULL::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM foundations f
+),
+grants AS (
+  SELECT 'grant_round' AS kind, g.id::text AS id, g.name, NULL::text AS abn, NULL::text AS state, NULL::text AS place,
+         array_to_string(g.categories, ', ') AS sector, g.amount_max::numeric AS money_in, NULL::numeric AS money_out,
+         g.application_status AS tier,
+         nullif(concat_ws(' · ', g.provider, CASE WHEN g.closes_at IS NOT NULL THEN 'closes ' || to_char(g.closes_at, 'DD Mon YYYY') END), '') AS meta,
+         '/grants/' || g.id AS href,
+         NULL::integer AS source_count, g.closes_at, g.amount_min::numeric AS amount_min, NULL::text AS postcode
+  FROM grant_opportunities g
+  WHERE g.closes_at IS NULL OR g.closes_at >= current_date
+),
+ppl AS (
+  SELECT 'person' AS kind, b.person_name_normalised AS id, b.person_name_display AS name, NULL::text AS abn, NULL::text AS state, NULL::text AS place,
+         array_to_string(b.organisations[1:3], ', ') AS sector,
+         coalesce(b.total_procurement_dollars, 0) + coalesce(b.total_justice_dollars, 0) AS money_in, coalesce(b.total_donation_dollars, 0) AS money_out,
+         CASE WHEN b.connects_community_controlled THEN 'connects community-controlled' END AS tier,
+         b.board_count || ' boards' AS meta,
+         '/person/' || regexp_replace(b.person_name_display, '\s', '%20', 'g') AS href,
+         b.board_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM mv_board_interlocks b
+),
+plc AS (
+  -- mv_funding_by_lga is not one row per council (1,725 rows, 1,030 distinct code+state on 2026-09-05): take the most
+  -- complete row per council name and state rather than summing, which would double-count re-ingested rows.
+  SELECT 'place' AS kind,
+         trim(both '-' from regexp_replace(lower(l.lga_name), '[^a-z0-9]+', '-', 'g')) || '-' || lower(coalesce(l.state, 'xx')) AS id,
+         trim(l.lga_name) AS name, NULL::text AS abn, upper(l.state) AS state, trim(l.lga_name) AS place, NULL::text AS sector,
+         l.total_funding AS money_in, NULL::numeric AS money_out,
+         CASE WHEN l.avg_seifa_decile IS NOT NULL THEN 'SEIFA decile ' || round(l.avg_seifa_decile)::text END AS tier,
+         l.entity_count || ' organisations · ' || l.community_controlled_count || ' community-controlled' AS meta,
+         '/place/council/' || trim(both '-' from regexp_replace(lower(l.lga_name), '[^a-z0-9]+', '-', 'g')) AS href,
+         l.entity_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM (
+    -- keys normalised: the same council appears with case and whitespace variants ("Cardinia" x3 for VIC)
+    SELECT DISTINCT ON (lower(trim(lga_name)), lower(coalesce(state, ''))) * FROM mv_funding_by_lga l0
+    WHERE lga_name IS NOT NULL
+      -- a council row with no state is a duplicate whenever the same name exists with a state (430 of 432 on 2026-09-05)
+      AND (state IS NOT NULL OR NOT EXISTS (SELECT 1 FROM mv_funding_by_lga l1 WHERE l1.state IS NOT NULL AND lower(trim(l1.lga_name)) = lower(trim(l0.lga_name))))
+    ORDER BY lower(trim(lga_name)), lower(coalesce(state, '')), entity_count DESC NULLS LAST, total_funding DESC NULLS LAST
+  ) l
+),
+alma AS (
+  SELECT 'intervention' AS kind, a.id::text AS id, a.name, NULL::text AS abn, NULL::text AS state, array_to_string(a.geography[1:2], ', ') AS place,
+         a.type AS sector, NULL::numeric AS money_in, NULL::numeric AS money_out, a.evidence_level AS tier,
+         nullif(concat_ws(' · ', a.operating_organization, CASE WHEN a.years_operating > 0 THEN a.years_operating || ' years' END), '') AS meta,
+         CASE WHEN a.gs_entity_id IS NOT NULL THEN '/entity/' || e.gs_id END AS href,
+         NULL::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, NULL::text AS postcode
+  FROM alma_interventions a LEFT JOIN gs_entities e ON e.id = a.gs_entity_id
+  WHERE a.review_status = 'Published'
+),
+pcd AS (
+  -- One row per postcode (postcodes are national; a second state on the same postcode is a placement error, keep the fullest
+  -- row). Label with the ABS-style locality from postcode_geo (upper-case, alphabetic, first alphabetically) rather than the
+  -- matview's own locality column, which carries mixed-case junk ("Charles" for 0870).
+  SELECT 'postcode' AS kind, p.postcode || '-au' AS id,
+         p.postcode || CASE WHEN loc.locality IS NOT NULL THEN ' ' || initcap(loc.locality) ELSE '' END AS name,
+         NULL::text AS abn, upper(p.state) AS state, initcap(coalesce(loc.locality, nullif(p.locality, ''))) AS place, NULL::text AS sector,
+         p.total_funding AS money_in, NULL::numeric AS money_out,
+         CASE WHEN p.seifa_irsd_decile IS NOT NULL THEN 'SEIFA decile ' || p.seifa_irsd_decile END AS tier,
+         nullif(concat_ws(' · ', nullif(p.remoteness, ''), p.entity_count || ' organisations'), '') AS meta,
+         '/places/' || p.postcode AS href,
+         p.entity_count::integer AS source_count, NULL::date AS closes_at, NULL::numeric AS amount_min, p.postcode
+  FROM (
+    SELECT DISTINCT ON (postcode) * FROM mv_funding_by_postcode
+    WHERE postcode ~ '^\d{4}$'
+    ORDER BY postcode, entity_count DESC NULLS LAST
+  ) p
+  LEFT JOIN LATERAL (
+    SELECT g.locality FROM postcode_geo g
+    WHERE g.postcode = p.postcode AND g.locality ~ '^[A-Z][A-Z ''-]+$'
+    ORDER BY g.locality LIMIT 1
+  ) loc ON true
+),
+u AS (
+  SELECT * FROM ent UNION ALL SELECT * FROM se UNION ALL SELECT * FROM fnd UNION ALL SELECT * FROM grants
+  UNION ALL SELECT * FROM ppl UNION ALL SELECT * FROM plc UNION ALL SELECT * FROM alma UNION ALL SELECT * FROM pcd
+)
+SELECT u.kind, u.id, u.name, u.abn, u.state, u.place, u.sector, u.money_in, u.money_out, u.tier, u.meta, u.href,
+       u.source_count, u.closes_at, u.amount_min, u.postcode,
+       to_tsvector('simple', concat_ws(' ', u.name, u.sector, u.place, u.abn, u.meta, u.postcode)) AS tsv,
+       now() AS built_at
+FROM u
+WHERE u.name IS NOT NULL AND length(trim(u.name)) > 1;
+
+CREATE UNIQUE INDEX mv_search_index_kind_id ON public.mv_search_index (kind, id);
+CREATE INDEX mv_search_index_name_trgm ON public.mv_search_index USING gin (name extensions.gin_trgm_ops);
+CREATE INDEX mv_search_index_tsv ON public.mv_search_index USING gin (tsv);
+CREATE INDEX mv_search_index_kind_state ON public.mv_search_index (kind, state);
+CREATE INDEX mv_search_index_abn ON public.mv_search_index (abn) WHERE abn IS NOT NULL;
+
+REVOKE ALL ON public.mv_search_index FROM anon, authenticated;
+GRANT SELECT ON public.mv_search_index TO service_role;
+
+CREATE OR REPLACE FUNCTION public.search_index_query(q text, kinds text[] DEFAULT NULL, p_state text DEFAULT NULL, p_limit integer DEFAULT 20)
+RETURNS TABLE (kind text, id text, name text, abn text, state text, place text, sector text, money_in numeric, money_out numeric, tier text, meta text, href text,
+               source_count integer, closes_at date, amount_min numeric, postcode text, score real)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH p AS (
+    SELECT trim(q) AS raw, lower(trim(q)) AS lq, regexp_replace(q, '\s', '', 'g') AS digits,
+           websearch_to_tsquery('simple', q) AS tsq
+  )
+  SELECT s.kind, s.id, s.name, s.abn, s.state, s.place, s.sector, s.money_in, s.money_out, s.tier, s.meta, s.href,
+         s.source_count, s.closes_at, s.amount_min, s.postcode,
+         -- the largest applicable bonus, not the first branch that happens to match ("0870 Charles" starts with "0870"
+         -- and used to take the prefix bonus instead of the postcode-row bonus)
+         (greatest(
+            CASE WHEN lower(s.name) = p.lq THEN 3.0 ELSE 0.0 END,
+            CASE WHEN lower(s.name) LIKE p.lq || '%' THEN 2.0 ELSE 0.0 END,
+            CASE WHEN s.abn = p.digits THEN 3.0 ELSE 0.0 END,
+            CASE WHEN s.postcode = p.digits AND s.kind = 'postcode' THEN 3.5 ELSE 0.0 END,
+            CASE WHEN s.postcode = p.digits THEN 2.5 ELSE 0.0 END)
+          + similarity(s.name, p.raw) + ts_rank(s.tsv, p.tsq))::real AS score
+  FROM public.mv_search_index s, p
+  WHERE length(p.raw) >= 2
+    AND (kinds IS NULL OR s.kind = ANY (kinds))
+    AND (p_state IS NULL OR s.state = p_state OR s.state IS NULL)
+    AND (s.name % p.raw OR s.tsv @@ p.tsq OR (p.digits ~ '^\d{11}$' AND s.abn = p.digits) OR (p.digits ~ '^\d{4}$' AND s.postcode = p.digits))
+  ORDER BY score DESC, s.money_in DESC NULLS LAST, s.name
+  LIMIT greatest(1, least(coalesce(p_limit, 20), 100));
+$$;
+COMMIT;

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -472,5 +472,13 @@ prefix name matches first, then trigram similarity plus tsvector rank, ABN when 
 it with `/api/search/index` and `lib/search/search-index.ts` (input whitelist, tested). The `/search` page moves onto it
 in its own PR because it is a public surface.
 
-Still to do in Phase 4: postcode rows, aliases from `gs_entity_aliases`, retiring the 17 `search_*` functions to wrappers,
-and the semantic path behind the lexical one.
+Three more builds the same afternoon (`20260905162000`, `163000`, `164000`): structured `source_count`, `closes_at`,
+`amount_min` and `postcode` columns; a twelfth kind, one row per postcode with an ABS-style locality label (3,243 rows);
+ranking by the greatest applicable bonus (the first-branch CASE let "0870 Charles" take the prefix bonus over the
+postcode-row bonus). Each rebuild is about thirteen seconds. Two unique-index rollbacks taught two grain facts:
+`mv_funding_by_lga` is not one row per council (case and whitespace variants), and `mv_gs_entity_stats` is not one row per
+entity. `/api/global-search`, the live lanes behind the header box and `/search`, now makes one call to the RPC instead
+of five separate lanes; the client is unchanged. Council-area rows have no lane in that client yet.
+
+Still to do in Phase 4: aliases from `gs_entity_aliases`, a council lane in the search client, retiring the 17 `search_*`
+functions to wrappers, and the semantic path behind the lexical one.


### PR DESCRIPTION
## What

- `/api/global-search` (the live lanes behind the header box and `/search`) makes one `search_index_query` call and sorts hits into the five shapes the client already renders. Client unchanged; council-area rows have no lane there yet.
- Three applied migrations on `mv_search_index`: `source_count`, `closes_at`, `amount_min`, `postcode`; a twelfth kind with one row per postcode labelled by the ABS-style locality (3,243 rows); ranking by the greatest applicable bonus. 440,060 rows.
- `lib/search` types and kinds follow; test updated (6 checks).

## Verification

`0870` → "0870 Alice Springs" first; `2000` → the postcode first; `alice springs` → the council; `mission australia` → the intervention and the charity. Parity clean after the applies. `scripts/precheck.sh` green.