### PR TITLE
justice_funding: drop the NSW FaCS table-of-contents rows loaded as grants

### DIFF
--- a/supabase/migrations/20260907140000_justice_funding_drop_nsw_facs_toc_rows.sql
+++ b/supabase/migrations/20260907140000_justice_funding_drop_nsw_facs_toc_rows.sql
@@ -1,0 +1,28 @@
+-- 20260907140000_justice_funding_drop_nsw_facs_toc_rows.sql
+-- Ten rows in justice_funding are the table of contents of the NSW FaCS 2018-19 NGO grants report, parsed as grants:
+-- recipient_name is a section heading ("2. Community Support and Development", "and Community Services Cluster",
+-- which is the second line of "1. State Outcomes delivered by the Family and Community Services Cluster") and
+-- amount_dollars is the page number (4, 5, 39, 41, 53, 57, 61, 66, 71, 73). Loaded 2026-03-27 by
+-- scripts/sql/ingest-nsw-facs-grants-2018-19.sql, a one-off, so they do not return on any scheduled run.
+-- Found 2026-09-07 when two-way sort made the bottom of the grant-recipient ranking visible (#442).
+-- $470 in total; program_name '1. State Outcomes delivered by the Family and Community Services Cluster' on all ten
+-- (the first dry run matched on a display-truncated version of that name and deleted nothing). Restore: re-insert from this list.
+BEGIN;
+
+DELETE FROM justice_funding
+WHERE source = 'nsw-facs-ngo-grants'
+  AND amount_dollars < 100
+  AND id IN (
+    '90886b67-3b53-46ba-bd07-0eeb5b1ee9d1', -- and Community Services Cluster, 4
+    'c52e3178-92c5-478b-bc26-a2fcea2313e2', -- 2. Community Support and Development, 5
+    '6ef04821-7e19-4768-92ee-ee73ab81325d', -- 3. Private Market Assistance, 39
+    '260ab098-28c3-4169-9fd7-cf9f9e137949', -- 4. Targeted Earlier Intervention, 41
+    '3d0752e0-0879-4395-8fc2-2bb341d869ae', -- 5. Child Protection, 53
+    'd906b92f-6ce8-493c-815b-d861f0efbaa3', -- 6. Domestic and Family Violence, 57
+    '17e24f8e-d84e-40dd-b13c-975e95dabd29', -- 7. Homelessness, 61
+    'd0e003c0-78c1-4dcc-b69b-7eb41a6041e4', -- 8. Out of Home Care and Permanency Support, 66
+    '2467f891-0fbd-4f6d-9c16-f88d7afb4eaf', -- 9. Social Housing, 71
+    'ac428cf8-28f8-40bc-a85b-e59d2fd51068'  -- 10. Supporting Legacy Services, 73
+  );
+
+COMMIT;

--- a/thoughts/shared/handoffs/allocation-intelligence/current.md
+++ b/thoughts/shared/handoffs/allocation-intelligence/current.md
@@ -9,15 +9,17 @@ status: active
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-09-07T08:05:00+10:00
+**Updated:** 2026-09-07T09:30:00+10:00
 **Goal:** Two surfaces that read the whole register: disadvantage versus dollars per council (`/allocation`) and seven-year charity trajectories (`/charities/trajectories`), plus three grounded posts for the Philanthropy Australia conference (Brisbane, 8 to 10 Sept 2026). Done when both pages are live and verified, and the posts have no unverified claim.
 **Branch:** main
 **Test:** `bash scripts/precheck.sh` · `node --env-file=.env scripts/check-migration-parity.mjs` · `node --env-file=.env scripts/check-private-exposure.mjs`
 
 ### Now
-[->] Nothing in progress. #444 merged `dd7ec00e`, verified live (foundations trust+QLD with state chips, $0 and 'no return filed'; charities Health + Very Remote). Open: #442 fragments at the bottom of ascending grants ('and Community Services Cluster'), Giving / yr placeholder on 9,242 foundations (script's enrich step writes via exec_sql, which is read-only), 523 pre-mid-2023 charities with no return in 2023 or 2024.
+[->] Nothing in progress. Stream closed: #446 (Giving column) merged `c609a725`; NSW FaCS table-of-contents rows deleted (migration 20260907140000, #442 closed). Open only: 523 pre-mid-2023 charities with no AIS in 2023 or 2024 (ACNC side), and the 955 scraped Giving figures that can mix program spend.
 
 ### This Session
+- [x] #446 merged `c609a725`: foundations.total_giving_annual placeholders (9,242 rows, $731m of guesses) replaced by latest AIS grants made ($3.33bn); 843 NULL where no return; old value in metadata.placeholder_giving. Root cause: refresh-acnc-ais.mjs enriches via exec_sql (SELECT-only), never wrote.
+- [x] #442 closed: the 'fragments' were the NSW FaCS 2018-19 report's table of contents loaded as 10 grants (page numbers as dollars, $470); deleted by migration 20260907140000 on Ben's "delete". Trap: program_name carried a trailing space, equality on the visible string matched nothing.
 - [x] #444 merged `dd7ec00e` and live: filters on six browse tables (sector/remoteness, sector, FY range, supplier state, donor party + until-year, foundation state), junk names out, foundations $0 vs 'no return filed', foundation type chips fixed (linked to the redirecting old path). Migration 20260907120000 applied.
 - [x] ACNC AIS 2024 loaded: 53,939 rows. The data.gov.au file changed shape (lowercase headers, no year column, y/n, dd/mm/yyyy, one duplicate ABN); refresh-acnc-ais.mjs fixed. Foundations with no return 2,224 -> 1,864 (1,341 registered after Jun 2023).
 - [x] #441 merged `f576e801` and live: two-way sort on all nine browse tables + /allocation, allocation search + sure chip, sidebar links, table width. Migration 20260907110000 applied.


### PR DESCRIPTION
Applied (migration 20260907140000, parity green) on Ben's "delete". Ten rows from the NSW FaCS 2018-19 NGO grants report's table of contents, loaded 2026-03-27 as grants with page numbers as amounts ($470 total). Each id listed in the migration for restore. Also the ledger. Closes #442.