### PR TITLE
Phase 5: every grant_opportunities writer on the one contract, plus a guard

### DIFF
--- a/apps/web/src/lib/grant-write-contract.test.ts
+++ b/apps/web/src/lib/grant-write-contract.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * grant_opportunities carries three unique indexes (url, (source, name), (name, source_id)) and ON CONFLICT resolves
+ * only the one it names. Every agent that picked its own key eventually hit one of the others: "VIC Grants Gateway"
+ * failed 51 of 57 nightly runs, and two agents worked around it by re-inserting the row with `url: null`, which threw
+ * the URL away and stored the round twice. All writers now go through scripts/lib/upsert-grant-opportunities.mjs.
+ *
+ * This test fails when a new writer picks its own conflict key again.
+ */
+const REPO = join(import.meta.dirname, '../../../..');
+const SCRIPTS = join(REPO, 'scripts');
+const CONTRACT = 'upsert-grant-opportunities.mjs';
+
+function scriptFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : scriptFiles(full);
+    return entry.isFile() && entry.name.endsWith('.mjs') ? [full] : [];
+  });
+}
+
+describe('grant_opportunities has one write contract', () => {
+  it('no script names its own conflict key on grant_opportunities', () => {
+    const offenders: string[] = [];
+    for (const file of scriptFiles(SCRIPTS)) {
+      if (file.endsWith(CONTRACT)) continue;
+      const src = readFileSync(file, 'utf8');
+      if (!src.includes("from('grant_opportunities')")) continue;
+      // an upsert on this table within a few lines of naming it
+      const windows = src.split("from('grant_opportunities')").slice(1);
+      for (const w of windows) {
+        const head = w.slice(0, 400);
+        if (/onConflict/.test(head)) offenders.push(file.replace(`${REPO}/`, ''));
+      }
+    }
+    expect(
+      [...new Set(offenders)],
+      'these write grant_opportunities with their own conflict key; use upsertGrantOpportunities() from scripts/lib/upsert-grant-opportunities.mjs, which resolves by url and by (source, name) and writes by primary key',
+    ).toEqual([]);
+  });
+
+  it('no script forces a row in by discarding its url', () => {
+    const offenders: string[] = [];
+    for (const file of scriptFiles(SCRIPTS)) {
+      const src = readFileSync(file, 'utf8');
+      if (!src.includes("from('grant_opportunities')")) continue;
+      if (/\.\.\.\s*\w+\s*,\s*url:\s*null/.test(src)) offenders.push(file.replace(`${REPO}/`, ''));
+    }
+    expect(
+      offenders,
+      'writing a grant round with url: null to dodge the unique index stores the same round twice and loses its address',
+    ).toEqual([]);
+  });
+});

--- a/scripts/import-gov-grants.mjs
+++ b/scripts/import-gov-grants.mjs
@@ -19,6 +19,7 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { parse } from 'csv-parse/sync';
+import { upsertGrantOpportunities } from './lib/upsert-grant-opportunities.mjs';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -141,39 +142,15 @@ async function upsertGrants(grants, source) {
     filteredGrants.push(grant);
   }
 
-  // Batch upsert 500 at a time using the concrete unique index the table exposes.
-  // Supabase/PostgREST cannot target the partial unique URL index.
-  const BATCH_SIZE = 500;
-  for (let i = 0; i < filteredGrants.length; i += BATCH_SIZE) {
-    const batch = filteredGrants.slice(i, i + BATCH_SIZE);
-    const { error } = await supabase
-      .from('grant_opportunities')
-      .upsert(batch, { onConflict: 'name,source_id', ignoreDuplicates: false });
-
-    if (error) {
-      console.error(`  Batch upsert error (${source}, offset ${i}): ${error.message}`);
-      // Fallback: individual inserts for this batch only
-      for (const g of batch) {
-        try {
-          const { error: singleErr } = await supabase
-            .from('grant_opportunities')
-            .upsert(g, { onConflict: 'name,source_id', ignoreDuplicates: false });
-          if (singleErr) {
-            if (/duplicate key value/i.test(singleErr.message)) {
-              continue;
-            }
-            stats.errors++;
-            if (stats.errors <= 3) console.error(`  Single upsert error: ${singleErr.message}`);
-          } else {
-            stats.upserted++;
-          }
-        } catch {
-          stats.errors++;
-        }
-      }
-    } else {
-      stats.upserted += batch.length;
-    }
+  // One write contract for every writer of grant_opportunities (scripts/lib/upsert-grant-opportunities.mjs): it
+  // resolves each row by url and by (source, name) and writes by primary key, so the three unique indexes on this
+  // table can no longer collide. It chunks and retries row by row internally.
+  const result = await upsertGrantOpportunities(supabase, filteredGrants);
+  stats.upserted += result.written;
+  stats.errors += result.failed + result.ambiguous;
+  if (result.errors.length > 0) {
+    console.error(`  ${result.failed + result.ambiguous} row(s) not written from ${source}:`);
+    result.errors.slice(0, 3).forEach((m) => console.error(`    ${m}`));
   }
   stats.total += filteredGrants.length;
   console.log(`  Upserted ${filteredGrants.length} grants from ${source}`);

--- a/scripts/import-public-discovered-grant-pages.mjs
+++ b/scripts/import-public-discovered-grant-pages.mjs
@@ -17,6 +17,7 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { createHash } from 'crypto';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import { upsertGrantOpportunities } from './lib/upsert-grant-opportunities.mjs';
 
 const AGENT_ID = 'import-public-discovered-grant-pages';
 const AGENT_NAME = 'Import Public Discovered Grant Pages';
@@ -344,11 +345,14 @@ async function main() {
     let upserted = 0;
     let cleaned = 0;
     if (!DRY_RUN && rows.length > 0) {
-      const { error } = await db
-        .from('grant_opportunities')
-        .upsert(rows, { onConflict: 'name,source_id', ignoreDuplicates: false });
-      if (error) throw error;
-      upserted = rows.length;
+      // One write contract (scripts/lib/upsert-grant-opportunities.mjs): resolves by url and by (source, name),
+      // writes by primary key, so the table's three unique indexes cannot collide.
+      const result = await upsertGrantOpportunities(db, rows);
+      if (result.failed + result.ambiguous > 0) {
+        console.error(`${result.failed + result.ambiguous} row(s) not written:`);
+        result.errors.slice(0, 3).forEach((m) => console.error(`  ${m}`));
+      }
+      upserted = result.written;
       cleaned = await markObsoleteRows(new Set(rows.map(row => row.source_id)));
       if (cleaned > 0) console.log(`Marked ${cleaned} obsolete public-discovered rows as duplicate`);
     }

--- a/scripts/ingest-grantconnect-go.mjs
+++ b/scripts/ingest-grantconnect-go.mjs
@@ -18,6 +18,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { logStart, logComplete, logFailed } from './lib/log-agent-run.mjs';
+import { upsertGrantOpportunities } from './lib/upsert-grant-opportunities.mjs';
 
 const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
@@ -182,41 +183,16 @@ async function main() {
   // (source, name) upsert then trips the url unique index and the whole batch
   // died, taking the run with it. A conflicting url identifies the stored row
   // precisely, so retry those rows as an update keyed on url.
-  let upserted = 0;
-  let retitled = 0;
-  const failedRows = [];
-  for (let i = 0; i < deduped.length; i += 100) {
-    const batch = deduped.slice(i, i + 100);
-    const { error } = await supabase.from('grant_opportunities').upsert(batch, { onConflict: 'source,name', ignoreDuplicates: false });
-    if (!error) {
-      upserted += batch.length;
-      continue;
-    }
-    // Batch had at least one url collision: go row by row so one bad row
-    // cannot take ninety-nine good ones with it.
-    for (const row of batch) {
-      const { error: rowError } = await supabase.from('grant_opportunities').upsert(row, { onConflict: 'source,name', ignoreDuplicates: false });
-      if (!rowError) {
-        upserted += 1;
-        continue;
-      }
-      if (/duplicate key.*url/i.test(rowError.message)) {
-        const { error: updateError } = await supabase.from('grant_opportunities').update(row).eq('url', row.url);
-        if (updateError) {
-          failedRows.push(`${row.name.slice(0, 60)}: ${updateError.message}`);
-        } else {
-          retitled += 1;
-          upserted += 1;
-        }
-      } else {
-        failedRows.push(`${row.name.slice(0, 60)}: ${rowError.message}`);
-      }
-    }
-  }
-  if (retitled > 0) console.log(`  ${retitled} retitled rows updated by url`);
-  if (failedRows.length > 0) {
-    console.log(`  ${failedRows.length} rows failed and were skipped:`);
-    failedRows.slice(0, 5).forEach((m) => console.log(`    ${m}`));
+  // One write contract for every writer of grant_opportunities: it resolves each row against the table by url and by
+  // (source, name) and writes by primary key, so no unique index is crossed. This replaces the hand-rolled
+  // batch/row/update-by-url ladder that used to live here.
+  const result = await upsertGrantOpportunities(supabase, deduped);
+  const upserted = result.written;
+  if (result.droppedInBatch > 0) console.log(`  ${result.droppedInBatch} duplicate row(s) collapsed within the batch`);
+  if (result.ambiguous > 0) console.log(`  ${result.ambiguous} row(s) skipped: they match two different stored rounds`);
+  if (result.errors.length > 0) {
+    console.log(`  ${result.failed} rows failed and were skipped:`);
+    result.errors.slice(0, 5).forEach((m) => console.log(`    ${m}`));
   }
   console.log(`Upserted ${upserted} rows (source=grantconnect)`);
 

--- a/scripts/ingest-strategic-grants-wrap-2026-07.mjs
+++ b/scripts/ingest-strategic-grants-wrap-2026-07.mjs
@@ -316,14 +316,10 @@ async function main() {
       continue;
     }
 
-    const { data, error } = await supabase
-      .from('grant_opportunities')
-      .upsert(row, { onConflict: 'name,source_id' })
-      .select('id, name, source_id, aligned_projects')
-      .single();
-
-    if (error) throw error;
-    results.push({ action: 'upserted-source-id', ...data });
+    // One write contract (scripts/lib/upsert-grant-opportunities.mjs), single-row form for the id.
+    const oneResult = await upsertOneGrantOpportunity(supabase, row);
+    if (oneResult.error) throw new Error(oneResult.error);
+    results.push({ action: oneResult.created ? 'inserted' : 'updated-existing', id: oneResult.id, name: row.name, source_id: row.source_id });
   }
 
   console.log(`Processed ${results.length} grant_opportunities rows.`);

--- a/scripts/lib/upsert-grant-opportunities.mjs
+++ b/scripts/lib/upsert-grant-opportunities.mjs
@@ -144,3 +144,37 @@ export async function upsertGrantOpportunities(supabase, rawRows, { chunkSize = 
 
   return { ...tally, droppedInBatch: dropped, ambiguous };
 }
+
+/**
+ * One row, with the id back. Same resolution rule as the batch path, for callers that need the id to link other
+ * records to the round (sync-foundation-programs links a foundation program to the round it produced).
+ *
+ * @returns {Promise<{id: string|null, created: boolean, error: string|null, ambiguous?: boolean}>}
+ */
+export async function upsertOneGrantOpportunity(supabase, row) {
+  const url = typeof row.url === 'string' && row.url.trim() ? row.url.trim() : null;
+  const candidate = { ...row, url };
+
+  const { byUrl, byPair } = await resolveExisting(supabase, [candidate], 1);
+  const urlId = url ? byUrl.get(url) : undefined;
+  const pairId = byPair.get(pairKey(candidate.source, candidate.name));
+  if (urlId && pairId && urlId !== pairId) {
+    return {
+      id: null,
+      created: false,
+      ambiguous: true,
+      error: `url belongs to ${urlId} but "${candidate.source}/${candidate.name}" belongs to ${pairId}; two rows are the same round, skipped pending a merge`,
+    };
+  }
+
+  const existingId = urlId ?? pairId;
+  const payload = existingId ? { ...candidate, id: existingId } : candidate;
+  const { data, error } = await supabase
+    .from('grant_opportunities')
+    .upsert(payload, { onConflict: existingId ? 'id' : 'url', ignoreDuplicates: false })
+    .select('id')
+    .maybeSingle();
+
+  if (error) return { id: null, created: false, error: error.message };
+  return { id: data?.id ?? existingId ?? null, created: !existingId, error: null };
+}

--- a/scripts/scrape-state-grants.mjs
+++ b/scripts/scrape-state-grants.mjs
@@ -22,6 +22,7 @@ import { createTASGrantsPlugin } from '../packages/grant-engine/src/sources/tas-
 import { createSAGrantsPlugin } from '../packages/grant-engine/src/sources/sa-grants.ts';
 import { createWAGrantsPlugin } from '../packages/grant-engine/src/sources/wa-grants.ts';
 import { createNTGrantsPlugin } from '../packages/grant-engine/src/sources/nt-grants.ts';
+import { upsertGrantOpportunities } from './lib/upsert-grant-opportunities.mjs';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -195,45 +196,16 @@ async function main() {
         };
       });
 
-      const { data, error } = await supabase
-        .from('grant_opportunities')
-        .upsert(batch, { onConflict: 'name,source_id', ignoreDuplicates: false });
-
-      if (error) {
-        console.error(`  Upsert error: ${error.message}`);
-        for (const row of batch) {
-          const { error: singleError } = await supabase
-            .from('grant_opportunities')
-            .upsert(row, { onConflict: 'name,source_id', ignoreDuplicates: false });
-
-          if (!singleError) {
-            totalNew++;
-            sourceNew++;
-            continue;
-          }
-
-          if (isDuplicateUrlError(singleError)) {
-            const { error: fallbackError } = await supabase
-              .from('grant_opportunities')
-              .upsert({ ...row, url: null }, { onConflict: 'name,source_id', ignoreDuplicates: false });
-
-            if (!fallbackError) {
-              totalNew++;
-              sourceNew++;
-              continue;
-            }
-
-            errors.push(`${plugin.id} fallback upsert: ${fallbackError.message}`);
-            console.error(`  Fallback upsert error: ${fallbackError.message}`);
-            continue;
-          }
-
-          errors.push(`${plugin.id} single upsert: ${singleError.message}`);
-          console.error(`  Single upsert error: ${singleError.message}`);
-        }
-      } else {
-        totalNew += batch.length;
-        sourceNew += batch.length;
+      // One write contract (scripts/lib/upsert-grant-opportunities.mjs). It replaces a three-step ladder whose last
+      // step retried the row with `url: null` when the url index bit, which pushed the round in a second time under a
+      // second identity and threw the URL away. Resolving by url and by (source, name) and writing by primary key
+      // means that collision cannot happen, so nothing has to be discarded to get a row in.
+      const result = await upsertGrantOpportunities(supabase, batch);
+      totalNew += result.written;
+      sourceNew += result.written;
+      for (const message of result.errors) {
+        errors.push(`${plugin.id}: ${message}`);
+        console.error(`  ${message}`);
       }
     }
 

--- a/scripts/sync-austender-open-tenders.mjs
+++ b/scripts/sync-austender-open-tenders.mjs
@@ -301,12 +301,13 @@ async function main() {
     return;
   }
 
-  let up = 0, err = 0;
-  for (const row of accepted) {
-    const { error } = await supabase.from('grant_opportunities').upsert(row, { onConflict: 'url' });
-    if (error) { console.error(`  upsert "${row.name.slice(0, 50)}": ${error.message.slice(0, 120)}`); err++; }
-    else up++;
-  }
+  // One write contract for every writer of grant_opportunities (scripts/lib/upsert-grant-opportunities.mjs).
+  // Conflicting on url alone was safe against the url index but not against (source, name): a re-published ATM under
+  // a name already stored would have raised there. The contract resolves both and writes by primary key.
+  const result = await upsertGrantOpportunities(supabase, accepted);
+  const up = result.written;
+  const err = result.failed + result.ambiguous;
+  for (const message of result.errors) console.error(`  ${message.slice(0, 160)}`);
   console.log(`\n✓ Upserted ${up}/${accepted.length} open ATMs (${err} errors).`);
   console.log('Rows are scored inline; nightly score-goods-relevance.mjs --rescore-all reconfirms.');
 }

--- a/scripts/sync-foundation-programs.mjs
+++ b/scripts/sync-foundation-programs.mjs
@@ -22,6 +22,7 @@ import { createClient } from '@supabase/supabase-js';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { logStart, logComplete } from './lib/log-agent-run.mjs';
+import { upsertOneGrantOpportunity } from './lib/upsert-grant-opportunities.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -811,22 +812,27 @@ async function main() {
 
       if (updateError) {
         if (isDuplicateUrlError(updateError)) {
-          const fallbackGrant = { ...grant, url: null, updated_at: new Date().toISOString() };
-          const { error: fallbackUpdateError } = await supabase
+          // The program's new URL already belongs to a DIFFERENT row: the two rows are the same round. This used to
+          // retry the update with `url: null`, which erased the URL from a row that had one to force the write
+          // through. Keep the stored URL instead and update everything else, so nothing is lost while the duplicate
+          // pair waits for a human merge.
+          const { url: _collidingUrl, ...withoutUrl } = grant;
+          const { error: keepUrlError } = await supabase
             .from('grant_opportunities')
-            .update(fallbackGrant)
+            .update({ ...withoutUrl, updated_at: new Date().toISOString() })
             .eq('id', existingGrant.id);
 
-          if (fallbackUpdateError) {
-            console.error(`  Error updating "${program.name}": ${fallbackUpdateError.message}`);
+          if (keepUrlError) {
+            console.error(`  Error updating "${program.name}": ${keepUrlError.message}`);
             errors++;
             recordFoundationSyncStat(foundationSyncStats, foundation.id, 'errors');
           } else {
+            console.warn(`  "${program.name}": its url is already stored on another round; kept the existing url and updated the rest`);
             updated++;
             if (existingGrant.name && existingGrant.name !== grant.name) {
               existingByKey.delete(`${foundation.id}::${existingGrant.name}`);
             }
-            const merged = { ...existingGrant, ...grant, url: null };
+            const merged = { ...existingGrant, ...withoutUrl };
             existingByKey.set(key, merged);
             existingBySourceId.set(String(program.id), merged);
             recordFoundationSyncStat(foundationSyncStats, foundation.id, 'updated');
@@ -853,43 +859,22 @@ async function main() {
 
     // Upsert on (source, name) per partial unique index grant_opportunities_source_name_uniq
     // (added 2026-05-07 in act-global-infrastructure to stop sync-drift bleed).
-    const { data: insertedGrant, error: insertError } = await supabase
-      .from('grant_opportunities')
-      .upsert(grant, { onConflict: 'source,name', ignoreDuplicates: false })
-      .select('id')
-      .single();
+    // One write contract (scripts/lib/upsert-grant-opportunities.mjs), single-row form because the id is needed to
+    // link the foundation program to the round it produced. It resolves by url and by (source, name) and writes by
+    // primary key, so the url index can no longer force the `url: null` fallback below.
+    const oneResult = await upsertOneGrantOpportunity(supabase, grant);
+    const insertedGrant = oneResult.id ? { id: oneResult.id } : null;
+    const insertError = oneResult.error ? { message: oneResult.error } : null;
 
     if (insertError) {
-      if (insertError.message.includes('duplicate') || insertError.message.includes('unique')) {
-        if (isDuplicateUrlError(insertError)) {
-          const fallbackGrant = { ...grant, url: null };
-          const { data: fallbackInsertedGrant, error: fallbackInsertError } = await supabase
-            .from('grant_opportunities')
-            .insert(fallbackGrant)
-            .select('id')
-            .single();
-
-          if (fallbackInsertError) {
-            console.error(`  Error syncing "${program.name}": ${fallbackInsertError.message}`);
-            errors++;
-            recordFoundationSyncStat(foundationSyncStats, foundation.id, 'errors');
-          } else {
-            inserted++;
-            const merged = { ...fallbackGrant, id: fallbackInsertedGrant?.id };
-            existingByKey.set(key, merged);
-            existingBySourceId.set(String(program.id), merged);
-            recordFoundationSyncStat(foundationSyncStats, foundation.id, 'inserted');
-            if (fallbackInsertedGrant?.id) touchedGrantIds.push(fallbackInsertedGrant.id);
-          }
-        } else {
-          skipped++;
-          recordFoundationSyncStat(foundationSyncStats, foundation.id, 'skipped');
-        }
-      } else {
-        console.error(`  Error syncing "${program.name}": ${insertError.message}`);
-        errors++;
-        recordFoundationSyncStat(foundationSyncStats, foundation.id, 'errors');
-      }
+      // The url-collision fallback that used to sit here re-inserted the row with `url: null`, which put the same
+      // round in a second time under a second identity and threw its URL away. The contract resolves by url and by
+      // (source, name) and writes by primary key, so that collision cannot happen and nothing has to be discarded to
+      // get a row in. What remains here is a genuine write error, or a round that matches two stored rows and needs
+      // a human merge (oneResult.ambiguous).
+      console.error(`  Error syncing "${program.name}": ${insertError.message}`);
+      errors++;
+      recordFoundationSyncStat(foundationSyncStats, foundation.id, 'errors');
     } else {
       inserted++;
       const merged = { ...grant, id: insertedGrant?.id };

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -545,11 +545,58 @@ The pipeline tables the review flagged as near-empty are confirmed: `funding_ghl
 `funding_awards` 5, `funding_programs` 4, `funding_match_recommendations` 3, `funding_sources` 3,
 `alma_funding_applications` 2. `grant_notification_outbox` holds 771 rows and has not been written to since 15 May.
 
+### Every writer is now on the contract (2026-09-05, same day)
+
+All seven converted: `ingest-vic-grants-open`, `ingest-grantconnect-go`, `import-gov-grants`,
+`import-public-discovered-grant-pages`, `scrape-state-grants`, `sync-foundation-programs`,
+`sync-austender-open-tenders`, plus the one-off `ingest-strategic-grants-wrap-2026-07`. Each carried its own retry
+ladder; there is now one. `apps/web/src/lib/grant-write-contract.test.ts` fails the build if a new writer names its own
+conflict key, or if any script writes a round with `url: null`.
+
+**The workaround was worse than the failure.** Two agents dodged the unique index by re-writing the row with
+`url: null`. In `scrape-state-grants` that inserted the same round a second time without its address. In
+`sync-foundation-programs` there were two: the insert path did the same, and the update path **erased the URL from a
+row that already had one** to force the write through. The update path now keeps the stored URL, updates everything
+else, and warns that the pair needs a human merge. 228 rows currently have no URL while the same name exists with one;
+the sampled ones came from `ghl_sync`, a different writer, so the fallbacks' own share of that is unmeasured.
+
+### The scorers, measured
+
+There is **one** working scorer, not four:
+
+| column | populated | reality |
+|---|---|---|
+| `act_grant_recommendations_current.fit_score` | 5,995 rows, 11 ACT projects, range 9-93, mean 23.1 | a real score |
+| `grant_opportunities.relevance_score` | 26,659 of 26,698 are exactly **50**, the column default | not a score |
+| `alma_funding_opportunities.relevance_score` | 13,100 of 13,102 are **0** | dead |
+| `grant_opportunities.fit_score` | 61 of 26,698 (0.2%) | barely populated |
+
+CivicGraph's surfaces all rank by the real one (`act_grant_recommendations_current`). Two consumers rank by a constant
+and therefore return an arbitrary order presented as a ranking: **JusticeHub's funding notification engine**
+(`src/lib/funding/notification-engine.ts:142`, orders `alma_funding_opportunities` by `relevance_score`) and
+**act-global's morning briefing** (`apps/command-center/src/app/api/briefing/morning/route.ts:256`, orders
+`grant_opportunities` by the same). Both are one-line changes in their own repos.
+
+### `alma_funding_opportunities` cannot become a view
+
+The review proposed replacing it with a view over the tables it is promoted from. It has **eleven writers** across
+three repos: two promotion jobs, three enrichment jobs (`backfill-alma-fields`, `auto-classify-llm`,
+`verify-alma-opportunities`), an ops triage route and the GHL handoff service in CivicGraph; an admin route that
+inserts and updates, a matching library that deletes, and a scraper in JusticeHub; and a Xero backfill in act-global.
+A view is read-only, so all eleven would break.
+
+Its rows also carry no link home: `source_id` is **NULL on all 13,102**, so a promoted row cannot be joined back to its
+origin by key. Matching by lower(name) does work: 6,609 of 6,642 promoted-from-grants rows match a `grant_opportunities`
+row, and 6,402 of 6,402 promoted-from-foundation-programs rows match a `foundation_programs` row (by URL it is only
+4,987 of 6,642).
+
+The read-side unified view is being built instead: one row per fundable thing, deduplicated by name against its origin,
+with provenance, leaving every writer alone.
+
 ### Next in Phase 5
 
-Point the other `source,name` agents at the shared contract; decide whether `idx_grant_opp_name_source_id` earns its
-place; make `alma_funding_opportunities` a view over the two tables it is promoted from; then the front-end and scorer
-consolidation the review describes.
+Decide whether `idx_grant_opp_name_source_id` earns its place now that nothing targets it; the two one-line ranking
+fixes in JusticeHub and act-global; then the front-end consolidation the review describes.
 **Two defects found by using it, same day.** (1) `search_index_query` took 2.8 s while the identical SQL with literal
 values took 124 ms. Not the generic plan (`plan_cache_mode = force_custom_plan` changed nothing and stays as
 documentation): the WHERE has four OR branches and one of them, `postcode = <param>`, had no index. With literals the


### PR DESCRIPTION
## What

All seven writers of `grant_opportunities` now go through `scripts/lib/upsert-grant-opportunities.mjs`: grantconnect, gov-grants, public-discovered pages, state-grants, foundation-programs, austender tenders, and the July one-off. Each previously carried its own batch/row/fallback ladder with a different conflict key.

**The workaround was worse than the failure it hid.** Two agents dodged the unique index by re-writing the row with `url: null`:
- `scrape-state-grants` inserted the same round a second time without its address.
- `sync-foundation-programs` did that on insert **and, on update, erased the URL from a row that already had one.** That path now keeps the stored URL, updates everything else, and warns that the duplicate pair needs a human merge.

`apps/web/src/lib/grant-write-contract.test.ts` fails the build if a new writer names its own conflict key, or if any script writes a round with `url: null`. It caught the update-path case above while I was writing it.

## Verification

`scripts/precheck.sh` green (tsc + full suite). Ten tests across the two contract test files. No `onConflict` on `grant_opportunities` remains outside the contract.

## Also in the findings

The scorer measurements (one real scorer; `relevance_score` is the default 50 on 26,659 of 26,698 rows and 0 on 13,100 of 13,102 alma rows; two consumers rank by those constants) and why `alma_funding_opportunities` cannot become a view (eleven writers across three repos, and `source_id` is NULL on all 13,102 rows so promoted rows have no link home).