### PR TITLE
Allocation: delivery-postcode lane and per-council charity trajectories

### DIFF
--- a/apps/web/src/app/allocation/[lga_code]/page.tsx
+++ b/apps/web/src/app/allocation/[lga_code]/page.tsx
@@ -70,6 +70,17 @@ export default async function CouncilAllocationPage({ params }: { params: Promis
           <Stat label="Justice grants on record" value={money(row.jf_grant_value)} sub={`${num(row.jf_grant_count)} rows, grant lane only`} />
           <Stat label="AusTender contracts, last 24 months" value={money(row.contract_value_24m)} sub="by supplier address" />
         </div>
+        <div className="mt-3 grid grid-cols-2 gap-3 md:grid-cols-4">
+          <Stat label="Commonwealth grants delivered here, 24 months" value={money(row.cw_delivery_value_24m)} sub={`${num(row.cw_delivery_count)} awards spread by delivery postcode, all time · ${perHead(row.cw_delivery_24m_per_head, row.population)}`} />
+          <Stat label="Recipient lane, where delivery is stated" value={money(row.cw_recipient_24m_with_delivery)} sub={row.cw_grant_value_24m > 0 ? `${row.cw_delivery_stated_pct == null ? '—' : Math.round(row.cw_delivery_stated_pct)}% of the ${money(row.cw_grant_value_24m)} received here states a delivery postcode` : 'no Commonwealth grants received here in 24 months'} tone={row.cw_grant_value_24m > 0 && (row.cw_delivery_stated_pct ?? 0) < 25 ? '#B8860B' : undefined} />
+          <Stat label="Charities shrinking" value={row.charities_tracked ? `${num(row.charities_shrinking)} of ${num(row.charities_tracked)}` : '—'} sub={row.charities_shrinking ? `${money(row.shrinking_revenue_lost)} a year less than their first statement, ${num(row.charities_growing)} growing, ${num(row.charities_lapsed)} lapsed` : row.charities_tracked ? `${num(row.charities_growing)} growing, ${num(row.charities_lapsed)} lapsed` : 'no charity here has a financial statement'} tone={row.charities_shrinking > 0 && (row.shrinking_share_pct ?? 0) >= 25 ? '#D02020' : undefined} />
+          <Stat label="Living on government, or in deficit" value={row.charities_tracked ? `${num(row.charities_gov_dependent)} · ${num(row.charities_three_year_deficit)}` : '—'} sub="70%+ revenue from government · deficits three statements running" />
+        </div>
+        {row.cw_grant_value_24m > 0 && (row.cw_delivery_stated_pct ?? 0) < 25 ? (
+          <p className="mt-3 max-w-3xl text-[12px]" style={{ color: '#555' }}>
+            The two grant lanes are only comparable where the agency stated a delivery postcode, and here that is {row.cw_delivery_stated_pct == null ? 'none' : `${Math.round(row.cw_delivery_stated_pct)}%`} of the money. The National Indigenous Australians Agency states no delivery postcode on any award; Health, Disability and Ageing on 2%. So a gap between received and delivered on this page is mostly the record being silent.
+          </p>
+        ) : null}
 
         {sure != null && sure < 40 ? (
           <p className="mt-4 border-4 border-bauhaus-black bg-[#FFF8E0] p-3 text-[13px]">
@@ -144,6 +155,8 @@ export default async function CouncilAllocationPage({ params }: { params: Promis
           <h2 className="font-display text-[13px] font-black uppercase tracking-widest">Where this comes from, and what is missing</h2>
           <ul className="mt-2 list-disc space-y-1 pl-5">
             <li>Population is the ABS Estimated Resident Population, 2023. Need is SEIFA IRSD 2021, held per postcode and weighted into the council by each postcode&apos;s share of it.</li>
+            <li>Commonwealth grants delivered here spread each GrantConnect award across councils by the ABS share of its stated delivery postcode, so a straddling postcode splits an award rather than picking a side. Only some agencies state one; the tile above says how much of this council&apos;s money does.</li>
+            <li>Charity direction is first statement to latest, 2017 to 2023, from the same Annual Information Statements; shrinking means revenue fell by more than a fifth and the latest year is above $0.</li>
             <li>Government revenue and donations are what every charity placed here reported to the ACNC for 2023. Councils, companies and schools file nothing here, so a place run by its shire council can read as $0.</li>
             <li>{num(row.unplaced_sharing_postcodes)} organisations use a postcode that crosses into this council and could not be placed on one side of the line. They are counted, never guessed.</li>
             {councilSlug ? (

--- a/apps/web/src/app/allocation/page.tsx
+++ b/apps/web/src/app/allocation/page.tsx
@@ -125,11 +125,12 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
           <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The table could not be read: {why}</p>
         ) : (
           <>
-            <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-5">
+            <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-6">
               <Stat label="Councils" value={num(nation.councils)} />
               <Stat label="Charity revenue from government, 2023" value={money(nation.charity_gov_revenue)} hint="Sum of revenue_from_government across every charity placed in a council, ACNC statements for 2023" />
               <Stat label="Donations and bequests, 2023" value={money(nation.charity_donations)} hint="Same statements, donations_and_bequests" />
               <Stat label="Commonwealth grants, last 24 months" value={money(nation.cw_grant_value_24m)} hint="GrantConnect awards approved in the last two years, by recipient's council" />
+              <Stat label="Of which state where delivered" value={nation.cw_grant_value_24m ? `${Math.round((100 * nation.cw_recipient_24m_with_delivery) / nation.cw_grant_value_24m)}%` : '—'} hint={`${money(nation.cw_recipient_24m_with_delivery)} of those awards carry a delivery postcode the ABS can place. The National Indigenous Australians Agency states none; Health 2%.`} tone="#B8860B" />
               <Stat label="Decile 1–2 councils under the median $/head" value={num(nation.under_median_disadvantaged)} hint={`National median government revenue per head is $${num(nation.median_gov_per_head)}`} tone="#D02020" />
             </div>
 
@@ -150,7 +151,7 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
             </p>
 
             <div className="mt-2 overflow-x-auto border-4 border-bauhaus-black bg-white">
-              <table className="w-full min-w-[1100px] border-collapse text-[13px]" style={{ fontVariantNumeric: 'tabular-nums' }}>
+              <table className="w-full min-w-[1300px] border-collapse text-[13px]" style={{ fontVariantNumeric: 'tabular-nums' }}>
                 <thead>
                   <tr className="border-b-4 border-bauhaus-black">
                     <Head label="Council" sortKey="name" current={f.sort} qs={qs} />
@@ -161,6 +162,8 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
                     <Head label="Gov $ / head" sortKey="gov_per_head" current={f.sort} qs={qs} className="text-right" title="Revenue from government reported by charities placed here, 2023, divided by population" />
                     <Head label="Donations / head" sortKey="donations_per_head" current={f.sort} qs={qs} className="text-right" title="Donations and bequests reported by charities placed here, 2023, divided by population" />
                     <Head label="Cwlth grants 24m / head" sortKey="grants_per_head" current={f.sort} qs={qs} className="text-right" title="GrantConnect awards to recipients placed here, approved in the last two years, divided by population" />
+                    <Head label="Delivered here / head" sortKey="delivered_per_head" current={f.sort} qs={qs} className="text-right" title="The same awards spread by the delivery postcode the agency stated, divided by population. Grey percentage: how much of this council's recipient-lane money carries a delivery postcode at all" />
+                    <Head label="Shrinking" sortKey="shrinking" current={f.sort} qs={qs} className="text-right" title="Charities placed here whose revenue fell more than 20% from first statement to latest (2017 to 2023), as a share of charities with a statement" />
                     <Head label="How sure" sortKey="sure" current={f.sort} qs={qs} className="text-right" title="Placed entities as a share of placed plus entities sharing this council's postcodes that could not be placed" />
                   </tr>
                 </thead>
@@ -183,11 +186,18 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
                       <td className="px-2 py-[6px] text-right">{perHead(r.donations_per_head, r.population)}</td>
                       <td className="px-2 py-[6px] text-right">{perHead(r.cw_grants_24m_per_head, r.population)}</td>
                       <td className="px-2 py-[6px] text-right">
+                        {perHead(r.cw_delivery_24m_per_head, r.population)}
+                        {r.cw_grant_value_24m > 0 ? <span className="ml-1 font-mono text-[10px]" style={{ color: '#777' }} title="Share of recipient-lane money here that states a delivery postcode">{r.cw_delivery_stated_pct == null ? '' : `${Math.round(r.cw_delivery_stated_pct)}%`}</span> : null}
+                      </td>
+                      <td className="px-2 py-[6px] text-right">
+                        {r.charities_tracked === 0 ? <span style={{ color: '#777' }}>—</span> : <><span className="font-black" style={{ color: r.charities_shrinking > 0 && (r.shrinking_share_pct ?? 0) >= 25 ? '#D02020' : '#121212' }}>{num(r.charities_shrinking)}</span><span className="ml-1 font-mono text-[10px]" style={{ color: '#777' }}>of {num(r.charities_tracked)}</span></>}
+                      </td>
+                      <td className="px-2 py-[6px] text-right">
                         <Sure pct={r.placed_share_pct} unplaced={r.unplaced_sharing_postcodes} />
                       </td>
                     </tr>
                   ))}
-                  {rows.length === 0 ? <tr><td colSpan={9} className="px-2 py-6 text-center" style={{ color: '#777' }}>No council matches these filters.</td></tr> : null}
+                  {rows.length === 0 ? <tr><td colSpan={11} className="px-2 py-6 text-center" style={{ color: '#777' }}>No council matches these filters.</td></tr> : null}
                 </tbody>
               </table>
             </div>
@@ -198,6 +208,8 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
                 <li><b>Need</b> is the SEIFA Index of Relative Socio-economic Disadvantage (2021), held per postcode and weighted into the council by each postcode's share. Decile 1 is the most disadvantaged tenth of Australia. The small arrow shows the worst postcode touching the council when it is more than a whole decile below the average.</li>
                 <li><b>Gov $ / head</b> and <b>Donations / head</b> come from the Annual Information Statements every registered charity files with the ACNC. This is the whole register for 2023, not a sample. An organisation that is not a charity (a council, a company, a school) files nothing here.</li>
                 <li><b>Money follows the recipient's address.</b> A land council or regional service in a hub town collects money that is spent hours away. A remote council can show $0 per head while being served from the next council over. Read the row together with its neighbours.</li>
+                <li><b>Delivered here / head</b> is the second lane on the same GrantConnect awards. Some agencies state the postcode where the money is to be spent; where they do, the award is spread across councils by the ABS postcode-to-council ratio, so a postcode that straddles two councils splits the award instead of picking a side. The grey percentage is how much of the council&apos;s recipient-lane money states a delivery postcode at all. It is low almost everywhere that matters: the National Indigenous Australians Agency states none, Health, Disability and Ageing 2%, Education 11%, while the Australian Research Council states one on every dollar. A blank here is the record being silent, not money going elsewhere.</li>
+                <li><b>Shrinking</b> counts charities placed here whose revenue fell more than a fifth between their first and latest statement, 2017 to 2023, out of those with a statement. A charity at $0 in its latest year is dormant and is not counted. The <Link href="/charities/trajectories" className="underline" style={{ color: '#1040C0' }}>trajectories page</Link> lists the councils where this share is highest.</li>
                 <li><b>How sure</b> is the share of organisations we could place. Where a postcode crosses two councils and nothing in the record says which side an organisation is on, it is left unplaced and counted here. A row at 10% is a row about what we cannot see; do not read its dollar figures as a finding.</li>
                 <li>Population is the ABS Estimated Resident Population for 2023. Commonwealth grants are GrantConnect awards approved in the last two years. Nothing on this page reads Xero, GoHighLevel or any private table.</li>
               </ul>

--- a/apps/web/src/app/charities/trajectories/page.tsx
+++ b/apps/web/src/app/charities/trajectories/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Shell } from '@/components/shell/shell';
 import { TREND_LABEL, trajectoryLists, type TrajectoryLists, type TrajectoryRow } from '@/lib/charity-trajectory';
+import { shrinkingCouncils, type AllocationRow } from '@/lib/allocation';
 
 export const dynamic = 'force-dynamic';
 export const metadata: Metadata = {
@@ -37,9 +38,10 @@ export default async function TrajectoriesPage({ searchParams }: { searchParams:
   const sp = await searchParams;
   const state = typeof sp.state === 'string' && STATES.includes(sp.state) ? sp.state : '';
   let lists: TrajectoryLists | null = null;
+  let councils: AllocationRow[] = [];
   let why: string | null = null;
   try {
-    lists = await trajectoryLists(state);
+    [lists, councils] = await Promise.all([trajectoryLists(state), shrinkingCouncils(state).catch(() => [] as AllocationRow[])]);
   } catch (e) {
     why = e instanceof Error ? e.message : String(e);
   }
@@ -141,6 +143,37 @@ export default async function TrajectoriesPage({ searchParams }: { searchParams:
                 { h: 'Donation share', r: (r) => pct(r.donation_share_last_pct), right: true },
               ]}
             />
+
+            <section className="mt-8">
+              <h2 className="font-display text-[15px] font-black uppercase tracking-widest">Councils where charities are shrinking</h2>
+              <p className="mt-1 text-[12px]" style={{ color: '#555' }}>Councils with ten or more charities on file, sorted by the share whose revenue fell more than a fifth from first statement to latest. Revenue lost is the sum of those falls, a year. Each council links to its allocation page with the charities named.</p>
+              <div className="mt-2 overflow-x-auto border-4 border-bauhaus-black bg-white">
+                <table className="w-full min-w-[820px] border-collapse text-[13px]" style={{ fontVariantNumeric: 'tabular-nums' }}>
+                  <thead>
+                    <tr className="border-b-4 border-bauhaus-black">
+                      {['Council', 'Need', 'Charities on file', 'Shrinking', 'Share', 'Revenue lost / yr', 'Growing', 'On government'].map((h, i) => (
+                        <th key={h} className={`px-2 py-2 font-mono text-[10px] font-black uppercase tracking-widest ${i >= 2 ? 'text-right' : 'text-left'}`} style={{ color: '#777' }}>{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {councils.map((c) => (
+                      <tr key={c.lga_code} className="border-b border-[#D0D0D0] hover:bg-[#F7F7F7]">
+                        <td className="px-2 py-[6px]"><Link href={`/allocation/${c.lga_code}`} className="font-semibold hover:underline" style={{ color: '#1040C0' }}>{c.lga_name}</Link><span className="ml-1 font-mono text-[10px]" style={{ color: '#777' }}>{[c.state, (c.remoteness ?? '').replace(' of Australia', '').replace(' Australia', '')].filter(Boolean).join(' · ')}</span></td>
+                        <td className="px-2 py-[6px] font-black" style={{ color: c.irsd_decile != null && c.irsd_decile <= 2.5 ? '#D02020' : '#121212' }}>{c.irsd_decile?.toFixed(1) ?? '—'}</td>
+                        <td className="px-2 py-[6px] text-right">{c.charities_tracked.toLocaleString('en-AU')}</td>
+                        <td className="px-2 py-[6px] text-right font-black" style={{ color: '#D02020' }}>{c.charities_shrinking.toLocaleString('en-AU')}</td>
+                        <td className="px-2 py-[6px] text-right">{c.shrinking_share_pct == null ? '—' : `${Math.round(c.shrinking_share_pct)}%`}</td>
+                        <td className="px-2 py-[6px] text-right">{money(c.shrinking_revenue_lost)}</td>
+                        <td className="px-2 py-[6px] text-right">{c.charities_growing.toLocaleString('en-AU')}</td>
+                        <td className="px-2 py-[6px] text-right">{c.charities_gov_dependent.toLocaleString('en-AU')}</td>
+                      </tr>
+                    ))}
+                    {councils.length === 0 ? <tr><td colSpan={8} className="px-2 py-4 text-center" style={{ color: '#777' }}>No council here has ten charities on file.</td></tr> : null}
+                  </tbody>
+                </table>
+              </div>
+            </section>
 
             <section className="mt-8 max-w-3xl border-4 border-bauhaus-black bg-white p-4 text-[13px] leading-relaxed">
               <h2 className="font-display text-[13px] font-black uppercase tracking-widest">How to read this</h2>

--- a/apps/web/src/lib/allocation.test.ts
+++ b/apps/web/src/lib/allocation.test.ts
@@ -4,8 +4,9 @@ import { parseAllocationFilters, summariseAllocation, type AllocationRow } from 
 const row = (o: Partial<AllocationRow>): AllocationRow => ({
   lga_code: '1', lga_name: 'A', state: 'QLD', remoteness: null, population: 1000, irsd_decile: 5, min_irsd_decile: 5,
   org_count: 1, community_controlled: 0, charities_reporting: 0, charity_revenue: 0, charity_gov_revenue: 0, charity_donations: 0,
-  charity_fte: 0, cw_grant_count: 0, cw_grant_value_24m: 0, jf_grant_count: 0, jf_grant_value: 0, contract_value_24m: 0, unplaced_sharing_postcodes: 0,
-  gov_revenue_per_head: 0, donations_per_head: 0, cw_grants_24m_per_head: 0, orgs_per_10k: 0, placed_share_pct: 100, ...o,
+  charity_fte: 0, cw_grant_count: 0, cw_grant_value_24m: 0, cw_delivery_count: 0, cw_delivery_value_24m: 0, cw_recipient_24m_with_delivery: 0, cw_delivery_stated_pct: null, jf_grant_count: 0, jf_grant_value: 0, contract_value_24m: 0, unplaced_sharing_postcodes: 0,
+  charities_tracked: 0, charities_shrinking: 0, charities_growing: 0, charities_lapsed: 0, charities_gov_dependent: 0, charities_three_year_deficit: 0, shrinking_revenue_lost: 0, shrinking_share_pct: null,
+  gov_revenue_per_head: 0, donations_per_head: 0, cw_grants_24m_per_head: 0, cw_delivery_24m_per_head: 0, orgs_per_10k: 0, placed_share_pct: 100, ...o,
 });
 
 describe('parseAllocationFilters', () => {

--- a/apps/web/src/lib/allocation.ts
+++ b/apps/web/src/lib/allocation.ts
@@ -26,13 +26,30 @@ export interface AllocationRow {
   charity_fte: number;
   cw_grant_count: number;
   cw_grant_value_24m: number;
+  /** Delivery lane: GrantConnect awards spread by delivery_postcode through the postcode-to-council ratio. */
+  cw_delivery_count: number;
+  cw_delivery_value_24m: number;
+  /** Recipient-lane 24m value on rows that also carry a mapped delivery postcode: the only fair comparison base. */
+  cw_recipient_24m_with_delivery: number;
+  /** That base as a share of the recipient lane. Low means the record is silent, not that money went elsewhere. */
+  cw_delivery_stated_pct: number | null;
   jf_grant_count: number;
   jf_grant_value: number;
   contract_value_24m: number;
   unplaced_sharing_postcodes: number;
+  /** Trajectory rollups from mv_charity_trajectory, charities placed here with at least one statement. */
+  charities_tracked: number;
+  charities_shrinking: number;
+  charities_growing: number;
+  charities_lapsed: number;
+  charities_gov_dependent: number;
+  charities_three_year_deficit: number;
+  shrinking_revenue_lost: number;
+  shrinking_share_pct: number | null;
   gov_revenue_per_head: number | null;
   donations_per_head: number | null;
   cw_grants_24m_per_head: number | null;
+  cw_delivery_24m_per_head: number | null;
   orgs_per_10k: number | null;
   placed_share_pct: number | null;
 }
@@ -44,6 +61,8 @@ export const ALLOCATION_SORTS = {
   donations_per_head: { column: 'donations_per_head', ascending: false, label: 'donations per head' },
   donations_per_head_asc: { column: 'donations_per_head', ascending: true, label: 'least donations per head' },
   grants_per_head: { column: 'cw_grants_24m_per_head', ascending: false, label: 'Commonwealth grants per head' },
+  delivered_per_head: { column: 'cw_delivery_24m_per_head', ascending: false, label: 'Commonwealth grants delivered here, per head' },
+  shrinking: { column: 'shrinking_share_pct', ascending: false, label: 'share of charities shrinking' },
   population: { column: 'population', ascending: false, label: 'population' },
   orgs: { column: 'org_count', ascending: false, label: 'organisations' },
   sure: { column: 'placed_share_pct', ascending: true, label: 'least sure first' },
@@ -104,6 +123,10 @@ export interface AllocationSummary {
   charity_gov_revenue: number;
   charity_donations: number;
   cw_grant_value_24m: number;
+  cw_delivery_value_24m: number;
+  cw_recipient_24m_with_delivery: number;
+  charities_tracked: number;
+  charities_shrinking: number;
   unplaced: number;
   /** Councils in decile 1-2 with fewer government dollars per head than the national median. */
   under_median_disadvantaged: number;
@@ -121,6 +144,10 @@ export function summariseAllocation(rows: AllocationRow[]): AllocationSummary {
     charity_gov_revenue: sum('charity_gov_revenue'),
     charity_donations: sum('charity_donations'),
     cw_grant_value_24m: sum('cw_grant_value_24m'),
+    cw_delivery_value_24m: sum('cw_delivery_value_24m'),
+    cw_recipient_24m_with_delivery: sum('cw_recipient_24m_with_delivery'),
+    charities_tracked: sum('charities_tracked'),
+    charities_shrinking: sum('charities_shrinking'),
     unplaced: sum('unplaced_sharing_postcodes'),
     under_median_disadvantaged: rows.filter((r) => r.irsd_decile != null && r.irsd_decile <= 2.5 && (r.gov_revenue_per_head ?? 0) < median).length,
     median_gov_per_head: median,
@@ -135,12 +162,32 @@ export async function allocationForCode(lgaCode: string): Promise<AllocationRow 
   return (data as AllocationRow | null) ?? null;
 }
 
+const NEIGHBOUR_COLS =
+  'lga_code, lga_name, state, remoteness, population, irsd_decile, min_irsd_decile, org_count, community_controlled, charities_reporting, charity_revenue, charity_gov_revenue, charity_donations, charity_fte, cw_grant_count, cw_grant_value_24m, cw_delivery_count, cw_delivery_value_24m, cw_recipient_24m_with_delivery, cw_delivery_stated_pct, jf_grant_count, jf_grant_value, contract_value_24m, unplaced_sharing_postcodes, charities_tracked, charities_shrinking, charities_growing, charities_lapsed, charities_gov_dependent, charities_three_year_deficit, shrinking_revenue_lost, shrinking_share_pct, gov_revenue_per_head, donations_per_head, cw_grants_24m_per_head, cw_delivery_24m_per_head, orgs_per_10k, placed_share_pct';
+
+/**
+ * Councils where charities are shrinking, for /charities/trajectories. A council needs at least `minTracked`
+ * charities with a statement before its share means anything: one shrinking charity out of one is 100%.
+ * Sorted by share, then by revenue lost, so the list reads as places rather than as a rerun of the national list.
+ */
+export async function shrinkingCouncils(state: string, limit = 25, minTracked = 10): Promise<AllocationRow[]> {
+  const db = getDirectServiceSupabase();
+  let q = db.from('mv_lga_allocation').select(NEIGHBOUR_COLS).gte('charities_tracked', minTracked);
+  if (state) q = q.eq('state', state);
+  const { data, error } = await q
+    .order('shrinking_share_pct', { ascending: false, nullsFirst: false })
+    .order('shrinking_revenue_lost', { ascending: false, nullsFirst: false })
+    .limit(limit);
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AllocationRow[];
+}
+
 /** Councils in the same state, ordered by need, for the "read the row with its neighbours" strip. */
 export async function stateNeighbours(state: string, limit = 12): Promise<AllocationRow[]> {
   const db = getDirectServiceSupabase();
   const { data, error } = await db
     .from('mv_lga_allocation')
-    .select('lga_code, lga_name, state, remoteness, population, irsd_decile, min_irsd_decile, org_count, community_controlled, charities_reporting, charity_revenue, charity_gov_revenue, charity_donations, charity_fte, cw_grant_count, cw_grant_value_24m, jf_grant_count, jf_grant_value, contract_value_24m, unplaced_sharing_postcodes, gov_revenue_per_head, donations_per_head, cw_grants_24m_per_head, orgs_per_10k, placed_share_pct')
+    .select(NEIGHBOUR_COLS)
     .eq('state', state)
     .order('irsd_decile', { ascending: true, nullsFirst: false })
     .limit(limit);

--- a/supabase/migrations/20260907090000_mv_lga_allocation_delivery_and_trajectory.sql
+++ b/supabase/migrations/20260907090000_mv_lga_allocation_delivery_and_trajectory.sql
@@ -1,0 +1,211 @@
+-- 20260907090000_mv_lga_allocation_delivery_and_trajectory.sql
+-- mv_lga_allocation, second cut: a delivery-postcode lane for Commonwealth grants, and per-council charity
+-- trajectory rollups. Recreated in place (no view or matview depends on it; checked pg_depend 2026-09-07).
+--
+-- Delivery lane. grantconnect_awards carries delivery_postcode on 152,546 of 291,264 rows; 146,568 are a
+-- four-digit postcode, 5,978 say 'Multiple', the rest are null. Those rows hold $51.3bn of $230.0bn. Money is
+-- spread across councils by abs_poa_lga_ratio (a postcode's share of each council), so a straddling postcode
+-- splits the award instead of picking a side. 220 of 2,708 distinct delivery postcodes are not in the ratio
+-- table and are dropped from the lane; they are not in the disclosure columns either, which is why the
+-- comparable base below is defined on the ratio JOIN, not on the postcode being present.
+--
+-- The recipient lane is untouched. The two are only comparable on the rows that have BOTH a placed recipient
+-- and a mapped delivery postcode, so the view carries that base per council:
+--   cw_recipient_24m_with_delivery   recipient-lane 24m value restricted to rows with a mapped delivery postcode
+--   cw_delivery_stated_pct           that base as a share of the recipient lane 24m value (how sure)
+--   cw_delivery_value_24m            what the delivery lane says was spent in this council over the same 24m
+-- A council with a large recipient figure and a small delivery figure is a hub; the reverse is a community
+-- served from somewhere else. Where cw_delivery_stated_pct is low the comparison is about the record.
+--
+-- Measured 2026-09-07 (dry run): nationally the comparable base is $3.36bn of a $30.55bn recipient lane over 24 months
+-- (11%). Coverage is by agency, not by year: the Australian Research Council states a delivery postcode on 100% of
+-- value, Employment 54%, Infrastructure 40%, Education 11%, Health, Disability and Ageing 2%, and the National
+-- Indigenous Australians Agency ($3.84bn in 24 months) on NONE. Alice Springs has a 1% base. The lane therefore
+-- cannot show the hub-versus-community gap for the agencies that create it; it shows where the record is silent.
+--
+-- Trajectory rollups read mv_charity_trajectory (nightly, refreshed first: mv_refresh_plan orders by pg_depend).
+-- 'shrinking' requires revenue_last > 0, matching /charities/trajectories: a $0 latest year is dormant, not shrinking.
+BEGIN;
+
+DROP MATERIALIZED VIEW IF EXISTS public.mv_lga_allocation;
+
+CREATE MATERIALIZED VIEW public.mv_lga_allocation AS
+WITH lga AS (
+  SELECT p.lga_code, p.lga_name, p.state, p.erp_2023 AS population, p.erp_2018, p.area_sqkm
+  FROM abs_lga_population p
+),
+need AS (
+  SELECT r.lga_code,
+         round(sum(s.score * r.ratio) / nullif(sum(r.ratio) FILTER (WHERE s.score IS NOT NULL), 0), 0) AS irsd_score,
+         round(sum(s.decile_national * r.ratio) / nullif(sum(r.ratio) FILTER (WHERE s.decile_national IS NOT NULL), 0), 1) AS irsd_decile,
+         min(s.decile_national) AS min_irsd_decile,
+         count(DISTINCT r.poa_code) AS postcode_count,
+         count(DISTINCT r.poa_code) FILTER (WHERE s.score IS NOT NULL) AS postcodes_with_seifa
+  FROM abs_poa_lga_ratio r
+  LEFT JOIN seifa_2021 s ON s.postcode = r.poa_code AND s.index_type = 'IRSD'
+  GROUP BY r.lga_code
+),
+remote AS (
+  SELECT DISTINCT ON (r.lga_code) r.lga_code, g.remoteness_2021 AS remoteness
+  FROM abs_poa_lga_ratio r
+  JOIN (SELECT postcode, min(remoteness_2021) AS remoteness_2021 FROM postcode_geo
+        WHERE remoteness_2021 IS NOT NULL AND remoteness_2021 <> '' GROUP BY postcode) g ON g.postcode = r.poa_code
+  GROUP BY r.lga_code, g.remoteness_2021
+  ORDER BY r.lga_code, sum(r.ratio) DESC
+),
+orgs AS (
+  SELECT e.lga_code,
+         count(*) AS org_count,
+         count(*) FILTER (WHERE e.is_community_controlled OR e.entity_type = 'indigenous_corp') AS community_controlled,
+         count(*) FILTER (WHERE e.entity_type = 'charity') AS charities
+  FROM gs_entities e
+  WHERE e.lga_code IS NOT NULL
+  GROUP BY e.lga_code
+),
+acnc AS (
+  SELECT e.lga_code,
+         count(*) AS charities_reporting,
+         sum(a.total_revenue) AS charity_revenue,
+         sum(a.revenue_from_government) AS charity_gov_revenue,
+         sum(a.donations_and_bequests) AS charity_donations,
+         sum(a.staff_fte) AS charity_fte,
+         sum(a.staff_volunteers) AS charity_volunteers
+  FROM acnc_ais a
+  JOIN gs_entities e ON e.abn = a.abn AND e.lga_code IS NOT NULL
+  WHERE a.ais_year = 2023
+  GROUP BY e.lga_code
+),
+mapped_dp AS (
+  -- delivery postcodes the ratio table can place; the comparable base for both lanes
+  SELECT DISTINCT poa_code FROM abs_poa_lga_ratio
+),
+cw AS (
+  SELECT e.lga_code,
+         count(*) AS cw_grant_count,
+         sum(g.value_aud) AS cw_grant_value,
+         sum(g.value_aud) FILTER (WHERE g.approval_date >= (current_date - interval '2 years')) AS cw_grant_value_24m,
+         sum(g.value_aud) FILTER (WHERE g.approval_date >= (current_date - interval '2 years') AND m.poa_code IS NOT NULL) AS cw_recipient_24m_with_delivery
+  FROM grantconnect_awards g
+  JOIN gs_entities e ON e.id = g.gs_entity_id AND e.lga_code IS NOT NULL
+  LEFT JOIN mapped_dp m ON m.poa_code = g.delivery_postcode
+  GROUP BY e.lga_code
+),
+cw_deliv AS (
+  SELECT r.lga_code,
+         round(sum(r.ratio))::int AS cw_delivery_count,
+         sum(g.value_aud * r.ratio) AS cw_delivery_value,
+         sum(g.value_aud * r.ratio) FILTER (WHERE g.approval_date >= (current_date - interval '2 years')) AS cw_delivery_value_24m
+  FROM grantconnect_awards g
+  JOIN abs_poa_lga_ratio r ON r.poa_code = g.delivery_postcode
+  GROUP BY r.lga_code
+),
+jf AS (
+  SELECT e.lga_code,
+         count(*) AS jf_grant_count,
+         sum(j.amount_dollars) AS jf_grant_value
+  FROM justice_funding j
+  JOIN gs_entities e ON e.id = j.gs_entity_id AND e.lga_code IS NOT NULL
+  WHERE j.measure_kind = 'grant'
+    AND j.is_aggregate IS NOT TRUE
+    AND lower(trim(j.recipient_name)) NOT IN ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other')
+  GROUP BY e.lga_code
+),
+contracts AS (
+  SELECT e.lga_code,
+         count(*) AS contract_count,
+         sum(c.contract_value) AS contract_value,
+         sum(c.contract_value) FILTER (WHERE c.contract_start >= (current_date - interval '2 years')) AS contract_value_24m
+  FROM austender_contracts c
+  JOIN gs_entities e ON e.abn = c.supplier_abn AND e.lga_code IS NOT NULL
+  WHERE c.supplier_abn IS NOT NULL
+  GROUP BY e.lga_code
+),
+traj AS (
+  SELECT t.lga_code,
+         count(*) AS charities_tracked,
+         count(*) FILTER (WHERE t.trend = 'shrinking' AND t.revenue_last > 0) AS charities_shrinking,
+         count(*) FILTER (WHERE t.trend = 'growing') AS charities_growing,
+         count(*) FILTER (WHERE t.trend = 'lapsed') AS charities_lapsed,
+         count(*) FILTER (WHERE t.gov_dependent) AS charities_gov_dependent,
+         count(*) FILTER (WHERE t.three_year_deficit) AS charities_three_year_deficit,
+         sum(t.revenue_first - t.revenue_last) FILTER (WHERE t.trend = 'shrinking' AND t.revenue_last > 0) AS shrinking_revenue_lost
+  FROM mv_charity_trajectory t
+  WHERE t.lga_code IS NOT NULL
+  GROUP BY t.lga_code
+),
+gaps AS (
+  SELECT r.lga_code, count(DISTINCT e.id) AS unplaced_sharing_postcodes
+  FROM gs_entities e
+  JOIN abs_poa_lga_ratio r ON r.poa_code = e.postcode
+  WHERE e.lga_code IS NULL
+    AND e.lga_source IN ('unresolved_multi_lga_postcode', 'state_conflict', 'postcode_unmapped_in_abs')
+  GROUP BY r.lga_code
+)
+SELECT lga.lga_code, lga.lga_name, lga.state, rm.remoteness,
+       lga.population, lga.erp_2018, lga.area_sqkm,
+       n.irsd_score, n.irsd_decile, n.min_irsd_decile, n.postcode_count, n.postcodes_with_seifa,
+       coalesce(o.org_count, 0)::int AS org_count,
+       coalesce(o.community_controlled, 0)::int AS community_controlled,
+       coalesce(o.charities, 0)::int AS charities,
+       coalesce(a.charities_reporting, 0)::int AS charities_reporting,
+       coalesce(a.charity_revenue, 0)::numeric AS charity_revenue,
+       coalesce(a.charity_gov_revenue, 0)::numeric AS charity_gov_revenue,
+       coalesce(a.charity_donations, 0)::numeric AS charity_donations,
+       coalesce(a.charity_fte, 0)::numeric AS charity_fte,
+       coalesce(a.charity_volunteers, 0)::bigint AS charity_volunteers,
+       coalesce(cw.cw_grant_count, 0)::int AS cw_grant_count,
+       coalesce(cw.cw_grant_value, 0)::numeric AS cw_grant_value,
+       coalesce(cw.cw_grant_value_24m, 0)::numeric AS cw_grant_value_24m,
+       -- delivery lane
+       coalesce(cd.cw_delivery_count, 0)::int AS cw_delivery_count,
+       coalesce(cd.cw_delivery_value, 0)::numeric AS cw_delivery_value,
+       coalesce(cd.cw_delivery_value_24m, 0)::numeric AS cw_delivery_value_24m,
+       coalesce(cw.cw_recipient_24m_with_delivery, 0)::numeric AS cw_recipient_24m_with_delivery,
+       round(100.0 * coalesce(cw.cw_recipient_24m_with_delivery, 0) / nullif(cw.cw_grant_value_24m, 0), 0) AS cw_delivery_stated_pct,
+       coalesce(jf.jf_grant_count, 0)::int AS jf_grant_count,
+       coalesce(jf.jf_grant_value, 0)::numeric AS jf_grant_value,
+       coalesce(c.contract_count, 0)::int AS contract_count,
+       coalesce(c.contract_value, 0)::numeric AS contract_value,
+       coalesce(c.contract_value_24m, 0)::numeric AS contract_value_24m,
+       coalesce(g.unplaced_sharing_postcodes, 0)::int AS unplaced_sharing_postcodes,
+       -- trajectory rollups
+       coalesce(t.charities_tracked, 0)::int AS charities_tracked,
+       coalesce(t.charities_shrinking, 0)::int AS charities_shrinking,
+       coalesce(t.charities_growing, 0)::int AS charities_growing,
+       coalesce(t.charities_lapsed, 0)::int AS charities_lapsed,
+       coalesce(t.charities_gov_dependent, 0)::int AS charities_gov_dependent,
+       coalesce(t.charities_three_year_deficit, 0)::int AS charities_three_year_deficit,
+       coalesce(t.shrinking_revenue_lost, 0)::numeric AS shrinking_revenue_lost,
+       round(100.0 * coalesce(t.charities_shrinking, 0) / nullif(t.charities_tracked, 0), 0) AS shrinking_share_pct,
+       -- per head, on ERP 2023
+       round(coalesce(a.charity_gov_revenue, 0) / nullif(lga.population, 0), 0) AS gov_revenue_per_head,
+       round(coalesce(a.charity_donations, 0) / nullif(lga.population, 0), 0) AS donations_per_head,
+       round(coalesce(cw.cw_grant_value_24m, 0) / nullif(lga.population, 0), 0) AS cw_grants_24m_per_head,
+       round(coalesce(cd.cw_delivery_value_24m, 0) / nullif(lga.population, 0), 0) AS cw_delivery_24m_per_head,
+       round(coalesce(o.org_count, 0) * 10000.0 / nullif(lga.population, 0), 1) AS orgs_per_10k,
+       -- how sure: share of entities touching this council's postcodes that are actually placed
+       round(100.0 * coalesce(o.org_count, 0) / nullif(coalesce(o.org_count, 0) + coalesce(g.unplaced_sharing_postcodes, 0), 0), 0) AS placed_share_pct,
+       now() AS refreshed_at
+FROM lga
+LEFT JOIN need n ON n.lga_code = lga.lga_code
+LEFT JOIN remote rm ON rm.lga_code = lga.lga_code
+LEFT JOIN orgs o ON o.lga_code = lga.lga_code
+LEFT JOIN acnc a ON a.lga_code = lga.lga_code
+LEFT JOIN cw ON cw.lga_code = lga.lga_code
+LEFT JOIN cw_deliv cd ON cd.lga_code = lga.lga_code
+LEFT JOIN jf ON jf.lga_code = lga.lga_code
+LEFT JOIN contracts c ON c.lga_code = lga.lga_code
+LEFT JOIN traj t ON t.lga_code = lga.lga_code
+LEFT JOIN gaps g ON g.lga_code = lga.lga_code;
+
+CREATE UNIQUE INDEX mv_lga_allocation_pk ON public.mv_lga_allocation (lga_code);
+CREATE INDEX mv_lga_allocation_state ON public.mv_lga_allocation (state);
+CREATE INDEX mv_lga_allocation_decile ON public.mv_lga_allocation (irsd_decile);
+
+GRANT SELECT ON public.mv_lga_allocation TO anon, authenticated, service_role;
+
+UPDATE public.mv_refresh_registry
+SET notes = 'Allocation Intelligence per council (lga_code); reads abs_lga_population, abs_poa_lga_ratio, seifa_2021, gs_entities, acnc_ais 2023, grantconnect_awards (recipient lane + delivery_postcode lane via abs_poa_lga_ratio), justice_funding (3 filters), austender_contracts, mv_charity_trajectory (must refresh first; pg_depend orders it); unique lga_code for concurrent refresh'
+WHERE mv_name = 'mv_lga_allocation';
+
+COMMIT;

--- a/supabase/types/database.types.ts
+++ b/supabase/types/database.types.ts
@@ -12,31 +12,6 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.5"
   }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
       _backup_articles_310_20260820: {
@@ -56387,13 +56362,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "community_programs_profiles_program_id_fkey"
-            columns: ["community_program_id"]
-            isOneToOne: false
-            referencedRelation: "programs_catalog_v"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "community_programs_profiles_program_id_fkey"
             columns: ["program_id"]
             isOneToOne: false
             referencedRelation: "programs_catalog_v"
@@ -56402,13 +56370,20 @@ export type Database = {
           {
             foreignKeyName: "community_programs_profiles_program_id_fkey"
             columns: ["community_program_id"]
+            isOneToOne: false
+            referencedRelation: "programs_catalog_v"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "community_programs_profiles_program_id_fkey"
+            columns: ["program_id"]
             isOneToOne: false
             referencedRelation: "registered_services"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "community_programs_profiles_program_id_fkey"
-            columns: ["program_id"]
+            columns: ["community_program_id"]
             isOneToOne: false
             referencedRelation: "registered_services"
             referencedColumns: ["id"]
@@ -57997,7 +57972,13 @@ export type Database = {
         Row: {
           area_sqkm: number | null
           charities: number | null
+          charities_gov_dependent: number | null
+          charities_growing: number | null
+          charities_lapsed: number | null
           charities_reporting: number | null
+          charities_shrinking: number | null
+          charities_three_year_deficit: number | null
+          charities_tracked: number | null
           charity_donations: number | null
           charity_fte: number | null
           charity_gov_revenue: number | null
@@ -58007,10 +57988,16 @@ export type Database = {
           contract_count: number | null
           contract_value: number | null
           contract_value_24m: number | null
+          cw_delivery_24m_per_head: number | null
+          cw_delivery_count: number | null
+          cw_delivery_stated_pct: number | null
+          cw_delivery_value: number | null
+          cw_delivery_value_24m: number | null
           cw_grant_count: number | null
           cw_grant_value: number | null
           cw_grant_value_24m: number | null
           cw_grants_24m_per_head: number | null
+          cw_recipient_24m_with_delivery: number | null
           donations_per_head: number | null
           erp_2018: number | null
           gov_revenue_per_head: number | null
@@ -58029,6 +58016,8 @@ export type Database = {
           postcodes_with_seifa: number | null
           refreshed_at: string | null
           remoteness: string | null
+          shrinking_revenue_lost: number | null
+          shrinking_share_pct: number | null
           state: string | null
           unplaced_sharing_postcodes: number | null
         }
@@ -69475,9 +69464,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       analysis_job_status_enum: ["queued", "processing", "completed", "failed"],

--- a/thoughts/shared/handoffs/allocation-intelligence/current.md
+++ b/thoughts/shared/handoffs/allocation-intelligence/current.md
@@ -11,11 +11,11 @@ status: active
 <!-- This section is extracted by SessionStart hook for quick resume -->
 **Updated:** 2026-09-07T05:00:00+10:00
 **Goal:** Two surfaces that read the whole register: disadvantage versus dollars per council (`/allocation`) and seven-year charity trajectories (`/charities/trajectories`), plus three grounded posts for the Philanthropy Australia conference (Brisbane, 8 to 10 Sept 2026). Done when both pages are live and verified, and the posts have no unverified claim.
-**Branch:** feat/allocation-delivery-lane (PR #437, VISIBLE, open)
+**Branch:** feat/allocation-delivery-lane (PR #437, VISIBLE, applied + verified, awaiting merge)
 **Test:** `bash scripts/precheck.sh` · `node --env-file=.env scripts/check-migration-parity.mjs` · `node --env-file=.env scripts/check-private-exposure.mjs`
 
 ### Now
-[->] PR #437 open, waits on two things in order: (1) Ben's `/db-apply supabase/migrations/20260907090000_mv_lga_allocation_delivery_and_trajectory.sql` (recreates mv_lga_allocation with the delivery lane + trajectory rollups; dry-run passed, ~12s); (2) regenerate `supabase/types/database.types.ts` onto the branch; then Ben eyeballs the preview and says merge. Merging before the apply breaks /allocation.
+[->] PR #437: migration APPLIED (tracker 20260907090000, parity green), types regenerated and pushed (`b965464d`), all three pages verified on local dev against the live view. CI running. Waits on Ben's preview look and the word "merge". Merge with `gh pr merge 437 --squash --delete-branch` (auto-merge not allowed on this repo).
 
 ### This Session
 - [x] #435 and #436 confirmed merged, branches gone.

--- a/thoughts/shared/handoffs/allocation-intelligence/current.md
+++ b/thoughts/shared/handoffs/allocation-intelligence/current.md
@@ -9,15 +9,17 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-09-06T20:10:00+10:00
+**Updated:** 2026-09-07T05:00:00+10:00
 **Goal:** Two surfaces that read the whole register: disadvantage versus dollars per council (`/allocation`) and seven-year charity trajectories (`/charities/trajectories`), plus three grounded posts for the Philanthropy Australia conference (Brisbane, 8 to 10 Sept 2026). Done when both pages are live and verified, and the posts have no unverified claim.
-**Branch:** main
+**Branch:** feat/allocation-delivery-lane (PR #437, VISIBLE, open)
 **Test:** `bash scripts/precheck.sh` · `node --env-file=.env scripts/check-migration-parity.mjs` · `node --env-file=.env scripts/check-private-exposure.mjs`
 
 ### Now
-[->] Nothing in progress. PR #435 (posts flag cleared, docs only) was merging in the background at clear; if it is still open, merge it (SAFE) and delete `docs/pa-posts-flag`. Then the stream is closed unless Ben picks a Next item.
+[->] PR #437 open, waits on two things in order: (1) Ben's `/db-apply supabase/migrations/20260907090000_mv_lga_allocation_delivery_and_trajectory.sql` (recreates mv_lga_allocation with the delivery lane + trajectory rollups; dry-run passed, ~12s); (2) regenerate `supabase/types/database.types.ts` onto the branch; then Ben eyeballs the preview and says merge. Merging before the apply breaks /allocation.
 
 ### This Session
+- [x] #435 and #436 confirmed merged, branches gone.
+- [x] Delivery-postcode lane + per-council trajectory rollups built (migration + /allocation, /allocation/[lga_code], /charities/trajectories), PR #437. Finding: delivery postcodes cover 11% of 24m recipient-lane money, by agency (NIAA none, Health 2%, ARC 100%); the lane shows where the record is silent.
 - [x] Migrations applied + committed: `20260906120000_abs_lga_population` (ABS ERP 2023, 546 councils, inlined), `20260906120100_mv_lga_allocation` (council-keyed, lga_code, how-sure column), `20260906120200_mv_charity_trajectory` (63,565 ABNs, 2017-2023). Both matviews nightly in mv_refresh_registry. Types regenerated.
 - [x] PR #430 merged `458bd4b2`: `/allocation`, `/charities/trajectories`, trajectory block on `/charities/[abn]`, sitemap, pointer from the old funding-deserts report. Live and checked in a browser.
 - [x] PR #429 (other session, `ecosystem_sites` public read) merged `611c405f` after allowlisting the table in `check-private-exposure.mjs` on Ben's "allowlist ecosystem sites". Parity + exposure green on main.
@@ -29,8 +31,8 @@ status: active
 - [x] PR #433 merged `375c7809`: `/allocation/[lga_code]`, a page for all 546 councils (tiles, low-sure warning, charities largest first with direction, neighbours by need); index links every council; `/allocation/*` chromeless. Dev server stopped.
 
 ### Next
-- [ ] `mv_lga_allocation` attributes money to the recipient's council; a delivery-postcode lane from `grantconnect_awards.delivery_postcode` would show the hub-versus-community gap directly.
-- [ ] `/charities/trajectories` lists are national top-25s; per-council rollups (shrinking charities by LGA) are one query away on `mv_charity_trajectory.lga_code`.
+- [ ] After #437 lands: verify /allocation, /allocation/30150 (Alice Springs area code check), /charities/trajectories live in a browser.
+- [ ] The delivery-lane finding (NIAA states no delivery postcode on $3.84bn) is a post-worthy claim; ground it before use.
 
 ### Decisions
 - **New matview, not a fix to mv_funding_deserts.** The old one is name-keyed off postcode_geo, which the LGA rebuild found wrong; the new one stands on `gs_entities.lga_code` and ABS population.


### PR DESCRIPTION
## What
- `mv_lga_allocation` recreated (migration `20260907090000`): a second GrantConnect lane spread by `delivery_postcode` through `abs_poa_lga_ratio`, the comparable recipient base (`cw_recipient_24m_with_delivery`) and its share (`cw_delivery_stated_pct`), plus trajectory rollups from `mv_charity_trajectory` (tracked, shrinking, growing, lapsed, gov-dependent, three-year deficit, revenue lost, shrinking share).
- `/allocation`: Delivered/head and Shrinking columns, a coverage tile, how-to-read bullets.
- `/allocation/[lga_code]`: delivery tiles with the comparison, trajectory tiles, low-coverage note.
- `/charities/trajectories`: councils where charities are shrinking (min 10 on file), linking to council pages.

## The finding
Delivery postcodes cover **11%** of recipient-lane money over 24 months ($3.36bn of $30.55bn), and coverage is by agency: ARC 100%, Employment 54%, Infrastructure 40%, Education 11%, Health 2%, **NIAA none** ($3.84bn). Alice Springs base is 1%. The lane cannot show the hub-versus-community gap for the agencies that create it; it shows where the record is silent, and every page says so.

## Order of landing
1. `/db-apply supabase/migrations/20260907090000_mv_lga_allocation_delivery_and_trajectory.sql` (Ben's verb). Dry-run in a rolled-back transaction: 546 rows, builds in ~12s, figures above.
2. Regenerate `supabase/types/database.types.ts`, commit to this branch.
3. Merge. **Merging before step 1 breaks `/allocation` (columns missing).**

## Verification
- precheck green locally (tsc + 851 tests).
- SQL dry-run against live DB with checks on Torres Strait Island, Mount Isa, Alice Springs, Central Desert, Brisbane.
- Not rendered locally: the pages need the new columns, which need the apply.