### PR TITLE
Grant names are titles again, not abstracts

### DIFF
--- a/supabase/migrations/20260905190000_grant_names_are_titles_not_abstracts.sql
+++ b/supabase/migrations/20260905190000_grant_names_are_titles_not_abstracts.sql
@@ -1,0 +1,63 @@
+-- 20260905190000_grant_names_are_titles_not_abstracts.sql
+-- 8,343 of 26,698 grant names are longer than 120 characters because the ingest put the whole abstract in the name
+-- field: 5,598 from arc-grants, 1,878 from brisbane-grants, 734 from Lotterywest. Every surface that lists a grant
+-- shows an abstract where a title belongs, including mv_search_index (7,418 of its rows).
+--
+-- The shape is "Title. Abstract...", so the title is the first sentence. Measured before writing:
+--   5,758 of the 8,343 split cleanly at a sentence boundary (10-200 chars, ending . ! or ?, followed by a capital)
+--   resulting titles run 12 to 197 characters, median 69
+--   5,678 of those already have the remaining text in `description`; 54 rows have no description at all
+--   0 of the new names collide with an existing row on (source, name) or on (name, source_id)
+--   4 rows would collide with EACH OTHER (two pairs sharing a first sentence) and are excluded
+-- The other 2,585 long names have no clean sentence boundary and are left exactly as they are.
+--
+-- NOTHING IS LOST AND IT IS REVERSIBLE: the full original goes to metadata->>'original_name', and a row that had no
+-- description gets the original text as its description. The rollback is at the bottom of this file.
+--
+-- Renaming rows in this table is not cosmetic: two of its three unique indexes are on name, which is why the
+-- collision checks above are in the WHERE clause and not just in the header.
+
+BEGIN;
+
+WITH candidate AS (
+  SELECT id, source, source_id, name, description,
+         regexp_replace(trim(substring(name from '^(.{10,200}?[.!?])\s+[A-Z"]')), '\.$', '') AS new_name
+  FROM public.grant_opportunities
+  WHERE length(name) > 120
+),
+shared_new_name AS (
+  SELECT source, new_name FROM candidate
+  WHERE new_name IS NOT NULL GROUP BY source, new_name HAVING count(*) > 1
+),
+usable AS (
+  SELECT c.* FROM candidate c
+  WHERE c.new_name IS NOT NULL
+    AND length(c.new_name) >= 10
+    AND c.new_name <> c.name
+    AND NOT EXISTS (SELECT 1 FROM shared_new_name s WHERE s.source IS NOT DISTINCT FROM c.source AND s.new_name = c.new_name)
+    AND NOT EXISTS (SELECT 1 FROM public.grant_opportunities g
+                    WHERE g.id <> c.id AND g.name = c.new_name AND g.source IS NOT DISTINCT FROM c.source)
+    AND NOT EXISTS (SELECT 1 FROM public.grant_opportunities g
+                    WHERE g.id <> c.id AND g.name = c.new_name AND g.source_id IS NOT DISTINCT FROM c.source_id)
+)
+UPDATE public.grant_opportunities g
+SET name = u.new_name,
+    description = CASE WHEN g.description IS NULL OR trim(g.description) = '' THEN u.name ELSE g.description END,
+    metadata = coalesce(g.metadata, '{}'::jsonb)
+               || jsonb_build_object('original_name', u.name, 'name_trimmed_at', now()),
+    updated_at = now()
+FROM usable u
+WHERE g.id = u.id;
+
+COMMIT;
+
+-- Post-check:
+--   SELECT count(*) FROM grant_opportunities WHERE metadata ? 'original_name';          -- rows changed
+--   SELECT count(*) FROM grant_opportunities WHERE length(name) > 120;                  -- what is left, all unsplittable
+--   SELECT count(*) FROM grant_opportunities WHERE metadata ? 'original_name' AND (description IS NULL OR trim(description) = '');  -- expect 0
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_search_index;                             -- so search shows titles too
+--
+-- Rollback (nothing else has to be undone):
+--   UPDATE grant_opportunities SET name = metadata->>'original_name',
+--          metadata = metadata - 'original_name' - 'name_trimmed_at'
+--   WHERE metadata ? 'original_name';

--- a/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
+++ b/thoughts/shared/findings/supabase-platform-review-2026-09-05.md
@@ -628,3 +628,25 @@ parallel, six at ~170 ms, which costs about one call.
 **And one in the tooling:** `scripts/ship-watch.mjs` split its `--verify` spec on the first `=`, so any URL with a query
 string was truncated and its expectation became `Number("mission")`. Two landings reported a live-check failure that had
 not happened. It now matches only a trailing three-digit code.
+
+### Grant names were abstracts (fixed 2026-09-05)
+
+Using the unified view exposed it: 8,343 of 26,698 grant names ran past 120 characters because the ingest put the whole
+abstract in the name field (arc-grants 5,598, brisbane-grants 1,878, Lotterywest 734). Every surface listing a grant
+showed an abstract where a title belongs, including 7,418 rows of `mv_search_index`.
+
+The shape is "Title. Abstract...", so the title is the first sentence. `20260905190000` renames the rows that split
+cleanly at a sentence boundary (10-200 characters, ending in `.`/`!`/`?`, followed by a capital):
+
+| measure | before | after |
+|---|---|---|
+| grant names over 120 chars | 8,343 | 2,654 |
+| search index names over 120 chars | 7,418 | 3,309 |
+| rows renamed | | 5,754 |
+
+Renaming rows in this table is not cosmetic, because two of its three unique indexes are on `name`. Measured first: no
+new name collided with an existing row on `(source, name)` or `(name, source_id)`, and the 4 rows that would have
+collided with each other are excluded. The remaining 2,654 long names have no clean sentence boundary and were left
+alone. Nothing is lost and it is reversible: the full original is in `metadata->>'original_name'` on all 5,754 rows, the
+54 rows that had no description got the original text as their description, and the rollback statement is in the
+migration footer.


### PR DESCRIPTION
## What

8,343 of 26,698 grant names ran past 120 characters because the ingest put the whole abstract in the name field (arc-grants 5,598, brisbane-grants 1,878, Lotterywest 734). Every surface that lists a grant showed an abstract where a title belongs, including 7,418 rows of `mv_search_index`.

The shape is `Title. Abstract...`, so `20260905190000` renames the rows that split cleanly at a sentence boundary to their first sentence.

| measure | before | after |
|---|---|---|
| grant names over 120 chars | 8,343 | 2,654 |
| search index names over 120 chars | 7,418 | 3,309 |
| rows renamed | | 5,754 |

## Why the guards are in the SQL, not just the header

Two of this table's three unique indexes are on `name`, so renaming rows can collide. Measured before writing: no new name collides with an existing row on `(source, name)` or `(name, source_id)`, and the 4 rows that would have collided with each other are excluded by the query. The 2,654 names with no clean sentence boundary are left exactly as they were.

## Reversible, nothing lost

The full original is in `metadata->>'original_name'` on all 5,754 renamed rows; the 54 rows that had no description got the original text as their description (verified: zero renamed rows lack a description). The rollback statement is in the migration footer.

## Verification

Applied with `scripts/db-apply.sh`; every count above measured after. `mv_search_index` refreshed concurrently, and a search for "perovskite" now returns three real titles where it used to return abstracts. `scripts/precheck.sh` green.