### PR TITLE
Browse tables: sort every column both ways; allocation search and sure chip; nav links; table fits

### DIFF
--- a/apps/web/src/app/allocation/page.tsx
+++ b/apps/web/src/app/allocation/page.tsx
@@ -7,9 +7,11 @@ import {
   ALLOCATION_SORTS,
   REMOTENESS_BANDS,
   STATES,
+  UNFILTERED,
   listAllocation,
   parseAllocationFilters,
   summariseAllocation,
+  type AllocationFilters,
   type AllocationRow,
   type AllocationSort,
 } from '@/lib/allocation';
@@ -65,12 +67,18 @@ function Chip({ href, active, children }: { href: string; active: boolean; child
   );
 }
 
-function Head({ label, sortKey, current, qs, className, title }: { label: string; sortKey: AllocationSort; current: AllocationSort; qs: (o: Record<string, string>) => string; className?: string; title?: string }) {
-  const active = current === sortKey;
+/**
+ * Every column sorts. First click gives the column its natural direction (need ascending, money descending);
+ * a click on the active column flips it. The arrow shows the direction in force; inactive columns show a
+ * faint pair so the reader knows they can be clicked.
+ */
+function Head({ label, sortKey, f, qs, className, title }: { label: string; sortKey: AllocationSort; f: AllocationFilters; qs: (o: Record<string, string>) => string; className?: string; title?: string }) {
+  const active = f.sort === sortKey;
+  const next = active ? (f.dir === 'asc' ? 'desc' : 'asc') : ALLOCATION_SORTS[sortKey].defaultDir;
   return (
-    <th className={`px-2 py-2 text-left font-mono text-[10px] font-black uppercase tracking-widest ${className ?? ''}`} title={title}>
-      <Link href={qs({ sort: sortKey })} className="hover:underline" style={{ color: active ? '#121212' : '#777777' }}>
-        {label}{active ? ' ▾' : ''}
+    <th className={`px-2 py-2 text-left font-mono text-[10px] font-black uppercase tracking-widest ${className ?? ''}`} title={title ? `${title}. Click to sort ${next === 'asc' ? 'lowest first' : 'highest first'}.` : `Sort ${next === 'asc' ? 'lowest first' : 'highest first'}`}>
+      <Link href={qs({ sort: sortKey, dir: next })} className="whitespace-nowrap hover:underline" style={{ color: active ? '#121212' : '#777777' }}>
+        {label}<span className="ml-[2px]" style={{ color: active ? '#D02020' : '#C0C0C0' }}>{active ? (f.dir === 'asc' ? '▲' : '▼') : '⇅'}</span>
       </Link>
     </th>
   );
@@ -83,10 +91,10 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
   let all: AllocationRow[] = [];
   let why: string | null = null;
   try {
-    const filtered = f.state || f.remoteness || f.decile;
+    const filtered = f.state || f.remoteness || f.decile || f.q || f.sure;
     [rows, all] = await Promise.all([
       listAllocation(f),
-      filtered ? listAllocation({ state: '', remoteness: '', decile: '', sort: 'need' }) : Promise.resolve([] as AllocationRow[]),
+      filtered ? listAllocation(UNFILTERED) : Promise.resolve([] as AllocationRow[]),
     ]);
     if (!filtered) all = rows;
   } catch (e) {
@@ -104,15 +112,21 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
   };
   const qs = (over: Record<string, string>) => {
     const p = new URLSearchParams();
-    const merged: Record<string, string> = { state: f.state, remoteness: f.remoteness, decile: f.decile, sort: f.sort, ...over };
-    for (const [k, v] of Object.entries(merged)) if (v && !(k === 'sort' && v === 'need')) p.set(k, v);
+    const merged: Record<string, string> = { state: f.state, remoteness: f.remoteness, decile: f.decile, q: f.q, sure: f.sure, sort: f.sort, dir: f.dir, ...over };
+    const sortKey = (merged.sort || 'need') as AllocationSort;
+    for (const [k, v] of Object.entries(merged)) {
+      if (!v) continue;
+      if (k === 'sort' && v === 'need') continue;
+      if (k === 'dir' && v === ALLOCATION_SORTS[sortKey].defaultDir) continue;
+      p.set(k, v);
+    }
     const s = p.toString();
     return `/allocation${s ? `?${s}` : ''}`;
   };
 
   return (
     <Shell title="Allocation">
-      <div className="mx-auto max-w-[1280px] px-6 py-6">
+      <div className="mx-auto max-w-[1600px] px-2 py-6">
         <h1 className="font-display text-[22px] font-extrabold uppercase tracking-tight">Disadvantage versus dollars, by council</h1>
         <p className="mt-2 max-w-3xl text-[14px] leading-relaxed" style={{ color: '#333' }}>
           Every council in Australia on one line: how disadvantaged it is, how many people live there, which
@@ -144,27 +158,39 @@ export default async function AllocationPage({ searchParams }: { searchParams: P
             </div>
             <div className="mt-2 flex flex-wrap gap-2">
               {DECILE_CHIPS.map((d) => <Chip key={d.key} href={qs({ decile: d.key })} active={f.decile === d.key}>{d.label}</Chip>)}
+              <Chip href={qs({ sure: f.sure === '80' ? '' : '80' })} active={f.sure === '80'}>Sure rows only (80%+)</Chip>
             </div>
+            <form action="/allocation" method="get" className="mt-3 flex flex-wrap items-center gap-2">
+              {f.state ? <input type="hidden" name="state" value={f.state} /> : null}
+              {f.remoteness ? <input type="hidden" name="remoteness" value={f.remoteness} /> : null}
+              {f.decile ? <input type="hidden" name="decile" value={f.decile} /> : null}
+              {f.sure ? <input type="hidden" name="sure" value={f.sure} /> : null}
+              {f.sort !== 'need' ? <input type="hidden" name="sort" value={f.sort} /> : null}
+              {f.dir !== ALLOCATION_SORTS[f.sort].defaultDir ? <input type="hidden" name="dir" value={f.dir} /> : null}
+              <input name="q" defaultValue={f.q} placeholder="Council name" maxLength={60} className="border-2 border-bauhaus-black bg-white px-2 py-1 font-mono text-[12px]" style={{ width: 220 }} />
+              <button type="submit" className="border-2 border-bauhaus-black bg-bauhaus-black px-2 py-1 font-mono text-[11px] font-black uppercase tracking-widest text-white">Find</button>
+              {f.q ? <Link href={qs({ q: '' })} className="font-mono text-[11px] uppercase tracking-widest underline" style={{ color: '#777' }}>clear</Link> : null}
+            </form>
 
             <p className="mt-4 font-mono text-[11px] uppercase tracking-widest" style={{ color: '#777' }}>
-              {rows.length} councils · sorted by {ALLOCATION_SORTS[f.sort].label} · click a column to sort
+              {rows.length} councils · sorted by {ALLOCATION_SORTS[f.sort].label}, {f.dir === 'asc' ? 'lowest first' : 'highest first'} · click a column to sort, click again to flip
             </p>
 
             <div className="mt-2 overflow-x-auto border-4 border-bauhaus-black bg-white">
-              <table className="w-full min-w-[1300px] border-collapse text-[13px]" style={{ fontVariantNumeric: 'tabular-nums' }}>
+              <table className="w-full min-w-[1180px] border-collapse text-[13px]" style={{ fontVariantNumeric: 'tabular-nums' }}>
                 <thead>
                   <tr className="border-b-4 border-bauhaus-black">
-                    <Head label="Council" sortKey="name" current={f.sort} qs={qs} />
-                    <th className="px-2 py-2 text-left font-mono text-[10px] font-black uppercase tracking-widest" style={{ color: '#777' }}>Where</th>
-                    <Head label="Need" sortKey="need" current={f.sort} qs={qs} title="SEIFA IRSD decile, weighted across the council's postcodes. 1 is the most disadvantaged tenth of Australia." />
-                    <Head label="People" sortKey="population" current={f.sort} qs={qs} className="text-right" title="ABS estimated resident population, 2023" />
-                    <Head label="Orgs" sortKey="orgs" current={f.sort} qs={qs} className="text-right" title="Entities placed in this council (community-controlled in brackets)" />
-                    <Head label="Gov $ / head" sortKey="gov_per_head" current={f.sort} qs={qs} className="text-right" title="Revenue from government reported by charities placed here, 2023, divided by population" />
-                    <Head label="Donations / head" sortKey="donations_per_head" current={f.sort} qs={qs} className="text-right" title="Donations and bequests reported by charities placed here, 2023, divided by population" />
-                    <Head label="Cwlth grants 24m / head" sortKey="grants_per_head" current={f.sort} qs={qs} className="text-right" title="GrantConnect awards to recipients placed here, approved in the last two years, divided by population" />
-                    <Head label="Delivered here / head" sortKey="delivered_per_head" current={f.sort} qs={qs} className="text-right" title="The same awards spread by the delivery postcode the agency stated, divided by population. Grey percentage: how much of this council's recipient-lane money carries a delivery postcode at all" />
-                    <Head label="Shrinking" sortKey="shrinking" current={f.sort} qs={qs} className="text-right" title="Charities placed here whose revenue fell more than 20% from first statement to latest (2017 to 2023), as a share of charities with a statement" />
-                    <Head label="How sure" sortKey="sure" current={f.sort} qs={qs} className="text-right" title="Placed entities as a share of placed plus entities sharing this council's postcodes that could not be placed" />
+                    <Head label="Council" sortKey="name" f={f} qs={qs} />
+                    <Head label="Where" sortKey="remoteness" f={f} qs={qs} title="ABS remoteness band of the council's largest postcode" />
+                    <Head label="Need" sortKey="need" f={f} qs={qs} title="SEIFA IRSD decile, weighted across the council's postcodes. 1 is the most disadvantaged tenth of Australia." />
+                    <Head label="People" sortKey="population" f={f} qs={qs} className="text-right" title="ABS estimated resident population, 2023" />
+                    <Head label="Orgs" sortKey="orgs" f={f} qs={qs} className="text-right" title="Entities placed in this council (community-controlled in brackets)" />
+                    <Head label="Gov $ / head" sortKey="gov_per_head" f={f} qs={qs} className="text-right" title="Revenue from government reported by charities placed here, 2023, divided by population" />
+                    <Head label="Donations / head" sortKey="donations_per_head" f={f} qs={qs} className="text-right" title="Donations and bequests reported by charities placed here, 2023, divided by population" />
+                    <Head label="Cwlth grants / head" sortKey="grants_per_head" f={f} qs={qs} className="text-right" title="GrantConnect awards to recipients placed here, approved in the last two years, divided by population" />
+                    <Head label="Delivered / head" sortKey="delivered_per_head" f={f} qs={qs} className="text-right" title="The same awards spread by the delivery postcode the agency stated, divided by population. Grey percentage: how much of this council's recipient-lane money carries a delivery postcode at all" />
+                    <Head label="Shrinking" sortKey="shrinking" f={f} qs={qs} className="text-right" title="Charities placed here whose revenue fell more than 20% from first statement to latest (2017 to 2023), as a share of charities with a statement" />
+                    <Head label="How sure" sortKey="sure" f={f} qs={qs} className="text-right" title="Placed entities as a share of placed plus entities sharing this council's postcodes that could not be placed" />
                   </tr>
                 </thead>
                 <tbody>

--- a/apps/web/src/app/charities/page.tsx
+++ b/apps/web/src/app/charities/page.tsx
@@ -29,6 +29,7 @@ export default async function CharityList({
   const state = typeof sp.state === 'string' ? sp.state : '';
   const size = typeof sp.size === 'string' ? sp.size : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'known';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   const supabase = getDirectServiceSupabase();
   let rows: OrgRow[] = [];
@@ -36,7 +37,7 @@ export default async function CharityList({
   let why: string | null = null;
   try {
     const [{ data, error }, s] = await Promise.all([
-      retryRpc(() => supabase.rpc('charity_browse', { p_q: q || null, p_state: state || null, p_size: size || null, p_sort: sort, p_limit: 200 })),
+      retryRpc(() => supabase.rpc('charity_browse', { p_q: q || null, p_state: state || null, p_size: size || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
       stats(),
     ]);
     if (error) throw new Error(error.message);
@@ -95,7 +96,7 @@ export default async function CharityList({
             q={q}
             state={state}
             size={size}
-            sort={sort}
+            sort={sort} dir={dir}
             statsLine={statsLine}
           />
         )}

--- a/apps/web/src/app/dashboard/browse/buyers/page.tsx
+++ b/apps/web/src/app/dashboard/browse/buyers/page.tsx
@@ -7,10 +7,10 @@ export const dynamic = 'force-dynamic';
 export const metadata: Metadata = { title: 'Government buyers — CivicGraph' };
 
 const load = unstable_cache(
-  async (q: string, from: number, sort: string) => {
+  async (q: string, from: number, sort: string, dir: string) => {
     const supabase = getDirectServiceSupabase();
     const [browse, stats] = await Promise.all([
-      supabase.rpc('contract_buyer_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('contract_buyer_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
       supabase.rpc('contract_browse_stats', { p_from_year: from }),
     ]);
     if (browse.error) throw new Error(browse.error.message);
@@ -30,12 +30,13 @@ export default async function BuyersBrowsePage({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const from = typeof sp.from === 'string' && /^\d{4}$/.test(sp.from) ? parseInt(sp.from, 10) : 2020;
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   let rows: SideRow[] = [];
   let statsLine = '';
   let why: string | null = null;
   try {
-    const { rows: data, stats } = await load(q, from, sort);
+    const { rows: data, stats } = await load(q, from, sort, dir);
     rows = (data as {
       buyer_key: string;
       buyer_name: string;
@@ -71,7 +72,7 @@ export default async function BuyersBrowsePage({
           cfg={{ side: 'buyer', basePath: '/dashboard/browse/buyers', counterpartyLabel: 'Suppliers', detailApi: '/api/browse/contract-buyer', counterpartySortKey: 'suppliers' }}
           q={q}
           fromYear={String(from)}
-          sort={sort}
+          sort={sort} dir={dir}
           statsLine={statsLine}
           caveat="AusTender: Commonwealth agencies only. A buyer's supplier mix is the procurement story a supply-side pitch lands into. The since-year floor is applied in the query."
         />

--- a/apps/web/src/app/dashboard/browse/contracts/page.tsx
+++ b/apps/web/src/app/dashboard/browse/contracts/page.tsx
@@ -8,10 +8,10 @@ export const metadata: Metadata = { title: 'Contract suppliers — CivicGraph' }
 
 // The rollup scans up to 767K rows (~3.5s): cache per (q, from, sort) for an hour.
 const load = unstable_cache(
-  async (q: string, from: number, sort: string) => {
+  async (q: string, from: number, sort: string, dir: string) => {
     const supabase = getDirectServiceSupabase();
     const [browse, stats] = await Promise.all([
-      supabase.rpc('contract_supplier_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('contract_supplier_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
       supabase.rpc('contract_browse_stats', { p_from_year: from }),
     ]);
     if (browse.error) throw new Error(browse.error.message);
@@ -31,12 +31,13 @@ export default async function ContractsBrowsePage({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const from = typeof sp.from === 'string' && /^\d{4}$/.test(sp.from) ? parseInt(sp.from, 10) : 2020;
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   let rows: SideRow[] = [];
   let statsLine = '';
   let why: string | null = null;
   try {
-    const { rows: data, stats } = await load(q, from, sort);
+    const { rows: data, stats } = await load(q, from, sort, dir);
     rows = (data as {
       supplier_key: string;
       supplier_name: string;
@@ -73,7 +74,7 @@ export default async function ContractsBrowsePage({
           cfg={{ side: 'supplier', basePath: '/dashboard/browse/contracts', counterpartyLabel: 'Buyers', detailApi: '/api/browse/contract-supplier', counterpartySortKey: 'buyers' }}
           q={q}
           fromYear={String(from)}
-          sort={sort}
+          sort={sort} dir={dir}
           statsLine={statsLine}
           caveat="AusTender: Commonwealth contracts only — state contracts live in their own registers. Suppliers are grouped by ABN where recorded, else by a normalised name — case, punctuation and the company suffix (PTY LTD / PTY LIMITED / P/L) are treated as the same word. The since-year floor is applied in the query; contracts with junk start dates are excluded by it."
         />

--- a/apps/web/src/app/dashboard/browse/donations/page.tsx
+++ b/apps/web/src/app/dashboard/browse/donations/page.tsx
@@ -9,10 +9,10 @@ export const metadata: Metadata = { title: 'Political donors — CivicGraph' };
 const FY_OPTIONS = ['1998-1999', '2014-15', '2019-20', '2022-23'];
 
 const load = unstable_cache(
-  async (q: string, from: string, sort: string) => {
+  async (q: string, from: string, sort: string, dir: string) => {
     const supabase = getDirectServiceSupabase();
     const [browse, stats] = await Promise.all([
-      supabase.rpc('donation_donor_browse', { p_q: q || null, p_from_fy: from, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('donation_donor_browse', { p_q: q || null, p_from_fy: from, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
       supabase.rpc('donation_browse_stats', { p_from_fy: from }),
     ]);
     if (browse.error) throw new Error(browse.error.message);
@@ -32,13 +32,14 @@ export default async function DonationsBrowsePage({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const from = typeof sp.from === 'string' && FY_OPTIONS.includes(sp.from) ? sp.from : '2014-15';
   const sortParam = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
   const rpcSort = sortParam === 'contracts' ? 'donations' : sortParam;
 
   let rows: SideRow[] = [];
   let statsLine = '';
   let why: string | null = null;
   try {
-    const { rows: data, stats } = await load(q, from, rpcSort);
+    const { rows: data, stats } = await load(q, from, rpcSort, dir);
     rows = (data as {
       donor_key: string;
       donor_name: string;
@@ -83,7 +84,7 @@ export default async function DonationsBrowsePage({
           }}
           q={q}
           fromYear={from}
-          sort={sortParam}
+          sort={sortParam} dir={dir}
           statsLine={statsLine}
           caveat="AEC declared receipts, 'donation received' only — the far larger 'other receipt' category (investment returns, transfers between branches) is excluded in the query. Donors are grouped by ABN where declared, else by a normalised name — case, punctuation and the company suffix (PTY LTD / PTY LIMITED / P/L / PROPRIETARY LIMITED) are treated as the same word, so one declarer is one row. Two genuinely different spellings of a name that never declares an ABN still appear twice. In the drawer's donation list the small line shows the financial year."
         />

--- a/apps/web/src/app/dashboard/people/PersonBrowser.tsx
+++ b/apps/web/src/app/dashboard/people/PersonBrowser.tsx
@@ -49,19 +49,22 @@ export default function PersonBrowser({
   rows,
   q,
   sort,
+  dir = '',
   statsLine,
   exclusionNote,
 }: {
   rows: PersonRow[];
   q: string;
   sort: string;
+  /** 'asc' | 'desc' | '' (natural) */
+  dir?: string;
   statsLine: string;
   exclusionNote: string;
 }) {
   const drawer = useDrawer<PersonDetail>();
   const detail = drawer.detail;
   const open = (norm: string) => drawer.open(norm, `/api/browse/person?norm=${encodeURIComponent(norm)}`);
-  const qs = makeQs('/dashboard/people', { q, sort });
+  const qs = makeQs('/dashboard/people', { q, sort, dir });
 
   return (
     <>
@@ -76,19 +79,20 @@ export default function PersonBrowser({
           className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
         />
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+        {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
-          <SortHeader label="Name" sortKey="name" current={sort} qs={qs} />
-          <SortHeader label="Influence" sortKey="influence" current={sort} qs={qs} width="w-[92px]" align="right" title="boards × attributed money, the default order" />
+          <SortHeader label="Name" sortKey="name" current={sort} dir={dir} qs={qs} />
+          <SortHeader label="Influence" sortKey="influence" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" title="boards × attributed money, the default order" />
           {/* The 10 is a ceiling, not a measurement (person_browse: board_count <= 10). The
               exclusion note says so, but it sits below 200 rows — by the time a reader has
               scrolled past a column of identical 10s they have already read them as counts. */}
-          <SortHeader label="Boards ≤10" sortKey="boards" current={sort} qs={qs} width="w-[96px]" align="right" title="a ceiling, not a count: identities credited with more than 10 boards are excluded, because above that a shared name usually means several people" />
-          <SortHeader label="Systems" sortKey="systems" current={sort} qs={qs} width="w-[64px]" align="right" />
-          <SortHeader label="Contracts $" sortKey="procurement" current={sort} qs={qs} width="w-[92px]" align="right" />
-          <SortHeader label="Grants $" sortKey="justice" current={sort} qs={qs} width="w-[92px]" align="right" />
-          <SortHeader label="Donations $" sortKey="donations" current={sort} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="Boards ≤10" sortKey="boards" current={sort} dir={dir} qs={qs} width="w-[96px]" align="right" title="a ceiling, not a count: identities credited with more than 10 boards are excluded, because above that a shared name usually means several people" />
+          <SortHeader label="Systems" sortKey="systems" current={sort} dir={dir} qs={qs} width="w-[64px]" align="right" />
+          <SortHeader label="Contracts $" sortKey="procurement" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="Grants $" sortKey="justice" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="Donations $" sortKey="donations" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
         </div>
         {rows.map((r) => (
           <button key={r.key} onClick={() => open(r.norm)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>

--- a/apps/web/src/app/dashboard/people/page.tsx
+++ b/apps/web/src/app/dashboard/people/page.tsx
@@ -30,6 +30,7 @@ export default async function PeoplePage({
   const sp = await searchParams;
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'influence';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   const supabase = getDirectServiceSupabase();
   let rows: PersonRow[] = [];
@@ -38,7 +39,7 @@ export default async function PeoplePage({
   let why: string | null = null;
   try {
     const [{ data, error }, s] = await Promise.all([
-      retryRpc(() => supabase.rpc('person_browse', { p_q: q || null, p_sort: sort, p_limit: 200 })),
+      retryRpc(() => supabase.rpc('person_browse', { p_q: q || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
       stats(),
     ]);
     if (error) throw new Error(error.message);
@@ -79,7 +80,7 @@ export default async function PeoplePage({
       {why ? (
         <p className="mt-4 text-[13px]" style={{ color: '#D02020' }}>The list could not be read: {why}</p>
       ) : (
-        <PersonBrowser rows={rows} q={q} sort={sort} statsLine={statsLine} exclusionNote={exclusionNote} />
+        <PersonBrowser rows={rows} q={q} sort={sort} dir={dir} statsLine={statsLine} exclusionNote={exclusionNote} />
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
+++ b/apps/web/src/app/dashboard/places/PlaceBrowser.tsx
@@ -62,6 +62,7 @@ export default function PlaceBrowser({
   q,
   state,
   sort,
+  dir = '',
   statsLine,
   caveat,
 }: {
@@ -69,6 +70,8 @@ export default function PlaceBrowser({
   q: string;
   state: string;
   sort: string;
+  /** 'asc' | 'desc' | '' (natural) */
+  dir?: string;
   statsLine: string;
   caveat: string;
 }) {
@@ -76,7 +79,7 @@ export default function PlaceBrowser({
   const detail = drawer.detail;
   const open = (row: PlaceRow) =>
     drawer.open(row.key, `/api/browse/place?lga=${encodeURIComponent(row.lga)}&state=${encodeURIComponent(row.state)}`);
-  const qs = makeQs('/dashboard/places', { q, state, sort });
+  const qs = makeQs('/dashboard/places', { q, state, sort, dir });
 
   return (
     <>
@@ -92,6 +95,7 @@ export default function PlaceBrowser({
         />
         {state ? <input type="hidden" name="state" value={state} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+        {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <Link href={qs({ state: '' })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === '' ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
@@ -106,13 +110,13 @@ export default function PlaceBrowser({
 
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
-          <SortHeader label="Council area" sortKey="name" current={sort} qs={qs} />
+          <SortHeader label="Council area" sortKey="name" current={sort} dir={dir} qs={qs} />
           <span className="w-[52px] shrink-0">State</span>
-          <SortHeader label="Entities" sortKey="entities" current={sort} qs={qs} width="w-[72px]" align="right" />
-          <SortHeader label="ACCO" sortKey="acco" current={sort} qs={qs} width="w-[64px]" align="right" title="community-controlled organisations" />
-          <SortHeader label="Funding $" sortKey="funding" current={sort} qs={qs} width="w-[92px]" align="right" />
-          <SortHeader label="SEIFA" sortKey="disadvantage" current={sort} qs={qs} width="w-[56px]" align="right" title="average SEIFA disadvantage decile, 1 = most disadvantaged; sorts most-disadvantaged first" />
-          <SortHeader label="Unfunded" sortKey="desert" current={sort} qs={qs} width="w-[76px]" align="right" title="how far funders and providers have fallen short of this area's measured need — a measure of funding behaviour, not of the community" />
+          <SortHeader label="Entities" sortKey="entities" current={sort} dir={dir} qs={qs} width="w-[72px]" align="right" />
+          <SortHeader label="ACCO" sortKey="acco" current={sort} dir={dir} qs={qs} width="w-[64px]" align="right" title="community-controlled organisations" />
+          <SortHeader label="Funding $" sortKey="funding" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="SEIFA" sortKey="disadvantage" naturalDir="asc" current={sort} dir={dir} qs={qs} width="w-[56px]" align="right" title="average SEIFA disadvantage decile, 1 = most disadvantaged; sorts most-disadvantaged first" />
+          <SortHeader label="Unfunded" sortKey="desert" current={sort} dir={dir} qs={qs} width="w-[76px]" align="right" title="how far funders and providers have fallen short of this area's measured need — a measure of funding behaviour, not of the community" />
         </div>
         {rows.map((r) => (
           <button key={r.key} onClick={() => open(r)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>

--- a/apps/web/src/app/dashboard/places/page.tsx
+++ b/apps/web/src/app/dashboard/places/page.tsx
@@ -26,6 +26,7 @@ export default async function PlacesPage({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const state = typeof sp.state === 'string' ? sp.state : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'funding';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   const supabase = getDirectServiceSupabase();
   let rows: PlaceRow[] = [];
@@ -33,7 +34,7 @@ export default async function PlacesPage({
   let why: string | null = null;
   try {
     const [{ data, error }, s] = await Promise.all([
-      supabase.rpc('place_browse', { p_q: q || null, p_state: state || null, p_sort: sort, p_limit: 200 }),
+      supabase.rpc('place_browse', { p_q: q || null, p_state: state || null, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
       stats(),
     ]);
     if (error) throw new Error(error.message);
@@ -74,7 +75,7 @@ export default async function PlacesPage({
           rows={rows}
           q={q}
           state={state}
-          sort={sort}
+          sort={sort} dir={dir}
           statsLine={statsLine}
           caveat="Funding attaches to an organisation's address, so head-office council areas collect their branches' figures. SEIFA decile 1 = most disadvantaged. The Unfunded column measures what funders and providers have NOT delivered against an area's measured need — it describes funding behaviour, not the community. Higher means less money and fewer providers reached an area with more measured need; metro councils sit around 50–70, and the extreme tail runs past 150."
         />

--- a/apps/web/src/app/foundations/page.tsx
+++ b/apps/web/src/app/foundations/page.tsx
@@ -21,6 +21,7 @@ export default async function FoundationsList({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const type = typeof sp.type === 'string' ? sp.type : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'giving';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   const supabase = getDirectServiceSupabase();
   let rows: BrowseRow[] = [];
@@ -31,7 +32,7 @@ export default async function FoundationsList({
       supabase.rpc('foundation_browse', {
         p_q: q || null,
         p_type: type || null,
-        p_sort: sort,
+        p_sort: sort, p_dir: dir || null,
         p_limit: 200,
       }),
       supabase.from('foundations').select('id', { count: 'exact', head: true }),
@@ -57,7 +58,7 @@ export default async function FoundationsList({
             The list could not be read: {why}. Nothing is estimated in its place.
           </p>
         ) : (
-          <FoundationsBrowser rows={rows} q={q} type={type} sort={sort} total={total} />
+          <FoundationsBrowser rows={rows} q={q} type={type} sort={sort} dir={dir} total={total} />
         )}
       </div>
     </Shell>

--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -38,6 +38,7 @@ export default async function GrantsBrowsePage({
   const state = typeof sp.state === 'string' ? sp.state : '';
   const topic = typeof sp.topic === 'string' ? sp.topic : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   const supabase = getDirectServiceSupabase();
   let rows: RecipientRow[] = [];
@@ -52,7 +53,7 @@ export default async function GrantsBrowsePage({
           p_q: q || null,
           p_state: state || null,
           p_topic: topic || null,
-          p_sort: sort,
+          p_sort: sort, p_dir: dir || null,
           p_limit: 200,
         }),
       ),
@@ -129,7 +130,7 @@ export default async function GrantsBrowsePage({
             q={q}
             state={state}
             topic={topic}
-            sort={sort}
+            sort={sort} dir={dir}
             statsLine={statsLine}
             coverageLine={coverageLine}
             topicLine={topicLine}

--- a/apps/web/src/app/social-enterprises/page.tsx
+++ b/apps/web/src/app/social-enterprises/page.tsx
@@ -27,6 +27,7 @@ export default async function SEList({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const state = typeof sp.state === 'string' ? sp.state : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'known';
+  const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
   const supabase = getDirectServiceSupabase();
   let rows: OrgRow[] = [];
@@ -34,7 +35,7 @@ export default async function SEList({
   let why: string | null = null;
   try {
     const [{ data, error }, s] = await Promise.all([
-      retryRpc(() => supabase.rpc('se_browse', { p_q: q || null, p_state: state || null, p_sort: sort, p_limit: 200 })),
+      retryRpc(() => supabase.rpc('se_browse', { p_q: q || null, p_state: state || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
       stats(),
     ]);
     if (error) throw new Error(error.message);
@@ -80,7 +81,7 @@ export default async function SEList({
             q={q}
             state={state}
             size=""
-            sort={sort}
+            sort={sort} dir={dir}
             statsLine={statsLine}
           />
         )}

--- a/apps/web/src/components/browse/ContractSideBrowser.tsx
+++ b/apps/web/src/components/browse/ContractSideBrowser.tsx
@@ -49,6 +49,7 @@ export default function ContractSideBrowser({
   q,
   fromYear,
   sort,
+  dir = '',
   statsLine,
   caveat,
 }: {
@@ -57,6 +58,8 @@ export default function ContractSideBrowser({
   q: string;
   fromYear: string;
   sort: string;
+  /** 'asc' | 'desc' | '' (natural) */
+  dir?: string;
   statsLine: string;
   caveat: string;
 }) {
@@ -64,7 +67,7 @@ export default function ContractSideBrowser({
   const detail = drawer.detail;
   const open = (key: string) =>
     drawer.open(key, `${cfg.detailApi}?key=${encodeURIComponent(key)}&from=${encodeURIComponent(fromYear || '2020')}`);
-  const qs = makeQs(cfg.basePath, { q, from: fromYear, sort });
+  const qs = makeQs(cfg.basePath, { q, from: fromYear, sort, dir });
   /** Name normalisation folds spellings together, but one name can still be several declared
    *  ABNs — three Pratt Holdings Pty Ltd rows, three real ABNs. Where the name alone cannot
    *  tell two rows apart, show the ABN that does. */
@@ -87,6 +90,7 @@ export default function ContractSideBrowser({
         />
         {fromYear ? <input type="hidden" name="from" value={fromYear} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+        {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>since</span>
@@ -99,11 +103,11 @@ export default function ContractSideBrowser({
 
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
-          <SortHeader label="Name" sortKey="name" current={sort} qs={qs} />
+          <SortHeader label="Name" sortKey="name" current={sort} dir={dir} qs={qs} />
           <span className="w-[220px] shrink-0">Top {cfg.counterpartyLabel.toLowerCase().replace(/s$/, '')}</span>
-          <SortHeader label={cfg.counterpartyLabel} sortKey={cfg.counterpartySortKey} current={sort} qs={qs} width="w-[72px]" align="right" />
-          <SortHeader label={(cfg.itemLabel ?? 'contract') === 'donation' ? 'Donations' : 'Contracts'} sortKey="contracts" current={sort} qs={qs} width="w-[76px]" align="right" />
-          <SortHeader label="Total $" sortKey="total" current={sort} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label={cfg.counterpartyLabel} sortKey={cfg.counterpartySortKey} current={sort} dir={dir} qs={qs} width="w-[72px]" align="right" />
+          <SortHeader label={(cfg.itemLabel ?? 'contract') === 'donation' ? 'Donations' : 'Contracts'} sortKey="contracts" current={sort} dir={dir} qs={qs} width="w-[76px]" align="right" />
+          <SortHeader label="Total $" sortKey="total" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
         </div>
         {rows.map((r) => (
           <button key={r.key} onClick={() => open(r.key)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>

--- a/apps/web/src/components/browse/FoundationsBrowser.tsx
+++ b/apps/web/src/components/browse/FoundationsBrowser.tsx
@@ -73,12 +73,15 @@ export default function FoundationsBrowser({
   q,
   type,
   sort,
+  dir = '',
   total,
 }: {
   rows: BrowseRow[];
   q: string;
   type: string;
   sort: string;
+  /** 'asc' | 'desc' | '' (natural) */
+  dir?: string;
   total: number;
 }) {
   const [openId, setOpenId] = useState<string | null>(null);
@@ -103,6 +106,7 @@ export default function FoundationsBrowser({
     if (q) p.set('q', q);
     if (type) p.set('type', type);
     if (sort) p.set('sort', sort);
+    if (dir) p.set('dir', dir);
     for (const [k, v] of Object.entries(over)) {
       if (v) p.set(k, v);
       else p.delete(k);
@@ -122,6 +126,7 @@ export default function FoundationsBrowser({
         />
         {type ? <input type="hidden" name="type" value={type} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+        {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <Link
@@ -148,12 +153,12 @@ export default function FoundationsBrowser({
           className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest"
           style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}
         >
-          <SortHeader label="Foundation" sortKey="name" current={sort} qs={qs} />
-          <SortHeader label="Giving / yr" sortKey="giving" current={sort} qs={qs} width="w-[92px]" align="right" />
-          <SortHeader label="Granted" sortKey="granted" current={sort} qs={qs} width="w-[100px]" align="right" title="grants + donations made, latest ACNC return" />
-          <SortHeader label="Assets" sortKey="assets" current={sort} qs={qs} width="w-[92px]" align="right" title="total assets, latest ACNC return" />
-          <SortHeader label="Grantees" sortKey="grantees" current={sort} qs={qs} width="w-[74px]" align="right" />
-          <SortHeader label="Board" sortKey="board" current={sort} qs={qs} width="w-[70px]" align="right" />
+          <SortHeader label="Foundation" sortKey="name" current={sort} dir={dir} qs={qs} />
+          <SortHeader label="Giving / yr" sortKey="giving" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="Granted" sortKey="granted" current={sort} dir={dir} qs={qs} width="w-[100px]" align="right" title="grants + donations made, latest ACNC return" />
+          <SortHeader label="Assets" sortKey="assets" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" title="total assets, latest ACNC return" />
+          <SortHeader label="Grantees" sortKey="grantees" current={sort} dir={dir} qs={qs} width="w-[74px]" align="right" />
+          <SortHeader label="Board" sortKey="board" current={sort} dir={dir} qs={qs} width="w-[70px]" align="right" />
         </div>
         {rows.map((r) => (
           <button

--- a/apps/web/src/components/browse/GrantBrowser.tsx
+++ b/apps/web/src/components/browse/GrantBrowser.tsx
@@ -37,6 +37,7 @@ export default function GrantBrowser({
   state,
   topic,
   sort,
+  dir = '',
   statsLine,
   coverageLine,
   topicLine,
@@ -47,6 +48,8 @@ export default function GrantBrowser({
   state: string;
   topic: string;
   sort: string;
+  /** 'asc' | 'desc' | '' (natural) */
+  dir?: string;
   statsLine: string;
   /** Coverage skew — stated up front, not buried in the caveat. UX audit pass 2, F1. */
   coverageLine?: string;
@@ -57,7 +60,7 @@ export default function GrantBrowser({
   const drawer = useDrawer<RecipientDetail>();
   const detail = drawer.detail;
   const open = (key: string) => drawer.open(key, `/api/browse/grant-recipient?key=${encodeURIComponent(key)}`);
-  const qs = makeQs('/dashboard/browse/grants', { q, state, topic, sort });
+  const qs = makeQs('/dashboard/browse/grants', { q, state, topic, sort, dir });
 
   return (
     <>
@@ -83,6 +86,7 @@ export default function GrantBrowser({
         {state ? <input type="hidden" name="state" value={state} /> : null}
         {topic ? <input type="hidden" name="topic" value={topic} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+        {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <Link href={qs({ state: '' })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === '' ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
@@ -104,11 +108,11 @@ export default function GrantBrowser({
 
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
-          <SortHeader label="Recipient" sortKey="name" current={sort} qs={qs} />
+          <SortHeader label="Recipient" sortKey="name" current={sort} dir={dir} qs={qs} />
           <span className="w-[110px] shrink-0">States</span>
-          <SortHeader label="Years" sortKey="recent" current={sort} qs={qs} width="w-[120px]" title="most recent grant year first" />
-          <SortHeader label="Grants" sortKey="grants" current={sort} qs={qs} width="w-[64px]" align="right" />
-          <SortHeader label="Total $" sortKey="total" current={sort} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="Years" sortKey="recent" current={sort} dir={dir} qs={qs} width="w-[120px]" title="most recent grant year first" />
+          <SortHeader label="Grants" sortKey="grants" current={sort} dir={dir} qs={qs} width="w-[64px]" align="right" />
+          <SortHeader label="Total $" sortKey="total" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
         </div>
         {rows.map((r) => (
           <button key={r.key} onClick={() => open(r.key)} className="flex w-full items-baseline gap-3 px-4 py-2 text-left hover:bg-[#FAFAF8]" style={{ borderBottom: '1px solid var(--shell-line)' }}>

--- a/apps/web/src/components/browse/OrgBrowser.tsx
+++ b/apps/web/src/components/browse/OrgBrowser.tsx
@@ -78,6 +78,7 @@ export default function OrgBrowser({
   state,
   size,
   sort,
+  dir = '',
   statsLine,
 }: {
   rows: OrgRow[];
@@ -86,6 +87,8 @@ export default function OrgBrowser({
   state: string;
   size: string;
   sort: string;
+  /** 'asc' | 'desc' | '' (natural) */
+  dir?: string;
   statsLine: string;
 }) {
   const [openAbn, setOpenAbn] = useState<string | null>(null);
@@ -107,7 +110,7 @@ export default function OrgBrowser({
 
   const qs = (over: Record<string, string>) => {
     const p = new URLSearchParams();
-    for (const [k, v] of Object.entries({ q, state, size, sort, ...over })) if (v) p.set(k, v);
+    for (const [k, v] of Object.entries({ q, state, size, sort, dir, ...over })) if (v) p.set(k, v);
     const s = p.toString();
     return `${cfg.basePath}${s ? `?${s}` : ''}`;
   };
@@ -127,6 +130,7 @@ export default function OrgBrowser({
         {state ? <input type="hidden" name="state" value={state} /> : null}
         {size ? <input type="hidden" name="size" value={size} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
+        {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <Link href={qs({ state: '' })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === '' ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
@@ -151,7 +155,7 @@ export default function OrgBrowser({
 
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>
-          <SortHeader label="Name" sortKey="name" current={sort} qs={qs} />
+          <SortHeader label="Name" sortKey="name" current={sort} dir={dir} qs={qs} />
           <span className="w-[190px] shrink-0">Detail</span>
           <Link
             href={qs({ sort: (sort || 'known') === 'known' ? 'least' : 'known' })}
@@ -161,8 +165,8 @@ export default function OrgBrowser({
           >
             {sort === 'least' ? 'Least known ▾' : 'Known ▾'}
           </Link>
-          <SortHeader label="Systems" sortKey="systems" current={sort} qs={qs} width="w-[64px]" align="right" />
-          <SortHeader label="Visible $" sortKey="dollars" current={sort} qs={qs} width="w-[92px]" align="right" />
+          <SortHeader label="Systems" sortKey="systems" current={sort} dir={dir} qs={qs} width="w-[64px]" align="right" />
+          <SortHeader label="Visible $" sortKey="dollars" current={sort} dir={dir} qs={qs} width="w-[92px]" align="right" />
         </div>
         {rows.map((r) => {
           const inner = (

--- a/apps/web/src/components/browse/browse-ui.tsx
+++ b/apps/web/src/components/browse/browse-ui.tsx
@@ -65,12 +65,12 @@ export function SortHeader({
   return (
     <Link
       href={qs({ sort: sortKey })}
-      title={title}
-      className={`${width ?? 'min-w-0 flex-1'} ${align === 'right' ? 'text-right' : ''} shrink-0 truncate hover:underline`}
+      title={title ? `${title}. Click to sort by this column.` : `Sort by ${label.toLowerCase()}`}
+      className={`${width ?? 'min-w-0 flex-1'} ${align === 'right' ? 'text-right' : ''} shrink-0 truncate whitespace-nowrap hover:underline`}
       style={{ color: active ? '#121212' : undefined }}
     >
       {label}
-      {active ? ' ▾' : ''}
+      <span className="ml-[2px]" style={{ color: active ? '#D02020' : '#C0C0C0' }}>{active ? '▾' : '⇅'}</span>
     </Link>
   );
 }

--- a/apps/web/src/components/browse/browse-ui.tsx
+++ b/apps/web/src/components/browse/browse-ui.tsx
@@ -47,6 +47,8 @@ export function SortHeader({
   label,
   sortKey,
   current,
+  dir,
+  naturalDir,
   qs,
   width,
   align,
@@ -55,6 +57,10 @@ export function SortHeader({
   label: string;
   sortKey: string;
   current: string;
+  /** Direction in the URL ('asc' | 'desc' | ''); '' means the column's natural direction. */
+  dir?: string;
+  /** What a first click gives. Names A to Z, everything else highest first, unless told otherwise. */
+  naturalDir?: 'asc' | 'desc';
   qs: (over: Record<string, string>) => string;
   /** Tailwind width class, e.g. 'w-[92px]'; omit for flex-1. */
   width?: string;
@@ -62,15 +68,19 @@ export function SortHeader({
   title?: string;
 }) {
   const active = current === sortKey;
+  const natural = naturalDir ?? (sortKey === 'name' ? 'asc' : 'desc');
+  const inForce = active ? (dir === 'asc' || dir === 'desc' ? dir : natural) : natural;
+  const next = active ? (inForce === 'asc' ? 'desc' : 'asc') : natural;
+  const words = next === 'asc' ? 'lowest first' : 'highest first';
   return (
     <Link
-      href={qs({ sort: sortKey })}
-      title={title ? `${title}. Click to sort by this column.` : `Sort by ${label.toLowerCase()}`}
+      href={active ? qs({ sort: sortKey, dir: next }) : qs({ sort: sortKey, dir: '' })}
+      title={`${title ? `${title}. ` : ''}Click to sort ${sortKey === 'name' ? (next === 'asc' ? 'A to Z' : 'Z to A') : words}.`}
       className={`${width ?? 'min-w-0 flex-1'} ${align === 'right' ? 'text-right' : ''} shrink-0 truncate whitespace-nowrap hover:underline`}
       style={{ color: active ? '#121212' : undefined }}
     >
       {label}
-      <span className="ml-[2px]" style={{ color: active ? '#D02020' : '#C0C0C0' }}>{active ? '▾' : '⇅'}</span>
+      <span className="ml-[2px]" style={{ color: active ? '#D02020' : '#C0C0C0' }}>{active ? (inForce === 'asc' ? '▲' : '▼') : '⇅'}</span>
     </Link>
   );
 }

--- a/apps/web/src/components/shell/shell.tsx
+++ b/apps/web/src/components/shell/shell.tsx
@@ -138,6 +138,8 @@ export async function Shell({ title, children }: ShellProps) {
           ['/dashboard/browse/contracts', 'Contract suppliers'],
           ['/dashboard/browse/buyers', 'Government buyers'],
           ['/dashboard/browse/donations', 'Political donors'],
+          ['/allocation', 'Councils: need vs dollars'],
+          ['/charities/trajectories', 'Charity trajectories'],
         ].map(([href, label]) => (
           <RailGroupLink
             key={href}

--- a/apps/web/src/lib/allocation.test.ts
+++ b/apps/web/src/lib/allocation.test.ts
@@ -11,12 +11,24 @@ const row = (o: Partial<AllocationRow>): AllocationRow => ({
 
 describe('parseAllocationFilters', () => {
   it('falls back to defaults on anything unrecognised', () => {
-    expect(parseAllocationFilters({ state: 'XX', sort: 'drop table', decile: '99', remoteness: 'Mars' }))
-      .toEqual({ state: '', remoteness: '', decile: '', sort: 'need' });
+    expect(parseAllocationFilters({ state: 'XX', sort: 'drop table', decile: '99', remoteness: 'Mars', dir: 'sideways', sure: '50' }))
+      .toEqual({ state: '', remoteness: '', decile: '', sort: 'need', dir: 'asc', q: '', sure: '' });
   });
   it('keeps recognised values', () => {
     expect(parseAllocationFilters({ state: 'NT', sort: 'sure', decile: '1-2' }).sort).toBe('sure');
     expect(parseAllocationFilters({ state: 'NT' }).state).toBe('NT');
+  });
+  it('gives each column its natural first direction and lets dir override it', () => {
+    expect(parseAllocationFilters({ sort: 'population' }).dir).toBe('desc');
+    expect(parseAllocationFilters({ sort: 'population', dir: 'asc' }).dir).toBe('asc');
+    expect(parseAllocationFilters({ sort: 'name' }).dir).toBe('asc');
+  });
+  it('still understands the old one-way keys', () => {
+    expect(parseAllocationFilters({ sort: 'gov_per_head_asc' })).toMatchObject({ sort: 'gov_per_head', dir: 'asc' });
+  });
+  it('keeps the name search short and the sure chip binary', () => {
+    expect(parseAllocationFilters({ q: '  Alice ' }).q).toBe('Alice');
+    expect(parseAllocationFilters({ sure: '80' }).sure).toBe('80');
   });
 });
 

--- a/apps/web/src/lib/allocation.ts
+++ b/apps/web/src/lib/allocation.ts
@@ -54,21 +54,30 @@ export interface AllocationRow {
   placed_share_pct: number | null;
 }
 
+/**
+ * Every column the table shows is sortable both ways. `defaultDir` is the direction a first click gives:
+ * need ascending (most disadvantaged first), names ascending, every money and count column descending.
+ * The old one-way keys (`gov_per_head_asc`, `donations_per_head_asc`) still parse, as sort + dir.
+ */
 export const ALLOCATION_SORTS = {
-  need: { column: 'irsd_decile', ascending: true, label: 'most disadvantaged first' },
-  gov_per_head: { column: 'gov_revenue_per_head', ascending: false, label: 'government revenue per head' },
-  gov_per_head_asc: { column: 'gov_revenue_per_head', ascending: true, label: 'least government revenue per head' },
-  donations_per_head: { column: 'donations_per_head', ascending: false, label: 'donations per head' },
-  donations_per_head_asc: { column: 'donations_per_head', ascending: true, label: 'least donations per head' },
-  grants_per_head: { column: 'cw_grants_24m_per_head', ascending: false, label: 'Commonwealth grants per head' },
-  delivered_per_head: { column: 'cw_delivery_24m_per_head', ascending: false, label: 'Commonwealth grants delivered here, per head' },
-  shrinking: { column: 'shrinking_share_pct', ascending: false, label: 'share of charities shrinking' },
-  population: { column: 'population', ascending: false, label: 'population' },
-  orgs: { column: 'org_count', ascending: false, label: 'organisations' },
-  sure: { column: 'placed_share_pct', ascending: true, label: 'least sure first' },
-  name: { column: 'lga_name', ascending: true, label: 'name' },
+  name: { column: 'lga_name', defaultDir: 'asc', label: 'name' },
+  remoteness: { column: 'remoteness', defaultDir: 'asc', label: 'remoteness' },
+  need: { column: 'irsd_decile', defaultDir: 'asc', label: 'need' },
+  population: { column: 'population', defaultDir: 'desc', label: 'population' },
+  orgs: { column: 'org_count', defaultDir: 'desc', label: 'organisations' },
+  gov_per_head: { column: 'gov_revenue_per_head', defaultDir: 'desc', label: 'government revenue per head' },
+  donations_per_head: { column: 'donations_per_head', defaultDir: 'desc', label: 'donations per head' },
+  grants_per_head: { column: 'cw_grants_24m_per_head', defaultDir: 'desc', label: 'Commonwealth grants per head' },
+  delivered_per_head: { column: 'cw_delivery_24m_per_head', defaultDir: 'desc', label: 'Commonwealth grants delivered here, per head' },
+  shrinking: { column: 'shrinking_share_pct', defaultDir: 'desc', label: 'share of charities shrinking' },
+  sure: { column: 'placed_share_pct', defaultDir: 'asc', label: 'how sure' },
 } as const;
 export type AllocationSort = keyof typeof ALLOCATION_SORTS;
+export type SortDir = 'asc' | 'desc';
+const LEGACY_SORTS: Record<string, [AllocationSort, SortDir]> = {
+  gov_per_head_asc: ['gov_per_head', 'asc'],
+  donations_per_head_asc: ['donations_per_head', 'asc'],
+};
 
 export const REMOTENESS_BANDS = [
   'Major Cities of Australia',
@@ -86,6 +95,11 @@ export interface AllocationFilters {
   /** '1-2', '3-5', '6-10' or '' */
   decile: string;
   sort: AllocationSort;
+  dir: SortDir;
+  /** Council name contains, case-insensitive. */
+  q: string;
+  /** '80' keeps rows placed at 80% or better; '' keeps all. */
+  sure: string;
 }
 
 const DECILE_BANDS: Record<string, [number, number]> = { '1-2': [0, 2.5], '3-5': [2.5, 5.5], '6-10': [5.5, 11] };
@@ -96,9 +110,18 @@ export function parseAllocationFilters(sp: Record<string, string | string[] | un
   const state = (STATES as readonly string[]).includes(one('state')) ? one('state') : '';
   const remoteness = (REMOTENESS_BANDS as readonly string[]).includes(one('remoteness')) ? one('remoteness') : '';
   const decile = one('decile') in DECILE_BANDS ? one('decile') : '';
-  const sort = (one('sort') in ALLOCATION_SORTS ? one('sort') : 'need') as AllocationSort;
-  return { state, remoteness, decile, sort };
+  let sort: AllocationSort = 'need';
+  let dir: SortDir | '' = '';
+  if (one('sort') in LEGACY_SORTS) [sort, dir] = LEGACY_SORTS[one('sort')];
+  else if (one('sort') in ALLOCATION_SORTS) sort = one('sort') as AllocationSort;
+  if (one('dir') === 'asc' || one('dir') === 'desc') dir = one('dir') as SortDir;
+  if (!dir) dir = ALLOCATION_SORTS[sort].defaultDir;
+  const q = one('q').trim().slice(0, 60);
+  const sure = one('sure') === '80' ? '80' : '';
+  return { state, remoteness, decile, sort, dir, q, sure };
 }
+
+export const UNFILTERED: AllocationFilters = { state: '', remoteness: '', decile: '', sort: 'need', dir: 'asc', q: '', sure: '' };
 
 export async function listAllocation(f: AllocationFilters): Promise<AllocationRow[]> {
   const db = getDirectServiceSupabase();
@@ -110,8 +133,10 @@ export async function listAllocation(f: AllocationFilters): Promise<AllocationRo
     const [lo, hi] = DECILE_BANDS[f.decile];
     q = q.gte('irsd_decile', lo).lt('irsd_decile', hi);
   }
+  if (f.q) q = q.ilike('lga_name', `%${f.q.replace(/[%_]/g, '')}%`);
+  if (f.sure === '80') q = q.gte('placed_share_pct', 80);
   // Nulls last on every sort: a council with no SEIFA or no population must not lead the list.
-  q = q.order(s.column, { ascending: s.ascending, nullsFirst: false }).order('lga_name', { ascending: true });
+  q = q.order(s.column, { ascending: f.dir === 'asc', nullsFirst: false }).order('lga_name', { ascending: true });
   const { data, error } = await q.limit(600);
   if (error) throw new Error(error.message);
   return (data ?? []) as AllocationRow[];

--- a/supabase/migrations/20260907110000_browse_rpc_sort_direction.sql
+++ b/supabase/migrations/20260907110000_browse_rpc_sort_direction.sql
@@ -1,0 +1,429 @@
+-- 20260907110000_browse_rpc_sort_direction.sql
+-- Two-way sort on the nine browse RPCs (issue #440). Each function gains `p_dir text DEFAULT NULL`; NULL keeps the
+-- column's natural direction (what every page did before), 'asc' or 'desc' overrides it. The default sort key of
+-- six functions ('total', 'influence', 'funding') lived in the ORDER BY fallback, not the CASE ladder, so each of
+-- those gets an explicit ascending branch too. NULLS LAST is now on every branch: a bare DESC put NULLs first.
+--
+-- Signatures change (a new trailing parameter), so the old signature is dropped first. CREATE OR REPLACE with a
+-- different argument list would leave two overloads and PostgREST cannot choose between them when p_dir is
+-- omitted. Bodies are pg_get_functiondef output from 2026-09-07 with only the ORDER BY lines and signature
+-- touched; SECURITY DEFINER and search_path preserved; grants re-issued as they were (foundation_browse was
+-- service_role only, and stays so).
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.charity_browse(p_q text, p_state text, p_size text, p_sort text, p_limit integer);
+DROP FUNCTION IF EXISTS public.contract_buyer_browse(p_q text, p_from_year integer, p_sort text, p_limit integer, p_offset integer);
+DROP FUNCTION IF EXISTS public.contract_supplier_browse(p_q text, p_from_year integer, p_sort text, p_limit integer, p_offset integer);
+DROP FUNCTION IF EXISTS public.donation_donor_browse(p_q text, p_from_fy text, p_sort text, p_limit integer, p_offset integer);
+DROP FUNCTION IF EXISTS public.foundation_browse(p_q text, p_type text, p_sort text, p_limit integer);
+DROP FUNCTION IF EXISTS public.grant_recipient_browse(p_q text, p_state text, p_topic text, p_sort text, p_limit integer, p_offset integer);
+DROP FUNCTION IF EXISTS public.person_browse(p_q text, p_sort text, p_limit integer, p_offset integer);
+DROP FUNCTION IF EXISTS public.place_browse(p_q text, p_state text, p_sort text, p_limit integer, p_offset integer);
+DROP FUNCTION IF EXISTS public.se_browse(p_q text, p_state text, p_sort text, p_limit integer);
+
+CREATE OR REPLACE FUNCTION public.charity_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_size text DEFAULT NULL::text, p_sort text DEFAULT 'known'::text, p_limit integer DEFAULT 200, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(abn text, name text, charity_size text, state text, is_foundation boolean, gs_id text, system_count integer, visible_dollars numeric, ais_year integer, total_assets numeric, known integer)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  -- OUT names are the app's contract: visible_dollars and known, not the MV's column names.
+  SELECT m.abn, m.name, m.charity_size, m.state, m.is_foundation,
+         m.gs_id, m.system_count, m.total_dollar_flow AS visible_dollars,
+         m.ais_year, m.total_assets, m.known_score AS known
+    FROM mv_charity_browse m
+   WHERE (p_q IS NULL OR m.name ILIKE '%' || p_q || '%')
+     AND (p_state IS NULL OR m.state = p_state)
+     AND (p_size IS NULL OR m.charity_size = p_size)
+   ORDER BY
+     CASE WHEN p_sort = 'known' AND coalesce(p_dir, 'desc') = 'desc' THEN m.known_score END DESC NULLS LAST,
+     CASE WHEN p_sort = 'known' AND p_dir = 'asc' THEN m.known_score END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND coalesce(p_dir, 'asc') = 'asc' THEN m.known_score END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND p_dir = 'desc' THEN m.known_score END DESC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND coalesce(p_dir, 'desc') = 'desc' THEN m.total_assets END DESC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND p_dir = 'asc' THEN m.total_assets END ASC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND coalesce(p_dir, 'desc') = 'desc' THEN m.total_dollar_flow END DESC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND p_dir = 'asc' THEN m.total_dollar_flow END ASC NULLS LAST,
+     m.name ASC
+   LIMIT least(greatest(coalesce(p_limit, 200), 1), 500)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.contract_buyer_browse(p_q text DEFAULT NULL::text, p_from_year integer DEFAULT 2020, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(buyer_key text, buyer_name text, contract_count bigint, total_value numeric, supplier_count bigint, top_supplier text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    lower(btrim(c.buyer_name)) AS buyer_key,
+    max(c.buyer_name) AS buyer_name,
+    count(*) AS contract_count,
+    sum(c.contract_value) AS total_value,
+    count(DISTINCT COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name)))) AS supplier_count,
+    (array_agg(c.supplier_name ORDER BY c.contract_value DESC NULLS LAST))[1] AS top_supplier
+  FROM austender_contracts c
+  WHERE c.buyer_name IS NOT NULL AND btrim(c.buyer_name) <> ''
+    AND c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+    AND c.contract_start < make_date(2031, 1, 1)
+    AND (p_q IS NULL OR c.buyer_name ILIKE '%' || p_q || '%')
+  GROUP BY lower(btrim(c.buyer_name))
+  ORDER BY
+    CASE WHEN p_sort = 'contracts' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'contracts' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'suppliers' AND coalesce(p_dir, 'desc') = 'desc' THEN count(DISTINCT COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name)))) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'suppliers' AND p_dir = 'asc' THEN count(DISTINCT COALESCE(NULLIF(c.supplier_abn, ''), lower(btrim(c.supplier_name)))) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN max(c.buyer_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN max(c.buyer_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(c.contract_value) END ASC NULLS LAST,
+    sum(c.contract_value) DESC NULLS LAST,
+    max(c.buyer_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.contract_supplier_browse(p_q text DEFAULT NULL::text, p_from_year integer DEFAULT 2020, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(supplier_key text, supplier_name text, supplier_abn text, contract_count bigint, total_value numeric, buyer_count bigint, top_buyer text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    COALESCE(NULLIF(c.supplier_abn, ''), m.abn, root.abn, n.nk) AS supplier_key,
+    mode() WITHIN GROUP (ORDER BY c.supplier_name) AS supplier_name,
+    max(COALESCE(NULLIF(c.supplier_abn, ''), m.abn, root.abn)) AS supplier_abn,
+    count(*) AS contract_count,
+    sum(c.contract_value) AS total_value,
+    count(DISTINCT c.buyer_name) AS buyer_count,
+    (array_agg(c.buyer_name ORDER BY c.contract_value DESC NULLS LAST))[1] AS top_buyer
+  FROM austender_contracts c
+  JOIN supplier_name_keys n ON n.supplier_name = c.supplier_name
+  LEFT JOIN donor_key_abn m ON m.n = n.nk
+  LEFT JOIN donor_key_abn root ON n.nk LIKE '% pty ltd'
+        AND root.n = regexp_replace(n.nk, ' pty ltd$', '')
+  WHERE c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+    AND c.contract_start < make_date(2031, 1, 1)
+    AND (p_q IS NULL OR c.supplier_name ILIKE '%' || p_q || '%')
+  GROUP BY COALESCE(NULLIF(c.supplier_abn, ''), m.abn, root.abn, n.nk)
+  ORDER BY
+    CASE WHEN p_sort = 'contracts' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'contracts' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'buyers' AND coalesce(p_dir, 'desc') = 'desc' THEN count(DISTINCT c.buyer_name) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'buyers' AND p_dir = 'asc' THEN count(DISTINCT c.buyer_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN mode() WITHIN GROUP (ORDER BY c.supplier_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN mode() WITHIN GROUP (ORDER BY c.supplier_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(c.contract_value) END ASC NULLS LAST,
+    sum(c.contract_value) DESC NULLS LAST,
+    mode() WITHIN GROUP (ORDER BY c.supplier_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.donation_donor_browse(p_q text DEFAULT NULL::text, p_from_fy text DEFAULT '2014-15'::text, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(donor_key text, donor_name text, donor_abn text, donation_count bigint, total_dollars numeric, recipient_count bigint, top_recipient text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    COALESCE(NULLIF(d.donor_abn, ''), m.abn, root.abn, n.nk) AS donor_key,
+    mode() WITHIN GROUP (ORDER BY d.donor_name) AS donor_name,
+    max(COALESCE(NULLIF(d.donor_abn, ''), m.abn, root.abn)) AS donor_abn,
+    count(*) AS donation_count,
+    sum(d.amount) AS total_dollars,
+    count(DISTINCT d.donation_to) AS recipient_count,
+    (array_agg(d.donation_to ORDER BY d.amount DESC NULLS LAST))[1] AS top_recipient
+  FROM political_donations d
+  JOIN donor_name_keys n ON n.donor_name = d.donor_name
+  LEFT JOIN donor_key_abn m ON m.n = n.nk
+  LEFT JOIN donor_key_abn root ON n.nk LIKE '% pty ltd'
+        AND root.n = regexp_replace(n.nk, ' pty ltd$', '')
+  WHERE d.receipt_type = 'donation received'
+    AND d.financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15')
+    AND (p_q IS NULL OR d.donor_name ILIKE '%' || p_q || '%')
+  GROUP BY COALESCE(NULLIF(d.donor_abn, ''), m.abn, root.abn, n.nk)
+  ORDER BY
+    CASE WHEN p_sort = 'donations' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'donations' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'recipients' AND coalesce(p_dir, 'desc') = 'desc' THEN count(DISTINCT d.donation_to) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'recipients' AND p_dir = 'asc' THEN count(DISTINCT d.donation_to) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN mode() WITHIN GROUP (ORDER BY d.donor_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN mode() WITHIN GROUP (ORDER BY d.donor_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(d.amount) END ASC NULLS LAST,
+    sum(d.amount) DESC NULLS LAST,
+    mode() WITHIN GROUP (ORDER BY d.donor_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.foundation_browse(p_q text DEFAULT NULL::text, p_type text DEFAULT NULL::text, p_sort text DEFAULT 'giving'::text, p_limit integer DEFAULT 200, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(id uuid, name text, abn text, type text, giving numeric, grantees bigint, board_links bigint, ais_year integer, granted numeric, total_assets numeric)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH g AS (
+    SELECT foundation_id, count(*) AS n FROM mv_foundation_grantees GROUP BY 1
+  ), b AS (
+    SELECT foundation_id, count(*) AS n FROM funder_board_paths GROUP BY 1
+  )
+  SELECT f.id, f.name, f.acnc_abn, f.type,
+         f.total_giving_annual,
+         coalesce(g.n, 0), coalesce(b.n, 0),
+         ais.ais_year::int, ais.grants_donations_au, ais.total_assets
+    FROM foundations f
+    LEFT JOIN g ON g.foundation_id = f.id
+    LEFT JOIN b ON b.foundation_id = f.id
+    -- LATERAL latest-AIS probe per foundation: the DISTINCT ON version deduplicated all 361K
+    -- AIS rows on every call (74s); ~11K index probes via idx_acnc_ais_lookup run in ~1s.
+    LEFT JOIN LATERAL (
+      SELECT a.ais_year, a.grants_donations_au, a.total_assets
+        FROM acnc_ais a
+       WHERE a.abn = f.acnc_abn
+       ORDER BY a.ais_year DESC
+       LIMIT 1
+    ) ais ON true
+   WHERE (p_q IS NULL OR f.name ILIKE '%' || p_q || '%')
+     AND (p_type IS NULL OR f.type = p_type)
+   ORDER BY
+     CASE WHEN p_sort = 'giving' AND coalesce(p_dir, 'desc') = 'desc' THEN f.total_giving_annual END DESC NULLS LAST,
+     CASE WHEN p_sort = 'giving' AND p_dir = 'asc' THEN f.total_giving_annual END ASC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND coalesce(p_dir, 'desc') = 'desc' THEN ais.total_assets END DESC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND p_dir = 'asc' THEN ais.total_assets END ASC NULLS LAST,
+     CASE WHEN p_sort = 'granted' AND coalesce(p_dir, 'desc') = 'desc' THEN ais.grants_donations_au END DESC NULLS LAST,
+     CASE WHEN p_sort = 'granted' AND p_dir = 'asc' THEN ais.grants_donations_au END ASC NULLS LAST,
+     CASE WHEN p_sort = 'grantees' AND coalesce(p_dir, 'desc') = 'desc' THEN coalesce(g.n, 0) END DESC NULLS LAST,
+     CASE WHEN p_sort = 'grantees' AND p_dir = 'asc' THEN coalesce(g.n, 0) END ASC NULLS LAST,
+     CASE WHEN p_sort = 'board' AND coalesce(p_dir, 'desc') = 'desc' THEN coalesce(b.n, 0) END DESC NULLS LAST,
+     CASE WHEN p_sort = 'board' AND p_dir = 'asc' THEN coalesce(b.n, 0) END ASC NULLS LAST,
+     f.name ASC
+   LIMIT least(greatest(coalesce(p_limit, 200), 1), 500);
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.grant_recipient_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_topic text DEFAULT NULL::text, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(recipient_key text, recipient_name text, recipient_abn text, grant_count bigint, total_dollars numeric, states text[], first_year text, last_year text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    lower(btrim(j.recipient_name)) AS recipient_key,
+    max(j.recipient_name) AS recipient_name,
+    max(j.recipient_abn) AS recipient_abn,
+    count(*) AS grant_count,
+    sum(j.amount_dollars) AS total_dollars,
+    array_agg(DISTINCT j.state) FILTER (WHERE j.state IS NOT NULL) AS states,
+    min(j.financial_year) AS first_year,
+    max(j.financial_year) AS last_year
+  FROM justice_funding j
+  WHERE j.measure_kind = 'grant'
+    AND j.is_aggregate IS NOT TRUE
+    AND j.recipient_name IS NOT NULL
+    AND btrim(j.recipient_name) <> ''
+    AND lower(btrim(j.recipient_name)) NOT IN
+        ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other','(blank)')
+    AND (p_q IS NULL OR j.recipient_name ILIKE '%' || p_q || '%')
+    AND (p_state IS NULL OR j.state = p_state)
+    AND (p_topic IS NULL OR j.topics @> ARRAY[p_topic])
+  GROUP BY lower(btrim(j.recipient_name))
+  ORDER BY
+    CASE WHEN p_sort = 'grants' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'grants' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'recent' AND coalesce(p_dir, 'desc') = 'desc' THEN max(j.financial_year) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'recent' AND p_dir = 'asc' THEN max(j.financial_year) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN max(j.recipient_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN max(j.recipient_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(j.amount_dollars) END ASC NULLS LAST,
+    sum(j.amount_dollars) DESC NULLS LAST,
+    max(j.recipient_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.person_browse(p_q text DEFAULT NULL::text, p_sort text DEFAULT 'influence'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(identity_key text, person_name text, person_name_normalised text, board_count bigint, acco_boards bigint, attributed_procurement numeric, attributed_justice numeric, attributed_donations numeric, financial_system_count integer, influence_score numeric)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    v.identity_key, v.person_name, v.person_name_normalised, v.board_count, v.acco_boards,
+    v.attributed_procurement, v.attributed_justice, v.attributed_donations,
+    v.financial_system_count, v.influence_score_attributed
+  FROM mv_person_identity_influence_v2 v
+  WHERE v.is_nominee_block IS NOT TRUE
+    AND v.board_count <= 10
+    AND (p_q IS NULL OR v.person_name ILIKE '%' || p_q || '%')
+  ORDER BY
+    CASE WHEN p_sort = 'boards' AND coalesce(p_dir, 'desc') = 'desc' THEN v.board_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'boards' AND p_dir = 'asc' THEN v.board_count END ASC NULLS LAST,
+    CASE WHEN p_sort = 'systems' AND coalesce(p_dir, 'desc') = 'desc' THEN v.financial_system_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'systems' AND p_dir = 'asc' THEN v.financial_system_count END ASC NULLS LAST,
+    CASE WHEN p_sort = 'procurement' AND coalesce(p_dir, 'desc') = 'desc' THEN v.attributed_procurement END DESC NULLS LAST,
+    CASE WHEN p_sort = 'procurement' AND p_dir = 'asc' THEN v.attributed_procurement END ASC NULLS LAST,
+    CASE WHEN p_sort = 'justice' AND coalesce(p_dir, 'desc') = 'desc' THEN v.attributed_justice END DESC NULLS LAST,
+    CASE WHEN p_sort = 'justice' AND p_dir = 'asc' THEN v.attributed_justice END ASC NULLS LAST,
+    CASE WHEN p_sort = 'donations' AND coalesce(p_dir, 'desc') = 'desc' THEN v.attributed_donations END DESC NULLS LAST,
+    CASE WHEN p_sort = 'donations' AND p_dir = 'asc' THEN v.attributed_donations END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN v.person_name END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN v.person_name END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'influence') = 'influence' AND p_dir = 'asc' THEN v.influence_score_attributed END ASC NULLS LAST,
+    v.influence_score_attributed DESC NULLS LAST,
+    v.person_name ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.place_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_sort text DEFAULT 'funding'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(lga_name text, state text, entity_count bigint, community_controlled_count bigint, total_funding numeric, avg_seifa_decile numeric, remoteness text, desert_score numeric)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  WITH lga AS (
+    SELECT f.lga_name, f.state,
+           sum(f.entity_count) AS entity_count,
+           sum(f.community_controlled_count) AS community_controlled_count,
+           sum(f.total_funding) AS total_funding,
+           avg(f.avg_seifa_decile) AS avg_seifa_decile
+    FROM mv_funding_by_lga f
+    WHERE f.lga_name IS NOT NULL
+    GROUP BY f.lga_name, f.state
+  ),
+  deserts AS (
+    SELECT d.lga_name, d.state,
+           max(d.desert_score) AS desert_score,
+           min(d.remoteness) AS remoteness
+    FROM mv_funding_deserts d
+    GROUP BY d.lga_name, d.state
+  )
+  SELECT
+    l.lga_name, l.state, l.entity_count, l.community_controlled_count,
+    l.total_funding, round(l.avg_seifa_decile, 1), d.remoteness, round(d.desert_score, 1)
+  FROM lga l
+  LEFT JOIN deserts d ON d.lga_name = l.lga_name AND d.state = l.state
+  WHERE (p_q IS NULL OR l.lga_name ILIKE '%' || p_q || '%')
+    AND (p_state IS NULL OR l.state = p_state)
+  ORDER BY
+    CASE WHEN p_sort = 'desert' AND coalesce(p_dir, 'desc') = 'desc' THEN d.desert_score END DESC NULLS LAST,
+    CASE WHEN p_sort = 'desert' AND p_dir = 'asc' THEN d.desert_score END ASC NULLS LAST,
+    CASE WHEN p_sort = 'entities' AND coalesce(p_dir, 'desc') = 'desc' THEN l.entity_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'entities' AND p_dir = 'asc' THEN l.entity_count END ASC NULLS LAST,
+    CASE WHEN p_sort = 'acco' AND coalesce(p_dir, 'desc') = 'desc' THEN l.community_controlled_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'acco' AND p_dir = 'asc' THEN l.community_controlled_count END ASC NULLS LAST,
+    CASE WHEN p_sort = 'disadvantage' AND coalesce(p_dir, 'asc') = 'asc' THEN l.avg_seifa_decile END ASC NULLS LAST,
+    CASE WHEN p_sort = 'disadvantage' AND p_dir = 'desc' THEN l.avg_seifa_decile END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN l.lga_name END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN l.lga_name END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'funding') = 'funding' AND p_dir = 'asc' THEN l.total_funding END ASC NULLS LAST,
+    l.total_funding DESC NULLS LAST,
+    l.lga_name ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.se_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_sort text DEFAULT 'known'::text, p_limit integer DEFAULT 200, p_dir text DEFAULT NULL::text)
+ RETURNS TABLE(id uuid, name text, abn text, sector text, state text, gs_id text, system_count integer, visible_dollars numeric, known integer, has_abn boolean, has_sector boolean, has_place boolean, has_web boolean, on_graph boolean, entries integer)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  WITH base AS (
+    SELECT
+      s.id, s.name, s.abn, s.sector, s.state, s.postcode, s.website, s.description,
+      p.gs_id, p.system_count, p.total_dollar_flow,
+      (s.abn IS NOT NULL) AS has_abn,
+      (s.sector IS NOT NULL) AS has_sector,
+      (s.postcode IS NOT NULL OR s.state IS NOT NULL) AS has_place,
+      (s.website IS NOT NULL OR s.description IS NOT NULL) AS has_web,
+      (p.gs_id IS NOT NULL) AS on_graph,
+      ((s.abn IS NOT NULL)::int + (s.sector IS NOT NULL)::int
+       + (s.postcode IS NOT NULL OR s.state IS NOT NULL)::int
+       + (s.website IS NOT NULL OR s.description IS NOT NULL)::int
+       + (p.gs_id IS NOT NULL)::int) AS known_score,
+      -- One group per ABN; ABN-less rows group only with themselves.
+      COALESCE(s.abn, s.id::text) AS grp
+    FROM social_enterprises s
+    LEFT JOIN LATERAL (
+      SELECT e.gs_id, e.system_count, e.total_dollar_flow
+        FROM mv_entity_power_index e
+       WHERE e.abn = s.abn
+       LIMIT 1
+    ) p ON s.abn IS NOT NULL
+  ), named AS (
+    SELECT b.abn, min(g.canonical_name) AS canonical_name
+      FROM base b
+      JOIN gs_entities g ON g.abn = b.abn
+     WHERE b.abn IS NOT NULL
+     GROUP BY 1
+  ), sectors AS (
+    -- Flattened separately: array_agg over text[] of differing lengths is an error, and the union
+    -- of a group's sectors is what a reader wants to see.
+    SELECT b.grp, string_agg(DISTINCT x, ', ') AS sector
+      FROM base b, LATERAL unnest(COALESCE(b.sector, ARRAY[]::text[])) AS x
+     GROUP BY 1
+  ), grouped AS (
+    SELECT
+      (array_agg(b.id ORDER BY length(b.name), b.name))[1] AS id,
+      COALESCE(n.canonical_name, (array_agg(b.name ORDER BY length(b.name), b.name))[1]) AS name,
+      max(b.abn) AS abn,
+      sec.sector,
+      CASE WHEN count(DISTINCT b.state) = 1 THEN max(b.state) ELSE NULL END AS state,
+      max(b.gs_id) AS gs_id,
+      max(b.system_count)::int AS system_count,
+      max(b.total_dollar_flow) AS visible_dollars,
+      max(b.known_score) AS known,
+      bool_or(b.has_abn) AS has_abn,
+      bool_or(b.has_sector) AS has_sector,
+      bool_or(b.has_place) AS has_place,
+      bool_or(b.has_web) AS has_web,
+      bool_or(b.on_graph) AS on_graph,
+      count(*)::int AS entries,
+      -- Kept out of the returned row; only the filters below need them.
+      bool_or(p_q IS NULL OR b.name ILIKE '%' || p_q || '%') AS name_match,
+      bool_or(p_state IS NULL OR b.state = p_state) AS state_match
+    FROM base b
+    LEFT JOIN named n ON n.abn = b.abn
+    LEFT JOIN sectors sec ON sec.grp = b.grp
+    GROUP BY b.grp, n.canonical_name, sec.sector
+  )
+  SELECT id, name, abn, sector, state, gs_id, system_count, visible_dollars, known,
+         has_abn, has_sector, has_place, has_web, on_graph, entries
+    FROM grouped
+   -- Matching on ANY entry in the group: searching "Ballarat Red Cross" must still find the row,
+   -- even though it now displays as Australian Red Cross Society.
+   WHERE name_match AND state_match
+   ORDER BY
+     CASE WHEN p_sort = 'known' AND coalesce(p_dir, 'desc') = 'desc' THEN known END DESC NULLS LAST,
+     CASE WHEN p_sort = 'known' AND p_dir = 'asc' THEN known END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND coalesce(p_dir, 'asc') = 'asc' THEN known END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND p_dir = 'desc' THEN known END DESC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND coalesce(p_dir, 'desc') = 'desc' THEN visible_dollars END DESC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND p_dir = 'asc' THEN visible_dollars END ASC NULLS LAST,
+     CASE WHEN p_sort = 'systems' AND coalesce(p_dir, 'desc') = 'desc' THEN system_count END DESC NULLS LAST,
+     CASE WHEN p_sort = 'systems' AND p_dir = 'asc' THEN system_count END ASC NULLS LAST,
+     name ASC
+   LIMIT least(greatest(coalesce(p_limit, 200), 1), 500)
+$function$
+;
+
+REVOKE EXECUTE ON FUNCTION public.charity_browse(p_q text, p_state text, p_size text, p_sort text, p_limit integer, p_dir text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.charity_browse(p_q text, p_state text, p_size text, p_sort text, p_limit integer, p_dir text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.contract_buyer_browse(p_q text, p_from_year integer, p_sort text, p_limit integer, p_offset integer, p_dir text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.contract_supplier_browse(p_q text, p_from_year integer, p_sort text, p_limit integer, p_offset integer, p_dir text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.donation_donor_browse(p_q text, p_from_fy text, p_sort text, p_limit integer, p_offset integer, p_dir text) TO anon, authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.foundation_browse(p_q text, p_type text, p_sort text, p_limit integer, p_dir text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.foundation_browse(p_q text, p_type text, p_sort text, p_limit integer, p_dir text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.grant_recipient_browse(p_q text, p_state text, p_topic text, p_sort text, p_limit integer, p_offset integer, p_dir text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.person_browse(p_q text, p_sort text, p_limit integer, p_offset integer, p_dir text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.place_browse(p_q text, p_state text, p_sort text, p_limit integer, p_offset integer, p_dir text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.se_browse(p_q text, p_state text, p_sort text, p_limit integer, p_dir text) TO anon, authenticated, service_role;
+
+COMMIT;

--- a/supabase/types/database.types.ts
+++ b/supabase/types/database.types.ts
@@ -66414,6 +66414,7 @@ export type Database = {
       capture_estate_snapshot: { Args: never; Returns: string }
       charity_browse: {
         Args: {
+          p_dir?: string
           p_limit?: number
           p_q?: string
           p_size?: string
@@ -66758,6 +66759,7 @@ export type Database = {
       contract_browse_stats: { Args: { p_from_year?: number }; Returns: Json }
       contract_buyer_browse: {
         Args: {
+          p_dir?: string
           p_from_year?: number
           p_limit?: number
           p_offset?: number
@@ -66779,6 +66781,7 @@ export type Database = {
       }
       contract_supplier_browse: {
         Args: {
+          p_dir?: string
           p_from_year?: number
           p_limit?: number
           p_offset?: number
@@ -66900,6 +66903,7 @@ export type Database = {
       donation_browse_stats: { Args: { p_from_fy?: string }; Returns: Json }
       donation_donor_browse: {
         Args: {
+          p_dir?: string
           p_from_fy?: string
           p_limit?: number
           p_offset?: number
@@ -67013,6 +67017,7 @@ export type Database = {
       }
       foundation_browse: {
         Args: {
+          p_dir?: string
           p_limit?: number
           p_q?: string
           p_sort?: string
@@ -67724,6 +67729,7 @@ export type Database = {
       grant_browse_stats: { Args: never; Returns: Json }
       grant_recipient_browse: {
         Args: {
+          p_dir?: string
           p_limit?: number
           p_offset?: number
           p_q?: string
@@ -68391,6 +68397,7 @@ export type Database = {
       }
       person_browse: {
         Args: {
+          p_dir?: string
           p_limit?: number
           p_offset?: number
           p_q?: string
@@ -68413,6 +68420,7 @@ export type Database = {
       person_detail: { Args: { p_norm: string }; Returns: Json }
       place_browse: {
         Args: {
+          p_dir?: string
           p_limit?: number
           p_offset?: number
           p_q?: string
@@ -68602,6 +68610,7 @@ export type Database = {
       }
       se_browse: {
         Args: {
+          p_dir?: string
           p_limit?: number
           p_q?: string
           p_sort?: string

--- a/thoughts/shared/handoffs/allocation-intelligence/current.md
+++ b/thoughts/shared/handoffs/allocation-intelligence/current.md
@@ -11,13 +11,15 @@ status: active
 <!-- This section is extracted by SessionStart hook for quick resume -->
 **Updated:** 2026-09-07T05:15:00+10:00
 **Goal:** Two surfaces that read the whole register: disadvantage versus dollars per council (`/allocation`) and seven-year charity trajectories (`/charities/trajectories`), plus three grounded posts for the Philanthropy Australia conference (Brisbane, 8 to 10 Sept 2026). Done when both pages are live and verified, and the posts have no unverified claim.
-**Branch:** main
+**Branch:** feat/browse-sort-filters (PR #441, VISIBLE, open)
 **Test:** `bash scripts/precheck.sh` · `node --env-file=.env scripts/check-migration-parity.mjs` · `node --env-file=.env scripts/check-private-exposure.mjs`
 
 ### Now
-[->] Nothing in progress. #437 merged `1fa759ba`, Vercel success, all three routes read live in a browser (Alice Springs tiles, QLD shrinking councils table, NT index columns + 11% tile). Stream closed unless Ben picks a Next item.
+[->] PR #441 open (VISIBLE): nav links, table width, two-way sort on every browse table + /allocation search/sure chip. Migration 20260907110000 (p_dir on nine browse RPCs) APPLIED, parity green, types regenerated, all nine tables verified both ways on local dev. Waits on Ben's look and "merge". Dev server may still be on 3013.
 
 ### This Session
+- [x] #439 merged `d79c8445`: grounded NIAA paragraph in post 1 (NIAA: delivery state on all, postcode on none, 79 'Multiple'; Health 2%).
+- [x] #440 filed (browse sort + filters), sort half built in #441; #442 filed (junk names at the bottom of rankings).
 - [x] #435 and #436 confirmed merged, branches gone.
 - [x] PR #437 merged `1fa759ba` and verified live. Migration 20260907090000 applied, parity green, types regenerated.
 - [x] Delivery-postcode lane + per-council trajectory rollups built (migration + /allocation, /allocation/[lga_code], /charities/trajectories), PR #437. Finding: delivery postcodes cover 11% of 24m recipient-lane money, by agency (NIAA none, Health 2%, ARC 100%); the lane shows where the record is silent.


### PR DESCRIPTION
Ben's three notes from the local look (2026-09-07), plus "migrate" for the cross-table sort.

1. **Allocation was not in the sidebar.** Added under Browse: "Councils: need vs dollars" and "Charity trajectories".
2. **Table read as cut off.** The page was capped at 1280px with the table scrolling inside it. Now uses the shell width (max 1600) with shorter headers.
3. **Sorting, everywhere.** Every browse table (charities, social enterprises, grant recipients, foundations, contract suppliers, government buyers, political donors, people, places) and `/allocation` now sorts on every column both ways: first click gives the natural direction, a second click flips it; ▲/▼ on the active column, ⇅ on the rest, all in the URL. `/allocation` also gets a council-name search and a "sure rows only (80%+)" chip.

Closes #440 for the sort half. The richer-filter half (state on contracts/buyers/donors, sector on charities, year ranges) is still open there.

## Database
Migration `20260907110000_browse_rpc_sort_direction.sql` **applied** and tracked, parity green. Nine RPCs gain `p_dir text DEFAULT NULL` (NULL = natural direction, so nothing changes for existing links). Old signatures dropped first so PostgREST has one candidate. NULLS LAST on every branch. ACLs re-issued exactly as they were (checked `proacl` before and after; `foundation_browse` stays service_role only). Types regenerated.

## Verified on local dev against the applied functions
Each of the nine tables rendered in both directions with the first row changing as expected (Red Cross $7.6bn vs $0 charities; Parklife Metro $11.4bn vs $0 suppliers; Stonnington decile 10 at the top of places when flipped). `/allocation`: population both ways, `q=alice` one row, `sure=80&state=NT` three rows. precheck green.

Seen on the way, not fixed here: #442 (junk names now visible at the bottom of rankings).
