### PR TITLE
PA posts: NIAA delivery-postcode paragraph, grounded

### DIFF
--- a/thoughts/shared/drafts/pa-conference-2026-09/posts.md
+++ b/thoughts/shared/drafts/pa-conference-2026-09/posts.md
@@ -1,8 +1,7 @@
 # Three posts for Philanthropy Australia, Brisbane, 8 to 10 September 2026
 
 Drafts, ACT voice. Every figure has a row in `posts.provenance.md`. The two surfaces they point at
-(`/allocation`, `/charities/trajectories`) are built on this branch and go live once the three
-migrations are applied and the PR is merged. Do not post until the links resolve.
+(`/allocation`, `/charities/trajectories`) are live as of 7 September 2026 (PRs #430, #433, #437).
 
 Posture, from the PA brief: accountability partner, never vendor. "We sell foundations nothing and
 represent none of them." Confessions stays the conscience, not the pitch.
@@ -31,6 +30,15 @@ Queensland, all Aboriginal shires: Torres Strait Island, Aurukun, Palm Island, D
 Vale, Kowanyama, Cherbourg, Yarrabah. Their rows read between 1% and 25% sure. Read that as a
 statement about the record, not about the place. Money follows the recipient's address, and the
 address is usually somewhere else.
+
+We tried the other lane. GrantConnect lets an agency say where a grant will be delivered, and some
+do. The Australian Research Council gives a delivery postcode on every dollar. In the last two years
+the National Indigenous Australians Agency published $3.84 billion of grants, with a delivery state
+on every one and a delivery postcode on none: 79 say "Multiple", the rest are blank. Health,
+Disability and Ageing gave a postcode on 2% of its $21.4 billion. The agencies that fund the places
+at the bottom of this list are the ones that do not say where the money lands. So the gap between
+the hub and the community stays a story told by address, and we print the coverage beside the
+figure so you can see how much of it is the record staying quiet.
 
 If you fund in those places, tell us which organisation is yours. The council page has a form.
 We will correct the row and say who corrected it.

--- a/thoughts/shared/drafts/pa-conference-2026-09/posts.provenance.md
+++ b/thoughts/shared/drafts/pa-conference-2026-09/posts.provenance.md
@@ -12,6 +12,9 @@ before posting.
 | $82.0bn government revenue, $10.8bn donations, 2023, placed charities | sums in `mv_lga_allocation`, live 2026-09-06 ($82.03bn, $10.83bn) | verified |
 | $107bn and $18.5bn, whole register 2023 | `SELECT sum(revenue_from_government), sum(donations_and_bequests) FROM acnc_ais WHERE ais_year=2023` ($107.27bn, $18.54bn, 53,207 statements) | verified |
 | eight councils named, all decile 1.0, gov $/head 0, sure 1–25% | dry-run query `WHERE population > 1000 ORDER BY irsd_decile, gov_revenue_per_head LIMIT 8` | verified (dry run, re-measured live 2026-09-06, unchanged) |
+| NIAA $3.84bn, 3,434 awards, delivery state on all, four-digit delivery postcode on 0, "Multiple" on 79 | `grantconnect_awards WHERE approval_date >= current_date - interval '2 years' AND agency = 'National Indigenous Australians Agency'`, live 2026-09-07; window Sep 2024 to Jul 2026, export of 2026-08-04 | verified |
+| Health, Disability and Ageing 2% of $21.4bn | same window, agency = 'Department of Health, Disability and Ageing': 2.28% of value, 0.7% of rows, 248 "Multiple" | verified |
+| ARC delivery postcode on every dollar | same window, 2,217 rows, 100% of value | verified (control: the field is mapped by `scripts/ingest-grantconnect.mjs` and all agencies were imported the same day, so the silence is GrantConnect's, not the ingest's) |
 | 63,565 charities with a statement | `mv_charity_trajectory` count | verified (dry run, re-measured live 2026-09-06, unchanged) |
 | 12,114 shrinking · 6,057 lapsed | trend counts | verified (dry run, re-measured live 2026-09-06, unchanged) |
 | 3,919 three-year deficits | 1,113 + 761 + 1,621 + 424 + 0 across trends | verified (dry run, re-measured live 2026-09-06, unchanged) |
@@ -24,7 +27,9 @@ before posting.
 | "not anti-philanthropy, anti pretending" | studio `docs/strategy/confessions-launch-and-content-engine.md` | verified in repo |
 | "we sell foundations nothing and represent none of them" | studio `business/philanthropy-australia-positioning-brief.md` | verified in repo |
 
-Ground pass run 2026-09-06 against the live views after apply. Verdict: PASS, no flags remaining
+Ground pass on the NIAA paragraph run 2026-09-07 against the live table. First wording ("states no
+delivery postcode") was held: NIAA states a delivery state on every award and "Multiple" on 79, so
+the post says that. Ground pass run 2026-09-06 against the live views after apply. Verdict: PASS, no flags remaining
 (Ben cleared the "nothing signed" line on 2026-09-06). Struck: the claimed order in which Fairfax, QIC and Villiers funded (no
 source). Reworded: the $82bn/$10.8bn line, which had read as the whole register when it is the
 placed subset.


### PR DESCRIPTION
Docs only. Adds the grounded NIAA paragraph to post 1 and three provenance rows. Held wording corrected: NIAA gives a delivery state on every award and 'Multiple' on 79, a usable postcode on none.