### PR TITLE
Retire grant_opportunities as an edge dataset

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -754,9 +754,9 @@ async function buildContractRelationships() {
 // ─── Phase 2b2: Grant opportunities → relationships ─────────────────────────
 
 async function buildGrantRelationships() {
-  log('\nPhase 2b2: Grant relationships...');
-  const d = edgeDataset('grant_opportunities');
-  await buildRelationshipsSetBased(d.label, d.cols, d.selectSql, d.prelude);
+  // Retired 2026-09-06: the only derivation was a foundation self-loop, forbidden since the
+  // 2026-08-20 self-loop migration. See the note in graph-edge-datasets.mjs.
+  log("\nPhase 2b2: Grant relationships... skipped (retired: self-loop derivation, see graph-edge-datasets.mjs)");
 }
 
 // ─── Phase 2c: Cross-registry links ──────────────────────────────────────────

--- a/scripts/lib/graph-edge-datasets.mjs
+++ b/scripts/lib/graph-edge-datasets.mjs
@@ -123,29 +123,11 @@ export const GRAPH_EDGE_DATASETS = [
      WHERE c.supplier_abn IS NOT NULL
        AND regexp_replace(c.supplier_abn, '\\s', '', 'g') ~ '^[0-9]{11}$'`,
   },
-  {
-    dataset: 'grant_opportunities',
-    relationshipType: 'grant',
-    label: 'Grant relationships',
-    sourceTable: 'grant_opportunities',
-    cols: '(source_entity_id, target_entity_id, relationship_type, amount, dataset, source_record_id, confidence, properties)',
-    prelude: '',
-    // self-ref edge on the foundation entity (foundation offers grant); amount = max || min.
-    selectSql: `SELECT
-       f_ent.id AS source_entity_id, f_ent.id AS target_entity_id, 'grant' AS relationship_type, coalesce(g.amount_max, g.amount_min),
-       'grant_opportunities', g.id::text AS source_record_id, 'registry',
-       jsonb_build_object(
-         'grant_name', g.name,
-         'categories', array_to_string(g.categories, ', '),
-         'closes_at',  g.closes_at,
-         'provider',   g.provider)
-     FROM grant_opportunities g
-     JOIN foundations f
-       ON f.id = g.foundation_id AND f.acnc_abn IS NOT NULL
-     JOIN gs_entities f_ent
-       ON f_ent.gs_id = 'AU-ABN-' || regexp_replace(f.acnc_abn, '\\s', '', 'g')
-     WHERE g.foundation_id IS NOT NULL`,
-  },
+  // `grant_opportunities` was RETIRED as an edge dataset on 2026-09-06. Its only derivation was a
+  // self-loop (foundation -> itself, one per program), which the 2026-08-20 self-loop migration
+  // deleted (6,229 rows) and now forbids via gs_relationships_no_judged_selfloops. Left in place, the
+  // build phase could only violate that constraint and the completeness gate counted 5,468 forbidden
+  // edges as "missing". A program is not a counterparty; it needs its own node before it can be an edge.
   {
     dataset: 'foundations',
     relationshipType: 'subsidiary_of',


### PR DESCRIPTION
## What
Removes `grant_opportunities` from `GRAPH_EDGE_DATASETS` and makes the build's grant phase a logged no-op.

## Why
The dataset's only derivation was a self-loop: foundation → itself, one edge per grant program. On 2026-08-20 the self-loop migration deleted 6,229 of exactly these rows and added `gs_relationships_no_judged_selfloops`, which forbids them. The recipe was never retired, so:
- `build-entity-graph` phase 2b2 could only fail on the CHECK constraint once it got past the blank-name crash fixed in #420
- `check-graph-completeness` counted 5,468 forbidden edges as "97% missing" and exited 1 every night

## Verification
`scripts/check-graph-completeness.mjs` now reports **No under-built datasets** across the five remaining datasets. `scripts/precheck.sh` green.

## Not touched
The 159 legacy `grant_opportunities` edges from March (company → foundation, a different derivation) stay. A grant program needs its own node before it can be an edge; that is a design decision, not a fix.