### PR TITLE
Search: 2.8s to 185ms, per-lane queries, and a ship-watch verify bug

### DIFF
--- a/apps/web/src/app/api/global-search/route.ts
+++ b/apps/web/src/app/api/global-search/route.ts
@@ -1,38 +1,45 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { parseSearchQuery, searchIndex, type SearchHit } from '@/lib/search/search-index';
+import { parseSearchQuery, searchIndex, type SearchHit, type SearchKind } from '@/lib/search/search-index';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * /api/global-search — the live lanes behind the header search and the /search page.
+ * /api/global-search — the live lanes behind the header box and the /search page.
  *
- * Until 2026-09-05 this ran five separate lanes (entities, grants, foundations, people via ILIKE on
- * mv_board_interlocks, places via postcode_geo), each with its own statement-timeout risk. It now makes ONE call to
- * search_index_query over mv_search_index and sorts the hits into the five shapes the client already renders, so the
- * page did not change. Council-area rows (kind "place") have no lane in this client yet and are left out here;
- * /api/search/index serves every kind.
+ * Until 2026-09-05 this ran five hand-written lanes (entity select, grants, foundations, an ILIKE over
+ * mv_board_interlocks, postcode_geo), each with its own statement-timeout risk. It now runs one query per lane against
+ * mv_search_index through search_index_query, in parallel.
  *
- * scope=full is the /search page (every lane). Any other scope is the header box: entities and grants only.
+ * ONE call for all lanes was tried first and starves them: a globally ranked top-60 for "alice springs" is 60 companies
+ * with "Alice Springs" in the name, so the grants, foundations, people and places lanes came back empty. Each lane needs
+ * its own top-N. Six calls at ~170 ms each, issued together, cost about one call.
  */
-const ENTITY_KINDS = new Set(['charity', 'company', 'indigenous_corp', 'government_body', 'program', 'social_enterprise', 'intervention']);
+const LANES: Record<'entities' | 'grants' | 'foundations' | 'people' | 'places', SearchKind[]> = {
+  entities: ['charity', 'company', 'indigenous_corp', 'government_body', 'program', 'social_enterprise', 'intervention'],
+  grants: ['grant_round'],
+  foundations: ['foundation'],
+  people: ['person'],
+  places: ['postcode'],
+};
 const LANE_CAP = 8;
 
 export async function GET(req: NextRequest) {
   const sp = req.nextUrl.searchParams;
   const fullScope = sp.get('scope') === 'full';
-  const query = parseSearchQuery({ q: sp.get('q'), state: sp.get('state'), limit: '60' });
-  if (!query) return NextResponse.json({ entities: [], foundations: [], grants: [], people: [], places: [] });
+  const base = parseSearchQuery({ q: sp.get('q'), state: sp.get('state'), limit: String(LANE_CAP) });
+  if (!base) return NextResponse.json({ entities: [], foundations: [], grants: [], people: [], places: [] });
 
-  let hits: SearchHit[];
+  const wanted = fullScope ? (Object.keys(LANES) as (keyof typeof LANES)[]) : (['entities', 'grants'] as const);
+  let results: SearchHit[][];
   try {
-    hits = await searchIndex(query);
+    results = await Promise.all(wanted.map((lane) => searchIndex({ ...base, kinds: LANES[lane] })));
   } catch (e) {
     return NextResponse.json({ error: (e as Error).message }, { status: 500 });
   }
+  const byLane = Object.fromEntries(wanted.map((lane, i) => [lane, results[i]])) as Record<string, SearchHit[]>;
+  const lane = (name: string) => byLane[name] ?? [];
 
-  const take = (pred: (h: SearchHit) => boolean) => hits.filter(pred).slice(0, LANE_CAP);
-
-  const entities = take((h) => ENTITY_KINDS.has(h.kind)).map((h) => ({
+  const entities = lane('entities').map((h) => ({
     id: h.id,
     name: h.name,
     entityType: h.kind.replace(/_/g, ' '),
@@ -42,7 +49,7 @@ export async function GET(req: NextRequest) {
     revenue: h.money_in,
     href: h.href ?? `/entity/${encodeURIComponent(h.id)}`,
   }));
-  const grants = take((h) => h.kind === 'grant_round').map((h) => ({
+  const grants = lane('grants').map((h) => ({
     id: h.id,
     name: h.name,
     amountMin: h.amount_min,
@@ -54,7 +61,7 @@ export async function GET(req: NextRequest) {
   }));
   if (!fullScope) return NextResponse.json({ entities, grants });
 
-  const foundations = take((h) => h.kind === 'foundation').map((h) => ({
+  const foundations = lane('foundations').map((h) => ({
     id: h.id,
     name: h.name,
     abn: h.abn,
@@ -62,12 +69,12 @@ export async function GET(req: NextRequest) {
     focus: h.sector ? h.sector.split(', ').filter(Boolean) : null,
     href: h.href ?? `/foundations/${h.id}`,
   }));
-  const people = take((h) => h.kind === 'person').map((h) => ({
+  const people = lane('people').map((h) => ({
     name: h.name,
     boardCount: h.source_count ?? 0,
     href: h.href ?? `/person/${encodeURIComponent(h.name)}`,
   }));
-  const places = take((h) => h.kind === 'postcode').map((h) => ({
+  const places = lane('places').map((h) => ({
     postcode: h.postcode ?? '',
     locality: h.place,
     state: h.state,

--- a/scripts/ship-watch.mjs
+++ b/scripts/ship-watch.mjs
@@ -11,8 +11,10 @@
  *
  *   --merge   squash-merge when every check passes. Omit for VISIBLE changes: the watcher then
  *             reports green and stops, leaving the merge to Ben after he has seen the preview.
- *   --verify  URL to curl after the deploy. `=CODE` asserts an exact status; otherwise any
- *             non-5xx counts as alive (an admin route legitimately answers 401/403/307).
+ *   --verify  URL to curl after the deploy. A trailing `=CODE` (three digits) asserts an exact status; otherwise any
+ *             non-5xx counts as alive (an admin route legitimately answers 401/403/307, and civicgraph.app answers
+ *             429 to every HTTP client because of Vercel's JS challenge, which is why 429 counts as alive here).
+ *             Query strings are safe: only a trailing three-digit `=CODE` is treated as an expectation.
  *
  * Never waits on advisory checks — only on what the rollup reports as pending. This repo has
  * no branch protection, so there is no required-check list to consult; every reported check is
@@ -113,7 +115,12 @@ async function checkState() {
 }
 
 async function verifyUrl(spec) {
-  const [url, expected] = spec.split('=');
+  // `URL=CODE`, but only when the tail is a bare 3-digit status. Splitting on the first `=` ate the query string of
+  // every URL that had one: `--verify '.../index?q=mission'` became url `.../index?q` with expected code "mission",
+  // and `Number("mission")` is NaN, so two landings on 2026-09-05 reported a live-check failure that had not happened.
+  const m = spec.match(/^(.*)=(\d{3})$/);
+  const url = m ? m[1] : spec;
+  const expected = m ? m[2] : null;
   try {
     const { stdout } = await exec('curl', ['-s', '-o', '/dev/null', '-w', '%{http_code}', '-L', '--max-time', '30', url]);
     const code = Number(stdout.trim());

--- a/supabase/migrations/20260905170000_search_index_query_force_custom_plan.sql
+++ b/supabase/migrations/20260905170000_search_index_query_force_custom_plan.sql
@@ -1,0 +1,12 @@
+-- 20260905170000_search_index_query_force_custom_plan.sql
+-- The query is fast; the plan cache was not. Measured 2026-09-05, same SQL:
+--   run as a plain statement          131 ms  (BitmapOr over the trigram and tsvector GIN indexes, ~1,035 candidates)
+--   run through search_index_query()  2,300-3,400 ms
+-- After five executions Postgres switches a parameterised SQL function to a GENERIC plan, which cannot know that
+-- `name % q` is selective for this particular q, so it stops using the GIN indexes. force_custom_plan makes it re-plan
+-- per call, which costs 0.05 ms of planning and returns the index scans. Same trap as the browse RPCs (see the memory
+-- note on RPC generic plans); the fix belongs on every search-shaped function that takes the query text as a parameter.
+BEGIN;
+ALTER FUNCTION public.search_index_query(text, text[], text, integer) SET plan_cache_mode = 'force_custom_plan';
+COMMIT;
+-- Post-check: six consecutive calls should all be ~150 ms, not the first five fast and the rest slow.

--- a/supabase/migrations/20260905171000_mv_search_index_postcode_index.sql
+++ b/supabase/migrations/20260905171000_mv_search_index_postcode_index.sql
@@ -1,0 +1,9 @@
+-- 20260905171000_mv_search_index_postcode_index.sql
+-- search_index_query took 2.8s while the same SQL with literal values took 124ms. Cause: the WHERE has four OR
+-- branches, and one of them, `p.digits ~ '^\d{4}$' AND s.postcode = p.digits`, has no index on postcode. With literal
+-- values the planner folds the regex to false and drops the branch; with function parameters it cannot fold, and one
+-- unindexable OR branch forces a sequential scan of all 440k rows. An index on postcode lets the BitmapOr cover every
+-- branch. (plan_cache_mode was tried first and changed nothing: it was never the generic plan.)
+BEGIN;
+CREATE INDEX IF NOT EXISTS mv_search_index_postcode ON public.mv_search_index (postcode) WHERE postcode IS NOT NULL;
+COMMIT;

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -482,3 +482,17 @@ of five separate lanes; the client is unchanged. Council-area rows have no lane 
 
 Still to do in Phase 4: aliases from `gs_entity_aliases`, a council lane in the search client, retiring the 17 `search_*`
 functions to wrappers, and the semantic path behind the lexical one.
+
+**Two defects found by using it, same day.** (1) `search_index_query` took 2.8 s while the identical SQL with literal
+values took 124 ms. Not the generic plan (`plan_cache_mode = force_custom_plan` changed nothing and stays as
+documentation): the WHERE has four OR branches and one of them, `postcode = <param>`, had no index. With literals the
+planner folds the regex guard to false and drops the branch; with parameters it cannot, and a single unindexable OR
+branch forces a sequential scan of all 440k rows. One partial index took it to **185 ms** (`20260905171000`). Worst
+observed query is now "aboriginal corporation" at 1.6 s, a very broad trigram match, left as a follow-up.
+(2) One globally ranked call bucketed into five lanes starves them: "alice springs" filled all 60 slots with companies
+and returned nothing for grants, foundations, people or places. `/api/global-search` now runs one query per lane in
+parallel, six at ~170 ms, which costs about one call.
+
+**And one in the tooling:** `scripts/ship-watch.mjs` split its `--verify` spec on the first `=`, so any URL with a query
+string was truncated and its expectation became `Number("mission")`. Two landings reported a live-check failure that had
+not happened. It now matches only a trailing three-digit code.


### PR DESCRIPTION
## What

- **`20260905171000`**: partial index on `mv_search_index.postcode`. `search_index_query` ran at 2.8s while the identical SQL with literal values ran at 124ms; the cause was one OR branch (`postcode = <param>`) with no index, which forces a sequential scan of 440k rows once the value is a parameter the planner cannot fold. Now **185ms**, stable across repeated calls.
- **`20260905170000`**: `plan_cache_mode = force_custom_plan` on the RPC. Tried first, changed nothing; kept because the header records that the generic plan was ruled out.
- **`/api/global-search`** runs one query per lane in parallel instead of bucketing one globally ranked call. "alice springs" used to return 8 companies and four empty lanes.
- **`scripts/ship-watch.mjs`** split `--verify` on the first `=`, so `?q=mission` became an expected status of "mission". Two landings today reported live-check failures that had not happened.

## Verification

Eight consecutive RPC calls at 180-190ms. Per-lane: entities 182ms, grants 165, foundations 155, people 170, places 155, councils 165. Worst broad query ("aboriginal corporation") 1.6s, noted as follow-up. `scripts/precheck.sh` green. Production verified in a real browser after the previous merge.