### PR TITLE
migration: ecosystem_sites.project_code

### DIFF
--- a/supabase/migrations/20260906043821_ecosystem_sites_project_code.sql
+++ b/supabase/migrations/20260906043821_ecosystem_sites_project_code.sql
@@ -1,0 +1,26 @@
+-- ecosystem_sites.project_code: which ACT project a site belongs to.
+--
+-- The typed project record (act-global-infrastructure/config/project-codes.json,
+-- via @act/projects) lists each project's sites. vercel-sync.mjs will upsert
+-- deployment state per site and needs to carry the owning code so the studio
+-- can show "live / broken, last deployed" per project. Plan:
+-- act-global-infrastructure/thoughts/shared/plans/project-record-and-site-sync.md
+--
+-- Text, not a foreign key: the codes live in a JSON file, not a table.
+-- Nullable: rows that are not ACT projects (external, experiments) stay NULL.
+BEGIN;
+
+ALTER TABLE public.ecosystem_sites
+  ADD COLUMN IF NOT EXISTS project_code text;
+
+COMMENT ON COLUMN public.ecosystem_sites.project_code IS
+  'ACT project code (e.g. ACT-JH) from config/project-codes.json; NULL when the site is not an ACT project';
+
+CREATE INDEX IF NOT EXISTS ecosystem_sites_project_code_idx
+  ON public.ecosystem_sites (project_code);
+
+COMMIT;
+
+-- post-check:
+-- SELECT column_name, data_type, is_nullable FROM information_schema.columns
+--  WHERE table_name='ecosystem_sites' AND column_name='project_code';


### PR DESCRIPTION
## What

`ecosystem_sites.project_code` (text, nullable, indexed): which ACT project a site belongs to, from `config/project-codes.json` via `@act/projects`. The infra Vercel sync will upsert deployment state per site carrying the owning code so the studio can show live/broken per project.

## Applied

Applied 2026-09-06 via `scripts/db-apply.sh` on Ben's verb, tracked as `20260906043821`. Post-check read the column and index back. Parity green (21 files, every post-baseline version has a file). Merging closes the tracker/main gap.

Note for the follow-up: RLS is on for `ecosystem_sites` with a service-role-only policy, so anon reads return 0 rows. The studio read in step 6 needs a permissive anon SELECT policy; separate migration, separate verb.

Plan: `act-global-infrastructure/thoughts/shared/plans/project-record-and-site-sync.md`