### PR TITLE
Phase 5: v_funding_opportunities, one place to read a fundable thing

### DIFF
--- a/apps/web/src/app/api/data/funding-opportunities/route.ts
+++ b/apps/web/src/app/api/data/funding-opportunities/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { fundingOpportunityCounts, listFundingOpportunities, type FundingQuery } from '@/lib/funding/opportunities';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/data/funding-opportunities?open=1&q=youth&origin=grant_opportunities&limit=50
+ *
+ * The one read path for a fundable thing, for this app and for JusticeHub, Empathy Ledger and act-global, so they stop
+ * writing their own SQL against grant_opportunities and alma_funding_opportunities. Unranked by design: see
+ * lib/funding/opportunities.ts.
+ */
+const ORIGINS = ['grant_opportunities', 'foundation_programs', 'alma_funding_opportunities'] as const;
+
+export async function GET(request: NextRequest) {
+  const sp = request.nextUrl.searchParams;
+  const originParam = sp.get('origin');
+  const query: FundingQuery = {
+    openOnly: sp.get('open') === '1' || sp.get('open') === 'true',
+    search: sp.get('q')?.trim() || undefined,
+    origin: (ORIGINS as readonly string[]).includes(originParam ?? '')
+      ? (originParam as FundingQuery['origin'])
+      : undefined,
+    closesBefore: sp.get('closes_before') || undefined,
+    minAmount: sp.get('min_amount') ? Number(sp.get('min_amount')) : undefined,
+    limit: sp.get('limit') ? Number(sp.get('limit')) : undefined,
+  };
+
+  try {
+    const [opportunities, counts] = await Promise.all([
+      listFundingOpportunities(query),
+      sp.get('counts') === '1' ? fundingOpportunityCounts() : Promise.resolve(undefined),
+    ]);
+    return NextResponse.json(
+      { opportunities, counts, query },
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600' } },
+    );
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/funding/opportunities.ts
+++ b/apps/web/src/lib/funding/opportunities.ts
@@ -1,0 +1,86 @@
+import { getServiceSupabase } from '@/lib/supabase';
+
+/**
+ * One place to read a fundable thing: `v_funding_opportunities`
+ * (supabase/migrations/20260905180000, deduped in 20260905181000).
+ *
+ * The view unions the canonical rounds in `grant_opportunities` with foundation programs that were never promoted into
+ * it, plus the handful of ALMA-native rows, and suppresses duplicates by name. It is READ ONLY on purpose: every source
+ * table keeps its own writers, including the eleven that write `alma_funding_opportunities`.
+ *
+ * It deliberately does not rank. `relevance_score` is the column default 50 on 26,659 of 26,698 grant rows and 0 on
+ * 13,100 of 13,102 ALMA rows, so ordering by it orders by a constant. Rank by closing date, amount, or the ACT
+ * recommendations matview, which is the one real scorer.
+ */
+export type FundingOpportunity = {
+  origin: 'grant_opportunities' | 'foundation_programs' | 'alma_funding_opportunities';
+  origin_id: string;
+  opportunity_key: string;
+  name: string;
+  funder: string | null;
+  description: string | null;
+  amount_min: number | null;
+  amount_max: number | null;
+  closes_at: string | null;
+  is_open: boolean;
+  url: string | null;
+  categories: string[] | null;
+  focus_areas: string[] | null;
+  source: string | null;
+  grant_type: string | null;
+  foundation_id: string | null;
+  verification_status: string | null;
+  alma_opportunity_type: string | null;
+  is_national: boolean | null;
+  jurisdictions: string[] | null;
+  eligible_org_types: string[] | null;
+  requires_dgr: boolean | null;
+  in_alma: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+  href: string | null;
+};
+
+export type FundingQuery = {
+  /** Only rounds that have not closed. A round with no closing date counts as open. */
+  openOnly?: boolean;
+  /** Case-insensitive match on the round's name. */
+  search?: string;
+  /** Restrict to one origin, e.g. to compare the canonical rounds against the rest. */
+  origin?: FundingOpportunity['origin'];
+  closesBefore?: string;
+  minAmount?: number;
+  limit?: number;
+};
+
+const MAX_LIMIT = 200;
+
+export async function listFundingOpportunities(query: FundingQuery = {}): Promise<FundingOpportunity[]> {
+  const db = getServiceSupabase();
+  let q = db.from('v_funding_opportunities').select('*');
+
+  if (query.openOnly) q = q.eq('is_open', true);
+  if (query.origin) q = q.eq('origin', query.origin);
+  if (query.search) q = q.ilike('name', `%${query.search.replace(/[%_]/g, '')}%`);
+  if (query.closesBefore) q = q.lte('closes_at', query.closesBefore);
+  if (query.minAmount != null) q = q.gte('amount_max', query.minAmount);
+
+  // Closing soonest first, and rounds with no closing date last: they are ongoing, not urgent.
+  const { data, error } = await q
+    .order('closes_at', { ascending: true, nullsFirst: false })
+    .limit(Math.min(Math.max(query.limit ?? 50, 1), MAX_LIMIT));
+
+  if (error) throw new Error(`v_funding_opportunities read failed: ${error.message}`);
+  return (data ?? []) as FundingOpportunity[];
+}
+
+/** Counts by origin, for a surface that wants to say where its list came from. */
+export async function fundingOpportunityCounts(): Promise<Array<{ origin: string; total: number; open: number }>> {
+  const db = getServiceSupabase();
+  const { data, error } = await db.rpc('exec_sql', {
+    query: `SELECT origin, count(*) AS total, count(*) FILTER (WHERE is_open) AS open
+            FROM v_funding_opportunities GROUP BY origin ORDER BY count(*) DESC`,
+  });
+  if (error) throw new Error(`v_funding_opportunities counts failed: ${error.message}`);
+  return (data ?? []) as Array<{ origin: string; total: number; open: number }>;
+}

--- a/supabase/migrations/20260905180000_v_funding_opportunities.sql
+++ b/supabase/migrations/20260905180000_v_funding_opportunities.sql
@@ -1,0 +1,179 @@
+-- 20260905180000_v_funding_opportunities.sql
+-- Phase 5 of the 2026-09-05 platform review: one place to READ a fundable thing.
+--
+-- The review proposed replacing alma_funding_opportunities with a view. It cannot be one: eleven writers across three
+-- repos touch it (two promotion jobs, three enrichment jobs, an ops triage route and the GHL handoff service in
+-- CivicGraph; an admin route that inserts and updates, a matching library that deletes, and a scraper in JusticeHub;
+-- a Xero backfill in act-global). A view is read-only, so all eleven would break. This is the read side instead:
+-- every table stays exactly as it is and keeps its writers, and anything that only READS gets one shape to read.
+--
+-- WHAT A ROW IS. One fundable thing, once. Three origins, in precedence order:
+--   1. grant_opportunities  (26,698) - the canonical rounds, including 1,665 already promoted from foundation programs
+--   2. foundation_programs  (2,792 of 4,457 not yet promoted into grant_opportunities, joined by source_id)
+--   3. alma_funding_opportunities - ONLY its own rows (58 of 13,102). The other 13,044 are promotions of the two
+--      tables above and would double-count.
+--
+-- DEDUPLICATION IS BY NAME, because there is no key to use: alma_funding_opportunities.source_id is NULL on all
+-- 13,102 rows, so a promoted row carries no link home. Measured 2026-09-05: lower(name) matches 6,609 of 6,642
+-- promoted-from-grants rows and 6,402 of 6,402 promoted-from-foundation-programs rows, where source_url manages only
+-- 4,987 of 6,642. Name matching is therefore the best available join, and it is used only to SUPPRESS duplicates and
+-- to carry ALMA's verification back onto the canonical row, never to merge two records into one.
+--
+-- WHAT IT DOES NOT DO. It does not score, rank or filter for relevance. `relevance_score` is the column default 50 on
+-- 26,659 of 26,698 grant rows and 0 on 13,100 of 13,102 alma rows, so ordering by it orders by a constant; the only
+-- real scorer is act_grant_recommendations_current, which is ACT-project-specific and stays where it is.
+--
+-- security_invoker, so every reader sees exactly what its own role may see. Not granted to anon: grant_opportunities
+-- is authenticated-read, and this view must not widen that.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.v_funding_opportunities WITH (security_invoker = true) AS
+WITH alma_enrichment AS (
+  -- ALMA's verification of a round, keyed by name so it can ride along with the canonical row. One row per name:
+  -- a name can carry several promoted copies, and the most recently touched one is the one to believe.
+  SELECT DISTINCT ON (lower(trim(a.name)))
+         lower(trim(a.name)) AS name_key,
+         a.verification_status,
+         a.opportunity_type,
+         a.is_national,
+         a.jurisdictions,
+         a.eligible_org_types,
+         a.requires_deductible_gift_recipient AS requires_dgr
+  FROM public.alma_funding_opportunities a
+  WHERE a.name IS NOT NULL
+  ORDER BY lower(trim(a.name)), a.updated_at DESC NULLS LAST, a.created_at DESC NULLS LAST
+),
+rounds AS (
+  SELECT
+    'grant_opportunities'::text          AS origin,
+    g.id::text                           AS origin_id,
+    g.name,
+    coalesce(g.provider, f.name)         AS funder,
+    g.description,
+    g.amount_min::numeric                AS amount_min,
+    g.amount_max::numeric                AS amount_max,
+    coalesce(g.closes_at, g.deadline)    AS closes_at,
+    g.url,
+    g.categories,
+    g.focus_areas,
+    g.source,
+    g.grant_type,
+    g.foundation_id,
+    g.created_at,
+    g.updated_at,
+    '/grants/' || g.id::text             AS href
+  FROM public.grant_opportunities g
+  LEFT JOIN public.foundations f ON f.id = g.foundation_id
+),
+programs AS (
+  -- Foundation programs that have not been promoted into grant_opportunities. The promoted ones are already above;
+  -- the link is grant_opportunities.source = 'foundation_program' AND source_id = foundation_programs.id.
+  SELECT
+    'foundation_programs'::text          AS origin,
+    p.id::text                           AS origin_id,
+    p.name,
+    f.name                               AS funder,
+    p.description,
+    p.amount_min,
+    p.amount_max,
+    p.deadline                           AS closes_at,
+    p.url,
+    p.categories,
+    p.thematic_focus                     AS focus_areas,
+    'foundation_program'::text           AS source,
+    p.program_type                       AS grant_type,
+    p.foundation_id,
+    p.created_at,
+    p.scraped_at                         AS updated_at,
+    '/foundations/' || p.foundation_id::text AS href
+  FROM public.foundation_programs p
+  LEFT JOIN public.foundations f ON f.id = p.foundation_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.grant_opportunities g
+    WHERE g.source = 'foundation_program' AND g.source_id = p.id::text
+  )
+),
+alma_native AS (
+  -- ALMA rows that are not promotions of the two tables above: 58 of 13,102 on 2026-09-05 (a manual seed, an oracle
+  -- research run, two smoke rows, 26 unlabelled). Suppressed by name if the round is already present.
+  SELECT
+    'alma_funding_opportunities'::text   AS origin,
+    a.id::text                           AS origin_id,
+    a.name,
+    a.funder_name                        AS funder,
+    a.description,
+    a.min_grant_amount                   AS amount_min,
+    a.max_grant_amount                   AS amount_max,
+    a.deadline                           AS closes_at,
+    coalesce(a.application_url, a.source_url) AS url,
+    NULL::text[]                         AS categories,
+    a.focus_areas,
+    coalesce(a.scrape_source, 'alma')    AS source,
+    a.opportunity_type                   AS grant_type,
+    NULL::uuid                           AS foundation_id,
+    a.created_at,
+    a.updated_at,
+    NULL::text                           AS href
+  FROM public.alma_funding_opportunities a
+  WHERE coalesce(a.scrape_source, '') NOT IN ('promotion-from-grant_opportunities', 'promotion-from-foundation-programs')
+    AND NOT EXISTS (SELECT 1 FROM public.grant_opportunities g WHERE lower(trim(g.name)) = lower(trim(a.name)))
+    AND NOT EXISTS (SELECT 1 FROM public.foundation_programs p WHERE lower(trim(p.name)) = lower(trim(a.name)))
+),
+unified AS (
+  SELECT * FROM rounds
+  UNION ALL SELECT * FROM programs
+  UNION ALL SELECT * FROM alma_native
+)
+SELECT
+  u.origin,
+  u.origin_id,
+  u.origin || ':' || u.origin_id        AS opportunity_key,
+  u.name,
+  u.funder,
+  u.description,
+  u.amount_min,
+  u.amount_max,
+  u.closes_at,
+  -- "open" means it has not closed. A round with no closing date is treated as open, which is how the ingest agents
+  -- record ongoing programs; the caller can tell the two apart with closes_at IS NULL.
+  (u.closes_at IS NULL OR u.closes_at >= current_date) AS is_open,
+  u.url,
+  u.categories,
+  u.focus_areas,
+  u.source,
+  u.grant_type,
+  u.foundation_id,
+  e.verification_status,
+  e.opportunity_type                    AS alma_opportunity_type,
+  e.is_national,
+  e.jurisdictions,
+  e.eligible_org_types,
+  e.requires_dgr,
+  (e.name_key IS NOT NULL)              AS in_alma,
+  u.created_at,
+  u.updated_at,
+  u.href
+FROM unified u
+LEFT JOIN alma_enrichment e ON e.name_key = lower(trim(u.name))
+WHERE u.name IS NOT NULL AND length(trim(u.name)) > 1;
+
+COMMENT ON VIEW public.v_funding_opportunities IS
+  'One row per fundable thing across grant_opportunities, unpromoted foundation_programs and ALMA-native rows. Read-only; every source table keeps its own writers. Deduplicated by lower(name) because alma_funding_opportunities.source_id is NULL on every row. Does not rank: relevance_score is a constant in both tables.';
+
+REVOKE ALL ON public.v_funding_opportunities FROM anon;
+GRANT SELECT ON public.v_funding_opportunities TO authenticated, service_role;
+
+INSERT INTO public.schema_ownership (object, owner, consumers, evidence, declared_on)
+VALUES ('v_funding_opportunities', 'grantscope', '{grantscope,justicehub,act}',
+        'Phase 5 unified read view over grant_opportunities + unpromoted foundation_programs + ALMA-native rows; read-only, security_invoker',
+        current_date)
+ON CONFLICT (object) DO NOTHING;
+
+COMMIT;
+
+-- Post-check:
+--   SELECT origin, count(*), count(*) FILTER (WHERE is_open) AS open FROM v_funding_opportunities GROUP BY 1;
+--   -- no round should appear twice under the same name and funder:
+--   SELECT count(*) FROM (SELECT lower(trim(name)), coalesce(lower(trim(funder)),'') FROM v_funding_opportunities
+--                         GROUP BY 1,2 HAVING count(*) > 1) d;

--- a/supabase/migrations/20260905181000_v_funding_opportunities_dedupe_by_name.sql
+++ b/supabase/migrations/20260905181000_v_funding_opportunities_dedupe_by_name.sql
@@ -1,0 +1,146 @@
+-- 20260905181000_v_funding_opportunities_dedupe_by_name.sql
+-- Follow-up within the hour. The first build left 13 rounds appearing twice: a foundation program whose name matches
+-- a stored grant round while carrying no source_id link to it. Suppress those by name as well, the same way the
+-- ALMA-native rows already are.
+--
+-- The other 87 duplicate name+funder groups the view surfaces are NOT introduced here: they already exist inside
+-- grant_opportunities, mostly as case-varying names ("Rio Tinto Community Giving Program" vs "...program"), which the
+-- three unique indexes do not catch because they are case-sensitive. They are left visible rather than hidden, because
+-- merging two stored rounds is a human call (the same rule the write contract follows).
+BEGIN;
+CREATE OR REPLACE VIEW public.v_funding_opportunities WITH (security_invoker = true) AS
+WITH alma_enrichment AS (
+  -- ALMA's verification of a round, keyed by name so it can ride along with the canonical row. One row per name:
+  -- a name can carry several promoted copies, and the most recently touched one is the one to believe.
+  SELECT DISTINCT ON (lower(trim(a.name)))
+         lower(trim(a.name)) AS name_key,
+         a.verification_status,
+         a.opportunity_type,
+         a.is_national,
+         a.jurisdictions,
+         a.eligible_org_types,
+         a.requires_deductible_gift_recipient AS requires_dgr
+  FROM public.alma_funding_opportunities a
+  WHERE a.name IS NOT NULL
+  ORDER BY lower(trim(a.name)), a.updated_at DESC NULLS LAST, a.created_at DESC NULLS LAST
+),
+rounds AS (
+  SELECT
+    'grant_opportunities'::text          AS origin,
+    g.id::text                           AS origin_id,
+    g.name,
+    coalesce(g.provider, f.name)         AS funder,
+    g.description,
+    g.amount_min::numeric                AS amount_min,
+    g.amount_max::numeric                AS amount_max,
+    coalesce(g.closes_at, g.deadline)    AS closes_at,
+    g.url,
+    g.categories,
+    g.focus_areas,
+    g.source,
+    g.grant_type,
+    g.foundation_id,
+    g.created_at,
+    g.updated_at,
+    '/grants/' || g.id::text             AS href
+  FROM public.grant_opportunities g
+  LEFT JOIN public.foundations f ON f.id = g.foundation_id
+),
+programs AS (
+  -- Foundation programs that have not been promoted into grant_opportunities. The promoted ones are already above;
+  -- the link is grant_opportunities.source = 'foundation_program' AND source_id = foundation_programs.id.
+  SELECT
+    'foundation_programs'::text          AS origin,
+    p.id::text                           AS origin_id,
+    p.name,
+    f.name                               AS funder,
+    p.description,
+    p.amount_min,
+    p.amount_max,
+    p.deadline                           AS closes_at,
+    p.url,
+    p.categories,
+    p.thematic_focus                     AS focus_areas,
+    'foundation_program'::text           AS source,
+    p.program_type                       AS grant_type,
+    p.foundation_id,
+    p.created_at,
+    p.scraped_at                         AS updated_at,
+    '/foundations/' || p.foundation_id::text AS href
+  FROM public.foundation_programs p
+  LEFT JOIN public.foundations f ON f.id = p.foundation_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.grant_opportunities g
+    WHERE g.source = 'foundation_program' AND g.source_id = p.id::text
+  )
+  -- and not promoted under a different link either: 13 programs match a stored round by name while carrying no
+  -- source_id link to it, and would otherwise appear twice.
+  AND NOT EXISTS (
+    SELECT 1 FROM public.grant_opportunities g WHERE lower(trim(g.name)) = lower(trim(p.name))
+  )
+),
+alma_native AS (
+  -- ALMA rows that are not promotions of the two tables above: 58 of 13,102 on 2026-09-05 (a manual seed, an oracle
+  -- research run, two smoke rows, 26 unlabelled). Suppressed by name if the round is already present.
+  SELECT
+    'alma_funding_opportunities'::text   AS origin,
+    a.id::text                           AS origin_id,
+    a.name,
+    a.funder_name                        AS funder,
+    a.description,
+    a.min_grant_amount                   AS amount_min,
+    a.max_grant_amount                   AS amount_max,
+    a.deadline                           AS closes_at,
+    coalesce(a.application_url, a.source_url) AS url,
+    NULL::text[]                         AS categories,
+    a.focus_areas,
+    coalesce(a.scrape_source, 'alma')    AS source,
+    a.opportunity_type                   AS grant_type,
+    NULL::uuid                           AS foundation_id,
+    a.created_at,
+    a.updated_at,
+    NULL::text                           AS href
+  FROM public.alma_funding_opportunities a
+  WHERE coalesce(a.scrape_source, '') NOT IN ('promotion-from-grant_opportunities', 'promotion-from-foundation-programs')
+    AND NOT EXISTS (SELECT 1 FROM public.grant_opportunities g WHERE lower(trim(g.name)) = lower(trim(a.name)))
+    AND NOT EXISTS (SELECT 1 FROM public.foundation_programs p WHERE lower(trim(p.name)) = lower(trim(a.name)))
+),
+unified AS (
+  SELECT * FROM rounds
+  UNION ALL SELECT * FROM programs
+  UNION ALL SELECT * FROM alma_native
+)
+SELECT
+  u.origin,
+  u.origin_id,
+  u.origin || ':' || u.origin_id        AS opportunity_key,
+  u.name,
+  u.funder,
+  u.description,
+  u.amount_min,
+  u.amount_max,
+  u.closes_at,
+  -- "open" means it has not closed. A round with no closing date is treated as open, which is how the ingest agents
+  -- record ongoing programs; the caller can tell the two apart with closes_at IS NULL.
+  (u.closes_at IS NULL OR u.closes_at >= current_date) AS is_open,
+  u.url,
+  u.categories,
+  u.focus_areas,
+  u.source,
+  u.grant_type,
+  u.foundation_id,
+  e.verification_status,
+  e.opportunity_type                    AS alma_opportunity_type,
+  e.is_national,
+  e.jurisdictions,
+  e.eligible_org_types,
+  e.requires_dgr,
+  (e.name_key IS NOT NULL)              AS in_alma,
+  u.created_at,
+  u.updated_at,
+  u.href
+FROM unified u
+LEFT JOIN alma_enrichment e ON e.name_key = lower(trim(u.name))
+WHERE u.name IS NOT NULL AND length(trim(u.name)) > 1;
+
+COMMIT;

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -590,8 +590,26 @@ origin by key. Matching by lower(name) does work: 6,609 of 6,642 promoted-from-g
 row, and 6,402 of 6,402 promoted-from-foundation-programs rows match a `foundation_programs` row (by URL it is only
 4,987 of 6,642).
 
-The read-side unified view is being built instead: one row per fundable thing, deduplicated by name against its origin,
-with provenance, leaving every writer alone.
+**Built instead: `v_funding_opportunities`** (`20260905180000`, deduped in `181000`). One row per fundable thing across
+the canonical rounds in `grant_opportunities` (26,698), foundation programs never promoted into it (2,533 of 4,457), and
+the ALMA-native rows (58 of 13,102; the other 13,044 are promotions and would double-count). **29,289 rows, 25,046 open,
+53 ms.** `security_invoker`, granted to authenticated and service_role only, so it cannot widen what any reader may see.
+Every source table keeps its writers untouched.
+
+Deduplication is by `lower(trim(name))` because there is no key to use. ALMA's verification rides along on the canonical
+row (`verification_status`, `in_alma`) rather than as a second row.
+
+Two things the first build taught, both now in the migration headers:
+- 13 foundation programs matched a stored round by name while carrying no `source_id` link to it, and appeared twice.
+  Suppressed by name, the same way the ALMA-native rows already were. Cross-origin duplicates are now zero.
+- **87 duplicate name+funder pairs already exist inside `grant_opportunities`**, mostly case-varying names ("Rio Tinto
+  Community Giving Program" against "...program"). The three unique indexes are case-sensitive and do not catch them.
+  The view leaves them visible rather than hiding them, because merging two stored rounds is a human call, the same
+  rule the write contract follows.
+
+Read it through `apps/web/src/lib/funding/opportunities.ts` or `GET /api/data/funding-opportunities`, which is also the
+path JusticeHub, Empathy Ledger and act-global should use instead of their own SQL. It does not rank: ordering by
+`relevance_score` orders by a constant.
 
 ### Next in Phase 5
 


### PR DESCRIPTION
## What

`v_funding_opportunities` unions the canonical rounds in `grant_opportunities` (26,698) with the foundation programs never promoted into it (2,533 of 4,457) and the 58 ALMA-native rows. The other 13,044 ALMA rows are promotions of those two tables and would double-count, so they are excluded; ALMA's verification rides along on the canonical row instead (`verification_status`, `in_alma`).

**29,289 rows, 25,046 open, 53 ms.** `security_invoker`, granted to `authenticated` and `service_role` only, so it cannot widen what any reader may see. Read it through `lib/funding/opportunities.ts` or `GET /api/data/funding-opportunities`.

**A view, not a replacement.** The review proposed replacing `alma_funding_opportunities`; it has eleven writers across three repos, so it stays exactly as it is with every writer intact.

## Two things the first build taught

- Deduplication has to be by `lower(trim(name))`: `alma_funding_opportunities.source_id` is NULL on all 13,102 rows, so a promoted row carries no link home. Name matches 6,609 of 6,642 and 6,402 of 6,402; URL manages only 4,987 of 6,642.
- 13 foundation programs matched a stored round by name with no `source_id` link and appeared twice; suppressed in `181000`, cross-origin duplicates now zero. The 87 duplicate pairs the view still shows already exist inside `grant_opportunities` (case-varying names the case-sensitive unique indexes miss) and are left visible, because merging two stored rounds is a human call.

## Verification

Both migrations applied via `scripts/db-apply.sh`; counts, duplicate check and timing measured after each. `scripts/precheck.sh` green.