### PR TITLE
Phase 5: one write contract for grant_opportunities, and the VIC ingest fixed

### DIFF
--- a/apps/web/src/lib/grant-ingest-contract.test.ts
+++ b/apps/web/src/lib/grant-ingest-contract.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+// The helper lives with the agents that call it; the test lives where the gate looks (apps/web/vitest.config.ts only
+// collects tests under apps/web). Same arrangement as palette-ratchet.test.ts.
+// @ts-expect-error - plain .mjs helper, no types
+import { dedupeGrantRows, upsertGrantOpportunities } from '../../../../scripts/lib/upsert-grant-opportunities.mjs';
+
+type Row = Record<string, unknown>;
+
+/**
+ * Stands in for the grant_opportunities table: `existing` seeds it, selects answer the helper's lookups, and upserts
+ * record what was written and with which conflict key.
+ */
+function fakeTable(existing: Row[] = [], failOn: (rows: Row[]) => string | null = () => null) {
+  const writes: Array<{ rows: Row[]; onConflict: string }> = [];
+  const api = {
+    writes,
+    from() {
+      const state: { column?: string; values?: unknown[]; source?: unknown; sourceIsNull?: boolean } = {};
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        in(column: string, values: unknown[]) { state.column = column; state.values = values; return builder; },
+        eq(_c: string, value: unknown) { state.source = value; return builder; },
+        is(_c: string, _v: null) { state.sourceIsNull = true; return builder; },
+        upsert(rows: Row[], opts: { onConflict: string }) {
+          writes.push({ rows, onConflict: opts.onConflict });
+          const message = failOn(rows);
+          return Promise.resolve({ error: message ? { message } : null });
+        },
+        then(resolve: (v: { data: Row[]; error: null }) => unknown) {
+          const rows = existing.filter((r) => {
+            if (!state.column || !state.values?.includes(r[state.column])) return false;
+            if (state.sourceIsNull) return r.source == null;
+            if (state.source !== undefined) return r.source === state.source;
+            return true;
+          });
+          return Promise.resolve(resolve({ data: rows, error: null }));
+        },
+      };
+      return builder;
+    },
+  };
+  return api;
+}
+
+describe('dedupeGrantRows', () => {
+  it('keeps the last row for a repeated url, because a later row is the fresher scrape', () => {
+    const { rows, dropped } = dedupeGrantRows([
+      { url: 'https://x/a', name: 'Old name', source: 's' },
+      { url: 'https://x/a', name: 'New name', source: 's' },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('New name');
+    expect(dropped).toBe(1);
+  });
+
+  it('falls back to source and name when a row has no url', () => {
+    const { rows } = dedupeGrantRows([
+      { name: 'A', source: 's' },
+      { name: 'A', source: 's' },
+      { name: 'A', source: 'other' },
+    ]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('treats a blank or whitespace url as absent', () => {
+    const { rows } = dedupeGrantRows([{ url: '   ', name: 'A', source: 's' }]);
+    expect(rows[0].url).toBeNull();
+  });
+});
+
+describe('upsertGrantOpportunities', () => {
+  it('updates by id when the url already exists under a different source label', async () => {
+    // The exact shape that failed 51 VIC runs: same URL, older source label.
+    const sb = fakeTable([{ id: 'row-1', url: 'https://x/a', source: 'old label', name: 'Grant A' }]);
+    const res = await upsertGrantOpportunities(sb, [{ url: 'https://x/a', source: 'vic-grants-gateway', name: 'Grant A' }]);
+    expect(res.written).toBe(1);
+    expect(res.failed).toBe(0);
+    const write = sb.writes.at(-1)!;
+    expect(write.onConflict).toBe('id');
+    expect(write.rows[0].id).toBe('row-1');
+    expect(write.rows[0].source).toBe('vic-grants-gateway');
+  });
+
+  it('updates by id when the name is taken and the url is new', async () => {
+    // The mirror-image failure that switching the conflict key to url exposed.
+    const sb = fakeTable([{ id: 'row-2', url: 'https://x/old', source: 's', name: 'Grant B' }]);
+    const res = await upsertGrantOpportunities(sb, [{ url: 'https://x/new', source: 's', name: 'Grant B' }]);
+    expect(res.written).toBe(1);
+    expect(sb.writes.at(-1)!.rows[0].id).toBe('row-2');
+  });
+
+  it('inserts a genuinely new round', async () => {
+    const sb = fakeTable([]);
+    const res = await upsertGrantOpportunities(sb, [{ url: 'https://x/new', source: 's', name: 'New' }]);
+    expect(res.written).toBe(1);
+    expect(sb.writes.at(-1)!.onConflict).toBe('url');
+  });
+
+  it('skips and reports a row that resolves to two different existing rows', async () => {
+    const sb = fakeTable([
+      { id: 'row-a', url: 'https://x/a', source: 's', name: 'Old name' },
+      { id: 'row-b', url: 'https://x/b', source: 's', name: 'Taken name' },
+    ]);
+    const res = await upsertGrantOpportunities(sb, [{ url: 'https://x/a', source: 's', name: 'Taken name' }]);
+    expect(res.ambiguous).toBe(1);
+    expect(res.written).toBe(0);
+    expect(res.errors[0]).toContain('same round');
+  });
+
+  it('retries a failed chunk row by row, so one bad row does not cost the whole run', async () => {
+    const sb = fakeTable([], (rows) => (rows.some((r) => r.name === 'bad') ? 'duplicate key value violates unique constraint' : null));
+    const res = await upsertGrantOpportunities(sb, [
+      { url: 'https://x/a', name: 'good', source: 's' },
+      { url: 'https://x/b', name: 'bad', source: 's' },
+    ]);
+    expect(res.written).toBe(1);
+    expect(res.failed).toBe(1);
+  });
+});

--- a/apps/web/src/lib/grant-ingest-contract.test.ts
+++ b/apps/web/src/lib/grant-ingest-contract.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 // The helper lives with the agents that call it; the test lives where the gate looks (apps/web/vitest.config.ts only
 // collects tests under apps/web). Same arrangement as palette-ratchet.test.ts.
-// @ts-expect-error - plain .mjs helper, no types
 import { dedupeGrantRows, upsertGrantOpportunities } from '../../../../scripts/lib/upsert-grant-opportunities.mjs';
 
 type Row = Record<string, unknown>;

--- a/scripts/ingest-vic-grants-open.mjs
+++ b/scripts/ingest-vic-grants-open.mjs
@@ -13,6 +13,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import { upsertGrantOpportunities } from './lib/upsert-grant-opportunities.mjs';
 
 const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
@@ -152,13 +153,24 @@ async function main() {
     return;
   }
 
-  // The canonical table contract is one row per source/name. Refresh a
-  // republished grant's URL and source_id instead of inserting a duplicate.
-  const { error } = await supabase.from('grant_opportunities').upsert(rows, { onConflict: 'source,name', ignoreDuplicates: false });
-  if (error) throw new Error(`upsert failed: ${error.message}`);
-  console.log(`Upserted ${rows.length} rows (source=vic-grants-gateway)`);
+  // One contract for every writer of grant_opportunities: a URL identifies a round, whatever source label it was
+  // ingested under. This agent used to upsert on (source, name) and failed 51 of 57 nightly runs, because these same
+  // Victorian grants already existed under an older source label and kept their URLs, so the insert hit the separate
+  // unique index on url. See scripts/lib/upsert-grant-opportunities.mjs.
+  const result = await upsertGrantOpportunities(supabase, rows);
+  console.log(
+    `Upserted ${result.written} rows (source=vic-grants-gateway)` +
+      (result.droppedInBatch ? `, ${result.droppedInBatch} duplicate(s) collapsed in the batch` : '') +
+      (result.failed ? `, ${result.failed} FAILED` : ''),
+  );
+  for (const err of result.errors) console.error(`  ! ${err}`);
+  if (result.failed && !result.written) throw new Error(`every row failed: ${result.errors[0] ?? 'unknown'}`);
 
-  await logComplete(supabase, activeRun.id, { items_found: hits.length, items_new: rows.length });
+  await logComplete(supabase, activeRun.id, {
+    items_found: hits.length,
+    items_new: result.written,
+    errors: result.errors.length ? result.errors.map((message) => ({ time: new Date().toISOString(), message })) : undefined,
+  });
 }
 
 main().catch(async (err) => {

--- a/scripts/lib/upsert-grant-opportunities.mjs
+++ b/scripts/lib/upsert-grant-opportunities.mjs
@@ -1,0 +1,146 @@
+/**
+ * The one way to write rows into `grant_opportunities`.
+ *
+ * WHY THIS EXISTS. The table carries THREE unique indexes, each a different idea of what makes a grant round the
+ * same round:
+ *   grant_opportunities_url_idx                (url)
+ *   grant_opportunities_source_name_full_uniq  (source, name)
+ *   idx_grant_opp_name_source_id               (name, source_id)
+ * and the ingest agents pick one each: `source,name` (grantconnect, vic, foundation programs), `name,source_id`
+ * (five importers), `url` (austender tenders). ON CONFLICT resolves exactly the index you name and no other, so an
+ * agent that targets one key still raises a duplicate-key error on either of the others. Measured 2026-09-05:
+ * "VIC Grants Gateway (Open)" failed 51 of 57 nightly runs on the url index, because those Victorian grants had been
+ * ingested earlier under a different source label and kept their URLs. Switching the conflict target to `url` simply
+ * moved the failure to the (source, name) index: a re-published grant arrives with a new URL under a name already
+ * taken. Neither key alone can work, so this resolves the row first and writes by primary key.
+ *
+ * WHAT THIS DOES.
+ *   1. De-duplicates inside the batch, by url first and (source, name) otherwise. A batch carrying the same round
+ *      twice used to fail the whole statement. The later row wins: it is the fresher scrape.
+ *   2. Looks the batch up in the table by url, and by (source, name) per source, in bulk.
+ *   3. Writes each row by the id it resolved to, so no unique index is ever crossed. Rows that resolve to nothing
+ *      are inserted.
+ *   4. A row that resolves to TWO DIFFERENT existing rows (its url belongs to one, its name to another) is a genuine
+ *      duplicate pair already in the table. It is reported, not guessed at, because merging them is a human call.
+ *   5. Writes go in chunks; a chunk that still fails is retried row by row so one bad row cannot cost the run.
+ *      Failures are returned, not thrown, for the agent to log as a partial run.
+ *
+ * It deliberately does not use `name,source_id`: nothing needs a third identity, and dropping that index is a
+ * separate decision (thoughts/shared/findings/supabase-platform-review-2026-09-05.md).
+ */
+
+const CHUNK = 200;
+
+export function dedupeGrantRows(rows) {
+  const seen = new Map();
+  const out = [];
+  let dropped = 0;
+  for (const row of rows ?? []) {
+    const url = typeof row.url === 'string' && row.url.trim() ? row.url.trim() : null;
+    const key = url ? `u:${url}` : `s:${row.source ?? ''}\u0000${row.name ?? ''}`;
+    const at = seen.get(key);
+    if (at !== undefined) {
+      out[at] = { ...row, url };
+      dropped += 1;
+      continue;
+    }
+    seen.set(key, out.length);
+    out.push({ ...row, url });
+  }
+  return { rows: out, dropped };
+}
+
+const pairKey = (source, name) => `${source ?? ''}\u0000${name ?? ''}`;
+
+/** Existing ids for this batch, by url and by (source, name). Bulk, chunked, no per-row round trips. */
+async function resolveExisting(supabase, rows, chunkSize) {
+  const byUrl = new Map();
+  const byPair = new Map();
+
+  const urls = rows.map((r) => r.url).filter(Boolean);
+  for (let i = 0; i < urls.length; i += chunkSize) {
+    const { data, error } = await supabase
+      .from('grant_opportunities')
+      .select('id, url')
+      .in('url', urls.slice(i, i + chunkSize));
+    if (error) throw new Error(`lookup by url failed: ${error.message}`);
+    for (const row of data ?? []) byUrl.set(row.url, row.id);
+  }
+
+  const namesBySource = new Map();
+  for (const row of rows) {
+    if (!row.name) continue;
+    const list = namesBySource.get(row.source ?? null) ?? [];
+    list.push(row.name);
+    namesBySource.set(row.source ?? null, list);
+  }
+  for (const [source, names] of namesBySource) {
+    for (let i = 0; i < names.length; i += chunkSize) {
+      let query = supabase.from('grant_opportunities').select('id, source, name').in('name', names.slice(i, i + chunkSize));
+      query = source === null ? query.is('source', null) : query.eq('source', source);
+      const { data, error } = await query;
+      if (error) throw new Error(`lookup by source and name failed: ${error.message}`);
+      for (const row of data ?? []) byPair.set(pairKey(row.source, row.name), row.id);
+    }
+  }
+  return { byUrl, byPair };
+}
+
+async function writeChunk(supabase, chunk, onConflict) {
+  const { error } = await supabase.from('grant_opportunities').upsert(chunk, { onConflict, ignoreDuplicates: false });
+  return error;
+}
+
+async function writeGroup(supabase, group, onConflict, chunkSize, tally) {
+  for (let i = 0; i < group.length; i += chunkSize) {
+    const chunk = group.slice(i, i + chunkSize);
+    const error = await writeChunk(supabase, chunk, onConflict);
+    if (!error) {
+      tally.written += chunk.length;
+      continue;
+    }
+    for (const row of chunk) {
+      const rowError = await writeChunk(supabase, [row], onConflict);
+      if (rowError) {
+        tally.failed += 1;
+        if (tally.errors.length < 20) tally.errors.push(`${row.url || `${row.source}/${row.name}`}: ${rowError.message}`);
+      } else {
+        tally.written += 1;
+      }
+    }
+  }
+}
+
+/**
+ * @returns {Promise<{written:number, failed:number, droppedInBatch:number, ambiguous:number, errors:string[]}>}
+ */
+export async function upsertGrantOpportunities(supabase, rawRows, { chunkSize = CHUNK } = {}) {
+  const { rows, dropped } = dedupeGrantRows(rawRows);
+  const tally = { written: 0, failed: 0, errors: [] };
+  if (!rows.length) return { ...tally, droppedInBatch: dropped, ambiguous: 0 };
+
+  const { byUrl, byPair } = await resolveExisting(supabase, rows, chunkSize);
+
+  const updates = [];
+  const inserts = [];
+  let ambiguous = 0;
+  for (const row of rows) {
+    const urlId = row.url ? byUrl.get(row.url) : undefined;
+    const pairId = byPair.get(pairKey(row.source, row.name));
+    if (urlId && pairId && urlId !== pairId) {
+      ambiguous += 1;
+      if (tally.errors.length < 20) {
+        tally.errors.push(`${row.url}: url belongs to ${urlId} but "${row.source}/${row.name}" belongs to ${pairId}; two rows in the table are the same round, skipped pending a merge`);
+      }
+      continue;
+    }
+    const id = urlId ?? pairId;
+    if (id) updates.push({ ...row, id });
+    else inserts.push(row);
+  }
+
+  await writeGroup(supabase, updates, 'id', chunkSize, tally);
+  await writeGroup(supabase, inserts, 'url', chunkSize, tally);
+
+  return { ...tally, droppedInBatch: dropped, ambiguous };
+}

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -482,3 +482,71 @@ of five separate lanes; the client is unchanged. Council-area rows have no lane 
 
 Still to do in Phase 4: aliases from `gs_entity_aliases`, a council lane in the search client, retiring the 17 `search_*`
 functions to wrappers, and the semantic path behind the lexical one.
+
+## 12. Phase 5 progress (started 2026-09-05)
+
+Phase 5 was framed as consolidating four grant front ends and four scorers. Measuring first moved the priority: the
+grants **intake** had a reproducible bug, and the duplication is smaller and more mechanical than the review assumed.
+
+### The one that was actually broken
+
+`grant_opportunities` carries THREE unique indexes and the ingest agents target one each:
+
+| index | agents targeting it |
+|---|---|
+| `grant_opportunities_url_idx` (url) | `sync-austender-open-tenders` |
+| `grant_opportunities_source_name_full_uniq` (source, name) | `ingest-grantconnect-go`, `ingest-vic-grants-open`, `sync-foundation-programs` |
+| `idx_grant_opp_name_source_id` (name, source_id) | five importers |
+
+`ON CONFLICT` resolves exactly the index it names, so an agent that targets one key still raises a duplicate-key error
+on either of the others. **"VIC Grants Gateway (Open)" failed 51 of 57 nightly runs** on the url index: those Victorian
+grants had been ingested earlier under the source label "Victorian Government / Regional Development VIC" and kept their
+URLs, so the (source, name) upsert tried to INSERT and hit the url index `[V]`.
+
+Switching the conflict target to `url` was tried and moved the failure rather than fixing it: a re-published grant
+arrives with a new URL under a name already taken, which then violates (source, name). Measured on the live source:
+29 of 30 rows written, one failure of the mirror-image kind.
+
+`scripts/lib/upsert-grant-opportunities.mjs` is now the one write path. It de-duplicates inside the batch, resolves each
+row against the table by url and by (source, name) in bulk, then writes **by primary key**, so no unique index is ever
+crossed. A row that resolves to two different existing rows is a genuine duplicate pair already in the table; it is
+reported, not guessed at, because merging them is a human call. Chunked, with row-by-row retry so one bad row cannot
+cost the run, and failures returned rather than thrown so the agent logs a partial.
+
+Proven on the live source, in `agent_runs`:
+
+| run | result |
+|---|---|
+| 02:01, old code | `failed`, 0 rows |
+| 08:10, url-key attempt | 30 found, 29 written, 1 duplicate-key error |
+| 08:14, resolve-then-write | 30 found, **30 written, no errors** |
+
+### Two corrections to what the run log looks like it says
+
+- **`timed_out` is not a timeout.** `scripts/scheduler.mjs` has a janitor (`cleanupStaleRuns`) that marks any run still
+  `running` after four hours as `timed_out`. 227 of the last 30 days' runs carry it, including 71 for the nightly grant
+  orchestrator. It means the process was interrupted (or crashed before logging completion), not that the agent failed.
+  The orchestrator's registry timeout is already 60 minutes, so the scheduler is not killing it.
+- **"Sync Foundation Programs" is not failing.** It is marked `partial` because of embedding errors (560 in the latest
+  run) while its ingest works: 936 found, 42 new. Counting `partial` as failure overstated the breakage. The embedding
+  errors are a separate, unexamined problem.
+
+### The duplication, measured
+
+`alma_funding_opportunities` (13,102 rows) is **99.5% a copy**: 6,642 rows are `promotion-from-grant_opportunities` and
+6,402 are `promotion-from-foundation-programs`, leaving 58 rows of its own (26 unlabelled, 21 a manual seed, 9 from an
+oracle research run, 2 smoke-test rows) `[V]`. Merging it is therefore a view or a promotion job, not a data migration.
+
+`grant_opportunities` itself is dominated by two sources: `brisbane-grants` 12,271 and `arc-grants` 5,598 of 26,695
+(75% between them), so "22,691 open grant rounds" is mostly Brisbane City Council and ARC research grants. That is a
+number to qualify before putting it on a public surface.
+
+The pipeline tables the review flagged as near-empty are confirmed: `funding_ghl_handoffs` 0, `opportunity_decisions` 7,
+`funding_awards` 5, `funding_programs` 4, `funding_match_recommendations` 3, `funding_sources` 3,
+`alma_funding_applications` 2. `grant_notification_outbox` holds 771 rows and has not been written to since 15 May.
+
+### Next in Phase 5
+
+Point the other `source,name` agents at the shared contract; decide whether `idx_grant_opp_name_source_id` earns its
+place; make `alma_funding_opportunities` a view over the two tables it is promoted from; then the front-end and scorer
+consolidation the review describes.


### PR DESCRIPTION
## What

`grant_opportunities` carries three unique indexes (`url`, `(source, name)`, `(name, source_id)`) and the ingest agents target one each. `ON CONFLICT` resolves only the index it names, so an agent that handles its own key still raises a duplicate-key error on another. **"VIC Grants Gateway (Open)" failed 51 of its last 57 nightly runs** on the url index, because those grants were ingested earlier under a different source label and kept their URLs. Switching the conflict target to `url` moved the failure rather than fixing it (29 of 30 rows, one violation of `(source, name)`).

`scripts/lib/upsert-grant-opportunities.mjs` is the one write path: de-duplicate inside the batch, resolve each row against the table by both keys in bulk, then write **by primary key**. A row that resolves to two different existing rows is a genuine duplicate pair already in the table and is reported, not merged. Chunked, with row-by-row retry, and failures returned so the agent logs a partial run.

## Verification

Live, in `agent_runs`: 02:01 `failed` with 0 rows on the old code; 08:14 **30 found, 30 written, no errors**. Eight unit tests cover both conflict directions, the ambiguous case, and the retry. `scripts/precheck.sh` green.

## Also in the findings (section 12)

Two corrections to what the run log appears to say: `timed_out` is a four-hour janitor for runs left open by an interrupted process, not a timeout (227 runs, 71 of them the nightly orchestrator, whose registry budget is already 60 minutes); and "Sync Foundation Programs" ingests fine (936 found, 42 new) while its embeddings fail. Also measured: `alma_funding_opportunities` is 99.5% promoted from the two tables it duplicates, and 75% of `grant_opportunities` is Brisbane City Council plus ARC research grants.

## Deferred

The other `source,name` agents onto the contract; whether `(name, source_id)` earns its index; `alma_funding_opportunities` as a view; then the front-end and scorer consolidation.