### PR TITLE
Re-enable the nightly graph completeness gate

### DIFF
--- a/supabase/migrations/20260906050000_reenable_check_graph_completeness.sql
+++ b/supabase/migrations/20260906050000_reenable_check_graph_completeness.sql
@@ -1,0 +1,7 @@
+-- Apply: scripts/db-apply.sh supabase/migrations/20260906050000_reenable_check_graph_completeness.sql
+-- Data-only. Re-enables the nightly graph completeness gate, disabled by 20260906020000 while it
+-- reported two false alarms. Both were recipe drift and are fixed (#422, #423, #425); the check now
+-- reads clean on every dataset, so its exit 1 means something again.
+UPDATE agent_schedules SET enabled = true, updated_at = now()
+WHERE agent_id = 'check-graph-completeness'
+RETURNING agent_id, enabled;


### PR DESCRIPTION
Data-only migration flipping `check-graph-completeness` back on. It was disabled this morning while reporting two false alarms; both were edge-recipe drift, fixed in #422, #423 and #425, and the check now reads clean on all five datasets. Ben applies with `scripts/db-apply.sh`.