### PR TITLE
Browse tables: filters on every table, junk names out of the rankings

### DIFF
--- a/apps/web/src/app/charities/page.tsx
+++ b/apps/web/src/app/charities/page.tsx
@@ -28,6 +28,8 @@ export default async function CharityList({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const state = typeof sp.state === 'string' ? sp.state : '';
   const size = typeof sp.size === 'string' ? sp.size : '';
+  const sector = typeof sp.sector === 'string' ? sp.sector.slice(0, 40) : '';
+  const remoteness = typeof sp.remoteness === 'string' ? sp.remoteness.slice(0, 40) : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'known';
   const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
@@ -37,7 +39,7 @@ export default async function CharityList({
   let why: string | null = null;
   try {
     const [{ data, error }, s] = await Promise.all([
-      retryRpc(() => supabase.rpc('charity_browse', { p_q: q || null, p_state: state || null, p_size: size || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
+      retryRpc(() => supabase.rpc('charity_browse', { p_q: q || null, p_state: state || null, p_size: size || null, p_sector: sector || null, p_remoteness: remoteness || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
       stats(),
     ]);
     if (error) throw new Error(error.message);
@@ -90,6 +92,8 @@ export default async function CharityList({
               knownLegend: 'facts held: size, state, graph match, financial return, visible money',
               stateFacets: ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'],
               sizeFacets: ['Small', 'Medium', 'Large'],
+              sectorFacets: ['Religion', 'Education', 'Social Welfare', 'Health', 'Community', 'Arts & Culture', 'Environment', 'Indigenous', 'Housing'],
+              remotenessFacets: ['Major Cities of Australia', 'Inner Regional Australia', 'Outer Regional Australia', 'Remote Australia', 'Very Remote Australia'],
               moneyCaveat:
                 'Known = facts we hold (size, state, graph match, financial return, visible money) — a short bar is our gap, not theirs.',
             }}
@@ -97,6 +101,8 @@ export default async function CharityList({
             state={state}
             size={size}
             sort={sort} dir={dir}
+            sector={sector}
+            remoteness={remoteness}
             statsLine={statsLine}
           />
         )}

--- a/apps/web/src/app/dashboard/browse/contracts/page.tsx
+++ b/apps/web/src/app/dashboard/browse/contracts/page.tsx
@@ -8,10 +8,10 @@ export const metadata: Metadata = { title: 'Contract suppliers — CivicGraph' }
 
 // The rollup scans up to 767K rows (~3.5s): cache per (q, from, sort) for an hour.
 const load = unstable_cache(
-  async (q: string, from: number, sort: string, dir: string) => {
+  async (q: string, from: number, sort: string, dir: string, state: string) => {
     const supabase = getDirectServiceSupabase();
     const [browse, stats] = await Promise.all([
-      supabase.rpc('contract_supplier_browse', { p_q: q || null, p_from_year: from, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
+      supabase.rpc('contract_supplier_browse', { p_q: q || null, p_from_year: from, p_state: state || null, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
       supabase.rpc('contract_browse_stats', { p_from_year: from }),
     ]);
     if (browse.error) throw new Error(browse.error.message);
@@ -32,12 +32,13 @@ export default async function ContractsBrowsePage({
   const from = typeof sp.from === 'string' && /^\d{4}$/.test(sp.from) ? parseInt(sp.from, 10) : 2020;
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
   const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
+  const state = typeof sp.state === 'string' && /^[A-Z]{2,3}$/.test(sp.state) ? sp.state : '';
 
   let rows: SideRow[] = [];
   let statsLine = '';
   let why: string | null = null;
   try {
-    const { rows: data, stats } = await load(q, from, sort, dir);
+    const { rows: data, stats } = await load(q, from, sort, dir, state);
     rows = (data as {
       supplier_key: string;
       supplier_name: string;
@@ -71,7 +72,8 @@ export default async function ContractsBrowsePage({
       ) : (
         <ContractSideBrowser
           rows={rows}
-          cfg={{ side: 'supplier', basePath: '/dashboard/browse/contracts', counterpartyLabel: 'Buyers', detailApi: '/api/browse/contract-supplier', counterpartySortKey: 'buyers' }}
+          cfg={{ side: 'supplier', basePath: '/dashboard/browse/contracts', counterpartyLabel: 'Buyers', detailApi: '/api/browse/contract-supplier', counterpartySortKey: 'buyers', stateFacets: ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'] }}
+          state={state}
           q={q}
           fromYear={String(from)}
           sort={sort} dir={dir}

--- a/apps/web/src/app/dashboard/browse/donations/page.tsx
+++ b/apps/web/src/app/dashboard/browse/donations/page.tsx
@@ -9,10 +9,10 @@ export const metadata: Metadata = { title: 'Political donors — CivicGraph' };
 const FY_OPTIONS = ['1998-1999', '2014-15', '2019-20', '2022-23'];
 
 const load = unstable_cache(
-  async (q: string, from: string, sort: string, dir: string) => {
+  async (q: string, from: string, sort: string, dir: string, toFy: string, to: string) => {
     const supabase = getDirectServiceSupabase();
     const [browse, stats] = await Promise.all([
-      supabase.rpc('donation_donor_browse', { p_q: q || null, p_from_fy: from, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
+      supabase.rpc('donation_donor_browse', { p_q: q || null, p_from_fy: from, p_to_fy: toFy || null, p_to: to || null, p_sort: sort, p_dir: dir || null, p_limit: 200 }),
       supabase.rpc('donation_browse_stats', { p_from_fy: from }),
     ]);
     if (browse.error) throw new Error(browse.error.message);
@@ -33,13 +33,15 @@ export default async function DonationsBrowsePage({
   const from = typeof sp.from === 'string' && FY_OPTIONS.includes(sp.from) ? sp.from : '2014-15';
   const sortParam = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
   const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
+  const toFy = typeof sp.to_year === 'string' && FY_OPTIONS.includes(sp.to_year) ? sp.to_year : '';
+  const to = typeof sp.to === 'string' ? sp.to.slice(0, 40) : '';
   const rpcSort = sortParam === 'contracts' ? 'donations' : sortParam;
 
   let rows: SideRow[] = [];
   let statsLine = '';
   let why: string | null = null;
   try {
-    const { rows: data, stats } = await load(q, from, rpcSort, dir);
+    const { rows: data, stats } = await load(q, from, rpcSort, dir, toFy, to);
     rows = (data as {
       donor_key: string;
       donor_name: string;
@@ -81,7 +83,11 @@ export default async function DonationsBrowsePage({
             counterpartySortKey: 'recipients',
             itemLabel: 'donation',
             yearOptions: FY_OPTIONS,
+            toYearOptions: FY_OPTIONS.slice(1),
+            toFacets: ['Labor', 'Liberal', 'National', 'Greens', 'One Nation', 'United Australia', 'Independent'],
           }}
+          toYear={toFy}
+          to={to}
           q={q}
           fromYear={from}
           sort={sortParam} dir={dir}

--- a/apps/web/src/app/dashboard/browse/foundations/page.tsx
+++ b/apps/web/src/app/dashboard/browse/foundations/page.tsx
@@ -10,6 +10,11 @@ import { redirect } from 'next/navigation';
  *
  * Temporary (307): nothing has burned this path, and the detail page below it still lives here.
  */
-export default function MovedBrowseFoundations() {
-  redirect('/foundations');
+export default async function MovedBrowseFoundations({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
+  // Keep the query string: a filter or sort link built against the old path must land filtered, not reset.
+  const sp = await searchParams;
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(sp)) if (typeof v === 'string' && v) p.set(k, v);
+  const s = p.toString();
+  redirect(`/foundations${s ? `?${s}` : ''}`);
 }

--- a/apps/web/src/app/foundations/page.tsx
+++ b/apps/web/src/app/foundations/page.tsx
@@ -20,6 +20,7 @@ export default async function FoundationsList({
   const sp = await searchParams;
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const type = typeof sp.type === 'string' ? sp.type : '';
+  const state = typeof sp.state === 'string' && /^[A-Z]{2,3}$/.test(sp.state) ? sp.state : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'giving';
   const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
@@ -32,6 +33,7 @@ export default async function FoundationsList({
       supabase.rpc('foundation_browse', {
         p_q: q || null,
         p_type: type || null,
+        p_state: state || null,
         p_sort: sort, p_dir: dir || null,
         p_limit: 200,
       }),
@@ -58,7 +60,7 @@ export default async function FoundationsList({
             The list could not be read: {why}. Nothing is estimated in its place.
           </p>
         ) : (
-          <FoundationsBrowser rows={rows} q={q} type={type} sort={sort} dir={dir} total={total} />
+          <FoundationsBrowser rows={rows} q={q} type={type} sort={sort} dir={dir} state={state} total={total} />
         )}
       </div>
     </Shell>

--- a/apps/web/src/app/grants/page.tsx
+++ b/apps/web/src/app/grants/page.tsx
@@ -37,6 +37,9 @@ export default async function GrantsBrowsePage({
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const state = typeof sp.state === 'string' ? sp.state : '';
   const topic = typeof sp.topic === 'string' ? sp.topic : '';
+  const fy = (v: unknown) => (typeof v === 'string' && /^\d{4}-\d{2}$/.test(v) ? v : '');
+  const fromFy = fy(sp.from);
+  const toFy = fy(sp.to);
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'total';
   const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
@@ -53,6 +56,8 @@ export default async function GrantsBrowsePage({
           p_q: q || null,
           p_state: state || null,
           p_topic: topic || null,
+          p_from_fy: fromFy || null,
+          p_to_fy: toFy || null,
           p_sort: sort, p_dir: dir || null,
           p_limit: 200,
         }),
@@ -131,6 +136,8 @@ export default async function GrantsBrowsePage({
             state={state}
             topic={topic}
             sort={sort} dir={dir}
+            fromFy={fromFy}
+            toFy={toFy}
             statsLine={statsLine}
             coverageLine={coverageLine}
             topicLine={topicLine}

--- a/apps/web/src/app/social-enterprises/page.tsx
+++ b/apps/web/src/app/social-enterprises/page.tsx
@@ -26,6 +26,7 @@ export default async function SEList({
   const sp = await searchParams;
   const q = typeof sp.q === 'string' ? sp.q.trim() : '';
   const state = typeof sp.state === 'string' ? sp.state : '';
+  const sector = typeof sp.sector === 'string' ? sp.sector.slice(0, 40) : '';
   const sort = typeof sp.sort === 'string' && sp.sort ? sp.sort : 'known';
   const dir = sp.dir === 'asc' || sp.dir === 'desc' ? sp.dir : '';
 
@@ -35,7 +36,7 @@ export default async function SEList({
   let why: string | null = null;
   try {
     const [{ data, error }, s] = await Promise.all([
-      retryRpc(() => supabase.rpc('se_browse', { p_q: q || null, p_state: state || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
+      retryRpc(() => supabase.rpc('se_browse', { p_q: q || null, p_state: state || null, p_sector: sector || null, p_sort: sort, p_dir: dir || null, p_limit: 200 })),
       stats(),
     ]);
     if (error) throw new Error(error.message);
@@ -75,6 +76,7 @@ export default async function SEList({
               knownMax: 5,
               knownLegend: 'facts held: ABN, sector, place, web/description, graph match',
               stateFacets: ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'],
+              sectorFacets: ['indigenous', 'community', 'education', 'employment', 'environment', 'health', 'civil construction', 'arts', 'retail', 'food'],
               moneyCaveat:
                 'Known = facts we hold (ABN, sector, place, web presence, graph match) — a short bar is our gap, not theirs. Dollars attach to the ABN; branches share their parent\u2019s figures.',
             }}
@@ -82,6 +84,7 @@ export default async function SEList({
             state={state}
             size=""
             sort={sort} dir={dir}
+            sector={sector}
             statsLine={statsLine}
           />
         )}

--- a/apps/web/src/components/browse/ContractSideBrowser.tsx
+++ b/apps/web/src/components/browse/ContractSideBrowser.tsx
@@ -30,6 +30,12 @@ export interface SideConfig {
   yearOptions?: string[];
   /** RPC sort key for the counterparty-count column ('buyers' | 'suppliers' | 'recipients'). */
   counterpartySortKey: string;
+  /** State chips: the supplier's state from gs_entities by ABN. Suppliers with no ABN on the contract drop out when one is chosen. */
+  stateFacets?: string[];
+  /** Upper-bound year chips (financial years for donations). */
+  toYearOptions?: string[];
+  /** Counterparty chips matched as a substring of the recipient name: 'Labor', 'Liberal', 'Greens'. */
+  toFacets?: string[];
 }
 
 interface SideDetail {
@@ -50,6 +56,9 @@ export default function ContractSideBrowser({
   fromYear,
   sort,
   dir = '',
+  state = '',
+  toYear = '',
+  to = '',
   statsLine,
   caveat,
 }: {
@@ -60,6 +69,9 @@ export default function ContractSideBrowser({
   sort: string;
   /** 'asc' | 'desc' | '' (natural) */
   dir?: string;
+  state?: string;
+  toYear?: string;
+  to?: string;
   statsLine: string;
   caveat: string;
 }) {
@@ -67,7 +79,7 @@ export default function ContractSideBrowser({
   const detail = drawer.detail;
   const open = (key: string) =>
     drawer.open(key, `${cfg.detailApi}?key=${encodeURIComponent(key)}&from=${encodeURIComponent(fromYear || '2020')}`);
-  const qs = makeQs(cfg.basePath, { q, from: fromYear, sort, dir });
+  const qs = makeQs(cfg.basePath, { q, from: fromYear, to_year: toYear, to, state, sort, dir });
   /** Name normalisation folds spellings together, but one name can still be several declared
    *  ABNs — three Pratt Holdings Pty Ltd rows, three real ABNs. Where the name alone cannot
    *  tell two rows apart, show the ABN that does. */
@@ -89,6 +101,9 @@ export default function ContractSideBrowser({
           className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
         />
         {fromYear ? <input type="hidden" name="from" value={fromYear} /> : null}
+        {toYear ? <input type="hidden" name="to_year" value={toYear} /> : null}
+        {to ? <input type="hidden" name="to" value={to} /> : null}
+        {state ? <input type="hidden" name="state" value={state} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
         {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
@@ -100,6 +115,41 @@ export default function ContractSideBrowser({
           </Link>
         ))}
       </div>
+      {cfg.toYearOptions?.length || cfg.toFacets?.length || cfg.stateFacets?.length ? (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          {cfg.toYearOptions?.length ? (
+            <>
+              <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>until</span>
+              {cfg.toYearOptions.map((y) => (
+                <Link key={y} href={qs({ to_year: toYear === y ? '' : y })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={toYear === y ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+                  {y}
+                </Link>
+              ))}
+            </>
+          ) : null}
+          {cfg.toFacets?.length ? (
+            <>
+              <span className="ml-2 font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>{cfg.counterpartyLabel.toLowerCase()}</span>
+              {cfg.toFacets.map((t) => (
+                <Link key={t} href={qs({ to: to === t ? '' : t })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={to === t ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+                  {t}
+                </Link>
+              ))}
+            </>
+          ) : null}
+          {cfg.stateFacets?.length ? (
+            <>
+              <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>state</span>
+              {cfg.stateFacets.map((st) => (
+                <Link key={st} href={qs({ state: state === st ? '' : st })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === st ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+                  {st}
+                </Link>
+              ))}
+              {state ? <span className="ml-2 font-mono text-[10px]" style={{ color: 'var(--shell-muted)' }}>by the supplier&apos;s registered state; contracts with no supplier ABN are left out</span> : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>

--- a/apps/web/src/components/browse/FoundationsBrowser.tsx
+++ b/apps/web/src/components/browse/FoundationsBrowser.tsx
@@ -38,8 +38,10 @@ const TYPES: [string, string][] = [
   ['university', 'Universities'],
 ];
 
+/** null is "no figure"; 0 is a figure and prints as $0. A dash for zero read as missing data (Ben, 2026-09-07). */
 function money(n: number | null): string {
-  if (!n) return '—';
+  if (n == null) return '—';
+  if (n === 0) return '$0';
   if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}bn`;
   if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}m`;
   // See browse-ui.tsx: "$0k" for a real amount under $500 is worse than the extra digits.
@@ -199,8 +201,14 @@ export default function FoundationsBrowser({
               ) : null}
             </span>
             <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.giving)}</span>
-            <span className="w-[100px] shrink-0 text-right font-mono text-[12.5px]">{money(r.granted)}</span>
-            <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.total_assets)}</span>
+            {r.ais_year == null ? (
+              <span className="w-[192px] shrink-0 text-right font-mono text-[10.5px]" style={{ color: 'var(--shell-muted)' }} title="Registered with the ACNC but no Annual Information Statement on file yet; most of these registered after June 2023">no return filed</span>
+            ) : (
+              <>
+                <span className="w-[100px] shrink-0 text-right font-mono text-[12.5px]">{money(r.granted)}</span>
+                <span className="w-[92px] shrink-0 text-right font-mono text-[12.5px]">{money(r.total_assets)}</span>
+              </>
+            )}
             <span className="w-[74px] shrink-0 text-right font-mono text-[12.5px]">{r.grantees || '—'}</span>
             <span className="w-[70px] shrink-0 text-right font-mono text-[12.5px]">{r.board_links || '—'}</span>
           </button>

--- a/apps/web/src/components/browse/FoundationsBrowser.tsx
+++ b/apps/web/src/components/browse/FoundationsBrowser.tsx
@@ -24,13 +24,18 @@ export interface BrowseRow {
   total_assets: number | null;
 }
 
+/** foundations.type values with enough rows to be worth a chip (measured 2026-09-07; 'philanthropic_foundation' had none). */
 const TYPES: [string, string][] = [
+  ['corporate_foundation', 'Corporate foundations'],
+  ['trust', 'Trusts'],
   ['grantmaker', 'Grantmakers'],
   ['private_ancillary_fund', 'Private ancillary funds'],
   ['public_ancillary_fund', 'Public ancillary funds'],
-  ['trust', 'Trusts'],
-  ['corporate_foundation', 'Corporate foundations'],
-  ['philanthropic_foundation', 'Philanthropic foundations'],
+  ['service_delivery', 'Service delivery'],
+  ['religious_organisation', 'Religious'],
+  ['international_aid', 'International aid'],
+  ['education_body', 'Education'],
+  ['university', 'Universities'],
 ];
 
 function money(n: number | null): string {
@@ -116,12 +121,12 @@ export default function FoundationsBrowser({
       else p.delete(k);
     }
     const s = p.toString();
-    return `/dashboard/browse/foundations${s ? `?${s}` : ''}`;
+    return `/foundations${s ? `?${s}` : ''}`;
   };
 
   return (
     <>
-      <form className="mt-4 flex flex-wrap items-center gap-2" action="/dashboard/browse/foundations">
+      <form className="mt-4 flex flex-wrap items-center gap-2" action="/foundations">
         <input
           name="q"
           defaultValue={q}

--- a/apps/web/src/components/browse/FoundationsBrowser.tsx
+++ b/apps/web/src/components/browse/FoundationsBrowser.tsx
@@ -74,6 +74,7 @@ export default function FoundationsBrowser({
   type,
   sort,
   dir = '',
+  state = '',
   total,
 }: {
   rows: BrowseRow[];
@@ -82,6 +83,8 @@ export default function FoundationsBrowser({
   sort: string;
   /** 'asc' | 'desc' | '' (natural) */
   dir?: string;
+  /** acnc_charities.state for the foundation's ABN. */
+  state?: string;
   total: number;
 }) {
   const [openId, setOpenId] = useState<string | null>(null);
@@ -107,6 +110,7 @@ export default function FoundationsBrowser({
     if (type) p.set('type', type);
     if (sort) p.set('sort', sort);
     if (dir) p.set('dir', dir);
+    if (state) p.set('state', state);
     for (const [k, v] of Object.entries(over)) {
       if (v) p.set(k, v);
       else p.delete(k);
@@ -125,6 +129,7 @@ export default function FoundationsBrowser({
           className="w-full max-w-[360px] bg-white px-3 py-2 font-mono text-[13px] shell-control"
         />
         {type ? <input type="hidden" name="type" value={type} /> : null}
+        {state ? <input type="hidden" name="state" value={state} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
         {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
@@ -144,6 +149,14 @@ export default function FoundationsBrowser({
             style={type === v ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}
           >
             {label}
+          </Link>
+        ))}
+      </div>
+      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>state</span>
+        {['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT'].map((st) => (
+          <Link key={st} href={qs({ state: state === st ? '' : st })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={state === st ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {st}
           </Link>
         ))}
       </div>

--- a/apps/web/src/components/browse/GrantBrowser.tsx
+++ b/apps/web/src/components/browse/GrantBrowser.tsx
@@ -29,6 +29,8 @@ interface RecipientDetail {
 }
 
 const STATES = ['NSW', 'VIC', 'QLD', 'WA', 'SA', 'TAS', 'NT', 'ACT', 'FED'];
+/** Justice funding runs 2008-09 to 2026-27; these are the years with enough rows to be worth a chip. */
+const FYS = ['2015-16', '2017-18', '2019-20', '2021-22', '2022-23', '2023-24', '2024-25'];
 const TOPICS = ['child-protection', 'family-services', 'youth-justice', 'indigenous', 'community-led', 'diversion'];
 
 export default function GrantBrowser({
@@ -38,6 +40,8 @@ export default function GrantBrowser({
   topic,
   sort,
   dir = '',
+  fromFy = '',
+  toFy = '',
   statsLine,
   coverageLine,
   topicLine,
@@ -50,6 +54,9 @@ export default function GrantBrowser({
   sort: string;
   /** 'asc' | 'desc' | '' (natural) */
   dir?: string;
+  /** Financial-year bounds on justice_funding.financial_year, inclusive, 'YYYY-YY'. */
+  fromFy?: string;
+  toFy?: string;
   statsLine: string;
   /** Coverage skew — stated up front, not buried in the caveat. UX audit pass 2, F1. */
   coverageLine?: string;
@@ -60,7 +67,7 @@ export default function GrantBrowser({
   const drawer = useDrawer<RecipientDetail>();
   const detail = drawer.detail;
   const open = (key: string) => drawer.open(key, `/api/browse/grant-recipient?key=${encodeURIComponent(key)}`);
-  const qs = makeQs('/dashboard/browse/grants', { q, state, topic, sort, dir });
+  const qs = makeQs('/dashboard/browse/grants', { q, state, topic, from: fromFy, to: toFy, sort, dir });
 
   return (
     <>
@@ -85,6 +92,8 @@ export default function GrantBrowser({
         />
         {state ? <input type="hidden" name="state" value={state} /> : null}
         {topic ? <input type="hidden" name="topic" value={topic} /> : null}
+        {fromFy ? <input type="hidden" name="from" value={fromFy} /> : null}
+        {toFy ? <input type="hidden" name="to" value={toFy} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
         {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
@@ -102,6 +111,20 @@ export default function GrantBrowser({
         {TOPICS.map((t) => (
           <Link key={t} href={qs({ topic: topic === t ? '' : t })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={topic === t ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
             {t.replace(/-/g, ' ')}
+          </Link>
+        ))}
+      </div>
+      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>from</span>
+        {FYS.map((y) => (
+          <Link key={`f${y}`} href={qs({ from: fromFy === y ? '' : y })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={fromFy === y ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {y}
+          </Link>
+        ))}
+        <span className="ml-2 font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>to</span>
+        {FYS.map((y) => (
+          <Link key={`t${y}`} href={qs({ to: toFy === y ? '' : y })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={toFy === y ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+            {y}
           </Link>
         ))}
       </div>

--- a/apps/web/src/components/browse/OrgBrowser.tsx
+++ b/apps/web/src/components/browse/OrgBrowser.tsx
@@ -30,6 +30,10 @@ export interface BrowserConfig {
   knownLegend: string;
   stateFacets: string[];
   sizeFacets?: string[];
+  /** Sector chips; matched case-insensitively against gs_entities.sector (charities) or social_enterprises.sector (SEs). */
+  sectorFacets?: string[];
+  /** ABS remoteness bands, from gs_entities.remoteness; charities only. */
+  remotenessFacets?: string[];
   moneyCaveat: string;
 }
 
@@ -79,6 +83,8 @@ export default function OrgBrowser({
   size,
   sort,
   dir = '',
+  sector = '',
+  remoteness = '',
   statsLine,
 }: {
   rows: OrgRow[];
@@ -89,6 +95,8 @@ export default function OrgBrowser({
   sort: string;
   /** 'asc' | 'desc' | '' (natural) */
   dir?: string;
+  sector?: string;
+  remoteness?: string;
   statsLine: string;
 }) {
   const [openAbn, setOpenAbn] = useState<string | null>(null);
@@ -110,7 +118,7 @@ export default function OrgBrowser({
 
   const qs = (over: Record<string, string>) => {
     const p = new URLSearchParams();
-    for (const [k, v] of Object.entries({ q, state, size, sort, dir, ...over })) if (v) p.set(k, v);
+    for (const [k, v] of Object.entries({ q, state, size, sector, remoteness, sort, dir, ...over })) if (v) p.set(k, v);
     const s = p.toString();
     return `${cfg.basePath}${s ? `?${s}` : ''}`;
   };
@@ -129,6 +137,8 @@ export default function OrgBrowser({
         />
         {state ? <input type="hidden" name="state" value={state} /> : null}
         {size ? <input type="hidden" name="size" value={size} /> : null}
+        {sector ? <input type="hidden" name="sector" value={sector} /> : null}
+        {remoteness ? <input type="hidden" name="remoteness" value={remoteness} /> : null}
         {sort ? <input type="hidden" name="sort" value={sort} /> : null}
         {dir ? <input type="hidden" name="dir" value={dir} /> : null}
       </form>
@@ -152,6 +162,30 @@ export default function OrgBrowser({
           </>
         ) : null}
       </div>
+      {cfg.sectorFacets?.length || cfg.remotenessFacets?.length ? (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          {cfg.sectorFacets?.length ? (
+            <>
+              <span className="font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>sector</span>
+              {cfg.sectorFacets.map((s) => (
+                <Link key={s} href={qs({ sector: sector === s ? '' : s })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={sector === s ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+                  {s}
+                </Link>
+              ))}
+            </>
+          ) : null}
+          {cfg.remotenessFacets?.length ? (
+            <>
+              <span className="ml-2 font-mono text-[10px] uppercase tracking-widest" style={{ color: 'var(--shell-muted)' }}>where</span>
+              {cfg.remotenessFacets.map((r) => (
+                <Link key={r} href={qs({ remoteness: remoteness === r ? '' : r })} className="px-2 py-1 font-mono text-[10px] font-black uppercase tracking-widest shell-control" style={remoteness === r ? { background: '#121212', color: '#F4F4F2' } : { background: '#FFF' }}>
+                  {r.replace(' of Australia', '').replace(' Australia', '')}
+                </Link>
+              ))}
+            </>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="mt-4 shell-card">
         <div className="flex items-baseline gap-3 px-4 py-2 font-mono text-[10px] font-black uppercase tracking-widest" style={{ borderBottom: '1px solid var(--shell-line)', color: 'var(--shell-muted)' }}>

--- a/apps/web/src/lib/justice-money.ts
+++ b/apps/web/src/lib/justice-money.ts
@@ -57,6 +57,9 @@ export function isRealRecipient(name: string | null | undefined): boolean {
   // recipient renders as a blank row carrying real dollars.
   const normalised = name.trim().toLowerCase();
   if (normalised === '') return false;
+  // The source glues this prefix onto real names ("No longer usedUSC Spartans Swim Club Inc"), so a
+  // list match cannot catch it. Mirrored in grant_recipient_browse (migration 20260907120000).
+  if (normalised.startsWith('no longer used')) return false;
   return !NON_RECIPIENT_NAMES.has(normalised);
 }
 

--- a/scripts/refresh-acnc-ais.mjs
+++ b/scripts/refresh-acnc-ais.mjs
@@ -106,6 +106,72 @@ const CSV_TO_DB = {
   'Incorporated_Association': 'incorporated_association',
 };
 
+/**
+ * The 2024 file (datadotgov_ais24.csv, 2026-09-07) dropped the CamelCase headers for lowercase words, has no
+ * AIS_Year column (the year comes from the dataset), writes flags as y/n and dates as dd/mm/yyyy. Parsed 0
+ * rows against the map above before this. Keyed on the header lower-cased and trimmed.
+ */
+const CSV_TO_DB_LOWER = {
+  'abn': 'abn',
+  'charity name': 'charity_name',
+  'registration status': 'registration_status',
+  'charity website': 'charity_website',
+  'charity size': 'charity_size',
+  'basic religious charity': 'basic_religious_charity',
+  'ais due date': 'ais_due_date',
+  'date ais received': 'date_ais_received',
+  'financial report date received': 'financial_report_date_received',
+  'conducted activities': 'conducted_activities',
+  'why charity did not conduct activities': 'why_not_conducted',
+  'how purposes were pursued': 'how_purposes_pursued',
+  'international activities details': 'international_activities_details',
+  'staff - full time': 'staff_full_time',
+  'staff - part time': 'staff_part_time',
+  'staff - casual': 'staff_casual',
+  'total full time equivalent staff': 'staff_fte',
+  'staff - volunteers': 'staff_volunteers',
+  'cash or accrual': 'cash_or_accrual',
+  'type of financial statement': 'financial_statement_type',
+  'report consolidated with more than one entity': 'report_consolidated',
+  'charity report has a modification': 'report_has_modification',
+  'type of report modification': 'modification_type',
+  'charity has reportable related party transactions': 'has_related_party_transactions',
+  'fin report from': 'fin_report_from',
+  'fin report to': 'fin_report_to',
+  'revenue from government': 'revenue_from_government',
+  'donations and bequests': 'donations_and_bequests',
+  'revenue from goods and services': 'revenue_from_goods_services',
+  'revenue from investments': 'revenue_from_investments',
+  'all other revenue': 'all_other_revenue',
+  'total revenue': 'total_revenue',
+  'other income': 'other_income',
+  'total gross income': 'total_gross_income',
+  'employee expenses': 'employee_expenses',
+  'interest expenses': 'interest_expenses',
+  'grants and donations made for use in australia': 'grants_donations_au',
+  'grants and donations made for use outside australia': 'grants_donations_intl',
+  'all other expenses': 'all_other_expenses',
+  'total expenses': 'total_expenses',
+  'net surplus/deficit': 'net_surplus_deficit',
+  'other comprehensive income': 'other_comprehensive_income',
+  'total comprehensive income': 'total_comprehensive_income',
+  'total current assets': 'total_current_assets',
+  'non-current loans receivable': 'non_current_loans_receivable',
+  'other non-current assets': 'other_non_current_assets',
+  'total non-current assets': 'total_non_current_assets',
+  'total assets': 'total_assets',
+  'total current liabilities': 'total_current_liabilities',
+  'non-current loans payable': 'non_current_loans_payable',
+  'other non-current liabilities': 'other_non_current_liabilities',
+  'total non-current liabilities': 'total_non_current_liabilities',
+  'total liabilities': 'total_liabilities',
+  'net assets/liabilities': 'net_assets_liabilities',
+  'key management personnel': 'has_key_management_personnel',
+  'number of key management personnel': 'num_key_management_personnel',
+  'total paid to key management personnel': 'total_paid_key_management',
+  'incorporated association': 'incorporated_association',
+};
+
 const BOOLEAN_COLS = new Set([
   'basic_religious_charity', 'conducted_activities', 'report_consolidated',
   'report_has_modification', 'has_related_party_transactions',
@@ -135,8 +201,11 @@ const NUMERIC_COLS = new Set([
 
 function parseValue(col, val) {
   if (val === '' || val === null || val === undefined) return null;
-  if (BOOLEAN_COLS.has(col)) return val === 'Y' || val === 'Yes' || val === 'true' || val === '1';
+  if (BOOLEAN_COLS.has(col)) return ['y', 'yes', 'true', '1'].includes(String(val).trim().toLowerCase());
   if (DATE_COLS.has(col)) {
+    // 2024 file writes dd/mm/yyyy; new Date() reads that as mm/dd and returns Invalid Date for day > 12.
+    const dmy = String(val).trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (dmy) return `${dmy[3]}-${dmy[2].padStart(2, '0')}-${dmy[1].padStart(2, '0')}`;
     const d = new Date(val);
     return isNaN(d.getTime()) ? null : d.toISOString().split('T')[0];
   }
@@ -202,7 +271,7 @@ async function downloadCsv(url, destPath) {
   await pipeline(resp.body, ws);
 }
 
-async function importCsv(csvPath, resourceId) {
+async function importCsv(csvPath, resourceId, datasetYear) {
   return new Promise((resolve, reject) => {
     const rows = [];
     const parser = createReadStream(csvPath).pipe(parse({
@@ -219,6 +288,15 @@ async function importCsv(csvPath, resourceId) {
           row[dbCol] = parseValue(dbCol, csvRow[csvCol]);
         }
       }
+      if (row.abn === undefined) {
+        // 2024-shape file: lowercase headers, no year column.
+        for (const [rawCol, val] of Object.entries(csvRow)) {
+          const dbCol = CSV_TO_DB_LOWER[rawCol.trim().toLowerCase()];
+          if (dbCol) row[dbCol] = parseValue(dbCol, val);
+        }
+      }
+      if (row.abn) row.abn = String(row.abn).replace(/\D/g, '');
+      if (!row.ais_year && datasetYear) row.ais_year = datasetYear;
       if (!row.abn || !row.ais_year) return; // skip invalid
       row.data_source = 'data.gov.au';
       row.resource_id = resourceId;
@@ -226,7 +304,18 @@ async function importCsv(csvPath, resourceId) {
       rows.push(row);
     });
 
-    parser.on('end', () => resolve(rows));
+    parser.on('end', () => {
+      // The 2024 file lists some ABNs twice (a re-lodged statement). One upsert cannot touch the same
+      // (abn, ais_year) twice, so the whole 500-row batch failed. Keep the latest lodgement per ABN.
+      const byAbn = new Map();
+      for (const r of rows) {
+        const prev = byAbn.get(r.abn);
+        if (!prev || (r.date_ais_received ?? '') > (prev.date_ais_received ?? '')) byAbn.set(r.abn, r);
+      }
+      const dupes = rows.length - byAbn.size;
+      if (dupes > 0) console.log(`  Collapsed ${dupes} duplicate ABN rows (kept the latest lodgement)`);
+      resolve([...byAbn.values()]);
+    });
     parser.on('error', reject);
   });
 }
@@ -346,7 +435,7 @@ async function main() {
 
       // Parse CSV
       console.log('  Parsing CSV...');
-      const rows = await importCsv(csvPath, resource.id);
+      const rows = await importCsv(csvPath, resource.id, resource.year);
       console.log(`  Parsed ${rows.length.toLocaleString()} rows`);
 
       // Upsert

--- a/supabase/migrations/20260907120000_browse_rpc_filters.sql
+++ b/supabase/migrations/20260907120000_browse_rpc_filters.sql
@@ -1,0 +1,327 @@
+-- 20260907120000_browse_rpc_filters.sql
+-- Filters on the browse RPCs (issue #440, second half) and the junk-name fix (#442). Same mechanics as
+-- 20260907110000: the old signature is dropped first, bodies are pg_get_functiondef output touched only at the
+-- signature and WHERE, grants re-issued as they were. Filters are IN (subquery) not correlated EXISTS: the EXISTS
+-- form ran 75s on suppliers and 16s on charities in the dry run (the pooler per-row trap), the IN form is below.
+--
+-- What each function gains, and where the column comes from (measured 2026-09-07):
+--   charity_browse          p_sector (gs_entities.sector by ABN, compared lower-cased: the column holds both
+--                           'Health' and 'health'), p_remoteness (gs_entities.remoteness, ABS band). Rows with an
+--                           empty name are dropped: two-way sort had put them at the top of ascending lists.
+--   se_browse               p_sector, matched against any entry of social_enterprises.sector (text[]).
+--   grant_recipient_browse  p_from_fy / p_to_fy on justice_funding.financial_year ('YYYY-YY' sorts as text).
+--                           Rows whose name starts 'no longer used' are dropped: the source glues that prefix onto
+--                           real names ("No longer usedUSC Spartans Swim Club Inc"), so a list match cannot catch it.
+--   contract_supplier_browse p_state: the supplier's state from gs_entities by ABN. Suppliers without an ABN on
+--                           the contract cannot be placed and drop out when a state is chosen; the page says so.
+--   donation_donor_browse   p_to_fy (upper bound to pair with p_from_fy); p_to, a substring of donation_to, so
+--                           'Labor', 'Liberal', 'Greens' work as party chips across branch names.
+--   foundation_browse       p_state from acnc_charities.state by acnc_abn.
+-- Not added: state on contract_buyer_browse (buyers are agencies, no state column anywhere) and state on
+-- donation_donor_browse (political_donations.source_state is 'federal' on every row).
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.charity_browse(p_q text, p_state text, p_size text, p_sort text, p_limit integer, p_dir text);
+DROP FUNCTION IF EXISTS public.contract_supplier_browse(p_q text, p_from_year integer, p_sort text, p_limit integer, p_offset integer, p_dir text);
+DROP FUNCTION IF EXISTS public.donation_donor_browse(p_q text, p_from_fy text, p_sort text, p_limit integer, p_offset integer, p_dir text);
+DROP FUNCTION IF EXISTS public.foundation_browse(p_q text, p_type text, p_sort text, p_limit integer, p_dir text);
+DROP FUNCTION IF EXISTS public.grant_recipient_browse(p_q text, p_state text, p_topic text, p_sort text, p_limit integer, p_offset integer, p_dir text);
+DROP FUNCTION IF EXISTS public.se_browse(p_q text, p_state text, p_sort text, p_limit integer, p_dir text);
+
+CREATE OR REPLACE FUNCTION public.charity_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_size text DEFAULT NULL::text, p_sort text DEFAULT 'known'::text, p_limit integer DEFAULT 200, p_dir text DEFAULT NULL::text, p_sector text DEFAULT NULL::text, p_remoteness text DEFAULT NULL::text)
+ RETURNS TABLE(abn text, name text, charity_size text, state text, is_foundation boolean, gs_id text, system_count integer, visible_dollars numeric, ais_year integer, total_assets numeric, known integer)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  -- OUT names are the app's contract: visible_dollars and known, not the MV's column names.
+  SELECT m.abn, m.name, m.charity_size, m.state, m.is_foundation,
+         m.gs_id, m.system_count, m.total_dollar_flow AS visible_dollars,
+         m.ais_year, m.total_assets, m.known_score AS known
+    FROM mv_charity_browse m
+   WHERE (p_q IS NULL OR m.name ILIKE '%' || p_q || '%')
+     AND (p_state IS NULL OR m.state = p_state)
+     AND (p_size IS NULL OR m.charity_size = p_size)
+     AND m.name IS NOT NULL AND btrim(m.name) <> ''
+     AND (p_sector IS NULL OR m.abn IN (SELECT g.abn FROM gs_entities g WHERE g.abn IS NOT NULL AND lower(g.sector) = lower(p_sector)))
+     AND (p_remoteness IS NULL OR m.abn IN (SELECT g.abn FROM gs_entities g WHERE g.abn IS NOT NULL AND g.remoteness = p_remoteness))
+   ORDER BY
+     CASE WHEN p_sort = 'known' AND coalesce(p_dir, 'desc') = 'desc' THEN m.known_score END DESC NULLS LAST,
+     CASE WHEN p_sort = 'known' AND p_dir = 'asc' THEN m.known_score END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND coalesce(p_dir, 'asc') = 'asc' THEN m.known_score END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND p_dir = 'desc' THEN m.known_score END DESC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND coalesce(p_dir, 'desc') = 'desc' THEN m.total_assets END DESC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND p_dir = 'asc' THEN m.total_assets END ASC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND coalesce(p_dir, 'desc') = 'desc' THEN m.total_dollar_flow END DESC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND p_dir = 'asc' THEN m.total_dollar_flow END ASC NULLS LAST,
+     m.name ASC
+   LIMIT least(greatest(coalesce(p_limit, 200), 1), 500)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.contract_supplier_browse(p_q text DEFAULT NULL::text, p_from_year integer DEFAULT 2020, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text, p_state text DEFAULT NULL::text)
+ RETURNS TABLE(supplier_key text, supplier_name text, supplier_abn text, contract_count bigint, total_value numeric, buyer_count bigint, top_buyer text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    COALESCE(NULLIF(c.supplier_abn, ''), m.abn, root.abn, n.nk) AS supplier_key,
+    mode() WITHIN GROUP (ORDER BY c.supplier_name) AS supplier_name,
+    max(COALESCE(NULLIF(c.supplier_abn, ''), m.abn, root.abn)) AS supplier_abn,
+    count(*) AS contract_count,
+    sum(c.contract_value) AS total_value,
+    count(DISTINCT c.buyer_name) AS buyer_count,
+    (array_agg(c.buyer_name ORDER BY c.contract_value DESC NULLS LAST))[1] AS top_buyer
+  FROM austender_contracts c
+  JOIN supplier_name_keys n ON n.supplier_name = c.supplier_name
+  LEFT JOIN donor_key_abn m ON m.n = n.nk
+  LEFT JOIN donor_key_abn root ON n.nk LIKE '% pty ltd'
+        AND root.n = regexp_replace(n.nk, ' pty ltd$', '')
+  WHERE c.contract_start >= make_date(GREATEST(COALESCE(p_from_year, 2020), 2000), 1, 1)
+    AND c.contract_start < make_date(2031, 1, 1)
+    AND (p_q IS NULL OR c.supplier_name ILIKE '%' || p_q || '%')
+    AND (p_state IS NULL OR NULLIF(c.supplier_abn, '') IN (SELECT g.abn FROM gs_entities g WHERE g.abn IS NOT NULL AND g.state = p_state))
+  GROUP BY COALESCE(NULLIF(c.supplier_abn, ''), m.abn, root.abn, n.nk)
+  ORDER BY
+    CASE WHEN p_sort = 'contracts' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'contracts' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'buyers' AND coalesce(p_dir, 'desc') = 'desc' THEN count(DISTINCT c.buyer_name) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'buyers' AND p_dir = 'asc' THEN count(DISTINCT c.buyer_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN mode() WITHIN GROUP (ORDER BY c.supplier_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN mode() WITHIN GROUP (ORDER BY c.supplier_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(c.contract_value) END ASC NULLS LAST,
+    sum(c.contract_value) DESC NULLS LAST,
+    mode() WITHIN GROUP (ORDER BY c.supplier_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.donation_donor_browse(p_q text DEFAULT NULL::text, p_from_fy text DEFAULT '2014-15'::text, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text, p_to_fy text DEFAULT NULL::text, p_to text DEFAULT NULL::text)
+ RETURNS TABLE(donor_key text, donor_name text, donor_abn text, donation_count bigint, total_dollars numeric, recipient_count bigint, top_recipient text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    COALESCE(NULLIF(d.donor_abn, ''), m.abn, root.abn, n.nk) AS donor_key,
+    mode() WITHIN GROUP (ORDER BY d.donor_name) AS donor_name,
+    max(COALESCE(NULLIF(d.donor_abn, ''), m.abn, root.abn)) AS donor_abn,
+    count(*) AS donation_count,
+    sum(d.amount) AS total_dollars,
+    count(DISTINCT d.donation_to) AS recipient_count,
+    (array_agg(d.donation_to ORDER BY d.amount DESC NULLS LAST))[1] AS top_recipient
+  FROM political_donations d
+  JOIN donor_name_keys n ON n.donor_name = d.donor_name
+  LEFT JOIN donor_key_abn m ON m.n = n.nk
+  LEFT JOIN donor_key_abn root ON n.nk LIKE '% pty ltd'
+        AND root.n = regexp_replace(n.nk, ' pty ltd$', '')
+  WHERE d.receipt_type = 'donation received'
+    AND d.financial_year >= COALESCE(NULLIF(p_from_fy, ''), '2014-15')
+    AND (p_q IS NULL OR d.donor_name ILIKE '%' || p_q || '%')
+    AND (NULLIF(p_to_fy, '') IS NULL OR d.financial_year <= p_to_fy)
+    AND (NULLIF(p_to, '') IS NULL OR d.donation_to ILIKE '%' || p_to || '%')
+  GROUP BY COALESCE(NULLIF(d.donor_abn, ''), m.abn, root.abn, n.nk)
+  ORDER BY
+    CASE WHEN p_sort = 'donations' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'donations' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'recipients' AND coalesce(p_dir, 'desc') = 'desc' THEN count(DISTINCT d.donation_to) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'recipients' AND p_dir = 'asc' THEN count(DISTINCT d.donation_to) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN mode() WITHIN GROUP (ORDER BY d.donor_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN mode() WITHIN GROUP (ORDER BY d.donor_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(d.amount) END ASC NULLS LAST,
+    sum(d.amount) DESC NULLS LAST,
+    mode() WITHIN GROUP (ORDER BY d.donor_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.foundation_browse(p_q text DEFAULT NULL::text, p_type text DEFAULT NULL::text, p_sort text DEFAULT 'giving'::text, p_limit integer DEFAULT 200, p_dir text DEFAULT NULL::text, p_state text DEFAULT NULL::text)
+ RETURNS TABLE(id uuid, name text, abn text, type text, giving numeric, grantees bigint, board_links bigint, ais_year integer, granted numeric, total_assets numeric)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH g AS (
+    SELECT foundation_id, count(*) AS n FROM mv_foundation_grantees GROUP BY 1
+  ), b AS (
+    SELECT foundation_id, count(*) AS n FROM funder_board_paths GROUP BY 1
+  )
+  SELECT f.id, f.name, f.acnc_abn, f.type,
+         f.total_giving_annual,
+         coalesce(g.n, 0), coalesce(b.n, 0),
+         ais.ais_year::int, ais.grants_donations_au, ais.total_assets
+    FROM foundations f
+    LEFT JOIN g ON g.foundation_id = f.id
+    LEFT JOIN b ON b.foundation_id = f.id
+    -- LATERAL latest-AIS probe per foundation: the DISTINCT ON version deduplicated all 361K
+    -- AIS rows on every call (74s); ~11K index probes via idx_acnc_ais_lookup run in ~1s.
+    LEFT JOIN LATERAL (
+      SELECT a.ais_year, a.grants_donations_au, a.total_assets
+        FROM acnc_ais a
+       WHERE a.abn = f.acnc_abn
+       ORDER BY a.ais_year DESC
+       LIMIT 1
+    ) ais ON true
+   WHERE (p_q IS NULL OR f.name ILIKE '%' || p_q || '%')
+     AND (p_type IS NULL OR f.type = p_type)
+     AND (p_state IS NULL OR f.acnc_abn IN (SELECT c.abn FROM acnc_charities c WHERE c.state = p_state))
+   ORDER BY
+     CASE WHEN p_sort = 'giving' AND coalesce(p_dir, 'desc') = 'desc' THEN f.total_giving_annual END DESC NULLS LAST,
+     CASE WHEN p_sort = 'giving' AND p_dir = 'asc' THEN f.total_giving_annual END ASC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND coalesce(p_dir, 'desc') = 'desc' THEN ais.total_assets END DESC NULLS LAST,
+     CASE WHEN p_sort = 'assets' AND p_dir = 'asc' THEN ais.total_assets END ASC NULLS LAST,
+     CASE WHEN p_sort = 'granted' AND coalesce(p_dir, 'desc') = 'desc' THEN ais.grants_donations_au END DESC NULLS LAST,
+     CASE WHEN p_sort = 'granted' AND p_dir = 'asc' THEN ais.grants_donations_au END ASC NULLS LAST,
+     CASE WHEN p_sort = 'grantees' AND coalesce(p_dir, 'desc') = 'desc' THEN coalesce(g.n, 0) END DESC NULLS LAST,
+     CASE WHEN p_sort = 'grantees' AND p_dir = 'asc' THEN coalesce(g.n, 0) END ASC NULLS LAST,
+     CASE WHEN p_sort = 'board' AND coalesce(p_dir, 'desc') = 'desc' THEN coalesce(b.n, 0) END DESC NULLS LAST,
+     CASE WHEN p_sort = 'board' AND p_dir = 'asc' THEN coalesce(b.n, 0) END ASC NULLS LAST,
+     f.name ASC
+   LIMIT least(greatest(coalesce(p_limit, 200), 1), 500);
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.grant_recipient_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_topic text DEFAULT NULL::text, p_sort text DEFAULT 'total'::text, p_limit integer DEFAULT 200, p_offset integer DEFAULT 0, p_dir text DEFAULT NULL::text, p_from_fy text DEFAULT NULL::text, p_to_fy text DEFAULT NULL::text)
+ RETURNS TABLE(recipient_key text, recipient_name text, recipient_abn text, grant_count bigint, total_dollars numeric, states text[], first_year text, last_year text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    lower(btrim(j.recipient_name)) AS recipient_key,
+    max(j.recipient_name) AS recipient_name,
+    max(j.recipient_abn) AS recipient_abn,
+    count(*) AS grant_count,
+    sum(j.amount_dollars) AS total_dollars,
+    array_agg(DISTINCT j.state) FILTER (WHERE j.state IS NOT NULL) AS states,
+    min(j.financial_year) AS first_year,
+    max(j.financial_year) AS last_year
+  FROM justice_funding j
+  WHERE j.measure_kind = 'grant'
+    AND j.is_aggregate IS NOT TRUE
+    AND j.recipient_name IS NOT NULL
+    AND btrim(j.recipient_name) <> ''
+    AND lower(btrim(j.recipient_name)) NOT IN
+        ('total','totals','grand total','subtotal','sub-total','various','n/a','na','unknown','tbc','other','(blank)','no longer used')
+    AND lower(btrim(j.recipient_name)) NOT LIKE 'no longer used%'
+    AND (p_q IS NULL OR j.recipient_name ILIKE '%' || p_q || '%')
+    AND (p_state IS NULL OR j.state = p_state)
+    AND (p_topic IS NULL OR j.topics @> ARRAY[p_topic])
+    AND (NULLIF(p_from_fy, '') IS NULL OR j.financial_year >= p_from_fy)
+    AND (NULLIF(p_to_fy, '') IS NULL OR j.financial_year <= p_to_fy)
+  GROUP BY lower(btrim(j.recipient_name))
+  ORDER BY
+    CASE WHEN p_sort = 'grants' AND coalesce(p_dir, 'desc') = 'desc' THEN count(*) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'grants' AND p_dir = 'asc' THEN count(*) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'recent' AND coalesce(p_dir, 'desc') = 'desc' THEN max(j.financial_year) END DESC NULLS LAST,
+    CASE WHEN p_sort = 'recent' AND p_dir = 'asc' THEN max(j.financial_year) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND coalesce(p_dir, 'asc') = 'asc' THEN max(j.recipient_name) END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name' AND p_dir = 'desc' THEN max(j.recipient_name) END DESC NULLS LAST,
+    CASE WHEN coalesce(p_sort, 'total') = 'total' AND p_dir = 'asc' THEN sum(j.amount_dollars) END ASC NULLS LAST,
+    sum(j.amount_dollars) DESC NULLS LAST,
+    max(j.recipient_name) ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 500)
+  OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.se_browse(p_q text DEFAULT NULL::text, p_state text DEFAULT NULL::text, p_sort text DEFAULT 'known'::text, p_limit integer DEFAULT 200, p_dir text DEFAULT NULL::text, p_sector text DEFAULT NULL::text)
+ RETURNS TABLE(id uuid, name text, abn text, sector text, state text, gs_id text, system_count integer, visible_dollars numeric, known integer, has_abn boolean, has_sector boolean, has_place boolean, has_web boolean, on_graph boolean, entries integer)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  WITH base AS (
+    SELECT
+      s.id, s.name, s.abn, s.sector, s.state, s.postcode, s.website, s.description,
+      p.gs_id, p.system_count, p.total_dollar_flow,
+      (s.abn IS NOT NULL) AS has_abn,
+      (s.sector IS NOT NULL) AS has_sector,
+      (s.postcode IS NOT NULL OR s.state IS NOT NULL) AS has_place,
+      (s.website IS NOT NULL OR s.description IS NOT NULL) AS has_web,
+      (p.gs_id IS NOT NULL) AS on_graph,
+      ((s.abn IS NOT NULL)::int + (s.sector IS NOT NULL)::int
+       + (s.postcode IS NOT NULL OR s.state IS NOT NULL)::int
+       + (s.website IS NOT NULL OR s.description IS NOT NULL)::int
+       + (p.gs_id IS NOT NULL)::int) AS known_score,
+      -- One group per ABN; ABN-less rows group only with themselves.
+      COALESCE(s.abn, s.id::text) AS grp
+    FROM social_enterprises s
+    LEFT JOIN LATERAL (
+      SELECT e.gs_id, e.system_count, e.total_dollar_flow
+        FROM mv_entity_power_index e
+       WHERE e.abn = s.abn
+       LIMIT 1
+    ) p ON s.abn IS NOT NULL
+  ), named AS (
+    SELECT b.abn, min(g.canonical_name) AS canonical_name
+      FROM base b
+      JOIN gs_entities g ON g.abn = b.abn
+     WHERE b.abn IS NOT NULL
+     GROUP BY 1
+  ), sectors AS (
+    -- Flattened separately: array_agg over text[] of differing lengths is an error, and the union
+    -- of a group's sectors is what a reader wants to see.
+    SELECT b.grp, string_agg(DISTINCT x, ', ') AS sector
+      FROM base b, LATERAL unnest(COALESCE(b.sector, ARRAY[]::text[])) AS x
+     GROUP BY 1
+  ), grouped AS (
+    SELECT
+      (array_agg(b.id ORDER BY length(b.name), b.name))[1] AS id,
+      COALESCE(n.canonical_name, (array_agg(b.name ORDER BY length(b.name), b.name))[1]) AS name,
+      max(b.abn) AS abn,
+      sec.sector,
+      CASE WHEN count(DISTINCT b.state) = 1 THEN max(b.state) ELSE NULL END AS state,
+      max(b.gs_id) AS gs_id,
+      max(b.system_count)::int AS system_count,
+      max(b.total_dollar_flow) AS visible_dollars,
+      max(b.known_score) AS known,
+      bool_or(b.has_abn) AS has_abn,
+      bool_or(b.has_sector) AS has_sector,
+      bool_or(b.has_place) AS has_place,
+      bool_or(b.has_web) AS has_web,
+      bool_or(b.on_graph) AS on_graph,
+      count(*)::int AS entries,
+      -- Kept out of the returned row; only the filters below need them.
+      bool_or(p_q IS NULL OR b.name ILIKE '%' || p_q || '%') AS name_match,
+      bool_or(p_state IS NULL OR b.state = p_state) AS state_match
+      , bool_or(p_sector IS NULL OR EXISTS (SELECT 1 FROM unnest(COALESCE(b.sector, ARRAY[]::text[])) x WHERE lower(x) = lower(p_sector))) AS sector_match
+    FROM base b
+    LEFT JOIN named n ON n.abn = b.abn
+    LEFT JOIN sectors sec ON sec.grp = b.grp
+    GROUP BY b.grp, n.canonical_name, sec.sector
+  )
+  SELECT id, name, abn, sector, state, gs_id, system_count, visible_dollars, known,
+         has_abn, has_sector, has_place, has_web, on_graph, entries
+    FROM grouped
+   -- Matching on ANY entry in the group: searching "Ballarat Red Cross" must still find the row,
+   -- even though it now displays as Australian Red Cross Society.
+   WHERE name_match AND state_match
+     AND sector_match
+   ORDER BY
+     CASE WHEN p_sort = 'known' AND coalesce(p_dir, 'desc') = 'desc' THEN known END DESC NULLS LAST,
+     CASE WHEN p_sort = 'known' AND p_dir = 'asc' THEN known END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND coalesce(p_dir, 'asc') = 'asc' THEN known END ASC NULLS LAST,
+     CASE WHEN p_sort = 'least' AND p_dir = 'desc' THEN known END DESC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND coalesce(p_dir, 'desc') = 'desc' THEN visible_dollars END DESC NULLS LAST,
+     CASE WHEN p_sort = 'dollars' AND p_dir = 'asc' THEN visible_dollars END ASC NULLS LAST,
+     CASE WHEN p_sort = 'systems' AND coalesce(p_dir, 'desc') = 'desc' THEN system_count END DESC NULLS LAST,
+     CASE WHEN p_sort = 'systems' AND p_dir = 'asc' THEN system_count END ASC NULLS LAST,
+     name ASC
+   LIMIT least(greatest(coalesce(p_limit, 200), 1), 500)
+$function$
+;
+
+REVOKE EXECUTE ON FUNCTION public.charity_browse(p_q text, p_state text, p_size text, p_sort text, p_limit integer, p_dir text, p_sector text, p_remoteness text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.charity_browse(p_q text, p_state text, p_size text, p_sort text, p_limit integer, p_dir text, p_sector text, p_remoteness text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.contract_supplier_browse(p_q text, p_from_year integer, p_sort text, p_limit integer, p_offset integer, p_dir text, p_state text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.donation_donor_browse(p_q text, p_from_fy text, p_sort text, p_limit integer, p_offset integer, p_dir text, p_to_fy text, p_to text) TO anon, authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.foundation_browse(p_q text, p_type text, p_sort text, p_limit integer, p_dir text, p_state text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.foundation_browse(p_q text, p_type text, p_sort text, p_limit integer, p_dir text, p_state text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.grant_recipient_browse(p_q text, p_state text, p_topic text, p_sort text, p_limit integer, p_offset integer, p_dir text, p_from_fy text, p_to_fy text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.se_browse(p_q text, p_state text, p_sort text, p_limit integer, p_dir text, p_sector text) TO anon, authenticated, service_role;
+
+COMMIT;

--- a/supabase/types/database.types.ts
+++ b/supabase/types/database.types.ts
@@ -66417,6 +66417,8 @@ export type Database = {
           p_dir?: string
           p_limit?: number
           p_q?: string
+          p_remoteness?: string
+          p_sector?: string
           p_size?: string
           p_sort?: string
           p_state?: string
@@ -66787,6 +66789,7 @@ export type Database = {
           p_offset?: number
           p_q?: string
           p_sort?: string
+          p_state?: string
         }
         Returns: {
           buyer_count: number
@@ -66909,6 +66912,8 @@ export type Database = {
           p_offset?: number
           p_q?: string
           p_sort?: string
+          p_to?: string
+          p_to_fy?: string
         }
         Returns: {
           donation_count: number
@@ -67021,6 +67026,7 @@ export type Database = {
           p_limit?: number
           p_q?: string
           p_sort?: string
+          p_state?: string
           p_type?: string
         }
         Returns: {
@@ -67730,11 +67736,13 @@ export type Database = {
       grant_recipient_browse: {
         Args: {
           p_dir?: string
+          p_from_fy?: string
           p_limit?: number
           p_offset?: number
           p_q?: string
           p_sort?: string
           p_state?: string
+          p_to_fy?: string
           p_topic?: string
         }
         Returns: {
@@ -68613,6 +68621,7 @@ export type Database = {
           p_dir?: string
           p_limit?: number
           p_q?: string
+          p_sector?: string
           p_sort?: string
           p_state?: string
         }


### PR DESCRIPTION
Second half of #440 and all of #442. Ben: "build the filters" and "fix the junk names" (2026-09-07).

## Filters added, each a chip row above the table, all in the URL
| table | new filters | source column |
|---|---|---|
| Charities | sector, remoteness | `gs_entities.sector` (case-folded), `gs_entities.remoteness` |
| Social enterprises | sector | any entry of `social_enterprises.sector` |
| Grant recipients | from / to financial year | `justice_funding.financial_year` |
| Contract suppliers | state | supplier's `gs_entities.state` by ABN; contracts with no supplier ABN drop out when a state is chosen, and the page says so |
| Political donors | until year, party (Labor, Liberal, National, Greens, One Nation, United Australia, Independent) | `financial_year`, substring of `donation_to` |
| Foundations | state | `acnc_charities.state` by `acnc_abn` |

Not added, with the reason in the migration header: state on government buyers (agencies have no state column) and state on donors (`source_state` is 'federal' on every row).

## Junk names (#442)
`charity_browse` drops rows with an empty name. `grant_recipient_browse` drops names starting "no longer used". `isRealRecipient()` mirrors the prefix rule. Still visible at the bottom of ascending grants: fragments like "and Community Services Cluster" and "2. Community Support", which are a source-parsing defect, not a name-list one.

## Database: APPLIED
Migration `20260907120000_browse_rpc_filters.sql` applied on Ben's "migrate", tracked, parity green, ACLs unchanged, types regenerated. Filters are IN (subquery): the correlated EXISTS draft ran 75s on suppliers; the applied form is under 2s on every function with filters on.

## Verified on local dev against the applied functions
Charities Health + Very Remote (Bamagau Kazil Torres Strait Islanders Corporation in the list), charities ascending with no blank names, SEs sector=indigenous, grants 2022-23 to 2023-24 (TAFE Queensland, Legal Aid Queensland), suppliers state=NT (Sitzler, Tiwi Partners), donors to=Greens until 2022-23, foundations state=QLD. precheck green.
