### PR TITLE
Orchestrator hygiene: fix three nightly failures, disable four dead schedules

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -466,7 +466,9 @@ async function buildEntities() {
   log('  Loading political parties...');
   const partyRows = await selectJsonRows('political party recipients',
     `SELECT DISTINCT donation_to FROM political_donations WHERE donation_to IS NOT NULL`);
-  const uniqueParties = partyRows.map((r) => r.donation_to).filter(Boolean);
+  // Whitespace-only recipient names reach here from the AEC feed; makeGsId throws on them, and one such row
+  // used to abort the whole nightly build (4 of the last 10 runs). Trim and drop them instead.
+  const uniqueParties = [...new Set(partyRows.map((r) => (r.donation_to ?? "").trim()).filter(Boolean))];
 
   if (!dryRun) {
     const partyEntities = uniqueParties.map((name) => ({

--- a/scripts/classify-community-controlled.mjs
+++ b/scripts/classify-community-controlled.mjs
@@ -13,7 +13,8 @@
  *   node scripts/classify-community-controlled.mjs --apply   # apply changes
  */
 import 'dotenv/config';
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from "@supabase/supabase-js";
+import { psql } from "./lib/psql.mjs";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
@@ -40,17 +41,15 @@ async function classify() {
   console.log(`[classify] Indigenous corporations (ORIC): ${oricCount}`);
 
   if (apply) {
-    // Previous version used supabase.from().update().eq() which silently
-    // failed on bulk updates >~500 rows (PostgREST client quirk). Use
-    // exec_sql RPC for the bulk update — hits the DB directly.
-    const { error: updateError } = await supabase.rpc('exec_sql', {
-      query: `UPDATE gs_entities
+    // exec_sql is SELECT-only (it wraps the query, so an UPDATE fails with "syntax error at or near SET"),
+    // which means this apply path silently wrote nothing on every scheduled run. psql() goes to the DB directly.
+    try {
+      psql(`UPDATE gs_entities
                 SET is_community_controlled = true
               WHERE entity_type = 'indigenous_corp'
-                AND is_community_controlled = false`,
-    });
-    if (updateError) {
-      console.error('[classify] ORIC bulk update failed:', updateError.message);
+                AND is_community_controlled = false`, { label: "classify-oric" });
+    } catch (err) {
+      console.error("[classify] ORIC bulk update failed:", err.message);
     }
   }
 
@@ -74,16 +73,14 @@ async function classify() {
       nameMatchCount += data.length;
       console.log(`[classify] "${pattern}": ${data.length} matches`);
       if (apply) {
-        // Same pattern — exec_sql for reliable bulk update
-        const { error: updateError } = await supabase.rpc('exec_sql', {
-          query: `UPDATE gs_entities
+        try {
+          psql(`UPDATE gs_entities
                     SET is_community_controlled = true
                   WHERE is_community_controlled = false
                     AND entity_type IN ('charity', 'social_enterprise', 'trust', 'unknown')
-                    AND canonical_name ILIKE '%${pattern.replace(/'/g, "''")}%'`,
-        });
-        if (updateError) {
-          console.error(`[classify] name "${pattern}" update failed:`, updateError.message);
+                    AND canonical_name ILIKE '%${pattern.replace(/'/g, "''")}%'`, { label: "classify-name" });
+        } catch (err) {
+          console.error(`[classify] name "${pattern}" update failed:`, err.message);
         }
       }
     }

--- a/scripts/lib/agent-registry.mjs
+++ b/scripts/lib/agent-registry.mjs
@@ -339,7 +339,7 @@ export const AGENTS = {
     displayName: 'Import Gov Grants',
     category: 'import',
     defaultPriority: 3,
-    timeoutMs: 600_000,
+    timeoutMs: 1_800_000,
     dependencies: [],
   },
   'ingest-abr-bulk': {
@@ -476,7 +476,7 @@ export const AGENTS = {
     displayName: 'Grant pipeline · ingest and promote',
     category: 'discovery',
     defaultPriority: 2,
-    timeoutMs: 1_200_000,
+    timeoutMs: 2_400_000,
     dependencies: [],
   },
   'nightly-grant-pipeline-enrich': {
@@ -484,7 +484,7 @@ export const AGENTS = {
     displayName: 'Grant pipeline · classify, enrich and verify',
     category: 'enrichment',
     defaultPriority: 3,
-    timeoutMs: 1_200_000,
+    timeoutMs: 2_400_000,
     dependencies: [],
   },
   'nightly-grant-pipeline-finalize': {

--- a/supabase/migrations/20260906020000_disable_noisy_orchestrator_schedules.sql
+++ b/supabase/migrations/20260906020000_disable_noisy_orchestrator_schedules.sql
@@ -1,0 +1,11 @@
+-- Apply: scripts/db-apply.sh supabase/migrations/20260906020000_disable_noisy_orchestrator_schedules.sql
+-- Data-only. Flips enabled=false on four agent_schedules rows the orchestrator kept retrying every night.
+-- Reversible: UPDATE agent_schedules SET enabled = true WHERE agent_id IN (...).
+UPDATE agent_schedules SET enabled = false, updated_at = now()
+WHERE agent_id IN (
+  'sync-goods-ghl',            -- GHL private-integration token in grantscope/.env returns 401; 14/17 failures in 30 days
+  'check-graph-completeness',  -- exits 1 by design while grant_opportunities edges are 97% missing; nothing reads it
+  'grantscope-discovery',      -- data widening (paused 2026-06-08); 3/8 runs hit the 30-minute timeout
+  'poll-source-frontier'       -- data widening; polled grant source pages every 6h
+)
+RETURNING agent_id, enabled;


### PR DESCRIPTION
## What
The PM2 `orchestrator` came back after a reboot and spent the morning retrying agents that fail for reasons unrelated to the data.

- **build-entity-graph**: whitespace-only `donation_to` names made `makeGsId` throw and abort the nightly build (4 of last 10 runs). Trimmed and dropped.
- **classify-community-controlled**: `exec_sql` is SELECT-only, so its UPDATEs failed with `syntax error at or near SET`. The apply path had never written a row. Now uses `psql()`.
- **Timeouts**: import-gov-grants 10→30 min, nightly grant ingest/enrich 20→40 min. Each timed out on real work then retried twice.
- **Migration (data-only)**: disables `sync-goods-ghl` (GHL token 401, 14/17 failures), `check-graph-completeness` (exits 1 by design, no consumer), `grantscope-discovery` and `poll-source-frontier` (data widening, paused 2026-06-08). Ben applies with `scripts/db-apply.sh`.

## Verification
`scripts/precheck.sh` green (tsc + vitest). `node --check` on the three scripts. `gs-id.test.mjs` passes.

## Follow-up
`GHL_API_KEY` in grantscope `.env` differs from the one in act-global-infrastructure and returns 401. Rotate it, then re-enable `sync-goods-ghl`.