### PR TITLE
Link buyer_id-less AusTender buyers by name, then mint the rest

### DIFF
--- a/scripts/build-entity-graph.mjs
+++ b/scripts/build-entity-graph.mjs
@@ -334,10 +334,15 @@ async function buildEntities() {
   // only saw buyers present in the first 1000 of ~770K contract rows. Push the DISTINCT to the DB
   // (instant) so every buyer becomes a government_body entity.
   log('  Loading government bodies...');
+  // The key is coalesce(buyer_id, buyer_name), the same key the contract edge recipe uses
+  // (graph-edge-datasets.mjs). Until 2026-09-06 rows without a buyer_id were skipped here, so 725
+  // state and territory buyers (NT infrastructure departments, universities, NSW Police, 25,806
+  // contracts) never had an entity and their contracts never had an edge.
   const buyerRows = await selectJsonRows('government buyers',
-    `SELECT DISTINCT ON (buyer_id) buyer_id, buyer_name
-       FROM austender_contracts
-      WHERE buyer_name IS NOT NULL AND buyer_id IS NOT NULL`);
+    `SELECT DISTINCT ON (key) key AS buyer_id, buyer_name
+       FROM (SELECT coalesce(NULLIF(buyer_id, ''), buyer_name) AS key, buyer_name
+               FROM austender_contracts WHERE buyer_name IS NOT NULL) b
+      ORDER BY key`);
 
   const uniqueBuyers = new Map();
   for (const b of buyerRows) {
@@ -370,12 +375,35 @@ async function buildEntities() {
     existingByName.set(key, existingByName.has(key) ? null : e.gs_id);
   }
 
+  // SECOND RUNG (2026-09-06, Ben's call, option "link then mint"): a buyer with no government
+  // identity may already exist under an ABN, typed company/charity/foundation because it arrived
+  // through an ABN register. The University of Queensland, TAFE NSW, NSW Police Force: 40 such
+  // buyers, 8,488 contracts. Link to that entity rather than mint a second node beside it. Same
+  // ambiguity rule as above: two candidates (Griffith University, NSW DPI) resolve to nothing and
+  // fall through to minting; person clusters are never candidates (Public Trustee).
+  const existingAnyByName = new Map();
+  const anyRows = await selectJsonRows('existing identities by buyer name',
+    `SELECT lower(trim(e.canonical_name)) AS k, count(*) AS n, min(e.gs_id) AS gs_id
+       FROM gs_entities e
+      WHERE e.entity_type NOT IN ('person', 'political_party')
+        AND lower(trim(e.canonical_name)) IN (
+              SELECT DISTINCT lower(trim(buyer_name)) FROM austender_contracts WHERE buyer_name IS NOT NULL)
+      GROUP BY 1`);
+  for (const r of anyRows) existingAnyByName.set(r.k, Number(r.n) === 1 ? r.gs_id : null);
+
   let govReused = 0;
+  let linkedByName = 0;
   function govGsId(buyerId, name) {
-    const existing = existingByName.get(String(name ?? '').trim().toLowerCase());
+    const key = String(name ?? '').trim().toLowerCase();
+    const existing = existingByName.get(key);
     if (existing) {
       govReused += 1;
       return existing;
+    }
+    const linked = existingAnyByName.get(key);
+    if (linked) {
+      linkedByName += 1;
+      return linked;
     }
     return makeGsId({ buyer_id: buyerId });
   }
@@ -397,6 +425,7 @@ async function buildEntities() {
     govEntities.length = 0;
     govEntities.push(...deduped);
     log(`  Government identities reused from existing entities: ${govReused}`);
+    log(`  Buyers linked by name to an existing ABN entity (not minted): ${linkedByName}`);
 
     for (let i = 0; i < govEntities.length; i += 500) {
       const chunk = govEntities.slice(i, i + 500);

--- a/scripts/lib/graph-edge-datasets.mjs
+++ b/scripts/lib/graph-edge-datasets.mjs
@@ -108,8 +108,13 @@ export const GRAPH_EDGE_DATASETS = [
     // from a merged buyer (216,822 of them, Home Affairs, the AFP, Finance...) fell out of the
     // derivation. Measured 2026-09-06: 147,608 existing edges looked "stale" because the recipe could
     // no longer produce them, and 377 contracts published since the merge had no edge at all.
-    // Resolution order, per distinct buyer key: exact gs_id, else the ONE government entity with that
-    // name. An ambiguous name (two entities) resolves to nothing, as in the entity phase.
+    // Resolution order, per distinct buyer key, identical to govGsId in the entity phase:
+    //   1. exact gs_id AU-GOV-<key>;
+    //   2. the ONE government entity with that name;
+    //   3. (2026-09-06, "link then mint") the ONE non-person entity of any type with that name, so a
+    //      state buyer that already exists under an ABN (universities, TAFE NSW, NSW Police) links to
+    //      that node instead of getting a second one.
+    // An ambiguous name (two entities) resolves to nothing at rungs 2 and 3, as in the entity phase.
     prelude: `CREATE TEMP TABLE austender_buyer_map AS
       WITH keys AS (
         SELECT DISTINCT coalesce(NULLIF(buyer_id, ''), buyer_name) AS key, lower(trim(buyer_name)) AS name_key
@@ -117,11 +122,20 @@ export const GRAPH_EDGE_DATASETS = [
       gov_by_name AS (
         SELECT lower(trim(canonical_name)) AS name_key, (array_agg(id))[1] AS entity_id, count(*) AS n
         FROM gs_entities WHERE entity_type = 'government_body' OR gs_id LIKE 'AU-GOV-%'
+        GROUP BY 1),
+      any_by_name AS (
+        SELECT lower(trim(canonical_name)) AS name_key, (array_agg(id))[1] AS entity_id, count(*) AS n
+        FROM gs_entities
+        WHERE entity_type NOT IN ('person', 'political_party')
+          AND lower(trim(canonical_name)) IN (SELECT name_key FROM keys)
         GROUP BY 1)
-      SELECT k.key, coalesce(g.id, CASE WHEN n.n = 1 THEN n.entity_id END) AS entity_id
+      SELECT k.key, coalesce(g.id,
+                             CASE WHEN n.n = 1 THEN n.entity_id END,
+                             CASE WHEN a.n = 1 THEN a.entity_id END) AS entity_id
       FROM keys k
       LEFT JOIN gs_entities g ON g.gs_id = 'AU-GOV-' || k.key
-      LEFT JOIN gov_by_name n ON n.name_key = k.name_key;
+      LEFT JOIN gov_by_name n ON n.name_key = k.name_key
+      LEFT JOIN any_by_name a ON a.name_key = k.name_key;
       DELETE FROM austender_buyer_map WHERE entity_id IS NULL;
       CREATE INDEX ON austender_buyer_map (key);
       ANALYZE austender_buyer_map;`,


### PR DESCRIPTION
## What
Two changes, kept in step so the build and the completeness gate agree:
- **Entity phase 1d** now keys buyers on `coalesce(buyer_id, buyer_name)` like the edge recipe, so buyers with no `buyer_id` get an entity. Resolution: existing government identity by name → the ONE existing non-person entity by name (link, no mint) → mint `AU-GOV-<name>`.
- **Edge recipe prelude** gets the same third rung.

## Why
725 state and territory buyers (NT infrastructure departments, universities, TAFE NSW, NSW Police, Queensland Corrective Services) carry no `buyer_id`. The entity phase skipped them, so 25,806 contracts had no edge. Of the 725, 43 names match an existing entity under an ABN; 40 are unambiguous and link (8,488 contracts). Griffith University (3 candidates), NSW DPI (2) and Public Trustee (a person cluster) refuse and mint, per the existing ambiguity rule.

## Effect
`check-graph-completeness --dataset=austender` expected: 740,287 → 747,948 today. The nightly build mints the remaining ~682 entities, after which rung 1 catches them and expected rises by the rest of the 25,806.

## Verification
Completeness check run locally with the new prelude. `scripts/precheck.sh` green. No data written; minting happens in the nightly `build-entity-graph`.