### PR TITLE
migration: ecosystem_sites story syndication state

### DIFF
--- a/supabase/migrations/20260906235234_ecosystem_sites_story_state.sql
+++ b/supabase/migrations/20260906235234_ecosystem_sites_story_state.sql
@@ -1,0 +1,23 @@
+-- ecosystem_sites: story syndication state per site, from Empathy Ledger.
+--
+-- Written by act-global-infrastructure/scripts/vercel-sync.mjs (daily) from
+-- Empathy Ledger's admin_syndication_by_site and syndication_site_traffic.
+-- The studio's /admin/ecosystem shows "consented but never pulled" per site,
+-- which is how The Harvest sat unnoticed for months. Plan:
+-- act-global-infrastructure/thoughts/shared/plans/syndication-out.md
+BEGIN;
+
+ALTER TABLE public.ecosystem_sites
+  ADD COLUMN IF NOT EXISTS el_site_slug text,
+  ADD COLUMN IF NOT EXISTS stories_consented integer,
+  ADD COLUMN IF NOT EXISTS stories_last_pull_at timestamptz;
+
+COMMENT ON COLUMN public.ecosystem_sites.el_site_slug IS 'Empathy Ledger syndication_sites.slug that consumes this site''s stories';
+COMMENT ON COLUMN public.ecosystem_sites.stories_consented IS 'articles + stories consented to this site in Empathy Ledger, as of the last sync';
+COMMENT ON COLUMN public.ecosystem_sites.stories_last_pull_at IS 'last time this site pulled from Empathy Ledger, as of the last sync; NULL = never';
+
+COMMIT;
+
+-- post-check:
+-- SELECT column_name, data_type FROM information_schema.columns
+--  WHERE table_name='ecosystem_sites' AND column_name IN ('el_site_slug','stories_consented','stories_last_pull_at');

--- a/supabase/migrations/20260907005751_ecosystem_sites_story_state_private.sql
+++ b/supabase/migrations/20260907005751_ecosystem_sites_story_state_private.sql
@@ -1,0 +1,15 @@
+-- The three story-syndication columns are operational telemetry for the
+-- studio's internal operations page, which reads with the service role.
+-- The public read policy on ecosystem_sites stays for name, url, status and
+-- deploy times; these columns are withheld from the public key.
+-- Raised by review on grantscope #449.
+BEGIN;
+
+REVOKE SELECT (el_site_slug, stories_consented, stories_last_pull_at)
+  ON public.ecosystem_sites FROM anon, authenticated;
+
+COMMIT;
+
+-- post-check:
+--   anon PostgREST: ecosystem_sites?select=slug            -> 200
+--   anon PostgREST: ecosystem_sites?select=stories_consented -> 401/403

--- a/supabase/migrations/20260907005847_ecosystem_sites_public_columns_explicit.sql
+++ b/supabase/migrations/20260907005847_ecosystem_sites_public_columns_explicit.sql
@@ -1,0 +1,16 @@
+-- Corrects 20260907005751: a column-level REVOKE does not narrow a
+-- table-level SELECT grant (privileges are additive), so anon could still
+-- read the story telemetry columns. Revoke the table grant and re-grant only
+-- the public columns explicitly. Service role is unaffected.
+BEGIN;
+
+REVOKE SELECT ON public.ecosystem_sites FROM anon, authenticated;
+GRANT SELECT (id, name, slug, url, description, category, status, last_check_at, response_time_ms, icon_url, display_order, created_at, updated_at, vercel_project_id, vercel_project_name, github_repo, health_score, health_trend, last_deployment_at, ssl_expires_at, project_code)
+  ON public.ecosystem_sites TO anon, authenticated;
+
+COMMIT;
+
+-- post-check:
+--   anon PostgREST: ecosystem_sites?select=slug              -> 200
+--   anon PostgREST: ecosystem_sites?select=stories_consented -> 401/403 (42501)
+--   service role:   ecosystem_sites?select=stories_consented -> 200

--- a/supabase/types/database.types.ts
+++ b/supabase/types/database.types.ts
@@ -16012,6 +16012,7 @@ export type Database = {
           created_at: string | null
           description: string | null
           display_order: number | null
+          el_site_slug: string | null
           github_repo: string | null
           health_score: number | null
           health_trend: string | null
@@ -16025,6 +16026,8 @@ export type Database = {
           slug: string
           ssl_expires_at: string | null
           status: string | null
+          stories_consented: number | null
+          stories_last_pull_at: string | null
           updated_at: string | null
           url: string
           vercel_project_id: string | null
@@ -16035,6 +16038,7 @@ export type Database = {
           created_at?: string | null
           description?: string | null
           display_order?: number | null
+          el_site_slug?: string | null
           github_repo?: string | null
           health_score?: number | null
           health_trend?: string | null
@@ -16048,6 +16052,8 @@ export type Database = {
           slug: string
           ssl_expires_at?: string | null
           status?: string | null
+          stories_consented?: number | null
+          stories_last_pull_at?: string | null
           updated_at?: string | null
           url: string
           vercel_project_id?: string | null
@@ -16058,6 +16064,7 @@ export type Database = {
           created_at?: string | null
           description?: string | null
           display_order?: number | null
+          el_site_slug?: string | null
           github_repo?: string | null
           health_score?: number | null
           health_trend?: string | null
@@ -16071,6 +16078,8 @@ export type Database = {
           slug?: string
           ssl_expires_at?: string | null
           status?: string | null
+          stories_consented?: number | null
+          stories_last_pull_at?: string | null
           updated_at?: string | null
           url?: string
           vercel_project_id?: string | null


### PR DESCRIPTION
Three nullable columns written by the infra site sync from Empathy Ledger's admin views: `el_site_slug`, `stories_consented`, `stories_last_pull_at`. The studio's operations page shows consented-but-never-pulled per site. Applied 2026-09-07 via `scripts/db-apply.sh` on Ben's verb; post-check read the columns back; parity green. Plan: `act-global-infrastructure/thoughts/shared/plans/syndication-out.md`.